### PR TITLE
client: send request source info only when clone source file segment is allocated

### DIFF
--- a/proto/nameserver2.proto
+++ b/proto/nameserver2.proto
@@ -349,6 +349,11 @@ message ProtoSession {
     // other useful infos
 };
 
+message CloneSourceSegment {
+    required uint64 segmentSize = 1;
+    repeated uint64 allocatedSegmentOffset = 2;
+}
+
 message OpenFileRequest {
     required string fileName = 1;
     required string owner = 2;
@@ -367,6 +372,7 @@ message OpenFileResponse {
     required StatusCode statusCode = 1;
     optional ProtoSession protoSession = 2;
     optional FileInfo   fileInfo = 3;
+    optional CloneSourceSegment cloneSourceSegment = 4;
 };
 
 message CloseFileRequest {

--- a/src/client/client_common.h
+++ b/src/client/client_common.h
@@ -29,6 +29,7 @@
 
 #include <string>
 #include <vector>
+#include <set>
 
 #include "include/client/libcurve.h"
 #include "src/common/net_common.h"
@@ -122,6 +123,22 @@ typedef struct SegmentInfo {
     LogicalPoolCopysetIDInfo lpcpIDInfo;
 } SegmentInfo_t;
 
+struct CloneSourceInfo {
+    std::string name;
+    uint64_t length = 0;
+    uint64_t segmentSize = 0;
+    std::set<uint64_t> allocatedSegmentOffsets;
+
+    /**
+     * @brief Determine whether the segment where the offset is located is
+     *        allocated
+     */
+    bool IsSegmentAllocated(uint64_t offset) const {
+        uint64_t segmentOffset = offset / segmentSize * segmentSize;
+        return allocatedSegmentOffsets.count(segmentOffset) != 0;
+    }
+};
+
 typedef struct FInfo {
     uint64_t        id;
     uint64_t        parentid;
@@ -138,8 +155,7 @@ typedef struct FInfo {
     std::string     filename;
     std::string     fullPathName;
     FileStatus      filestatus;
-    std::string     cloneSource;
-    uint64_t        cloneLength{0};
+    CloneSourceInfo sourceInfo;
 
     FInfo() {
         id = 0;

--- a/src/client/service_helper.cpp
+++ b/src/client/service_helper.cpp
@@ -34,49 +34,59 @@
 namespace curve {
 namespace client {
 
-void ServiceHelper::ProtoFileInfo2Local(const curve::mds::FileInfo* finfo,
+void ServiceHelper::ProtoFileInfo2Local(const curve::mds::FileInfo& finfo,
                                         FInfo_t* fi) {
-    if (finfo->has_owner()) {
-        fi->owner = finfo->owner();
+    if (finfo.has_owner()) {
+        fi->owner = finfo.owner();
     }
-    if (finfo->has_filename()) {
-        fi->filename = finfo->filename();
+    if (finfo.has_filename()) {
+        fi->filename = finfo.filename();
     }
-    if (finfo->has_id()) {
-        fi->id = finfo->id();
+    if (finfo.has_id()) {
+        fi->id = finfo.id();
     }
-    if (finfo->has_parentid()) {
-        fi->parentid = finfo->parentid();
+    if (finfo.has_parentid()) {
+        fi->parentid = finfo.parentid();
     }
-    if (finfo->has_filetype()) {
-        fi->filetype = static_cast<FileType>(finfo->filetype());
+    if (finfo.has_filetype()) {
+        fi->filetype = static_cast<FileType>(finfo.filetype());
     }
-    if (finfo->has_chunksize()) {
-        fi->chunksize = finfo->chunksize();
+    if (finfo.has_chunksize()) {
+        fi->chunksize = finfo.chunksize();
     }
-    if (finfo->has_length()) {
-        fi->length = finfo->length();
+    if (finfo.has_length()) {
+        fi->length = finfo.length();
     }
-    if (finfo->has_ctime()) {
-        fi->ctime = finfo->ctime();
+    if (finfo.has_ctime()) {
+        fi->ctime = finfo.ctime();
     }
-    if (finfo->has_chunksize()) {
-        fi->chunksize = finfo->chunksize();
+    if (finfo.has_chunksize()) {
+        fi->chunksize = finfo.chunksize();
     }
-    if (finfo->has_segmentsize()) {
-        fi->segmentsize = finfo->segmentsize();
+    if (finfo.has_segmentsize()) {
+        fi->segmentsize = finfo.segmentsize();
     }
-    if (finfo->has_seqnum()) {
-        fi->seqnum = finfo->seqnum();
+    if (finfo.has_seqnum()) {
+        fi->seqnum = finfo.seqnum();
     }
-    if (finfo->has_filestatus()) {
-        fi->filestatus = (FileStatus)finfo->filestatus();
+    if (finfo.has_filestatus()) {
+        fi->filestatus = (FileStatus)finfo.filestatus();
     }
-    if (finfo->has_clonesource()) {
-        fi->cloneSource = finfo->clonesource();
-    }
-    if (finfo->has_clonelength()) {
-        fi->cloneLength = finfo->clonelength();
+}
+
+void ServiceHelper::ProtoCloneSourceInfo2Local(
+    const curve::mds::OpenFileResponse& openFileResponse,
+    CloneSourceInfo* info) {
+    const curve::mds::FileInfo& fileInfo = openFileResponse.fileinfo();
+    const curve::mds::CloneSourceSegment& sourceSegment =
+        openFileResponse.clonesourcesegment();
+
+    info->name = fileInfo.clonesource();
+    info->length = fileInfo.clonelength();
+    info->segmentSize = sourceSegment.segmentsize();
+    for (int i = 0; i < sourceSegment.allocatedsegmentoffset_size(); ++i) {
+        info->allocatedSegmentOffsets.insert(
+            sourceSegment.allocatedsegmentoffset(i));
     }
 }
 

--- a/src/client/service_helper.h
+++ b/src/client/service_helper.h
@@ -94,8 +94,12 @@ class ServiceHelper {
      * @param: finfo为proto格式的文件信息
      * @param: fi为本地格式的文件信息
      */
-    static void ProtoFileInfo2Local(const curve::mds::FileInfo* finfo,
+    static void ProtoFileInfo2Local(const curve::mds::FileInfo& finfo,
                                     FInfo_t* fi);
+
+    static void ProtoCloneSourceInfo2Local(
+        const curve::mds::OpenFileResponse& openFileResponse,
+        CloneSourceInfo* info);
     /**
      * 从chunkserver端获取最新的leader信息
      * @param[in]: getLeaderInfo为对应copyset的信息

--- a/src/client/splitor.cpp
+++ b/src/client/splitor.cpp
@@ -297,23 +297,41 @@ bool Splitor::GetOrAllocateSegment(bool allocateIfNotExist,
 RequestSourceInfo Splitor::CalcRequestSourceInfo(IOTracker* ioTracker,
                                                  MetaCache* metaCache,
                                                  ChunkIndex chunkIdx) {
-    const FInfo* fileInfo = metaCache->GetFileInfo();
-    if (fileInfo->cloneSource.empty()) {
-        return {};
-    }
-
     OpType type = ioTracker->Optype();
     if (type != OpType::READ && type != OpType::WRITE) {
         return {};
     }
 
-    uint64_t offset = static_cast<uint64_t>(chunkIdx) * fileInfo->chunksize;
+    const FInfo* fileInfo = metaCache->GetFileInfo();
+    const CloneSourceInfo& sourceInfo = fileInfo->sourceInfo;
 
-    if (offset >= fileInfo->cloneLength) {
+    if (sourceInfo.name.empty()) {
         return {};
     }
 
-    return {fileInfo->cloneSource, offset};
+    uint64_t offset = static_cast<uint64_t>(chunkIdx) * fileInfo->chunksize;
+    if (sourceInfo.IsSegmentAllocated(offset)) {
+        return {sourceInfo.name, offset};
+    } else {
+        return {};
+    }
+
+    // if (fileInfo->cloneSource.empty()) {
+    //     return {};
+    // }
+
+    // OpType type = ioTracker->Optype();
+    // if (type != OpType::READ && type != OpType::WRITE) {
+    //     return {};
+    // }
+
+    // uint64_t offset = static_cast<uint64_t>(chunkIdx) * fileInfo->chunksize;
+
+    // if (offset >= fileInfo->cloneLength) {
+    //     return {};
+    // }
+
+    // return {fileInfo->cloneSource, offset};
 }
 
 }   // namespace client

--- a/src/mds/nameserver2/curvefs.h
+++ b/src/mds/nameserver2/curvefs.h
@@ -316,7 +316,8 @@ class CurveFS {
     StatusCode OpenFile(const std::string &fileName,
                         const std::string &clientIP,
                         ProtoSession *protoSession,
-                        FileInfo  *fileInfo);
+                        FileInfo  *fileInfo,
+                        CloneSourceSegment** cloneSourceSegment = nullptr);
 
     /**
      *  @brief close file

--- a/src/mds/nameserver2/namespace_service.cpp
+++ b/src/mds/nameserver2/namespace_service.cpp
@@ -1180,10 +1180,12 @@ void NameSpaceService::OpenFile(::google::protobuf::RpcController* controller,
 
     ProtoSession *protoSession = new ProtoSession();
     FileInfo *fileInfo = new FileInfo();
+    CloneSourceSegment* cloneSourceSegment = nullptr;
     retCode = kCurveFS.OpenFile(request->filename(),
                                 clientIP,
                                 protoSession,
-                                fileInfo);
+                                fileInfo,
+                                &cloneSourceSegment);
     if (retCode != StatusCode::kOK)  {
         response->set_statuscode(retCode);
         if (google::ERROR != GetMdsLogLevel(retCode)) {
@@ -1212,6 +1214,11 @@ void NameSpaceService::OpenFile(::google::protobuf::RpcController* controller,
         response->set_allocated_protosession(protoSession);
         response->set_allocated_fileinfo(fileInfo);
         response->set_statuscode(StatusCode::kOK);
+
+        if (cloneSourceSegment != nullptr) {
+            response->set_allocated_clonesourcesegment(cloneSourceSegment);
+        }
+
         LOG(INFO) << "logid = " << cntl->log_id()
                   << ", OpenFile ok, filename = " << request->filename()
                   << ", clientip = " << clientIP

--- a/src/mds/nameserver2/namespace_storage.cpp
+++ b/src/mds/nameserver2/namespace_storage.cpp
@@ -21,6 +21,7 @@
  */
 
 #include <glog/logging.h>
+#include <utility>
 #include "src/mds/nameserver2/namespace_storage.h"
 #include "src/mds/nameserver2/helper/namespace_helper.h"
 #include "src/common/namespace_define.h"
@@ -402,7 +403,7 @@ StoreStatus NameServerStorageImp::ListSegment(InodeID id,
         bool decodeOK = NameSpaceStorageCodec::DecodeSegment(out[i],
                                                              &segment);
         if (decodeOK) {
-            segments->emplace_back(segment);
+            segments->emplace_back(std::move(segment));
         } else {
             LOG(ERROR) << "decode one segment err";
             return StoreStatus::InternalError;

--- a/test/client/BUILD
+++ b/test/client/BUILD
@@ -49,6 +49,7 @@ cc_test(
                 "libcurve_client_unittest.cpp",
                 "lease_executor_test.cpp",
                 "request_sender_test.cpp",
+                "mds_client_test.cpp"
                 ]
     ),
     copts = COPTS,
@@ -335,4 +336,30 @@ cc_library(
             "//src/client:curve_client",
             ],
     visibility = ["//visibility:public"],
+)
+
+cc_test(
+    name = "client_mds_client_test",
+    srcs = [
+        "mds_client_test.cpp"],
+    copts = COPTS,
+    visibility = ["//visibility:public"],
+    deps = [
+        "//external:braft",
+        "//external:brpc",
+        "//external:gflags",
+        "//external:glog",
+        "//external:leveldb",
+        "//external:protobuf",
+        "//include/client:include_client",
+        "//proto:chunkserver-cc-protos",
+        "//proto:nameserver2_cc_proto",
+        "//proto:topology_cc_proto",
+        "//src/client:curve_client",
+        "//src/common:curve_common",
+        "//src/common/concurrent:curve_concurrent",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+        "//test/client/mock:curve_client_mock"
+    ],
 )

--- a/test/client/client_mdsclient_metacache_unittest.cpp
+++ b/test/client/client_mdsclient_metacache_unittest.cpp
@@ -1448,8 +1448,8 @@ TEST_F(MDSClientTest, CreateCloneFile) {
                                          10 * 1024 * 1024, 0, 4 * 1024 * 1024,
                                          &finfo));
     ASSERT_EQ(5, finfo.id);
-    ASSERT_EQ(cloneSource, finfo.cloneSource);
-    ASSERT_EQ(cloneLength, finfo.cloneLength);
+    ASSERT_EQ(cloneSource, finfo.sourceInfo.name);
+    ASSERT_EQ(cloneLength, finfo.sourceInfo.length);
 }
 
 TEST_F(MDSClientTest, CompleteCloneMeta) {

--- a/test/client/mds_client_test.cpp
+++ b/test/client/mds_client_test.cpp
@@ -1,0 +1,219 @@
+/*
+ *  Copyright (c) 2020 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * Project: curve
+ * Date: Wed Jan 13 09:48:12 CST 2021
+ * Author: wuhanqing
+ */
+
+#include "src/client/mds_client.h"
+
+#include <brpc/server.h>
+#include <glog/logging.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "test/client/mock/mock_namespace_service.h"
+
+namespace curve {
+namespace client {
+
+using ::testing::_;
+using ::testing::DoAll;
+using ::testing::Invoke;
+using ::testing::Return;
+using ::testing::SetArgPointee;
+
+constexpr uint64_t kGiB = 1024ull * 1024 * 1024;
+
+template <typename RpcRequestType, typename RpcResponseType,
+          bool RpcFailed = false>
+void FakeRpcService(google::protobuf::RpcController* cntl_base,
+                    const RpcRequestType* request, RpcResponseType* response,
+                    google::protobuf::Closure* done) {
+    if (RpcFailed) {
+        brpc::Controller* cntl = static_cast<brpc::Controller*>(cntl_base);
+        cntl->SetFailed(112, "Not connected to");
+    }
+    done->Run();
+}
+
+class MDSClientTest : public testing::Test {
+ protected:
+    void SetUp() override {
+        const std::string mdsAddr1 = "127.0.0.1:9600";
+        const std::string mdsAddr2 = "127.0.0.1:9601";
+
+        ASSERT_EQ(0, server_.AddService(&mockNameService_,
+                                        brpc::SERVER_DOESNT_OWN_SERVICE));
+
+        // only start mds on mdsAddr1
+        ASSERT_EQ(0, server_.Start(mdsAddr1.c_str(), nullptr));
+
+        option_.mdsAddrs = {mdsAddr2, mdsAddr1};
+        option_.mdsRPCTimeoutMs = 500;            // 500ms
+        option_.mdsMaxRPCTimeoutMS = 2000;        // 2s
+        option_.mdsRPCRetryIntervalUS = 1000000;  // 100ms
+        option_.mdsMaxRetryMS = 8000;             // 8s
+        option_.mdsMaxFailedTimesBeforeChangeMDS = 2;
+
+        ASSERT_EQ(LIBCURVE_ERROR::OK, mdsClient_.Initialize(option_));
+    }
+
+    void TearDown() override {
+        server_.Stop(0);
+        LOG(INFO) << "server stopped";
+        server_.Join();
+        LOG(INFO) << "server joined";
+    }
+
+ protected:
+    brpc::Server server_;
+    curve::mds::MockNameService mockNameService_;
+    MDSClient mdsClient_;
+    MetaServerOption option_;
+};
+
+TEST_F(MDSClientTest, TestOpenFile) {
+    const std::string fileName = "/TestOpenFile";
+    UserInfo userInfo;
+    userInfo.owner = "test";
+
+    FInfo fileInfo;
+    LeaseSession session;
+
+    // rpc always failed
+    {
+        EXPECT_CALL(mockNameService_, OpenFile(_, _, _, _))
+            .WillRepeatedly(Invoke(
+                FakeRpcService<OpenFileRequest, OpenFileResponse, true>));
+
+        auto startMs = TimeUtility::GetTimeofDayMs();
+        ASSERT_EQ(LIBCURVE_ERROR::FAILED,
+                  mdsClient_.OpenFile(fileName, userInfo, &fileInfo, &session));
+        auto endMs = TimeUtility::GetTimeofDayMs();
+        ASSERT_LE(option_.mdsMaxRetryMS, endMs - startMs);
+    }
+
+    // rpc response failed
+    {
+        curve::mds::OpenFileResponse response;
+        response.set_statuscode(curve::mds::StatusCode::kFileNotExists);
+
+        EXPECT_CALL(mockNameService_, OpenFile(_, _, _, _))
+            .WillRepeatedly(DoAll(
+                SetArgPointee<2>(response),
+                Invoke(FakeRpcService<OpenFileRequest, OpenFileResponse>)));
+
+        ASSERT_EQ(LIBCURVE_ERROR::FAILED,
+                  mdsClient_.OpenFile(fileName, userInfo, &fileInfo, &session));
+    }
+
+    // open normal file success
+    {
+        curve::mds::OpenFileResponse response;
+        response.set_statuscode(curve::mds::StatusCode::kOK);
+        response.set_allocated_fileinfo(new curve::mds::FileInfo());
+
+        auto* protoSession = new curve::mds::ProtoSession();
+        protoSession->set_sessionid("1");
+        protoSession->set_leasetime(1);
+        protoSession->set_createtime(1);
+        protoSession->set_sessionstatus(curve::mds::SessionStatus::kSessionOK);
+
+        response.set_allocated_protosession(protoSession);
+
+        EXPECT_CALL(mockNameService_, OpenFile(_, _, _, _))
+            .WillRepeatedly(DoAll(
+                SetArgPointee<2>(response),
+                Invoke(FakeRpcService<OpenFileRequest, OpenFileResponse>)));
+
+        ASSERT_EQ(LIBCURVE_ERROR::OK,
+                  mdsClient_.OpenFile(fileName, userInfo, &fileInfo, &session));
+    }
+
+    // open clone file, but response doesn't contains clone source segment
+    {
+        curve::mds::OpenFileResponse response;
+        response.set_statuscode(curve::mds::StatusCode::kOK);
+
+        auto* protoFileInfo = new curve::mds::FileInfo();
+        protoFileInfo->set_clonesource("/clone");
+
+        auto* protoSession = new curve::mds::ProtoSession();
+        protoSession->set_sessionid("1");
+        protoSession->set_leasetime(1);
+        protoSession->set_createtime(1);
+        protoSession->set_sessionstatus(curve::mds::SessionStatus::kSessionOK);
+
+        response.set_allocated_fileinfo(protoFileInfo);
+        response.set_allocated_protosession(protoSession);
+
+        EXPECT_CALL(mockNameService_, OpenFile(_, _, _, _))
+            .WillRepeatedly(DoAll(
+                SetArgPointee<2>(response),
+                Invoke(FakeRpcService<OpenFileRequest, OpenFileResponse>)));
+
+        ASSERT_EQ(LIBCURVE_ERROR::FAILED,
+                  mdsClient_.OpenFile(fileName, userInfo, &fileInfo, &session));
+    }
+
+    // open clone file success
+    {
+        curve::mds::OpenFileResponse response;
+        response.set_statuscode(curve::mds::StatusCode::kOK);
+
+        auto* protoFileInfo = new curve::mds::FileInfo();
+        protoFileInfo->set_clonesource("/clone");
+        protoFileInfo->set_clonelength(10 * kGiB);
+
+        auto* protoSession = new curve::mds::ProtoSession();
+        protoSession->set_sessionid("1");
+        protoSession->set_leasetime(1);
+        protoSession->set_createtime(1);
+        protoSession->set_sessionstatus(curve::mds::SessionStatus::kSessionOK);
+
+        auto* cloneSourceSegment = new curve::mds::CloneSourceSegment();
+        cloneSourceSegment->set_segmentsize(1ull * 1024 * 1024 * 1024);
+        cloneSourceSegment->add_allocatedsegmentoffset(0 * kGiB);
+        cloneSourceSegment->add_allocatedsegmentoffset(1 * kGiB);
+        cloneSourceSegment->add_allocatedsegmentoffset(9 * kGiB);
+
+        response.set_allocated_fileinfo(protoFileInfo);
+        response.set_allocated_protosession(protoSession);
+        response.set_allocated_clonesourcesegment(cloneSourceSegment);
+
+        EXPECT_CALL(mockNameService_, OpenFile(_, _, _, _))
+            .WillRepeatedly(DoAll(
+                SetArgPointee<2>(response),
+                Invoke(FakeRpcService<OpenFileRequest, OpenFileResponse>)));
+
+        ASSERT_EQ(LIBCURVE_ERROR::OK,
+                  mdsClient_.OpenFile(fileName, userInfo, &fileInfo, &session));
+
+        ASSERT_EQ(fileInfo.sourceInfo.name, "/clone");
+        ASSERT_EQ(fileInfo.sourceInfo.length, 10 * kGiB);
+        ASSERT_EQ(fileInfo.sourceInfo.segmentSize, 1 * kGiB);
+        ASSERT_EQ(fileInfo.sourceInfo.allocatedSegmentOffsets,
+                  std::set<uint64_t>({0 * kGiB, 1 * kGiB, 9 * kGiB}));
+    }
+}
+
+}  // namespace client
+}  // namespace curve

--- a/test/client/mock/BUILD
+++ b/test/client/mock/BUILD
@@ -1,0 +1,47 @@
+#
+#  Copyright (c) 2020 NetEase Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+COPTS = [
+    "-DGFLAGS=gflags",
+    "-DOS_LINUX",
+    "-DSNAPPY",
+    "-DHAVE_SSE42",
+    "-DNDEBUG",
+    "-fno-omit-frame-pointer",
+    "-momit-leaf-frame-pointer",
+    "-msse4.2",
+    "-pthread",
+    "-Wsign-compare",
+    "-Wno-unused-parameter",
+    "-Wno-unused-variable",
+    "-Woverloaded-virtual",
+    "-Wnon-virtual-dtor",
+    "-Wno-missing-field-initializers",
+    "-std=c++11",
+]
+
+cc_library(
+    name = "curve_client_mock",
+    srcs = glob(
+        ["*.h"]
+    ),
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+    copts = COPTS
+)

--- a/test/client/mock/mock_namespace_service.h
+++ b/test/client/mock/mock_namespace_service.h
@@ -1,0 +1,60 @@
+/*
+ *  Copyright (c) 2020 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * Project: curve
+ * Date: Wed Jan 13 09:48:12 CST 2021
+ * Author: wuhanqing
+ */
+
+#ifndef TEST_CLIENT_MOCK_MOCK_NAMESPACE_SERVICE_H_
+#define TEST_CLIENT_MOCK_MOCK_NAMESPACE_SERVICE_H_
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "proto/nameserver2.pb.h"
+
+namespace curve {
+namespace mds {
+
+class MockNameService : public CurveFSService {
+ public:
+    MOCK_METHOD4(OpenFile, void(google::protobuf::RpcController* cntl,
+                                const OpenFileRequest* request,
+                                OpenFileResponse* response,
+                                google::protobuf::Closure* done));
+
+    MOCK_METHOD4(DeleteFile, void(google::protobuf::RpcController* cntl,
+                                  const DeleteFileRequest* request,
+                                  DeleteFileResponse* response,
+                                  google::protobuf::Closure* done));
+
+    MOCK_METHOD4(RenameFile, void(google::protobuf::RpcController* cntl,
+                                  const RenameFileRequest* request,
+                                  RenameFileResponse* response,
+                                  google::protobuf::Closure* done));
+
+    MOCK_METHOD4(ChangeOwner, void(google::protobuf::RpcController* cntl,
+                                  const ChangeOwnerRequest* request,
+                                  ChangeOwnerResponse* response,
+                                  google::protobuf::Closure* done));
+};
+
+}  // namespace mds
+}  // namespace curve
+
+#endif  // TEST_CLIENT_MOCK_MOCK_NAMESPACE_SERVICE_H_


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Problem Summary:

### What is changed and how it works?

What's Changed:  
Previously, when client reads and writes data within the length of the source file, rpc will carry the source file information. 
Now, only when client reads and writes data within the range that source file' segment is allocated, rpc will carry the source file information.

How it Works:

Side effects(Breaking backward compatibility? Performance regression?): 

### Check List

- [x] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license
