### PR TITLE
ansible: support disk partition and vd* as chunkserver

### DIFF
--- a/curve-chunkserver/home/nbs/chunkserver_deploy.sh
+++ b/curve-chunkserver/home/nbs/chunkserver_deploy.sh
@@ -142,7 +142,7 @@ function fstab_record {
   if [ $? -ne 0 ]
   then
   echo "#curvefs" >> /etc/fstab
-  for i in `lsblk|grep chunkserver|awk '{print $1}'`
+  for i in `lsblk|grep chunkserver|awk '{print $1}' | grep -Eo 'sd.*|vd.*'`
   do
     echo "UUID=`ls -l /dev/disk/by-uuid/|grep $i|awk '{print $9}'`    `lsblk|grep $i|awk '{print $7}'`    ext4  rw,errors=remount-ro    0    0" >> /etc/fstab
   done


### PR DESCRIPTION
Fixes: issue #349

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: close #349 <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

What's Changed: add disk partition and virtual disk support when deploy chunkserver.

How it Works: use regular to handle lsblk prefix of disk partition and virtual disk.

Side effects(Breaking backward compatibility? Performance regression?): 

### Check List

- [x] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license
