### PR TITLE
client: send request source info only when clone source file segment is allocated and file status is CloneMetaInstalled

### DIFF
--- a/proto/nameserver2.proto
+++ b/proto/nameserver2.proto
@@ -349,6 +349,11 @@ message ProtoSession {
     // other useful infos
 };
 
+message CloneSourceSegment {
+    required uint64 segmentSize = 1;
+    repeated uint64 allocatedSegmentOffset = 2;
+}
+
 message OpenFileRequest {
     required string fileName = 1;
     required string owner = 2;
@@ -367,6 +372,7 @@ message OpenFileResponse {
     required StatusCode statusCode = 1;
     optional ProtoSession protoSession = 2;
     optional FileInfo   fileInfo = 3;
+    optional CloneSourceSegment cloneSourceSegment = 4;
 };
 
 message CloseFileRequest {

--- a/src/client/client_common.h
+++ b/src/client/client_common.h
@@ -29,6 +29,7 @@
 
 #include <string>
 #include <vector>
+#include <unordered_set>
 
 #include "include/client/libcurve.h"
 #include "src/common/net_common.h"
@@ -122,6 +123,23 @@ typedef struct SegmentInfo {
     LogicalPoolCopysetIDInfo lpcpIDInfo;
 } SegmentInfo_t;
 
+struct CloneSourceInfo {
+    std::string name;
+    uint64_t length = 0;
+    uint64_t segmentSize = 0;
+    std::unordered_set<uint64_t> allocatedSegmentOffsets;
+
+    CloneSourceInfo() = default;
+
+    CloneSourceInfo(const CloneSourceInfo& other)
+        : name(other.name),
+          length(other.length),
+          segmentSize(other.segmentSize),
+          allocatedSegmentOffsets(other.allocatedSegmentOffsets) {}
+
+    bool IsSegmentAllocated(uint64_t offset) const;
+};
+
 typedef struct FInfo {
     uint64_t        id;
     uint64_t        parentid;
@@ -138,8 +156,7 @@ typedef struct FInfo {
     std::string     filename;
     std::string     fullPathName;
     FileStatus      filestatus;
-    std::string     cloneSource;
-    uint64_t        cloneLength{0};
+    CloneSourceInfo sourceInfo;
 
     FInfo() {
         id = 0;
@@ -280,6 +297,34 @@ class ClientDummyServerInfo {
 };
 
 inline void TrivialDeleter(void* ptr) {}
+
+inline const char* FileStatusToName(FileStatus status) {
+    switch (status) {
+        case FileStatus::Created:
+            return "Created";
+        case FileStatus::Deleting:
+            return "Deleting";
+        case FileStatus::Cloning:
+            return "Cloning";
+        case FileStatus::CloneMetaInstalled:
+            return "CloneMetaInstalled";
+        case FileStatus::Cloned:
+            return "Cloned";
+        case FileStatus::BeingCloned:
+            return "BeingCloned";
+        default:
+            return "Unknown";
+    }
+}
+
+inline bool CloneSourceInfo::IsSegmentAllocated(uint64_t offset) const {
+    if (length == 0) {
+        return false;
+    }
+
+    uint64_t segmentOffset = offset / segmentSize * segmentSize;
+    return allocatedSegmentOffsets.count(segmentOffset) != 0;
+}
 
 }   // namespace client
 }   // namespace curve

--- a/src/client/lease_executor.h
+++ b/src/client/lease_executor.h
@@ -125,10 +125,11 @@ class LeaseExecutor {
     void IncremRefreshFailed();
 
     /**
-     * 每次续约会携带新的文件信息，该函数检查当前文件是否需要更新版本信息
-     * @param: newversion是lease续约后从mds端携带回来的版本号
+     * @brief Updating local file information consistent with MDS record.
+     *        Currently, only seqnum and file status are updated
+     * @param fileInfo Latest file information returned by refresh session RPC
      */
-    void CheckNeedUpdateVersion(uint64_t newversion);
+    void CheckNeedUpdateFileInfo(const FInfo& fileInfo);
 
  private:
     // 与mds进行lease续约的文件名

--- a/src/client/mds_client.cpp
+++ b/src/client/mds_client.cpp
@@ -284,8 +284,23 @@ LIBCURVE_ERROR MDSClient::OpenFile(const std::string& filename,
             lease->leaseTime     = leasesession.leasetime();
             lease->createTime    = leasesession.createtime();
 
-            FileInfo finfo = response.fileinfo();
-            ServiceHelper::ProtoFileInfo2Local(&finfo, fi);
+            const curve::mds::FileInfo& protoFileInfo = response.fileinfo();
+            ServiceHelper::ProtoFileInfo2Local(protoFileInfo, fi);
+
+            if (protoFileInfo.has_clonesource() &&
+                protoFileInfo.filestatus() ==
+                    curve::mds::FileStatus::kFileCloneMetaInstalled) {
+                if (!response.has_clonesourcesegment()) {
+                    LOG(WARNING) << filename
+                                 << " has clone source and status is "
+                                    "CloneMetaInstalled, but response does not "
+                                    "contains clone source segment";
+                    return retcode;
+                }
+
+                ServiceHelper::ProtoCloneSourceInfo2Local(response,
+                                                          &fi->sourceInfo);
+            }
         } else {
             LOG(WARNING) << "mds response has no file info or session info!";
             return LIBCURVE_ERROR::FAILED;
@@ -380,8 +395,7 @@ LIBCURVE_ERROR MDSClient::GetFileInfo(const std::string& filename,
         }
 
         if (response.has_fileinfo()) {
-            FileInfo finfo = response.fileinfo();
-            ServiceHelper::ProtoFileInfo2Local(&finfo, fi);
+            ServiceHelper::ProtoFileInfo2Local(response.fileinfo(), fi);
         }
 
         LIBCURVE_ERROR retcode;
@@ -420,8 +434,7 @@ LIBCURVE_ERROR MDSClient::CreateSnapShot(const std::string& filename,
              stcode == StatusCode::kFileUnderSnapShot) &&
             hasinfo) {
             FInfo_t* fi = new (std::nothrow) FInfo_t;
-            curve::mds::FileInfo finfo = response.snapshotfileinfo();
-            ServiceHelper::ProtoFileInfo2Local(&finfo, fi);
+            ServiceHelper::ProtoFileInfo2Local(response.snapshotfileinfo(), fi);
             *seq = fi->seqnum;
             delete fi;
             if (stcode == StatusCode::kOK) {
@@ -436,7 +449,7 @@ LIBCURVE_ERROR MDSClient::CreateSnapShot(const std::string& filename,
 
         if (hasinfo) {
             FInfo_t fi;
-            ServiceHelper::ProtoFileInfo2Local(&response.snapshotfileinfo(), &fi);  // NOLINT
+            ServiceHelper::ProtoFileInfo2Local(response.snapshotfileinfo(), &fi);  // NOLINT
             *seq = fi.seqnum;
         }
 
@@ -513,8 +526,7 @@ LIBCURVE_ERROR MDSClient::ListSnapShot(const std::string& filename,
 
         for (int i = 0; i < response.fileinfo_size(); i++) {
             FInfo_t tempInfo;
-            FileInfo finfo = response.fileinfo(i);
-            ServiceHelper::ProtoFileInfo2Local(&finfo, &tempInfo);
+            ServiceHelper::ProtoFileInfo2Local(response.fileinfo(i), &tempInfo);
             snapif->insert(std::make_pair(tempInfo.seqnum, tempInfo));
         }
 
@@ -638,8 +650,8 @@ LIBCURVE_ERROR MDSClient::RefreshSession(const std::string& filename,
                 break;
             case StatusCode::kOK:
                 if (response.has_fileinfo()) {
-                    FileInfo finfo = response.fileinfo();
-                    ServiceHelper::ProtoFileInfo2Local(&finfo, &resp->finfo);
+                    ServiceHelper::ProtoFileInfo2Local(response.fileinfo(),
+                                                       &resp->finfo);
                     resp->status = LeaseRefreshResult::Status::OK;
                 } else {
                     LOG(WARNING) << "session response has no fileinfo!";
@@ -819,8 +831,9 @@ LIBCURVE_ERROR MDSClient::CreateCloneFile(const std::string& source,
             << ", log id = " << cntl->log_id();
 
         if (stcode == StatusCode::kOK) {
-            FileInfo finfo = response.fileinfo();
-            ServiceHelper::ProtoFileInfo2Local(&finfo, fileinfo);
+            ServiceHelper::ProtoFileInfo2Local(response.fileinfo(), fileinfo);
+            fileinfo->sourceInfo.name = response.fileinfo().clonesource();
+            fileinfo->sourceInfo.length = response.fileinfo().clonelength();
         }
 
         return retcode;

--- a/src/client/metacache.h
+++ b/src/client/metacache.h
@@ -221,6 +221,12 @@ class MetaCache {
         fileInfo_.seqnum = newSn;
     }
 
+    FileStatus GetLatestFileStatus() const { return fileInfo_.filestatus; }
+
+    void SetLatestFileStatus(FileStatus status) {
+        fileInfo_.filestatus = status;
+    }
+
     /**
      * 获取对应的copyset的LeaderMayChange标志
      */

--- a/src/client/request_context.h
+++ b/src/client/request_context.h
@@ -37,19 +37,22 @@ namespace client {
 
 struct RequestSourceInfo {
     std::string cloneFileSource;
-    uint64_t cloneFileOffset{0};
+    uint64_t cloneFileOffset = 0;
+    bool valid = false;
 
     RequestSourceInfo() = default;
     RequestSourceInfo(const std::string& source, uint64_t offset)
-        : cloneFileSource(source), cloneFileOffset(offset) {}
+        : cloneFileSource(source), cloneFileOffset(offset), valid(true) {}
+
+    bool IsValid() const { return valid; }
 };
 
 inline std::ostream& operator<<(std::ostream& os,
                                 const RequestSourceInfo& location) {
-    if (location.cloneFileSource.empty()) {
-        os << "empty";
-    } else {
+    if (location.IsValid()) {
         os << location.cloneFileSource << ":" << location.cloneFileOffset;
+    } else {
+        os << "empty";
     }
 
     return os;

--- a/src/client/request_sender.cpp
+++ b/src/client/request_sender.cpp
@@ -95,7 +95,7 @@ int RequestSender::ReadChunk(const ChunkIDInfo& idinfo,
     request.set_offset(offset);
     request.set_size(length);
 
-    if (!sourceInfo.cloneFileSource.empty()) {
+    if (sourceInfo.IsValid()) {
         request.set_clonefilesource(sourceInfo.cloneFileSource);
         request.set_clonefileoffset(sourceInfo.cloneFileOffset);
     }
@@ -136,7 +136,7 @@ int RequestSender::WriteChunk(const ChunkIDInfo& idinfo,
     request.set_offset(offset);
     request.set_size(length);
 
-    if (!sourceInfo.cloneFileSource.empty()) {
+    if (sourceInfo.IsValid()) {
         request.set_clonefilesource(sourceInfo.cloneFileSource);
         request.set_clonefileoffset(sourceInfo.cloneFileOffset);
     }

--- a/src/client/service_helper.cpp
+++ b/src/client/service_helper.cpp
@@ -34,49 +34,59 @@
 namespace curve {
 namespace client {
 
-void ServiceHelper::ProtoFileInfo2Local(const curve::mds::FileInfo* finfo,
+void ServiceHelper::ProtoFileInfo2Local(const curve::mds::FileInfo& finfo,
                                         FInfo_t* fi) {
-    if (finfo->has_owner()) {
-        fi->owner = finfo->owner();
+    if (finfo.has_owner()) {
+        fi->owner = finfo.owner();
     }
-    if (finfo->has_filename()) {
-        fi->filename = finfo->filename();
+    if (finfo.has_filename()) {
+        fi->filename = finfo.filename();
     }
-    if (finfo->has_id()) {
-        fi->id = finfo->id();
+    if (finfo.has_id()) {
+        fi->id = finfo.id();
     }
-    if (finfo->has_parentid()) {
-        fi->parentid = finfo->parentid();
+    if (finfo.has_parentid()) {
+        fi->parentid = finfo.parentid();
     }
-    if (finfo->has_filetype()) {
-        fi->filetype = static_cast<FileType>(finfo->filetype());
+    if (finfo.has_filetype()) {
+        fi->filetype = static_cast<FileType>(finfo.filetype());
     }
-    if (finfo->has_chunksize()) {
-        fi->chunksize = finfo->chunksize();
+    if (finfo.has_chunksize()) {
+        fi->chunksize = finfo.chunksize();
     }
-    if (finfo->has_length()) {
-        fi->length = finfo->length();
+    if (finfo.has_length()) {
+        fi->length = finfo.length();
     }
-    if (finfo->has_ctime()) {
-        fi->ctime = finfo->ctime();
+    if (finfo.has_ctime()) {
+        fi->ctime = finfo.ctime();
     }
-    if (finfo->has_chunksize()) {
-        fi->chunksize = finfo->chunksize();
+    if (finfo.has_chunksize()) {
+        fi->chunksize = finfo.chunksize();
     }
-    if (finfo->has_segmentsize()) {
-        fi->segmentsize = finfo->segmentsize();
+    if (finfo.has_segmentsize()) {
+        fi->segmentsize = finfo.segmentsize();
     }
-    if (finfo->has_seqnum()) {
-        fi->seqnum = finfo->seqnum();
+    if (finfo.has_seqnum()) {
+        fi->seqnum = finfo.seqnum();
     }
-    if (finfo->has_filestatus()) {
-        fi->filestatus = (FileStatus)finfo->filestatus();
+    if (finfo.has_filestatus()) {
+        fi->filestatus = (FileStatus)finfo.filestatus();
     }
-    if (finfo->has_clonesource()) {
-        fi->cloneSource = finfo->clonesource();
-    }
-    if (finfo->has_clonelength()) {
-        fi->cloneLength = finfo->clonelength();
+}
+
+void ServiceHelper::ProtoCloneSourceInfo2Local(
+    const curve::mds::OpenFileResponse& openFileResponse,
+    CloneSourceInfo* info) {
+    const curve::mds::FileInfo& fileInfo = openFileResponse.fileinfo();
+    const curve::mds::CloneSourceSegment& sourceSegment =
+        openFileResponse.clonesourcesegment();
+
+    info->name = fileInfo.clonesource();
+    info->length = fileInfo.clonelength();
+    info->segmentSize = sourceSegment.segmentsize();
+    for (int i = 0; i < sourceSegment.allocatedsegmentoffset_size(); ++i) {
+        info->allocatedSegmentOffsets.insert(
+            sourceSegment.allocatedsegmentoffset(i));
     }
 }
 

--- a/src/client/service_helper.h
+++ b/src/client/service_helper.h
@@ -94,8 +94,13 @@ class ServiceHelper {
      * @param: finfo为proto格式的文件信息
      * @param: fi为本地格式的文件信息
      */
-    static void ProtoFileInfo2Local(const curve::mds::FileInfo* finfo,
+    static void ProtoFileInfo2Local(const curve::mds::FileInfo& finfo,
                                     FInfo_t* fi);
+
+    static void ProtoCloneSourceInfo2Local(
+        const curve::mds::OpenFileResponse& openFileResponse,
+        CloneSourceInfo* info);
+
     /**
      * 从chunkserver端获取最新的leader信息
      * @param[in]: getLeaderInfo为对应copyset的信息

--- a/src/client/splitor.cpp
+++ b/src/client/splitor.cpp
@@ -297,23 +297,21 @@ bool Splitor::GetOrAllocateSegment(bool allocateIfNotExist,
 RequestSourceInfo Splitor::CalcRequestSourceInfo(IOTracker* ioTracker,
                                                  MetaCache* metaCache,
                                                  ChunkIndex chunkIdx) {
-    const FInfo* fileInfo = metaCache->GetFileInfo();
-    if (fileInfo->cloneSource.empty()) {
-        return {};
-    }
-
     OpType type = ioTracker->Optype();
     if (type != OpType::READ && type != OpType::WRITE) {
         return {};
     }
 
-    uint64_t offset = static_cast<uint64_t>(chunkIdx) * fileInfo->chunksize;
-
-    if (offset >= fileInfo->cloneLength) {
-        return {};
+    const FInfo* fileInfo = metaCache->GetFileInfo();
+    if (fileInfo->filestatus == FileStatus::CloneMetaInstalled) {
+        const CloneSourceInfo& sourceInfo = fileInfo->sourceInfo;
+        uint64_t offset = static_cast<uint64_t>(chunkIdx) * fileInfo->chunksize;
+        if (sourceInfo.IsSegmentAllocated(offset)) {
+            return {sourceInfo.name, offset};
+        }
     }
 
-    return {fileInfo->cloneSource, offset};
+    return {};
 }
 
 }   // namespace client

--- a/src/mds/nameserver2/curvefs.cpp
+++ b/src/mds/nameserver2/curvefs.cpp
@@ -31,6 +31,7 @@
 #include "src/common/timeutility.h"
 #include "src/mds/nameserver2/namespace_storage.h"
 #include "src/mds/common/mds_define.h"
+#include "src/mds/nameserver2/helper/namespace_helper.h"
 
 using curve::common::TimeUtility;
 using curve::mds::topology::LogicalPool;
@@ -1343,7 +1344,8 @@ StatusCode CurveFS::GetSnapShotFileSegment(
 StatusCode CurveFS::OpenFile(const std::string &fileName,
                              const std::string &clientIP,
                              ProtoSession *protoSession,
-                             FileInfo  *fileInfo) {
+                             FileInfo  *fileInfo,
+                             CloneSourceSegment* cloneSourceSegment) {
     // check the existence of the file
     StatusCode ret;
     ret = GetFileInfo(fileName, fileInfo);
@@ -1361,6 +1363,8 @@ StatusCode CurveFS::OpenFile(const std::string &fileName,
         return ret;
     }
 
+    LOG(INFO) << "FileInfo, " << fileInfo->DebugString();
+
     if (fileInfo->filetype() != FileType::INODE_PAGEFILE) {
         LOG(ERROR) << "OpenFile file type not support, fileName = " << fileName
                    << ", clientIP = " << clientIP
@@ -1369,6 +1373,11 @@ StatusCode CurveFS::OpenFile(const std::string &fileName,
     }
 
     fileRecordManager_->GetRecordParam(protoSession);
+
+    // clone file
+    if (fileInfo->has_clonesource() && isPathValid(fileInfo->clonesource())) {
+        return ListCloneSourceFileSegments(fileInfo, cloneSourceSegment);
+    }
 
     return StatusCode::kOK;
 }
@@ -1892,6 +1901,61 @@ StatusCode CurveFS::CheckHasCloneRely(const std::string & filename,
     return StatusCode::kOK;
 }
 
+StatusCode CurveFS::ListCloneSourceFileSegments(
+    const FileInfo* fileInfo, CloneSourceSegment* cloneSourceSegment) const {
+    if (fileInfo->filestatus() != FileStatus::kFileCloneMetaInstalled) {
+        LOG(INFO) << fileInfo->filename()
+                  << " hash clone source, but file status is "
+                  << FileStatus_Name(fileInfo->filestatus())
+                  << ", return empty CloneSourceSegment";
+        return StatusCode::kOK;
+    }
+
+    if (!cloneSourceSegment) {
+        LOG(ERROR) << "OpenFile failed, file has clone source, but "
+                      "cloneSourceSegments is nullptr, filename = "
+                   << fileInfo->filename();
+        return StatusCode::kParaError;
+    }
+
+    FileInfo cloneSourceFileInfo;
+    StatusCode ret = GetFileInfo(fileInfo->clonesource(), &cloneSourceFileInfo);
+    if (ret != StatusCode::kOK) {
+        LOG(ERROR)
+            << "OpenFile failed, Get clone source file info failed, ret = "
+            << StatusCode_Name(ret) << ", filename = " << fileInfo->filename()
+            << ", clone source = " << fileInfo->clonesource()
+            << ", file status = " << FileStatus_Name(fileInfo->filestatus());
+        return ret;
+    }
+
+    std::vector<PageFileSegment> segments;
+    StoreStatus status =
+        storage_->ListSegment(cloneSourceFileInfo.id(), &segments);
+    if (status != StoreStatus::OK) {
+        LOG(ERROR) << "OpenFile failed, list clone source segment failed, "
+                      "filename = "
+                   << fileInfo->filename()
+                   << ", source file name = " << fileInfo->clonesource()
+                   << ", ret = " << status;
+        return StatusCode::kStorageError;
+    }
+
+    cloneSourceSegment->set_segmentsize(fileInfo->segmentsize());
+
+    if (segments.empty()) {
+        LOG(WARNING) << "Clone source file has no segments, filename = "
+                     << fileInfo->clonesource();
+    } else {
+        for (const auto& segment : segments) {
+            cloneSourceSegment->add_allocatedsegmentoffset(
+                segment.startoffset());
+        }
+    }
+
+    return StatusCode::kOK;
+}
+
 StatusCode CurveFS::FindFileMountPoint(
     const std::string& fileName,
     ClientInfo* clientInfo) {
@@ -1931,4 +1995,3 @@ bvar::PassiveStatus<uint64_t> g_open_file_num_bvar(
                         GetOpenFileNum, &kCurveFS);
 }   // namespace mds
 }   // namespace curve
-

--- a/src/mds/nameserver2/curvefs.h
+++ b/src/mds/nameserver2/curvefs.h
@@ -316,7 +316,8 @@ class CurveFS {
     StatusCode OpenFile(const std::string &fileName,
                         const std::string &clientIP,
                         ProtoSession *protoSession,
-                        FileInfo  *fileInfo);
+                        FileInfo  *fileInfo,
+                        CloneSourceSegment* cloneSourceSegment = nullptr);
 
     /**
      *  @brief close file
@@ -626,6 +627,15 @@ class CurveFS {
         return timePass >= times * std::chrono::microseconds(expiredUs);
     }
 
+    /**
+     * @brief list clone source file's segment,
+     *        if current file status is in kFileCloneMetaInstalled
+     * @param fileInfo current file info
+     * @param[out] cloneSourceSegment source file allocated segments
+     */
+    StatusCode ListCloneSourceFileSegments(
+        const FileInfo* fileInfo, CloneSourceSegment* cloneSourceSegment) const;
+
  private:
     FileInfo rootFileInfo_;
     std::shared_ptr<NameServerStorage> storage_;
@@ -645,4 +655,3 @@ extern CurveFS &kCurveFS;
 }   // namespace mds
 }   // namespace curve
 #endif   // SRC_MDS_NAMESERVER2_CURVEFS_H_
-

--- a/src/mds/nameserver2/helper/namespace_helper.h
+++ b/src/mds/nameserver2/helper/namespace_helper.h
@@ -51,6 +51,32 @@ class NameSpaceStorageCodec {
     static bool DecodeSegmentAllocValue(
         const std::string &value, uint16_t *lid, uint64_t *alloc);
 };
+
+inline bool isPathValid(const std::string path) {
+    if (path.empty() || path[0] != '/') {
+        return false;
+    }
+
+    if (path.size() > 1U && path[path.size() - 1] == '/') {
+        return false;
+    }
+
+    bool slash = false;
+    for (uint32_t i = 0; i < path.size(); i++) {
+        if (path[i] == '/') {
+            if (slash) {
+                return false;
+            }
+            slash = true;
+        } else {
+            slash = false;
+        }
+    }
+
+    // if some other limits to path can add here in the future
+    return true;
+}
+
 }   // namespace mds
 }   // namespace curve
 

--- a/test/client/BUILD
+++ b/test/client/BUILD
@@ -50,6 +50,7 @@ cc_test(
                 "libcurve_client_unittest.cpp",
                 "lease_executor_test.cpp",
                 "request_sender_test.cpp",
+                "mds_client_test.cpp"
                 ]
     ),
     copts = COPTS,

--- a/test/client/client_mdsclient_metacache_unittest.cpp
+++ b/test/client/client_mdsclient_metacache_unittest.cpp
@@ -1448,8 +1448,8 @@ TEST_F(MDSClientTest, CreateCloneFile) {
                                          10 * 1024 * 1024, 0, 4 * 1024 * 1024,
                                          &finfo));
     ASSERT_EQ(5, finfo.id);
-    ASSERT_EQ(cloneSource, finfo.cloneSource);
-    ASSERT_EQ(cloneLength, finfo.cloneLength);
+    ASSERT_EQ(cloneSource, finfo.sourceInfo.name);
+    ASSERT_EQ(cloneLength, finfo.sourceInfo.length);
 }
 
 TEST_F(MDSClientTest, CompleteCloneMeta) {

--- a/test/client/iotracker_splitor_unittest.cpp
+++ b/test/client/iotracker_splitor_unittest.cpp
@@ -950,18 +950,25 @@ TEST_F(IOTrackerSplitorTest, InvalidParam) {
 }
 
 TEST(SplitorTest, RequestSourceInfoTest) {
-    using curve::client::ChunkIndex;
-    using curve::client::RequestSourceInfo;
-
     IOTracker ioTracker(nullptr, nullptr, nullptr);
     ioTracker.SetOpType(OpType::READ);
 
     MetaCache metaCache;
     FInfo_t fileInfo;
     fileInfo.chunksize = 16 * 1024 * 1024;          // 16M
-    fileInfo.cloneLength = 10ull * 1024 * 1024 * 1024;  // 10G
-    fileInfo.cloneSource = "/clonesource";
+    fileInfo.filestatus = FileStatus::CloneMetaInstalled;
 
+    CloneSourceInfo cloneSourceInfo;
+    cloneSourceInfo.name = "/clonesource";
+    cloneSourceInfo.length = 10ull * 1024 * 1024 * 1024;      // 10GB
+    cloneSourceInfo.segmentSize = 1ull * 1024 * 1024 * 1024;  // 1GB
+
+    // 源卷只分配了第一个和最后一个segment
+    cloneSourceInfo.allocatedSegmentOffsets.insert(0);
+    cloneSourceInfo.allocatedSegmentOffsets.insert(cloneSourceInfo.length -
+                                                   cloneSourceInfo.segmentSize);
+
+    fileInfo.sourceInfo = cloneSourceInfo;
     metaCache.UpdateFileInfo(fileInfo);
 
     ChunkIndex chunkIdx = 0;
@@ -970,26 +977,51 @@ TEST(SplitorTest, RequestSourceInfoTest) {
     // 第一个chunk
     sourceInfo =
         Splitor::CalcRequestSourceInfo(&ioTracker, &metaCache, chunkIdx);
-    ASSERT_EQ(sourceInfo.cloneFileSource, fileInfo.cloneSource);
+    ASSERT_TRUE(sourceInfo.IsValid());
+    ASSERT_EQ(sourceInfo.cloneFileSource, fileInfo.sourceInfo.name);
     ASSERT_EQ(sourceInfo.cloneFileOffset, 0);
 
     // 克隆卷最后一个chunk
-    chunkIdx = fileInfo.cloneLength / fileInfo.chunksize - 1;
-    LOG(INFO) << "clone length = " << fileInfo.cloneLength
+    chunkIdx = fileInfo.sourceInfo.length / fileInfo.chunksize - 1;
+    LOG(INFO) << "clone length = " << fileInfo.sourceInfo.length
               << ", chunk size = " << fileInfo.chunksize
               << ", chunk idx = " << chunkIdx;
 
     // offset = 10*1024*1024*1024 - 16 * 1024 * 1024 = 10720641024
     sourceInfo =
         Splitor::CalcRequestSourceInfo(&ioTracker, &metaCache, chunkIdx);
-    ASSERT_EQ(sourceInfo.cloneFileSource, fileInfo.cloneSource);
+    ASSERT_TRUE(sourceInfo.IsValid());
+    ASSERT_EQ(sourceInfo.cloneFileSource, fileInfo.sourceInfo.name);
     ASSERT_EQ(sourceInfo.cloneFileOffset, 10720641024);
 
+    // 源卷未分配segment
+    // 读取每个segment的第一个chunk
+    for (int i = 1; i < 9; ++i) {
+        ChunkIndex chunkIdx =
+            i * cloneSourceInfo.segmentSize / fileInfo.chunksize;
+        RequestSourceInfo sourceInfo = Splitor::CalcRequestSourceInfo(
+            &ioTracker, &metaCache, chunkIdx);
+        ASSERT_FALSE(sourceInfo.IsValid());
+        ASSERT_TRUE(sourceInfo.cloneFileSource.empty());
+        ASSERT_EQ(sourceInfo.cloneFileOffset, 0);
+    }
+
     // 超过长度
-    chunkIdx = fileInfo.cloneLength / fileInfo.chunksize;
+    chunkIdx = fileInfo.sourceInfo.length / fileInfo.chunksize;
 
     sourceInfo =
         Splitor::CalcRequestSourceInfo(&ioTracker, &metaCache, chunkIdx);
+    ASSERT_FALSE(sourceInfo.IsValid());
+    ASSERT_TRUE(sourceInfo.cloneFileSource.empty());
+    ASSERT_EQ(sourceInfo.cloneFileOffset, 0);
+
+    // 源卷长度为0
+    chunkIdx = 0;
+    fileInfo.sourceInfo.length = 0;
+    metaCache.UpdateFileInfo(fileInfo);
+    sourceInfo =
+        Splitor::CalcRequestSourceInfo(&ioTracker, &metaCache, chunkIdx);
+    ASSERT_FALSE(sourceInfo.IsValid());
     ASSERT_TRUE(sourceInfo.cloneFileSource.empty());
     ASSERT_EQ(sourceInfo.cloneFileOffset, 0);
 
@@ -998,11 +1030,11 @@ TEST(SplitorTest, RequestSourceInfoTest) {
     ioTracker.SetOpType(OpType::READ_SNAP);
     sourceInfo =
         Splitor::CalcRequestSourceInfo(&ioTracker, &metaCache, chunkIdx);
+    ASSERT_FALSE(sourceInfo.IsValid());
     ASSERT_TRUE(sourceInfo.cloneFileSource.empty());
     ASSERT_EQ(sourceInfo.cloneFileOffset, 0);
 
-    fileInfo.cloneSource.clear();
-    fileInfo.cloneLength = 0;
+    fileInfo.filestatus = FileStatus::Cloned;
     metaCache.UpdateFileInfo(fileInfo);
 
     chunkIdx = 0;
@@ -1010,6 +1042,7 @@ TEST(SplitorTest, RequestSourceInfoTest) {
     // 不是克隆卷
     sourceInfo =
         Splitor::CalcRequestSourceInfo(&ioTracker, &metaCache, chunkIdx);
+    ASSERT_FALSE(sourceInfo.IsValid());
     ASSERT_TRUE(sourceInfo.cloneFileSource.empty());
     ASSERT_EQ(sourceInfo.cloneFileOffset, 0);
 }
@@ -1181,10 +1214,16 @@ TEST_F(IOTrackerSplitorTest, StartReadNotAllocateSegmentFromOrigin) {
 
     FInfo_t fileInfo;
     fileInfo.chunksize = 4 * 1024 * 1024;               // 4M
-    fileInfo.cloneLength = 10ull * 1024 * 1024 * 1024;  // 10G
     fileInfo.fullPathName = "/1_userinfo_.txt";
     fileInfo.owner = "userinfo";
-    fileInfo.cloneSource = "/clonesource";
+    fileInfo.filestatus = FileStatus::CloneMetaInstalled;
+    fileInfo.sourceInfo.name = "/clonesource";
+    fileInfo.sourceInfo.segmentSize = 1ull * 1024 * 1024 * 1024;
+    fileInfo.sourceInfo.length = 10ull * 1024 * 1024 * 1024;
+    for (uint64_t i = 0; i < fileInfo.sourceInfo.length;
+         i += fileInfo.sourceInfo.segmentSize) {
+        fileInfo.sourceInfo.allocatedSegmentOffsets.insert(i);
+    }
     fileInfo.userinfo = userinfo;
     mc->UpdateFileInfo(fileInfo);
 
@@ -1249,10 +1288,16 @@ TEST_F(IOTrackerSplitorTest, AsyncStartReadNotAllocateSegmentFromOrigin) {
 
     FInfo_t fileInfo;
     fileInfo.chunksize = 4 * 1024 * 1024;
-    fileInfo.cloneLength = 10ull * 1024 * 1024 * 1024;
     fileInfo.filename = "1_userinfo_.txt";
     fileInfo.owner = "userinfo";
-    fileInfo.cloneSource = "/clonesource";
+    fileInfo.filestatus = FileStatus::CloneMetaInstalled;
+    fileInfo.sourceInfo.name = "/clonesource";
+    fileInfo.sourceInfo.segmentSize = 1ull * 1024 * 1024 * 1024;
+    fileInfo.sourceInfo.length = 10ull * 1024 * 1024 * 1024;
+    for (uint64_t i = 0; i < fileInfo.sourceInfo.length;
+         i += fileInfo.sourceInfo.segmentSize) {
+        fileInfo.sourceInfo.allocatedSegmentOffsets.insert(i);
+    }
     fileInfo.userinfo = userinfo;
     mc->UpdateFileInfo(fileInfo);
 

--- a/test/client/mock/BUILD
+++ b/test/client/mock/BUILD
@@ -1,3 +1,19 @@
+#
+#  Copyright (c) 2020 NetEase Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
 COPTS = [
     "-DGFLAGS=gflags",
     "-DOS_LINUX",
@@ -19,10 +35,9 @@ COPTS = [
 
 cc_library(
     name = "curve_client_mock",
-    srcs = glob([
-                "*.h",
-                "*.cpp",
-                ]),
+    srcs = glob(
+        ["*.h"]
+    ),
     visibility = ["//visibility:public"],
     deps = [
         "@com_google_googletest//:gtest",
@@ -31,4 +46,3 @@ cc_library(
     ],
     copts = COPTS
 )
-

--- a/test/client/mock/mock_namespace_service.h
+++ b/test/client/mock/mock_namespace_service.h
@@ -33,6 +33,11 @@ namespace mds {
 
 class MockNameService : public CurveFSService {
  public:
+    MOCK_METHOD4(OpenFile, void(google::protobuf::RpcController* cntl,
+                                const OpenFileRequest* request,
+                                OpenFileResponse* response,
+                                google::protobuf::Closure* done));
+
     MOCK_METHOD4(DeleteFile, void(google::protobuf::RpcController* cntl,
                                   const DeleteFileRequest* request,
                                   DeleteFileResponse* response,

--- a/test/client/request_sender_test.cpp
+++ b/test/client/request_sender_test.cpp
@@ -194,6 +194,7 @@ TEST_F(RequestSenderTest, TestWriteChunkSourceInfo) {
 
         sourceInfo.cloneFileSource = "/test_WriteChunkSourceInfo";
         sourceInfo.cloneFileOffset = 0;
+        sourceInfo.valid = true;
 
         requestSender.WriteChunk(ChunkIDInfo(), 0, {}, 0, 0,
                                  sourceInfo, &closure);
@@ -247,6 +248,7 @@ TEST_F(RequestSenderTest, TestReadChunkSourceInfo) {
 
         sourceInfo.cloneFileSource = "/test_ReadChunkSourceInfo";
         sourceInfo.cloneFileOffset = 0;
+        sourceInfo.valid = true;
 
         requestSender.ReadChunk(ChunkIDInfo(), 0, 0, 0, appliedIndex,
                                 sourceInfo, &closure);

--- a/test/mds/nameserver2/curvefs_test.cpp
+++ b/test/mds/nameserver2/curvefs_test.cpp
@@ -2939,6 +2939,172 @@ TEST_F(CurveFSTest, testOpenFile) {
             curvefs_->OpenFile("/file1", "127.0.0.1", &protoSession, &fileInfo),
             StatusCode::kOK);
     }
+
+    // open clone file, clone source is not a valid curve file
+    {
+        ProtoSession protoSession;
+        FileInfo fileInfo;
+        fileInfo.set_filetype(FileType::INODE_PAGEFILE);
+        fileInfo.set_clonesource("123456-7890-xxxx-xxxxxx");
+        fileInfo.set_filestatus(FileStatus::kFileCloneMetaInstalled);
+
+        EXPECT_CALL(*storage_, GetFile(_, _, _))
+            .WillOnce(Return(StoreStatus::OK));
+
+        CloneSourceSegment sourceSegment;
+        ASSERT_EQ(curvefs_->OpenFile("/file1", "127.0.0.1", &protoSession,
+                                     &fileInfo, &sourceSegment),
+                  StatusCode::kOK);
+        ASSERT_FALSE(sourceSegment.IsInitialized());
+    }
+
+    // open a flattened clone file
+    {
+        ProtoSession protoSession;
+        FileInfo fileInfo;
+        fileInfo.set_filetype(FileType::INODE_PAGEFILE);
+        fileInfo.set_clonesource("/clonefile");
+        fileInfo.set_filestatus(FileStatus::kFileCloned);
+        CloneSourceSegment sourceSegment;
+
+        EXPECT_CALL(*storage_, GetFile(_, _, _))
+            .WillOnce(Return(StoreStatus::OK));
+
+        ASSERT_EQ(StatusCode::kOK,
+                  curvefs_->OpenFile("/file1", "127.0.0.1", &protoSession,
+                                     &fileInfo, &sourceSegment));
+        ASSERT_FALSE(sourceSegment.IsInitialized());
+    }
+
+    // open clone file, cloneSourceSegments is nullptr
+    {
+        ProtoSession protoSession;
+        FileInfo fileInfo;
+        fileInfo.set_filetype(FileType::INODE_PAGEFILE);
+        fileInfo.set_clonesource("/clonefile");
+        fileInfo.set_filestatus(FileStatus::kFileCloneMetaInstalled);
+
+        EXPECT_CALL(*storage_, GetFile(_, _, _))
+            .WillOnce(Return(StoreStatus::OK));
+
+        ASSERT_EQ(curvefs_->OpenFile("/file1", "127.0.0.1", &protoSession,
+                                     &fileInfo, nullptr),
+                  StatusCode::kParaError);
+    }
+
+    // open clone file, get clone file info failed
+    {
+        ProtoSession protoSession;
+        FileInfo fileInfo;
+        fileInfo.set_filetype(FileType::INODE_PAGEFILE);
+        fileInfo.set_clonesource("/clonefile");
+        fileInfo.set_filestatus(FileStatus::kFileCloneMetaInstalled);
+
+        EXPECT_CALL(*storage_, GetFile(_, _, _))
+            .WillOnce(Return(StoreStatus::OK))
+            .WillOnce(Return(StoreStatus::KeyNotExist));
+
+        CloneSourceSegment sourceSegment;
+        ASSERT_EQ(curvefs_->OpenFile("/file1", "127.0.0.1", &protoSession,
+                                     &fileInfo, &sourceSegment),
+                  StatusCode::kFileNotExists);
+        ASSERT_FALSE(sourceSegment.IsInitialized());
+    }
+
+    // open clone file, list clone file segment failed
+    {
+        ProtoSession protoSession;
+        FileInfo fileInfo;
+        fileInfo.set_filetype(FileType::INODE_PAGEFILE);
+        fileInfo.set_clonesource("/clonefile");
+        fileInfo.set_filestatus(FileStatus::kFileCloneMetaInstalled);
+
+        EXPECT_CALL(*storage_, GetFile(_, _, _))
+            .Times(2)
+            .WillRepeatedly(Return(StoreStatus::OK));
+
+        EXPECT_CALL(*storage_, ListSegment(_, _))
+            .WillOnce(Return(StoreStatus::InternalError));
+
+        CloneSourceSegment sourceSegment;
+        ASSERT_EQ(curvefs_->OpenFile("/file1", "127.0.0.1", &protoSession,
+                                     &fileInfo, &sourceSegment),
+                  StatusCode::kStorageError);
+        ASSERT_FALSE(sourceSegment.IsInitialized());
+    }
+
+    // open clone file, clone source file has no segments
+    {
+        ProtoSession protoSession;
+        FileInfo fileInfo;
+        fileInfo.set_filetype(FileType::INODE_PAGEFILE);
+        fileInfo.set_clonesource("/clonefile");
+        fileInfo.set_filestatus(FileStatus::kFileCloneMetaInstalled);
+
+        EXPECT_CALL(*storage_, GetFile(_, _, _))
+            .Times(2)
+            .WillRepeatedly(Return(StoreStatus::OK));
+
+        std::vector<PageFileSegment> segments;
+        EXPECT_CALL(*storage_, ListSegment(_, _))
+            .WillOnce(
+                DoAll(SetArgPointee<1>(segments), Return(StoreStatus::OK)));
+
+        CloneSourceSegment sourceSegment;
+        ASSERT_EQ(curvefs_->OpenFile("/file1", "127.0.0.1", &protoSession,
+                                     &fileInfo, &sourceSegment),
+                  StatusCode::kOK);
+
+        ASSERT_TRUE(sourceSegment.IsInitialized());
+        ASSERT_EQ(0, sourceSegment.allocatedsegmentoffset_size());
+    }
+
+    // open clone file success
+    {
+        ProtoSession protoSession;
+        FileInfo fileInfo;
+        fileInfo.set_filetype(FileType::INODE_PAGEFILE);
+        fileInfo.set_clonesource("/clonefile");
+        fileInfo.set_filestatus(FileStatus::kFileCloneMetaInstalled);
+        fileInfo.set_segmentsize(1 * kGB);
+
+        FileInfo cloneSourceFileInfo;
+        cloneSourceFileInfo.set_segmentsize(1 * kGB);
+
+        EXPECT_CALL(*storage_, GetFile(_, _, _))
+            .WillOnce(Return(StoreStatus::OK))
+            .WillOnce(DoAll(SetArgPointee<2>(cloneSourceFileInfo),
+                            Return(StoreStatus::OK)));
+
+        PageFileSegment segment1;
+        segment1.set_logicalpoolid(1);
+        segment1.set_segmentsize(1 * kGB);
+        segment1.set_chunksize(16 * kMB);
+        segment1.set_startoffset(0 * kGB);
+
+        PageFileSegment segment2;
+        segment2.set_logicalpoolid(1);
+        segment2.set_segmentsize(1 * kGB);
+        segment2.set_chunksize(16 * kMB);
+        segment2.set_startoffset(1 * kGB);
+
+        std::vector<PageFileSegment> segments{segment1, segment2};
+
+        EXPECT_CALL(*storage_, ListSegment(_, _))
+            .WillOnce(
+                DoAll(SetArgPointee<1>(segments), Return(StoreStatus::OK)));
+
+        CloneSourceSegment sourceSegment;
+        ASSERT_EQ(curvefs_->OpenFile("/file1", "127.0.0.1", &protoSession,
+                                     &fileInfo, &sourceSegment),
+                  StatusCode::kOK);
+
+        ASSERT_TRUE(sourceSegment.IsInitialized());
+        ASSERT_EQ(2, sourceSegment.allocatedsegmentoffset_size());
+        ASSERT_EQ(0 * kGB, sourceSegment.allocatedsegmentoffset(0));
+        ASSERT_EQ(1 * kGB, sourceSegment.allocatedsegmentoffset(1));
+        ASSERT_EQ(1 * kGB, sourceSegment.segmentsize());
+    }
 }
 
 TEST_F(CurveFSTest, testCloseFile) {


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Problem Summary:

### What is changed and how it works?

What's Changed:

Previously, when client reads and writes data within the length of the source file, rpc will carry the source file information.
Now, only when client reads and writes data within the range that source file' segment is allocated, and file status is CloneMetaInstalled, rpc will carry the source file information.

How it Works:

Side effects(Breaking backward compatibility? Performance regression?): 

### Check List

- [x] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license
