### PR TITLE
Fix mk-tar script python build error

### DIFF
--- a/mk-tar.sh
+++ b/mk-tar.sh
@@ -95,6 +95,12 @@ function build_curvefs_python() {
 
         bash ./curvefs_python/configure.sh $(basename ${bin})
 
+        # Backup tmp so files
+        mkdir -p /tmp/curve_python_tmp
+        cp ./curvefs_python/tmplib/* /tmp/curve_python_tmp
+        # Recover tmp so file
+        cp /tmp/curve_python_tmp/* ./curvefs_python/tmplib
+
         if [ $? -ne 0 ]; then
             echo "configure for ${bin} failed"
             continue


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: close #215

Problem Summary:

### What is changed and how it works?

What's Changed:

Make sure the required temp so file exist when building python package with mk-tar.sh

How it Works:

Backup and Restore the required temp so file before `bazel build` action when building python package. See https://github.com/opencurve/curve/issues/215 for detail

Side effects(Breaking backward compatibility? Performance regression?): 

N/A

### Check List

- [x] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license
