### PR TITLE
clean huge temp files in CI

### DIFF
--- a/ut.sh
+++ b/ut.sh
@@ -30,7 +30,7 @@ bazel build tools/... --compilation_mode=dbg --collect_code_coverage  --jobs=64 
 bazel build src/... --compilation_mode=dbg --collect_code_coverage  --jobs=64 --copt   -DHAVE_ZLIB=1 --define=with_glog=true --define=libunwind=true --copt -DGFLAGS_NS=google --copt -Wno-error=format-security --copt -DUSE_BTHREAD_MUTEX
 bazel build test/... --compilation_mode=dbg --collect_code_coverage  --jobs=64 --copt   -DHAVE_ZLIB=1 --define=with_glog=true --define=libunwind=true --copt -DGFLAGS_NS=google --copt -Wno-error=format-security --copt -DUSE_BTHREAD_MUTEX
 for i in 0 1 2 3; do mkdir -p $i/{copysets,recycler}; done
-for i in `find bazel-bin/test/ -type f -executable -exec file -i '{}' \; | grep  -E 'x-executable|x-sharedlib' | grep "charset=binary" | grep -v ".so"|grep test | grep -Ev 'snapshot-server|snapshot_dummy_server|client-test|server-test|multi|topology_dummy|curve_client_workflow|curve_fake_mds' | awk -F":" '{print $1'}`;do sudo $i 2>&1 | tee $i.log  & done  
+for i in `find bazel-bin/test/ -type f -executable -exec file -i '{}' \; | grep  -E 'x-executable|x-sharedlib' | grep "charset=binary" | grep -v ".so"|grep test | grep -Ev 'snapshot-server|snapshot_dummy_server|client-test|server-test|multi|topology_dummy|curve_client_workflow|curve_fake_mds' | awk -F":" '{print $1'}`;do sleep 10; sudo $i 2>&1 | tee $i.log  & done  
 
 count=2
 check=0


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

clean Huge files in CI (in KB):
26082940        ttt
4764572 RcvSCSTest2
4764560 RcvSCSTest3
4764560 RcvSCSTest1
596404  thirdparties
……
ttt is used in unstable_chunkserver_exception_test,
RcvSCSTest* is used in snapshotcloneserver_recover_test

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?): 

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
