### PR TITLE
unittest: fix client integration test failed

### DIFF
--- a/test/integration/client/chunkserver_exception_test.cpp
+++ b/test/integration/client/chunkserver_exception_test.cpp
@@ -237,7 +237,7 @@ class CSModuleException : public ::testing::Test {
         ASSERT_NE(fd, -1);
 
         // 8. 先睡眠10s，让chunkserver选出leader
-        std::this_thread::sleep_for(std::chrono::seconds(5));
+        std::this_thread::sleep_for(std::chrono::seconds(10));
     }
 
     void TearDown() {
@@ -245,7 +245,9 @@ class CSModuleException : public ::testing::Test {
         UnInit();
         ASSERT_EQ(0, cluster->StopCluster());
         delete cluster;
-        system("rm -rf moduleException6 moduleException4 moduleException5");
+        system(
+            "rm -rf moduleException6 moduleException4 moduleException5 "
+            "module_exception_test_chunkserver.etcd");
     }
 
     void CreateOpenFileBackend() {

--- a/test/integration/client/config/topo_example_1.json
+++ b/test/integration/client/config/topo_example_1.json
@@ -1,7 +1,7 @@
 {
     "logicalpools": [
         {
-            "copysetnum": 300,
+            "copysetnum": 30,
             "name": "logicalPool1",
             "physicalpool": "pool1",
             "replicasnum": 3,
@@ -40,4 +40,3 @@
         }
     ]
 }
-


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Problem Summary:

fix client integration test failed which caused by create copysets too slow

### What is changed and how it works?

What's Changed:  change copyset num from 300 to 30

How it Works:

Side effects(Breaking backward compatibility? Performance regression?): 

### Check List

- [x] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license
