### PR TITLE
fix bug that will not close _direct_fd

### DIFF
--- a/src/chunkserver/raftlog/curve_segment.cpp
+++ b/src/chunkserver/raftlog/curve_segment.cpp
@@ -90,7 +90,8 @@ int CurveSegment::create() {
                            << "' with fd=" << _fd;
     if (FLAGS_enableWalDirectWrite) {
         _direct_fd = ::open(path.c_str(), O_RDWR|O_NOATIME|O_DIRECT, 0644);
-        LOG_IF(FATAL, _direct_fd < 0) << "failed to open file with O_DIRECT";
+        LOG_IF(FATAL, _direct_fd < 0) << "failed to open file with O_DIRECT"
+                                         ", error: " << strerror(errno);
         butil::make_close_on_exec(_direct_fd);
     }
     _meta.bytes += _meta_page_size;

--- a/src/chunkserver/raftlog/curve_segment.h
+++ b/src/chunkserver/raftlog/curve_segment.h
@@ -73,14 +73,14 @@ class BAIDU_CACHELINE_ALIGNMENT CurveSegment:
     CurveSegment(const std::string& path, const int64_t first_index,
                  int checksum_type)
         : _path(path), _meta(CurveSegmentMeta()),
-        _fd(-1), _is_open(true),
+        _fd(-1), _direct_fd(-1), _is_open(true),
         _first_index(first_index), _last_index(first_index - 1),
         _checksum_type(checksum_type),
         _meta_page_size(kWalFilePool->GetFilePoolOpt().metaPageSize) {}
     CurveSegment(const std::string& path, const int64_t first_index,
             const int64_t last_index, int checksum_type)
         : _path(path), _meta(CurveSegmentMeta()),
-        _fd(-1), _is_open(false),
+        _fd(-1), _direct_fd(-1), _is_open(false),
         _first_index(first_index), _last_index(last_index),
         _checksum_type(checksum_type),
         _meta_page_size(kWalFilePool->GetFilePoolOpt().metaPageSize) {
@@ -89,6 +89,10 @@ class BAIDU_CACHELINE_ALIGNMENT CurveSegment:
         if (_fd >= 0) {
             ::close(_fd);
             _fd = -1;
+        }
+        if (_direct_fd >= 0) {
+            ::close(_direct_fd);
+            _direct_fd = -1;
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Fix the bug that _direct_fd will not be close when segment destructed.

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?): 

### Check List

- [x] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license
