### PR TITLE
fix bug;

### DIFF
--- a/test/chunkserver/multiple_copysets_io_test.cpp
+++ b/test/chunkserver/multiple_copysets_io_test.cpp
@@ -308,10 +308,6 @@ int update_leader(CopysetInfo *copyset) {
                                                          copyset->conf,
                                                          &peerId);
     if (status.ok()) {
-        if (*copyset->ep[copyset->leader] == peerId.addr) {
-            return copyset->leader;
-        }
-        copyset->leader = -1;
         for (unsigned int j = 0; j < copyset->conf.size(); j++) {
             if (*copyset->ep[j] == peerId.addr) {
                 copyset->leader = j;
@@ -677,6 +673,7 @@ int init_copysets() {
 
     for (int i = 0; i < nr_copysets; i++) {
         CopysetInfo *info = new CopysetInfo();
+        info->leader = -1;
         info->poolId = poolId;
         info->copysetId = i + copysetIdBase;
         info->conf = conf;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: [335](https://github.com/opencurve/curve/issues/335)

Problem Summary:

copyset->leader is not explicitly initialized, which means that its initial value is 0, and the leader will be returned directly when it is judged in update_leader() that the election of the leader fails, which results in a correct value being returned in the case of an error.

### What is changed and how it works?

/curve/test/chunkserver/multiple_copysets_io_test.cpp
- function update_leader()
- function init_copysets()

Initialize copyset->leader to -1, and delete a meaningless judgment in update_leader.

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?): 

It is necessary to traverse all the configurations every time to find the index corresponding to the leader.

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
