### PR TITLE
chunkserver: get walfilepool without using global variable

### DIFF
--- a/src/chunkserver/chunkserver.cpp
+++ b/src/chunkserver/chunkserver.cpp
@@ -137,12 +137,11 @@ int ChunkServer::Run(int argc, char** argv) {
     LOG_IF(FATAL, false == chunkfilePool->Initialize(chunkFilePoolOptions))
         << "Failed to init chunk file pool";
 
-
-
     // Init Wal file pool
     std::string raftLogUri;
     LOG_IF(FATAL, !conf.GetStringValue("copyset.raft_log_uri", &raftLogUri));
     std::string raftLogProtocol = UriParser::GetProtocolFromUri(raftLogUri);
+    std::shared_ptr<FilePool> walFilePool = nullptr;
     bool useChunkFilePoolAsWalPool = true;
     if (raftLogProtocol == kProtocalCurve) {
         LOG_IF(FATAL, !conf.GetBoolValue(
@@ -152,12 +151,12 @@ int ChunkServer::Run(int argc, char** argv) {
         if (!useChunkFilePoolAsWalPool) {
             FilePoolOptions walFilePoolOptions;
             InitWalFilePoolOptions(&conf, &walFilePoolOptions);
-            kWalFilePool = std::make_shared<FilePool>(fs);
-            LOG_IF(FATAL, false == kWalFilePool->Initialize(walFilePoolOptions))
+            walFilePool = std::make_shared<FilePool>(fs);
+            LOG_IF(FATAL, false == walFilePool->Initialize(walFilePoolOptions))
                 << "Failed to init wal file pool";
             LOG(INFO) << "initialize walpool success.";
         } else {
-            kWalFilePool = chunkfilePool;
+            walFilePool = chunkfilePool;
             LOG(INFO) << "initialize to use chunkfilePool as walpool success.";
         }
     }
@@ -209,7 +208,7 @@ int ChunkServer::Run(int argc, char** argv) {
     InitTrashOptions(&conf, &trashOptions);
     trashOptions.localFileSystem = fs;
     trashOptions.chunkFilePool = chunkfilePool;
-    trashOptions.walPool = kWalFilePool;
+    trashOptions.walPool = walFilePool;
     trash_ = std::make_shared<Trash>();
     LOG_IF(FATAL, trash_->Init(trashOptions) != 0)
         << "Failed to init Trash";
@@ -219,6 +218,7 @@ int ChunkServer::Run(int argc, char** argv) {
     InitCopysetNodeOptions(&conf, &copysetNodeOptions);
     copysetNodeOptions.concurrentapply = &concurrentapply;
     copysetNodeOptions.chunkFilePool = chunkfilePool;
+    copysetNodeOptions.walFilePool = walFilePool;
     copysetNodeOptions.localFileSystem = fs;
     copysetNodeOptions.trash = trash_;
 
@@ -269,7 +269,7 @@ int ChunkServer::Run(int argc, char** argv) {
     metric->MonitorTrash(trash_.get());
     metric->MonitorChunkFilePool(chunkfilePool.get());
     if (raftLogProtocol == kProtocalCurve && !useChunkFilePoolAsWalPool) {
-        metric->MonitorWalFilePool(kWalFilePool.get());
+        metric->MonitorWalFilePool(walFilePool.get());
     }
     metric->ExposeConfigMetric(&conf);
 

--- a/src/chunkserver/config_info.cpp
+++ b/src/chunkserver/config_info.cpp
@@ -45,6 +45,7 @@ CopysetNodeOptions::CopysetNodeOptions()
       pageSize(4096),
       concurrentapply(nullptr),
       chunkFilePool(nullptr),
+      walFilePool(nullptr),
       localFileSystem(nullptr),
       snapshotThrottle(nullptr) {
 }

--- a/src/chunkserver/config_info.h
+++ b/src/chunkserver/config_info.h
@@ -95,6 +95,8 @@ struct CopysetNodeOptions {
     ConcurrentApplyModule *concurrentapply;
     // Chunk file池子
     std::shared_ptr<FilePool> chunkFilePool;
+    // WAL file pool
+    std::shared_ptr<FilePool> walFilePool;
     // 文件系统适配层
     std::shared_ptr<LocalFileSystem> localFileSystem;
     // 回收站, 心跳模块判断该chunkserver不在copyset配置组时，

--- a/src/chunkserver/copyset_node.cpp
+++ b/src/chunkserver/copyset_node.cpp
@@ -34,6 +34,7 @@
 #include <cassert>
 
 #include "src/chunkserver/raftsnapshot/curve_filesystem_adaptor.h"
+#include "src/chunkserver/raftlog/curve_segment_log_storage.h"
 #include "src/chunkserver/chunk_closure.h"
 #include "src/chunkserver/op_request.h"
 #include "src/fs/fs_common.h"
@@ -187,6 +188,10 @@ int CopysetNode::Init(const CopysetNodeOptions &options) {
         // TODO(yyk) 后续考虑添加datastore层面的io metric
         metric_->MonitorDataStore(dataStore_.get());
     }
+
+    // In order to get more copysetNode's information in CurveSegmentLogStorage
+    // without using global variables.
+    BindForCurveSegmentLogStorage(options.walFilePool);
 
     return 0;
 }

--- a/src/chunkserver/raftlog/curve_segment_log_storage.cpp
+++ b/src/chunkserver/raftlog/curve_segment_log_storage.cpp
@@ -41,10 +41,21 @@
 #include <braft/protobuf_file.h>
 #include <braft/local_storage.pb.h>
 #include "src/chunkserver/raftlog/curve_segment_log_storage.h"
+#include "src/chunkserver/datastore/file_pool.h"
 #include "src/chunkserver/raftlog/define.h"
 
 namespace curve {
 namespace chunkserver {
+
+std::shared_ptr<FilePool> BindForCurveSegmentLogStorage(
+        std::shared_ptr<FilePool> walFilePool) {
+    static std::shared_ptr<FilePool> walFilePool_ = nullptr;
+    if (nullptr != walFilePool) {
+        walFilePool_ = walFilePool;
+    }
+
+    return walFilePool_;
+}
 
 void RegisterCurveSegmentLogStorageOrDie() {
     static CurveSegmentLogStorage logStorage;
@@ -192,7 +203,8 @@ int CurveSegmentLogStorage::list_segments(bool is_empty) {
                       << " first_index: " << first_index
                       << " last_index: " << last_index;
             CurveSegment* segment = new CurveSegment(_path, first_index,
-                                            last_index, _checksum_type);
+                                            last_index, _checksum_type,
+                                            _walFilePool);
             _segments[first_index] = segment;
             continue;
         }
@@ -204,7 +216,8 @@ int CurveSegmentLogStorage::list_segments(bool is_empty) {
                 << " first_index: " << first_index;
             if (!_open_segment) {
                 _open_segment =
-                    new CurveSegment(_path, first_index, _checksum_type);
+                    new CurveSegment(_path, first_index, _checksum_type,
+                            _walFilePool);
                 continue;
             } else {
                 LOG(WARNING) << "open segment conflict, path: " << _path
@@ -664,7 +677,10 @@ void CurveSegmentLogStorage::sync() {
 
 braft::LogStorage* CurveSegmentLogStorage::new_instance(
                             const std::string& uri) const {
-    return new CurveSegmentLogStorage(uri);
+    std::shared_ptr<FilePool> walFilePool =
+        BindForCurveSegmentLogStorage(nullptr);
+
+    return new CurveSegmentLogStorage(uri, true, walFilePool);
 }
 
 scoped_refptr<Segment> CurveSegmentLogStorage::open_segment(
@@ -674,14 +690,14 @@ scoped_refptr<Segment> CurveSegmentLogStorage::open_segment(
         BAIDU_SCOPED_LOCK(_mutex);
         if (!_open_segment) {
             _open_segment = new CurveSegment(_path, last_log_index() + 1,
-                                             _checksum_type);
+                                             _checksum_type, _walFilePool);
             if (_open_segment->create() != 0) {
                 _open_segment = NULL;
                 return NULL;
             }
         }
-        uint32_t maxTotalFileSize = kWalFilePool->GetFilePoolOpt().fileSize
-                                + kWalFilePool->GetFilePoolOpt().metaPageSize;
+        uint32_t maxTotalFileSize = _walFilePool->GetFilePoolOpt().fileSize
+                                + _walFilePool->GetFilePoolOpt().metaPageSize;
         if (_open_segment->bytes() + to_write > maxTotalFileSize) {
             _segments[_open_segment->first_index()] = _open_segment;
             prev_open_segment.swap(_open_segment);
@@ -692,7 +708,7 @@ scoped_refptr<Segment> CurveSegmentLogStorage::open_segment(
             if (prev_open_segment->close(_enable_sync) == 0) {
                 BAIDU_SCOPED_LOCK(_mutex);
                 _open_segment = new CurveSegment(_path, last_log_index() + 1,
-                                                 _checksum_type);
+                                                 _checksum_type, _walFilePool);
                 if (_open_segment->create() == 0) {
                     // success
                     break;

--- a/test/chunkserver/raftlog/test_curve_segment.cpp
+++ b/test/chunkserver/raftlog/test_curve_segment.cpp
@@ -52,12 +52,10 @@ class CurveSegmentTest : public testing::Test {
     void SetUp() {
         lfs = std::make_shared<MockLocalFileSystem>();
         file_pool = std::make_shared<MockFilePool>(lfs);
-        kWalFilePool = file_pool;
         std::string cmd = std::string("mkdir ") + kRaftLogDataDir;
         ::system(cmd.c_str());
     }
     void TearDown() {
-        kWalFilePool = nullptr;
         std::string cmd = std::string("rm -rf ") + kRaftLogDataDir;
         ::system(cmd.c_str());
     }
@@ -129,7 +127,7 @@ TEST_F(CurveSegmentTest, open_segment) {
     EXPECT_CALL(*file_pool, RecycleFile(_))
         .WillOnce(Return(0));
     scoped_refptr<CurveSegment> seg1 =
-                new CurveSegment(kRaftLogDataDir, 1, 0);
+                new CurveSegment(kRaftLogDataDir, 1, 0, file_pool);
 
     // not open
     braft::LogEntry* entry = seg1->get(1);
@@ -158,7 +156,7 @@ TEST_F(CurveSegmentTest, open_segment) {
                                 new braft::ConfigurationManager;
     // load open segment
     scoped_refptr<CurveSegment> seg2 =
-                        new CurveSegment(kRaftLogDataDir, 1, 0);
+                        new CurveSegment(kRaftLogDataDir, 1, 0, file_pool);
     ASSERT_EQ(0, seg2->load(configuration_manager));
 
     read_entries_curve_segment(seg2);
@@ -189,7 +187,7 @@ TEST_F(CurveSegmentTest, closed_segment) {
     EXPECT_CALL(*file_pool, RecycleFile(_))
         .WillOnce(Return(0));
     scoped_refptr<CurveSegment> seg1 =
-                new CurveSegment(kRaftLogDataDir, 1, 0);
+                new CurveSegment(kRaftLogDataDir, 1, 0, file_pool);
 
     // create and open
     std::string path = kRaftLogDataDir;
@@ -215,7 +213,7 @@ TEST_F(CurveSegmentTest, closed_segment) {
                                 new braft::ConfigurationManager;
     // load closed segment
     scoped_refptr<CurveSegment> seg2 =
-                        new CurveSegment(kRaftLogDataDir, 1, 10, 0);
+                        new CurveSegment(kRaftLogDataDir, 1, 10, 0, file_pool);
     ASSERT_EQ(0, seg2->load(configuration_manager));
 
     read_entries_curve_segment(seg2);


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Problem Summary: In order to get more `copysetNode`'s information in `CurveSegmentLogStorage` object without using global variables.

### What is changed and how it works?

What's Changed: Repalce static variable with global variable.

How it Works: Browse the code for detail.

Side effects(Breaking backward compatibility? Performance regression?): none.

### Check List

- [x] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license
