### PR TITLE
mds: check file in-use when Delete/Rename/ChangeOwner

### DIFF
--- a/src/client/iomanager4file.cpp
+++ b/src/client/iomanager4file.cpp
@@ -227,10 +227,10 @@ void IOManager4File::LeaseTimeoutBlockIO() {
     }
 }
 
-void IOManager4File::RefeshSuccAndResumeIO() {
+void IOManager4File::ResumeIO() {
     std::unique_lock<std::mutex> lk(exitMtx_);
     if (exit_ == false) {
-        scheduler_->RefeshSuccAndResumeIO();
+        scheduler_->ResumeIO();
     } else {
         LOG(WARNING) << "io manager already exit, no need resume io!";
     }

--- a/src/client/iomanager4file.h
+++ b/src/client/iomanager4file.h
@@ -175,6 +175,14 @@ class IOManager4File : public IOManager {
         mc_.SetLatestFileSn(newSn);
     }
 
+    /**
+     * @brief get current file inodeid
+     * @return file inodeid
+     */
+    uint64_t InodeId() const {
+        return mc_.InodeId();
+    }
+
  private:
     friend class LeaseExecutor;
     friend class FlightIOGuard;
@@ -187,7 +195,7 @@ class IOManager4File : public IOManager {
     /**
      * 当lease又续约成功的时候，LeaseExecutor调用该接口恢复IO
      */
-    void RefeshSuccAndResumeIO();
+    void ResumeIO();
 
     /**
      * 当lesaeexcutor发现版本变更，调用该接口开始等待inflight回来，这段期间IO是hang的

--- a/src/client/lease_executor.h
+++ b/src/client/lease_executor.h
@@ -68,10 +68,8 @@ class LeaseExecutor {
      * @param: mdsclient是与mds续约的client
      * @param: iomanager会在续约失败或者版本变更的时候进行io调度
      */
-    LeaseExecutor(const LeaseOption& leaseOpt,
-                 UserInfo_t userinfo,
-                 MDSClient* mdscllent,
-                 IOManager4File* iomanager);
+    LeaseExecutor(const LeaseOption& leaseOpt, UserInfo_t userinfo,
+                  MDSClient* mdscllent, IOManager4File* iomanager);
 
     ~LeaseExecutor();
 

--- a/src/client/libcurve_file.cpp
+++ b/src/client/libcurve_file.cpp
@@ -196,6 +196,7 @@ int FileClient::Open(const std::string& filename,
         fileserviceMap_[fd] = fileserv;
     }
 
+    LOG(INFO) << "Open success, filname = " << filename << ", fd = " << fd;
     openedFileNum_ << 1;
 
     return fd;
@@ -277,6 +278,8 @@ int FileClient::Read(int fd, char* buf, off_t offset, size_t len) {
     }
 
     if (CheckAligned(offset, len) == false) {
+        LOG(ERROR) << "Read request not aligned, length = " << len
+                   << ", offset = " << offset << ", fd = " << fd;
         return -LIBCURVE_ERROR::NOT_ALIGNED;
     }
 
@@ -296,6 +299,8 @@ int FileClient::Write(int fd, const char* buf, off_t offset, size_t len) {
     }
 
     if (CheckAligned(offset, len) == false) {
+        LOG(ERROR) << "Write request not aligned, length = " << len
+                   << ", offset = " << offset << ", fd = " << fd;
         return -LIBCURVE_ERROR::NOT_ALIGNED;
     }
 
@@ -316,6 +321,8 @@ int FileClient::AioRead(int fd, CurveAioContext* aioctx,
     }
 
     if (CheckAligned(aioctx->offset, aioctx->length) == false) {
+        LOG(ERROR) << "AioRead request not aligned, length = " << aioctx->length
+                   << ", offset = " << aioctx->offset << ", fd = " << fd;
         return -LIBCURVE_ERROR::NOT_ALIGNED;
     }
 
@@ -339,6 +346,9 @@ int FileClient::AioWrite(int fd, CurveAioContext* aioctx,
     }
 
     if (CheckAligned(aioctx->offset, aioctx->length) == false) {
+        LOG(ERROR) << "AioWrite request not aligned, length = "
+                   << aioctx->length << ", offset = " << aioctx->offset
+                   << ", fd = " << fd;
         return -LIBCURVE_ERROR::NOT_ALIGNED;
     }
 

--- a/src/client/metacache.h
+++ b/src/client/metacache.h
@@ -237,6 +237,10 @@ class MetaCache {
         return unstableHelper_;
     }
 
+    uint64_t InodeId() const {
+        return fileInfo_.id;
+    }
+
  private:
     /**
      * @brief 从mds更新copyset复制组信息

--- a/src/client/request_scheduler.h
+++ b/src/client/request_scheduler.h
@@ -118,7 +118,7 @@ class RequestScheduler : public Uncopyable {
      * 当lease又续约成功的时候，LeaseExecutor调用该接口恢复IO,
      * IO调度被恢复
      */
-    void RefeshSuccAndResumeIO() {
+    void ResumeIO() {
         std::unique_lock<std::mutex> lk(leaseRefreshmtx_);
         blockIO_.store(false);
         leaseRefreshcv_.notify_all();

--- a/src/mds/nameserver2/curvefs.h
+++ b/src/mds/nameserver2/curvefs.h
@@ -613,6 +613,19 @@ class CurveFS {
                                  const std::string &owner,
                                  bool *isHasCloneRely);
 
+    /**
+     * @brief check whether mds has started for enough time, based on the
+     *        file record expiration time(mds.file.expiredTimeUs)
+     * @param times multiple of file record expiration time
+     * @return return true if ok, otherwise return false
+     */
+    bool IsStartEnoughTime(int times) const {
+        std::chrono::steady_clock::duration timePass =
+            std::chrono::steady_clock::now() - startTime_;
+        uint32_t expiredUs = fileRecordManager_->GetFileRecordExpiredTimeUs();
+        return timePass >= times * std::chrono::microseconds(expiredUs);
+    }
+
  private:
     FileInfo rootFileInfo_;
     std::shared_ptr<NameServerStorage> storage_;

--- a/src/mds/nameserver2/file_record.cpp
+++ b/src/mds/nameserver2/file_record.cpp
@@ -88,6 +88,10 @@ void FileRecordManager::UpdateFileRecord(const std::string& fileName,
     fileRecords_.emplace(fileName, record);
 }
 
+void FileRecordManager::RemoveFileRecord(const std::string& filename) {
+    WriteLockGuard lk(rwlock_);
+    fileRecords_.erase(filename);
+}
 
 void FileRecordManager::Scan() {
     while (sleeper_.wait_for(

--- a/src/mds/nameserver2/file_record.h
+++ b/src/mds/nameserver2/file_record.h
@@ -141,6 +141,8 @@ class FileRecord {
 
 class FileRecordManager {
  public:
+    virtual ~FileRecordManager() = default;
+
     /**
      * @brief initialization
      * @param[in] sessionOption session configuration
@@ -160,7 +162,7 @@ class FileRecordManager {
      * @brief Get the expired time of the file
      * @return the expired time
      */
-    uint32_t GetFileRecordExpiredTimeUs() const {
+    virtual uint32_t GetFileRecordExpiredTimeUs() const {
         return fileRecordOptions_.fileRecordExpiredTimeUs;
     }
 
@@ -172,6 +174,12 @@ class FileRecordManager {
                           const std::string& clientVersion,
                           const std::string& clientIP,
                           uint32_t clientPort);
+
+    /**
+     * @brief remove file record corresponding to filename
+     * @param filename file record that to be deleted
+     */
+    void RemoveFileRecord(const std::string& filename);
 
     /**
      * @brief Get the client version corresponding to the input file
@@ -198,8 +206,8 @@ class FileRecordManager {
 
     std::set<ClientIpPortType> ListAllClient() const;
 
-    bool FindFileMountPoint(const std::string& fileName,
-                            ClientIpPortType* ipPort) const;
+    virtual bool FindFileMountPoint(const std::string& fileName,
+                                    ClientIpPortType* ipPort) const;
 
  private:
     /**

--- a/src/snapshotcloneserver/common/curvefs_client.cpp
+++ b/src/snapshotcloneserver/common/curvefs_client.cpp
@@ -338,7 +338,9 @@ int CurveFsClientImpl::RenameCloneFile(
     };
     RetryCondition condition = [] (int ret) {
         return ret != LIBCURVE_ERROR::OK &&
-               ret != -LIBCURVE_ERROR::NOTEXIST;
+               ret != -LIBCURVE_ERROR::NOTEXIST &&
+               ret != -LIBCURVE_ERROR::NOT_SUPPORT &&
+               ret != -LIBCURVE_ERROR::FILE_OCCUPIED;  // file is in-use
     };
     RetryHelper retryHelper(method, condition);
     return retryHelper.RetryTimeSecAndReturn(clientMethodRetryTimeSec_,
@@ -356,7 +358,9 @@ int CurveFsClientImpl::DeleteFile(
     };
     RetryCondition condition = [] (int ret) {
         return ret != LIBCURVE_ERROR::OK &&
-               ret != -LIBCURVE_ERROR::NOTEXIST;
+               ret != -LIBCURVE_ERROR::NOTEXIST &&
+               ret != -LIBCURVE_ERROR::NOT_SUPPORT &&
+               ret != -LIBCURVE_ERROR::FILE_OCCUPIED;
     };
     RetryHelper retryHelper(method, condition);
     return retryHelper.RetryTimeSecAndReturn(clientMethodRetryTimeSec_,
@@ -385,7 +389,9 @@ int CurveFsClientImpl::ChangeOwner(const std::string& filename,
         return fileClient_->ChangeOwner(filename, newOwner, userInfo);
     };
     RetryCondition condition = [] (int ret) {
-        return ret != LIBCURVE_ERROR::OK;
+        return ret != LIBCURVE_ERROR::OK &&
+            ret != LIBCURVE_ERROR::NOT_SUPPORT &&
+            ret != LIBCURVE_ERROR::FILE_OCCUPIED;
     };
     RetryHelper retryHelper(method, condition);
     return retryHelper.RetryTimeSecAndReturn(clientMethodRetryTimeSec_,

--- a/test/client/BUILD
+++ b/test/client/BUILD
@@ -46,6 +46,7 @@ cc_test(
                 "libcbd_libcurve_test.cpp",
                 "inflight_rpc_control_test.cpp",
                 "mds_failover_test.cpp",
+                "mds_client_test.cpp",
                 "libcurve_client_unittest.cpp",
                 "lease_executor_test.cpp",
                 "request_sender_test.cpp",
@@ -335,4 +336,30 @@ cc_library(
             "//src/client:curve_client",
             ],
     visibility = ["//visibility:public"],
+)
+
+cc_test(
+    name = "client_mds_client_test",
+    srcs = [
+        "mds_client_test.cpp"],
+    copts = COPTS,
+    visibility = ["//visibility:public"],
+    deps = [
+        "//external:braft",
+        "//external:brpc",
+        "//external:gflags",
+        "//external:glog",
+        "//external:leveldb",
+        "//external:protobuf",
+        "//include/client:include_client",
+        "//proto:chunkserver-cc-protos",
+        "//proto:nameserver2_cc_proto",
+        "//proto:topology_cc_proto",
+        "//src/client:curve_client",
+        "//src/common:curve_common",
+        "//src/common/concurrent:curve_concurrent",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+        "//test/client/mock:curve_client_mock"
+    ],
 )

--- a/test/client/fake/fakeMDS.cpp
+++ b/test/client/fake/fakeMDS.cpp
@@ -235,6 +235,11 @@ bool FakeMDS::StartService() {
     ::curve::mds::ReFreshSessionResponse* refreshresp = new ::curve::mds::ReFreshSessionResponse();      // NOLINT
     refreshresp->set_statuscode(::curve::mds::StatusCode::kOK);
     refreshresp->set_sessionid("1234");
+
+    auto* refreshFileInfo = new ::curve::mds::FileInfo();
+    refreshFileInfo->set_id(1);
+    refreshresp->set_allocated_fileinfo(refreshFileInfo);
+
     FakeReturn* refreshfakeret = new FakeReturn(nullptr, static_cast<void*>(refreshresp));      // NOLINT
     fakecurvefsservice_.SetRefreshSession(refreshfakeret, nullptr);
 

--- a/test/client/fake/fakeMDS.h
+++ b/test/client/fake/fakeMDS.h
@@ -238,7 +238,7 @@ class FakeMDSCurveFSService : public curve::mds::CurveFSService {
                 curve::mds::FileInfo * info = new curve::mds::FileInfo;
                 info->set_seqnum(seq++);
                 info->set_filename("_filename_");
-                info->set_id(1);
+                info->set_id(resp->fileinfo().id());
                 info->set_parentid(0);
                 info->set_filetype(curve::mds::FileType::INODE_PAGEFILE);
                 info->set_chunksize(4 * 1024 * 1024);

--- a/test/client/iotracker_splitor_unittest.cpp
+++ b/test/client/iotracker_splitor_unittest.cpp
@@ -116,6 +116,7 @@ class IOTrackerSplitorTest : public ::testing::Test {
 
     void TearDown() {
         writeData.clear();
+        fileinstance_->Close();
         fileinstance_->UnInitialize();
         mdsclient_.UnInitialize();
         delete fileinstance_;
@@ -309,6 +310,13 @@ class IOTrackerSplitorTest : public ::testing::Test {
         for (auto iter : cpinfoVec) {
             mc->UpdateCopysetInfo(lpcsIDInfo.lpid, iter.cpid_, iter);
         }
+
+        // 5. set close response
+        auto* closeResp = new ::curve::mds::CloseFileResponse();
+        closeResp->set_statuscode(::curve::mds::StatusCode::kOK);
+        auto* closeFakeRet =
+            new FakeReturn(nullptr, static_cast<void*>(closeResp));
+        curvefsservice.SetCloseFile(closeFakeRet);
     }
 
     FileClient *fileClient_;
@@ -765,6 +773,7 @@ TEST_F(IOTrackerSplitorTest, ExceptionTest_TEST) {
     if (waitthread.joinable()) {
         waitthread.join();
     }
+    fileserv->Close();
     fileserv->UnInitialize();
     delete fileserv;
     delete mockschuler;

--- a/test/client/libcbd_libcurve_test.cpp
+++ b/test/client/libcbd_libcurve_test.cpp
@@ -100,6 +100,7 @@ class TestLibcbdLibcurve : public ::testing::Test {
             usleep(100 * 1000);
         }
         ASSERT_EQ(ret, 0);
+        Close(ret);
     }
 
     void TearDown() {

--- a/test/client/libcurve_interface_unittest.cpp
+++ b/test/client/libcurve_interface_unittest.cpp
@@ -830,6 +830,7 @@ TEST(TestLibcurveInterface, UnstableChunkserverTest) {
         }
     }
 
+    fileinstance_.Close();
     fileinstance_.UnInitialize();
     mdsclient_.UnInitialize();
     mds.UnInitialize();
@@ -942,6 +943,7 @@ TEST(TestLibcurveInterface, ResumeTimeoutBackoff) {
     ASSERT_GE(elapsedMs, 52 * 1000);
     ASSERT_LE(elapsedMs, 55 * 1000);
 
+    fileinstance_.Close();
     fileinstance_.UnInitialize();
     mdsclient_.UnInitialize();
     mds.UnInitialize();

--- a/test/client/mds_client_test.cpp
+++ b/test/client/mds_client_test.cpp
@@ -1,0 +1,258 @@
+/*
+ *  Copyright (c) 2020 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * Project: curve
+ * Date: Wed Jan 13 09:48:12 CST 2021
+ * Author: wuhanqing
+ */
+
+#include "src/client/mds_client.h"
+
+#include <brpc/server.h>
+#include <glog/logging.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "test/client/mock/mock_namespace_service.h"
+
+namespace curve {
+namespace client {
+
+using ::testing::_;
+using ::testing::DoAll;
+using ::testing::Invoke;
+using ::testing::Return;
+using ::testing::SetArgPointee;
+
+template <typename RpcRequestType, typename RpcResponseType>
+void FakeRpcService(google::protobuf::RpcController* cntl,
+                    const RpcRequestType* request, RpcResponseType* response,
+                    google::protobuf::Closure* done) {
+    done->Run();
+}
+
+class MDSClientTest : public testing::Test {
+ protected:
+    void SetUp() override {
+        const std::string mdsAddr1 = "127.0.0.1:9600";
+        const std::string mdsAddr2 = "127.0.0.1:9601";
+
+        ASSERT_EQ(0, server_.AddService(&mockNameService_,
+                                        brpc::SERVER_DOESNT_OWN_SERVICE));
+
+        // only start mds on mdsAddr1
+        ASSERT_EQ(0, server_.Start(mdsAddr1.c_str(), nullptr));
+
+        option_.mdsAddrs = {mdsAddr2, mdsAddr1};
+        option_.mdsRPCTimeoutMs = 500;            // 500ms
+        option_.mdsMaxRPCTimeoutMS = 2000;        // 2s
+        option_.mdsRPCRetryIntervalUS = 1000000;  // 100ms
+        option_.mdsMaxRetryMS = 8000;             // 8s
+        option_.mdsMaxFailedTimesBeforeChangeMDS = 2;
+
+        ASSERT_EQ(LIBCURVE_ERROR::OK, mdsClient_.Initialize(option_));
+    }
+
+    void TearDown() override {
+        server_.Stop(0);
+        LOG(INFO) << "server stopped";
+        server_.Join();
+        LOG(INFO) << "server joined";
+    }
+
+ protected:
+    brpc::Server server_;
+    curve::mds::MockNameService mockNameService_;
+    MDSClient mdsClient_;
+    MetaServerOption option_;
+};
+
+TEST_F(MDSClientTest, TestRenameFile) {
+    UserInfo userInfo;
+    const std::string srcName = "/TestRenameFile";
+    const std::string destName = "/TestRenameFile-New";
+
+    // mds return not support
+    {
+        curve::mds::RenameFileResponse response;
+        response.set_statuscode(curve::mds::StatusCode::kNotSupported);
+        EXPECT_CALL(mockNameService_, RenameFile(_, _, _, _))
+            .WillRepeatedly(DoAll(
+                SetArgPointee<2>(response),
+                Invoke(FakeRpcService<RenameFileRequest, RenameFileResponse>)));
+
+        auto startMs = TimeUtility::GetTimeofDayMs();
+        ASSERT_EQ(LIBCURVE_ERROR::NOT_SUPPORT,
+                  mdsClient_.RenameFile(userInfo, srcName, destName));
+        auto endMs = TimeUtility::GetTimeofDayMs();
+        ASSERT_LE(option_.mdsMaxRetryMS, endMs - startMs);
+    }
+
+    // mds return file is occupied
+    {
+        curve::mds::RenameFileResponse response;
+        response.set_statuscode(curve::mds::StatusCode::kFileOccupied);
+
+        EXPECT_CALL(mockNameService_, RenameFile(_, _, _, _))
+            .WillRepeatedly(DoAll(
+                SetArgPointee<2>(response),
+                Invoke(FakeRpcService<RenameFileRequest, RenameFileResponse>)));
+
+        ASSERT_EQ(LIBCURVE_ERROR::FILE_OCCUPIED,
+                  mdsClient_.RenameFile(userInfo, srcName, destName));
+    }
+
+    // mds first return not support, then success
+    {
+        curve::mds::RenameFileResponse responseNotSupport;
+        responseNotSupport.set_statuscode(
+            curve::mds::StatusCode::kNotSupported);
+        curve::mds::RenameFileResponse responseOK;
+        responseOK.set_statuscode(curve::mds::StatusCode::kOK);
+
+        EXPECT_CALL(mockNameService_, RenameFile(_, _, _, _))
+            .WillOnce(DoAll(
+                SetArgPointee<2>(responseNotSupport),
+                Invoke(FakeRpcService<RenameFileRequest, RenameFileResponse>)))
+            .WillOnce(DoAll(
+                SetArgPointee<2>(responseOK),
+                Invoke(FakeRpcService<RenameFileRequest, RenameFileResponse>)));
+
+        ASSERT_EQ(LIBCURVE_ERROR::OK,
+                  mdsClient_.RenameFile(userInfo, srcName, destName));
+    }
+}
+
+TEST_F(MDSClientTest, TestDeleteFile) {
+    UserInfo userInfo;
+    const std::string fileName = "/TestDeleteFile";
+
+    // mds return not support
+    {
+        curve::mds::DeleteFileResponse response;
+        response.set_statuscode(curve::mds::StatusCode::kNotSupported);
+        EXPECT_CALL(mockNameService_, DeleteFile(_, _, _, _))
+            .WillRepeatedly(DoAll(
+                SetArgPointee<2>(response),
+                Invoke(FakeRpcService<DeleteFileRequest, DeleteFileResponse>)));
+
+        auto startMs = TimeUtility::GetTimeofDayMs();
+        ASSERT_EQ(LIBCURVE_ERROR::NOT_SUPPORT,
+                  mdsClient_.DeleteFile(fileName, userInfo));
+        auto endMs = TimeUtility::GetTimeofDayMs();
+        ASSERT_LE(option_.mdsMaxRetryMS, endMs - startMs);
+    }
+
+    // mds return file is occupied
+    {
+        curve::mds::DeleteFileResponse response;
+        response.set_statuscode(curve::mds::StatusCode::kFileOccupied);
+
+        EXPECT_CALL(mockNameService_, DeleteFile(_, _, _, _))
+            .WillRepeatedly(DoAll(
+                SetArgPointee<2>(response),
+                Invoke(FakeRpcService<DeleteFileRequest, DeleteFileResponse>)));
+
+        ASSERT_EQ(LIBCURVE_ERROR::FILE_OCCUPIED,
+                  mdsClient_.DeleteFile(fileName, userInfo));
+    }
+
+    // mds first return not support, then success
+    {
+        curve::mds::DeleteFileResponse responseNotSupport;
+        responseNotSupport.set_statuscode(
+            curve::mds::StatusCode::kNotSupported);
+        curve::mds::DeleteFileResponse responseOK;
+        responseOK.set_statuscode(curve::mds::StatusCode::kOK);
+
+        EXPECT_CALL(mockNameService_, DeleteFile(_, _, _, _))
+            .WillOnce(DoAll(
+                SetArgPointee<2>(responseNotSupport),
+                Invoke(FakeRpcService<DeleteFileRequest, DeleteFileResponse>)))
+            .WillOnce(DoAll(
+                SetArgPointee<2>(responseOK),
+                Invoke(FakeRpcService<DeleteFileRequest, DeleteFileResponse>)));
+
+        ASSERT_EQ(LIBCURVE_ERROR::OK,
+                  mdsClient_.DeleteFile(fileName, userInfo));
+    }
+}
+
+TEST_F(MDSClientTest, TestChangeOwner) {
+    UserInfo userInfo;
+    const std::string fileName = "/TestChangeOwner";
+    const std::string newUser = "newuser";
+
+    // mds return not support
+    {
+        curve::mds::ChangeOwnerResponse response;
+        response.set_statuscode(curve::mds::StatusCode::kNotSupported);
+        EXPECT_CALL(mockNameService_, ChangeOwner(_, _, _, _))
+            .WillRepeatedly(DoAll(
+                SetArgPointee<2>(response),
+                Invoke(
+                    FakeRpcService<ChangeOwnerRequest, ChangeOwnerResponse>)));
+
+        auto startMs = TimeUtility::GetTimeofDayMs();
+        ASSERT_EQ(LIBCURVE_ERROR::NOT_SUPPORT,
+                  mdsClient_.ChangeOwner(fileName, newUser, userInfo));
+        auto endMs = TimeUtility::GetTimeofDayMs();
+        ASSERT_LE(option_.mdsMaxRetryMS, endMs - startMs);
+    }
+
+    // mds return file is occupied
+    {
+        curve::mds::ChangeOwnerResponse response;
+        response.set_statuscode(curve::mds::StatusCode::kFileOccupied);
+
+        EXPECT_CALL(mockNameService_, ChangeOwner(_, _, _, _))
+            .WillRepeatedly(DoAll(
+                SetArgPointee<2>(response),
+                Invoke(
+                    FakeRpcService<ChangeOwnerRequest, ChangeOwnerResponse>)));
+
+        ASSERT_EQ(LIBCURVE_ERROR::FILE_OCCUPIED,
+                  mdsClient_.ChangeOwner(fileName, newUser, userInfo));
+    }
+
+    // mds first return not support, then success
+    {
+        curve::mds::ChangeOwnerResponse responseNotSupport;
+        responseNotSupport.set_statuscode(
+            curve::mds::StatusCode::kNotSupported);
+        curve::mds::ChangeOwnerResponse responseOK;
+        responseOK.set_statuscode(curve::mds::StatusCode::kOK);
+
+        EXPECT_CALL(mockNameService_, ChangeOwner(_, _, _, _))
+            .WillOnce(DoAll(
+                SetArgPointee<2>(responseNotSupport),
+                Invoke(
+                    FakeRpcService<ChangeOwnerRequest, ChangeOwnerResponse>)))
+            .WillOnce(DoAll(
+                SetArgPointee<2>(responseOK),
+                Invoke(
+                    FakeRpcService<ChangeOwnerRequest, ChangeOwnerResponse>)));
+
+        ASSERT_EQ(LIBCURVE_ERROR::OK,
+                  mdsClient_.ChangeOwner(fileName, newUser, userInfo));
+    }
+}
+
+}  // namespace client
+}  // namespace curve

--- a/test/client/mock/BUILD
+++ b/test/client/mock/BUILD
@@ -1,0 +1,34 @@
+COPTS = [
+    "-DGFLAGS=gflags",
+    "-DOS_LINUX",
+    "-DSNAPPY",
+    "-DHAVE_SSE42",
+    "-DNDEBUG",
+    "-fno-omit-frame-pointer",
+    "-momit-leaf-frame-pointer",
+    "-msse4.2",
+    "-pthread",
+    "-Wsign-compare",
+    "-Wno-unused-parameter",
+    "-Wno-unused-variable",
+    "-Woverloaded-virtual",
+    "-Wnon-virtual-dtor",
+    "-Wno-missing-field-initializers",
+    "-std=c++11",
+]
+
+cc_library(
+    name = "curve_client_mock",
+    srcs = glob([
+                "*.h",
+                "*.cpp",
+                ]),
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+        "//external:gflags",
+    ],
+    copts = COPTS
+)
+

--- a/test/client/mock/mock_namespace_service.h
+++ b/test/client/mock/mock_namespace_service.h
@@ -1,0 +1,55 @@
+/*
+ *  Copyright (c) 2020 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * Project: curve
+ * Date: Wed Jan 13 09:48:12 CST 2021
+ * Author: wuhanqing
+ */
+
+#ifndef TEST_CLIENT_MOCK_MOCK_NAMESPACE_SERVICE_H_
+#define TEST_CLIENT_MOCK_MOCK_NAMESPACE_SERVICE_H_
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "proto/nameserver2.pb.h"
+
+namespace curve {
+namespace mds {
+
+class MockNameService : public CurveFSService {
+ public:
+    MOCK_METHOD4(DeleteFile, void(google::protobuf::RpcController* cntl,
+                                  const DeleteFileRequest* request,
+                                  DeleteFileResponse* response,
+                                  google::protobuf::Closure* done));
+
+    MOCK_METHOD4(RenameFile, void(google::protobuf::RpcController* cntl,
+                                  const RenameFileRequest* request,
+                                  RenameFileResponse* response,
+                                  google::protobuf::Closure* done));
+
+    MOCK_METHOD4(ChangeOwner, void(google::protobuf::RpcController* cntl,
+                                  const ChangeOwnerRequest* request,
+                                  ChangeOwnerResponse* response,
+                                  google::protobuf::Closure* done));
+};
+
+}  // namespace mds
+}  // namespace curve
+
+#endif  // TEST_CLIENT_MOCK_MOCK_NAMESPACE_SERVICE_H_

--- a/test/integration/chunkserver/chunkserver_clone_recover.cpp
+++ b/test/integration/chunkserver/chunkserver_clone_recover.cpp
@@ -578,7 +578,7 @@ class CSCloneRecoverTest : public ::testing::Test {
         ASSERT_EQ(0, strncmp(chunkData2_.c_str(), temp.get(), kChunkSize));
 
         LOG(INFO) << "Prepare curveFS file done";
-        ::close(fd_);
+        curve::test::FileCommonOperation::Close(fd_);
     }
 
     void prepareSourceDataInS3() {

--- a/test/integration/client/common/file_operation.cpp
+++ b/test/integration/client/common/file_operation.cpp
@@ -61,5 +61,10 @@ int FileCommonOperation::Open(const std::string& filename,
 
     return fd;
 }
+
+void FileCommonOperation::Close(int fd) {
+    ::Close(fd);
+}
+
 }   //  namespace test
 }   //  namespace curve

--- a/test/integration/client/common/file_operation.h
+++ b/test/integration/client/common/file_operation.h
@@ -34,6 +34,8 @@ class FileCommonOperation {
    * 指定文件名，打开文件，如果没创建则先创建，返回fd
    */
     static int Open(const std::string& filename, const std::string& owner);
+
+    static void Close(int fd);
 };
 }   //  namespace test
 }   //  namespace curve

--- a/test/integration/client/unstable_chunkserver_exception_test.cpp
+++ b/test/integration/client/unstable_chunkserver_exception_test.cpp
@@ -263,6 +263,7 @@ class UnstableCSModuleException : public ::testing::Test {
             th.join();
         }
 
+        curve::test::FileCommonOperation::Close(fd);
         LOG(INFO) << "stop all write thread, filename " << filename;
     }
 

--- a/test/mds/nameserver2/mock/mock_file_record_manager.h
+++ b/test/mds/nameserver2/mock/mock_file_record_manager.h
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (c) 2020 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * Project: curve
+ * Created Date: Tue Nov  3 22:23:04 CST 2020
+ * Author: wuhanqing
+ */
+
+#ifndef TEST_MDS_NAMESERVER2_MOCK_MOCK_FILE_RECORD_MANAGER_H_
+#define TEST_MDS_NAMESERVER2_MOCK_MOCK_FILE_RECORD_MANAGER_H_
+
+#include <gmock/gmock.h>
+
+#include <string>
+
+#include "src/mds/nameserver2/file_record.h"
+
+namespace curve {
+namespace mds {
+
+class MockFileRecordManager : public FileRecordManager {
+ public:
+    MockFileRecordManager() = default;
+    ~MockFileRecordManager() = default;
+
+    MOCK_CONST_METHOD0(GetFileRecordExpiredTimeUs, uint32_t());
+    MOCK_CONST_METHOD2(FindFileMountPoint,
+                       bool(const std::string&, ClientIpPortType*));
+};
+
+}  // namespace mds
+}  // namespace curve
+
+#endif  // TEST_MDS_NAMESERVER2_MOCK_MOCK_FILE_RECORD_MANAGER_H_

--- a/test/resources.list
+++ b/test/resources.list
@@ -47,6 +47,8 @@ Used port list:
 
     use port : 19500 - 19999
 
+    mds_client_test : 9600, 9601
+
 # mds & snapshotcloneserver
     use port : 8900~8999, 8888
     use port(xuchaojie) : 8900~8999


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Problem Summary:

Client will not change the file metadata after it gets it from MDS, 
Recover creates a new file and rename it to orginal file, so the original file's metadata will be changed.
Therefore, when the file is being used, the recover operation will lead to inconsistency.

### What is changed and how it works?

What's Changed:

MDS check whether file is being used when Rename/Delete/ChangeOwner.
This check based on file record, and if file is being used,  client RefreshSession will add a file record of current file.

How it Works:

Side effects(Breaking backward compatibility? Performance regression?): 

### Check List

- [x] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license
