### PR TITLE
fix atomic bug of FilePool::GetFile()

### DIFF
--- a/test/chunkserver/datastore/BUILD
+++ b/test/chunkserver/datastore/BUILD
@@ -53,7 +53,6 @@ cc_test(
     copts = ["-std=c++11"],
     deps = [
         "@com_google_googletest//:gtest",
-        "//external:braft",
         "//external:gflags",
         "//include:include-common",
         "//include/chunkserver:include-chunkserver",


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?
Problem Summary:
In MDSExceptionTest 
two thread running FilePool::GetFile (getFileFromPool=false) get the same filename, and write concurrently, one of them failed in rename operation:
I 2020-12-23T15:03:40.595710+0800 2375935 file_pool.cpp:289] src path = ./moduleException1/chunkfilepool//268, dist path = ./moduleException1/copysets/4294967574/log/curve_log_inprogress_00000000000000000001
I 2020-12-23T15:03:40.595726+0800 2375978 copyset_node.cpp:434] Copyset: (1, 274, 4294967570), peer id: 127.0.0.1:22225:0 become leader, term is: 2
I 2020-12-23T15:03:40.595696+0800 2375911 file_pool.cpp:289] src path = ./moduleException1/chunkfilepool//268, dist path = ./moduleException1/copysets/4294967572/log/curve_log_inprogress_00000000000000000001
I 2020-12-23T15:03:40.609778+0800 2375935 file_pool.cpp:310] get file success! now pool size = 0
……
I 2020-12-23T15:03:40.609822+0800 2375935 curve_segment.cpp:89] Created new segment `./moduleException1/copysets/4294967574/log/curve_log_inprogress_00000000000000000001' with fd=560
W 2020-12-23T15:03:40.609853+0800 2375911 ext4_filesystem_impl.cpp:240] rename failed: No such file or directory. old path: ./moduleException1/chunkfilepool//268, new path: ./moduleException1/copysets/4294967572/log/curve_log_inprogress_00000000000000000001, flag: 1
E 2020-12-23T15:03:40.609890+0800 2375911 file_pool.cpp:308] file rename failed, ./moduleException1/chunkfilepool//268

### What is changed and how it works?

What's Changed:
old code:
currentmaxfilenum_.fetch_add(1)
srcpath = currentdir_ + "/" + std::to_string(currentmaxfilenum_);
new code:
srcpath = currentdir_ + "/" + std::to_string(currentmaxfilenum_.fetch_add(1));

btw, additional file pool test case is provided.
