### PR TITLE
fix a todo: wrap initializing code of raft node options into a function

### DIFF
--- a/src/chunkserver/copyset_node.h
+++ b/src/chunkserver/copyset_node.h
@@ -276,6 +276,13 @@ class CopysetNode : public braft::StateMachine,
     void ListPeers(std::vector<Peer>* peers);
 
     /**
+     * @brief initialize raft node options corresponding to the copyset node
+     * @param options
+     * @return
+     */
+    void InitRaftNodeOptions(const CopysetNodeOptions &options);
+
+    /**
      * 下面的接口都是继承StateMachine实现的接口
      */
  public:


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number:  <!-- REMOVE this line if no issue to close -->

Problem Summary: #323
wrap initializing code of raft node options into a function

### What is changed and how it works?
What's Changed:
* src/chunkserver/copyset_node.h
* src/chunkserver/copyset_node.cpp

How it Works:
a simple warpping

Side effects(Breaking backward compatibility? Performance regression?): 

### Check List

- [x] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license

### Miscellaneous
There seems to be lots of `// todo` which probably already be fixed, and that makes me confused so much.
Can I get in touch with someone privately (like adding wechat) to get some tips? I'm really interested in distributed system & storage and learned a lot of theory, but have a poor experience in large-scale engineering & c++ programming because I am still in my sophomore year......anyway thanks a lot for open source this project
