### PR TITLE
fix: forget set some fields in RequestSender

### DIFF
--- a/src/client/client_common.cpp
+++ b/src/client/client_common.cpp
@@ -35,6 +35,8 @@ const char* OpTypeToString(OpType optype) {
         return "ReadSnapshot";
     case OpType::DELETE_SNAP:
         return "DeleteSnapshot";
+    case OpType::CREATE_CLONE:
+        return "CreateCloneChunk";
     case OpType::RECOVER_CHUNK:
         return "RecoverChunk";
     case OpType::GET_CHUNK_INFO:

--- a/src/client/io_tracker.cpp
+++ b/src/client/io_tracker.cpp
@@ -294,11 +294,11 @@ void IOTracker::Done() {
         MetricHelper::IncremUserEPSCount(fileMetric_, type_);
         if (type_ == OpType::READ || type_ == OpType::WRITE) {
             LOG(ERROR) << "file [" << fileMetric_->filename << "]"
-                    << ", IO Error, OpType = " << static_cast<int>(type_)
+                    << ", IO Error, OpType = " << OpTypeToString(type_)
                     << ", offset = " << offset_
                     << ", length = " << length_;
         } else {
-            LOG(ERROR) << ", IO Error, OpType = " << static_cast<int>(type_);
+            LOG(ERROR) << "IO Error, OpType = " << OpTypeToString(type_);
         }
     }
 

--- a/src/client/request_closure.h
+++ b/src/client/request_closure.h
@@ -127,7 +127,7 @@ class RequestClosure : public ::google::protobuf::Closure {
     /**
      * 获取下一次rpc超时时间, rpc超时时间实现了指数退避的策略
      */
-    uint64_t GetNextTimeoutMS() {
+    uint64_t GetNextTimeoutMS() const {
        return nextTimeoutMS_;
     }
 

--- a/src/client/request_sender.h
+++ b/src/client/request_sender.h
@@ -69,7 +69,7 @@ class RequestSender {
      * @param sourceInfo 数据源信息
      * @param done:上一层异步回调的closure
      */
-    int ReadChunk(ChunkIDInfo idinfo,
+    int ReadChunk(const ChunkIDInfo& idinfo,
                   uint64_t sn,
                   off_t offset,
                   size_t length,
@@ -87,7 +87,7 @@ class RequestSender {
    * @param sourceInfo 数据源信息
    * @param done:上一层异步回调的closure
    */
-    int WriteChunk(ChunkIDInfo idinfo,
+    int WriteChunk(const ChunkIDInfo& idinfo,
                    uint64_t sn,
                    const char *buf,
                    off_t offset,
@@ -103,7 +103,7 @@ class RequestSender {
      * @param length:读的长度
      * @param done:上一层异步回调的closure
      */
-    int ReadChunkSnapshot(ChunkIDInfo idinfo,
+    int ReadChunkSnapshot(const ChunkIDInfo& idinfo,
                           uint64_t sn,
                           off_t offset,
                           size_t length,
@@ -116,7 +116,7 @@ class RequestSender {
      * @param correctedSn:chunk需要修正的版本号
      * @param done:上一层异步回调的closure
      */
-    int DeleteChunkSnapshotOrCorrectSn(ChunkIDInfo idinfo,
+    int DeleteChunkSnapshotOrCorrectSn(const ChunkIDInfo& idinfo,
                             uint64_t correctedSn,
                             ClientClosure *done);
 
@@ -126,7 +126,7 @@ class RequestSender {
      * @param done:上一层异步回调的closure
      * @param retriedTimes:已经重试了几次
      */
-    int GetChunkInfo(ChunkIDInfo idinfo,
+    int GetChunkInfo(const ChunkIDInfo& idinfo,
                      ClientClosure *done);
 
     /**
@@ -146,7 +146,7 @@ class RequestSender {
     *
     * @return 错误码
     */
-    int CreateCloneChunk(ChunkIDInfo idinfo,
+    int CreateCloneChunk(const ChunkIDInfo& idinfo,
                   ClientClosure *done,
                   const std::string &location,
                   uint64_t sn,
@@ -177,6 +177,12 @@ class RequestSender {
     bool IsSocketHealth() {
        return channel_.CheckHealth() == 0;
     }
+
+ private:
+    void SetOperationStartTime(ClientClosure* done, OpType type) const;
+    void SetRpcTimeout(ClientClosure* done, brpc::Controller* cntl) const;
+    void SetCommonFields(ClientClosure* done, brpc::Controller* cntl,
+                         google::protobuf::Message* rcpResponse) const;
 
  private:
     // Rpc stub配置


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Problem Summary:  forget set come fields in RequestSender, so in some scenarios, the number of retries runs out quickly, causing an error to be returned to the upper layer

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?): 

### Check List

- [x] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license
