### PR TITLE
client: fix segment fault in SourceReader

### DIFF
--- a/src/client/client_metric.h
+++ b/src/client/client_metric.h
@@ -30,6 +30,7 @@
 
 #include "src/common/timeutility.h"
 #include "src/client/client_common.h"
+#include "src/common/string_util.h"
 
 using curve::common::TimeUtility;
 
@@ -200,8 +201,7 @@ struct MDSClientMetric {
     explicit MDSClientMetric(const std::string& prefix_ = "")
         : prefix(!prefix_.empty()
                      ? prefix_
-                     : "curve_mds_client_" +
-                           std::to_string(reinterpret_cast<uint64_t>(this))),
+                     : "curve_mds_client_" + common::ToHexString(this)),
           metaserverAddress(prefix, "current_metaserver_addr", GetStringValue,
                             &metaserverAddr),
           openFile(prefix, "openFile"),

--- a/src/client/file_instance.cpp
+++ b/src/client/file_instance.cpp
@@ -24,6 +24,7 @@
 
 #include <butil/endpoint.h>
 #include <glog/logging.h>
+#include <utility>
 
 #include "proto/nameserver2.pb.h"
 #include "proto/topology.pb.h"
@@ -50,7 +51,7 @@ FileInstance::FileInstance()
       readonly_(false) {}
 
 bool FileInstance::Initialize(const std::string& filename,
-                              MDSClient* mdsclient,
+                              std::shared_ptr<MDSClient> mdsclient,
                               const UserInfo_t& userinfo,
                               const FileServiceOption& fileservicopt,
                               bool readonly) {
@@ -69,11 +70,12 @@ bool FileInstance::Initialize(const std::string& filename,
         }
 
         finfo_.userinfo = userinfo;
-        mdsclient_ = mdsclient;
+        mdsclient_ = std::move(mdsclient);
 
         finfo_.fullPathName = filename;
 
-        if (!iomanager4file_.Initialize(filename, fileopt_.ioOpt, mdsclient_)) {
+        if (!iomanager4file_.Initialize(filename, fileopt_.ioOpt,
+                                        mdsclient_.get())) {
             LOG(ERROR) << "Init io context manager failed, filename = "
                        << filename;
             break;
@@ -82,7 +84,8 @@ bool FileInstance::Initialize(const std::string& filename,
         iomanager4file_.UpdateFileInfo(finfo_);
 
         leaseExecutor_.reset(new (std::nothrow) LeaseExecutor(
-            fileopt_.leaseOpt, finfo_.userinfo, mdsclient_, &iomanager4file_));
+            fileopt_.leaseOpt, finfo_.userinfo, mdsclient_.get(),
+            &iomanager4file_));
         if (CURVE_UNLIKELY(leaseExecutor_ == nullptr)) {
             LOG(ERROR) << "Allocate LeaseExecutor failed, filename = "
                        << filename;
@@ -97,10 +100,13 @@ bool FileInstance::Initialize(const std::string& filename,
 
 void FileInstance::UnInitialize() {
     iomanager4file_.UnInitialize();
+
+    // release the ownership of mdsclient
+    mdsclient_.reset();
 }
 
 int FileInstance::Read(char* buf, off_t offset, size_t length) {
-    return iomanager4file_.Read(buf, offset, length, mdsclient_);
+    return iomanager4file_.Read(buf, offset, length, mdsclient_.get());
 }
 
 int FileInstance::Write(const char* buf, off_t offset, size_t len) {
@@ -108,11 +114,11 @@ int FileInstance::Write(const char* buf, off_t offset, size_t len) {
         DVLOG(9) << "open with read only, do not support write!";
         return -1;
     }
-    return iomanager4file_.Write(buf, offset, len, mdsclient_);
+    return iomanager4file_.Write(buf, offset, len, mdsclient_.get());
 }
 
 int FileInstance::AioRead(CurveAioContext* aioctx, UserDataType dataType) {
-    return iomanager4file_.AioRead(aioctx, mdsclient_, dataType);
+    return iomanager4file_.AioRead(aioctx, mdsclient_.get(), dataType);
 }
 
 int FileInstance::AioWrite(CurveAioContext* aioctx, UserDataType dataType) {
@@ -120,12 +126,12 @@ int FileInstance::AioWrite(CurveAioContext* aioctx, UserDataType dataType) {
         DVLOG(9) << "open with read only, do not support write!";
         return -1;
     }
-    return iomanager4file_.AioWrite(aioctx, mdsclient_, dataType);
+    return iomanager4file_.AioWrite(aioctx, mdsclient_.get(), dataType);
 }
 
 int FileInstance::Discard(off_t offset, size_t length) {
     if (!readonly_) {
-        return iomanager4file_.Discard(offset, length, mdsclient_);
+        return iomanager4file_.Discard(offset, length, mdsclient_.get());
     }
 
     LOG(ERROR) << "Open with read only, not support Discard";
@@ -134,7 +140,7 @@ int FileInstance::Discard(off_t offset, size_t length) {
 
 int FileInstance::AioDiscard(CurveAioContext* aioctx) {
     if (!readonly_) {
-        return iomanager4file_.AioDiscard(aioctx, mdsclient_);
+        return iomanager4file_.AioDiscard(aioctx, mdsclient_.get());
     }
 
     LOG(ERROR) << "Open with read only, not support AioDiscard";
@@ -197,7 +203,7 @@ int FileInstance::Close() {
 
 FileInstance* FileInstance::NewInitedFileInstance(
     const FileServiceOption& fileServiceOption,
-    MDSClient* mdsClient,
+    std::shared_ptr<MDSClient> mdsClient,
     const std::string& filename,
     const UserInfo& userInfo,
     bool readonly) {
@@ -207,7 +213,7 @@ FileInstance* FileInstance::NewInitedFileInstance(
         return nullptr;
     }
 
-    bool ret = instance->Initialize(filename, mdsClient, userInfo,
+    bool ret = instance->Initialize(filename, std::move(mdsClient), userInfo,
                                     fileServiceOption, readonly);
     if (!ret) {
         LOG(ERROR) << "FileInstance initialize failed"
@@ -222,11 +228,11 @@ FileInstance* FileInstance::NewInitedFileInstance(
 }
 
 FileInstance* FileInstance::Open4Readonly(const FileServiceOption& opt,
-                                          MDSClient* mdsclient,
+                                          std::shared_ptr<MDSClient> mdsclient,
                                           const std::string& filename,
                                           const UserInfo& userInfo) {
     FileInstance* instance = FileInstance::NewInitedFileInstance(
-        opt, mdsclient, filename, userInfo, true);
+        opt, std::move(mdsclient), filename, userInfo, true);
     if (instance == nullptr) {
         LOG(ERROR) << "NewInitedFileInstance failed, filename = " << filename;
         return nullptr;

--- a/src/client/file_instance.h
+++ b/src/client/file_instance.h
@@ -52,7 +52,7 @@ class CURVE_CACHELINE_ALIGNMENT FileInstance {
      * @return: 成功返回true、否则返回false
      */
     bool Initialize(const std::string& filename,
-                    MDSClient* mdsclient,
+                    std::shared_ptr<MDSClient> mdsclient,
                     const UserInfo_t& userinfo,
                     const FileServiceOption& fileservicopt,
                     bool readonly = false);
@@ -152,13 +152,13 @@ class CURVE_CACHELINE_ALIGNMENT FileInstance {
 
     static FileInstance* NewInitedFileInstance(
         const FileServiceOption& fileServiceOption,
-        MDSClient* mdsClient,
+        std::shared_ptr<MDSClient> mdsClient,
         const std::string& filename,
         const UserInfo& userInfo,
         bool readonly);
 
     static FileInstance* Open4Readonly(const FileServiceOption& opt,
-                                       MDSClient* mdsclient,
+                                       std::shared_ptr<MDSClient> mdsclient,
                                        const std::string& filename,
                                        const UserInfo& userInfo);
 
@@ -170,7 +170,7 @@ class CURVE_CACHELINE_ALIGNMENT FileInstance {
     FileServiceOption       fileopt_;
 
     // MDSClient是FileInstance与mds通信的唯一出口
-    MDSClient*              mdsclient_;
+    std::shared_ptr<MDSClient> mdsclient_;
 
     // 每个文件都持有与MDS通信的lease，LeaseExecutor是续约执行者
     std::unique_ptr<LeaseExecutor> leaseExecutor_;

--- a/src/client/libcurve_file.cpp
+++ b/src/client/libcurve_file.cpp
@@ -29,6 +29,7 @@
 #include <memory>
 #include <mutex>   // NOLINT
 #include <thread>  // NOLINT
+#include <utility>
 
 #include "include/client/libcurve.h"
 #include "include/curve_compiler_specific.h"
@@ -42,6 +43,7 @@
 #include "src/common/curve_version.h"
 #include "src/common/net_common.h"
 #include "src/common/uuid.h"
+#include "src/common/string_util.h"
 
 #define PORT_LIMIT  65535
 
@@ -96,11 +98,14 @@ void InitLogging(const std::string& confPath) {
     static LoggerGuard guard(confPath);
 }
 
-FileClient::FileClient(): fdcount_(0), openedFileNum_("opened_file_num") {
-    inited_ = false;
-    mdsClient_ = nullptr;
-    fileserviceMap_.clear();
-}
+FileClient::FileClient()
+    : rwlock_(),
+      fdcount_(0),
+      fileserviceMap_(),
+      clientconfig_(),
+      mdsClient_(),
+      inited_(false),
+      openedFileNum_(common::ToHexString(this)) {}
 
 int FileClient::Init(const std::string& configpath) {
     if (inited_) {
@@ -116,17 +121,13 @@ int FileClient::Init(const std::string& configpath) {
         return -LIBCURVE_ERROR::FAILED;
     }
 
-    mdsClient_ = new (std::nothrow) MDSClient();
-    if (mdsClient_ == nullptr) {
-        return -LIBCURVE_ERROR::FAILED;
-    }
 
-    auto ret = mdsClient_->Initialize(clientconfig_.
-               GetFileServiceOption().metaServerOpt);
+    auto tmpMdsClient = std::make_shared<MDSClient>();
+
+    auto ret = tmpMdsClient->Initialize(
+        clientconfig_.GetFileServiceOption().metaServerOpt);
     if (LIBCURVE_ERROR::OK != ret) {
         LOG(ERROR) << "Init global mds client failed!";
-        delete mdsClient_;
-        mdsClient_ = nullptr;
         return -LIBCURVE_ERROR::FAILED;
     }
 
@@ -139,12 +140,10 @@ int FileClient::Init(const std::string& configpath) {
 
     bool rc = StartDummyServer();
     if (rc == false) {
-        mdsClient_->UnInitialize();
-        delete mdsClient_;
-        mdsClient_ = nullptr;
         return -LIBCURVE_ERROR::FAILED;
     }
 
+    mdsClient_ = std::move(tmpMdsClient);
     inited_ = true;
     return LIBCURVE_ERROR::OK;
 }
@@ -161,11 +160,7 @@ void FileClient::UnInit() {
     }
     fileserviceMap_.clear();
 
-    if (mdsClient_ != nullptr) {
-        mdsClient_->UnInitialize();
-        delete mdsClient_;
-        mdsClient_ = nullptr;
-    }
+    mdsClient_.reset();
     inited_ = false;
 }
 

--- a/src/client/libcurve_file.h
+++ b/src/client/libcurve_file.h
@@ -28,6 +28,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include <memory>
 
 #include "include/client/libcurve.h"
 #include "src/client/client_common.h"
@@ -314,31 +315,6 @@ class FileClient {
         return openedFileNum_.get_value();
     }
 
-    /**
-     * test use, set the mdsclient_
-     */
-    void SetMdsClient(MDSClient* client) {
-        mdsClient_ = client;
-    }
-
-    /**
-     * test use, set the clientconfig_
-     */
-    void SetClientConfig(ClientConfig cfg) {
-        clientconfig_ = cfg;
-    }
-
-    const ClientConfig& GetClientConfig() {
-        return clientconfig_;
-    }
-
-    /**
-     * test use, get the fileserviceMap_
-     */
-    std::unordered_map<int, FileInstance*>& GetFileServiceMap() {
-        return fileserviceMap_;
-    }
-
  private:
     bool StartDummyServer();
 
@@ -360,7 +336,7 @@ class FileClient {
     ClientConfig clientconfig_;
 
     // fileclient对应的全局mdsclient
-    MDSClient* mdsClient_;
+    std::shared_ptr<MDSClient> mdsClient_;
 
     // 是否初始化成功
     bool inited_;

--- a/src/client/mds_client_base.cpp
+++ b/src/client/mds_client_base.cpp
@@ -21,17 +21,16 @@
  */
 
 #include "src/client/mds_client_base.h"
+
+#include "src/common/authenticator.h"
 #include "src/common/curve_version.h"
 
 namespace curve {
 namespace client {
 
-const char* kRootUserName = "root";
+using curve::common::Authenticator;
 
-int MDSClientBase::Init(const MetaServerOption& metaServerOpt) {
-    metaServerOpt_ = metaServerOpt;
-    return 0;
-}
+const char* kRootUserName = "root";
 
 void MDSClientBase::OpenFile(const std::string& filename,
                              const UserInfo_t& userinfo,
@@ -364,11 +363,10 @@ void MDSClientBase::GetOrAllocateSegment(bool allocate,
     request.set_allocateifnotexist(allocate);
     FillUserInfo(&request, fi->userinfo);
 
-    LOG(INFO) << "GetOrAllocateSegment: allocate = " << allocate
-                << ", owner = " << fi->owner
-                << ", offset = " << offset
-                << ", segment offset = " << seg_offset
-                << ", log id = " << cntl->log_id();
+    LOG(INFO) << "GetOrAllocateSegment: filename = " << fi->fullPathName
+              << ", allocate = " << allocate << ", owner = " << fi->owner
+              << ", offset = " << offset << ", segment offset = " << seg_offset
+              << ", log id = " << cntl->log_id();
 
     curve::mds::CurveFSService_Stub stub(channel);
     stub.GetOrAllocateSegment(cntl, &request, response, NULL);

--- a/src/client/mds_client_base.h
+++ b/src/client/mds_client_base.h
@@ -33,14 +33,10 @@
 #include "proto/nameserver2.pb.h"
 #include "proto/topology.pb.h"
 #include "src/client/client_common.h"
-#include "src/client/config_info.h"
-#include "src/common/authenticator.h"
 #include "src/common/timeutility.h"
 
 namespace curve {
 namespace client {
-
-using curve::common::Authenticator;
 
 using curve::mds::OpenFileRequest;
 using curve::mds::OpenFileResponse;
@@ -96,12 +92,6 @@ extern const char* kRootUserName;
 // 返回给调用者，有调用者处理
 class MDSClientBase {
  public:
-    /**
-     * @param: metaServerOpt为mdsclient的配置信息
-     * @return: 成功0， 否则-1
-     */
-    int Init(const MetaServerOption& metaServerOpt);
-
     /**
      * 打开文件
      * @param: filename是文件名
@@ -468,7 +458,7 @@ class MDSClientBase {
      * 为不同的request填充user信息
      * @param: request是待填充的变量指针
      */
-    template <class T>
+    template <typename T>
     void FillUserInfo(T* request, const UserInfo_t& userinfo) {
         uint64_t date = curve::common::TimeUtility::GetTimeofDayUs();
         request->set_owner(userinfo.owner);
@@ -482,9 +472,6 @@ class MDSClientBase {
     }
 
     std::string CalcSignature(const UserInfo& userinfo, uint64_t date) const;
-
-    // 当前模块的初始化option配置
-    MetaServerOption metaServerOpt_;
 };
 
 }   //  namespace client

--- a/src/client/source_reader.cpp
+++ b/src/client/source_reader.cpp
@@ -122,8 +122,8 @@ SourceReader::ReadHandler* SourceReader::GetReadHandler(
         }
     }
 
-    FileInstance* instance =
-        FileInstance::Open4Readonly(fileOption_, mdsclient, fileName, userInfo);
+    FileInstance* instance = FileInstance::Open4Readonly(
+        fileOption_, mdsclient->shared_from_this(), fileName, userInfo);
     if (instance == nullptr) {
         return nullptr;
     }

--- a/src/common/string_util.h
+++ b/src/common/string_util.h
@@ -138,6 +138,12 @@ static bool StringToTime(const std::string& value, uint64_t* expireTime) {
     return true;
 }
 
+inline std::string ToHexString(void* p) {
+    std::ostringstream oss;
+    oss << "0x" << std::hex << reinterpret_cast<uint64_t>(p);
+    return oss.str();
+}
+
 }  // namespace common
 }  // namespace curve
 

--- a/test/client/client_mdsclient_metacache_unittest.cpp
+++ b/test/client/client_mdsclient_metacache_unittest.cpp
@@ -123,7 +123,6 @@ class MDSClientTest : public ::testing::Test {
     }
 
     void TearDown() {
-        mdsclient_.UnInitialize();
         UnInit();
         ASSERT_EQ(0, server.Stop(0));
         ASSERT_EQ(0, server.Join());

--- a/test/client/client_metric_test.cpp
+++ b/test/client/client_metric_test.cpp
@@ -68,8 +68,8 @@ TEST(MetricTest, ChunkServer_MetricTest) {
     metaopt.mdsRPCTimeoutMs = 500;
     metaopt.mdsRPCRetryIntervalUS = 200;
 
-    MDSClient  mdsclient;
-    ASSERT_EQ(0, mdsclient.Initialize(metaopt));
+    std::shared_ptr<MDSClient> mdsclient = std::make_shared<MDSClient>();
+    ASSERT_EQ(0, mdsclient->Initialize(metaopt));
 
     FLAGS_chunkserver_list = "127.0.0.1:9130:0,127.0.0.1:9131:0,127.0.0.1:9132:0";   // NOLINT
 
@@ -101,7 +101,7 @@ TEST(MetricTest, ChunkServer_MetricTest) {
     auto opt = cc.GetFileServiceOption();
 
     FileInstance fi;
-    ASSERT_TRUE(fi.Initialize(filename.c_str(), &mdsclient, userinfo, opt));
+    ASSERT_TRUE(fi.Initialize(filename.c_str(), mdsclient, userinfo, opt));
 
     FileMetric* fm = fi.GetIOManager4File()->GetMetric();
 
@@ -168,7 +168,6 @@ TEST(MetricTest, ChunkServer_MetricTest) {
     delete[] buffer;
     fi.UnInitialize();
     mds.UnInitialize();
-    mdsclient.UnInitialize();
 }
 
 bool flag = false;
@@ -186,8 +185,8 @@ TEST(MetricTest, SuspendRPC_MetricTest) {
     metaopt.mdsRPCTimeoutMs = 500;
     metaopt.mdsRPCRetryIntervalUS = 200;
 
-    MDSClient  mdsclient;
-    ASSERT_EQ(0, mdsclient.Initialize(metaopt));
+    std::shared_ptr<MDSClient> mdsclient = std::make_shared<MDSClient>();
+    ASSERT_EQ(0, mdsclient->Initialize(metaopt));
 
     FLAGS_chunkserver_list = "127.0.0.1:9130:0,127.0.0.1:9131:0,127.0.0.1:9132:0";   // NOLINT
 
@@ -217,7 +216,7 @@ TEST(MetricTest, SuspendRPC_MetricTest) {
     ioSenderOpt.failRequestOpt.chunkserverMaxRPCTimeoutMS = 50;
 
     FileInstance fi;
-    ASSERT_TRUE(fi.Initialize(filename.c_str(), &mdsclient, userinfo, opt));
+    ASSERT_TRUE(fi.Initialize(filename.c_str(), mdsclient, userinfo, opt));
 
     FileMetric* fm = fi.GetIOManager4File()->GetMetric();
 
@@ -286,7 +285,6 @@ TEST(MetricTest, SuspendRPC_MetricTest) {
     delete[] buf1;
     fi.UnInitialize();
     mds.UnInitialize();
-    mdsclient.UnInitialize();
 }
 
 TEST(MetricTest, MetricHelperTest) {

--- a/test/client/client_session_unittest.cpp
+++ b/test/client/client_session_unittest.cpp
@@ -94,9 +94,9 @@ TEST(ClientSession, LeaseTaskTest) {
     UserInfo_t userinfo;
     userinfo.owner = "userinfo";
 
-    MDSClient mdsclient;
-    mdsclient.Initialize(cc.GetFileServiceOption().metaServerOpt);
-    ASSERT_TRUE(fileinstance.Initialize(filename, &mdsclient, userinfo,
+    std::shared_ptr<MDSClient> mdsclient = std::make_shared<MDSClient>();
+    mdsclient->Initialize(cc.GetFileServiceOption().metaServerOpt);
+    ASSERT_TRUE(fileinstance.Initialize(filename, mdsclient, userinfo,
                                         cc.GetFileServiceOption()));
 
     brpc::Server server;

--- a/test/client/client_userinfo_unittest.cpp
+++ b/test/client/client_userinfo_unittest.cpp
@@ -94,13 +94,13 @@ TEST_F(CurveClientUserAuthFail, CurveClientUserAuthFailTest) {
     userinfo.owner = "userinfo";
     UserInfo_t emptyuserinfo;
 
-    MDSClient mdsclient;
-    mdsclient.Initialize(cc.GetFileServiceOption().metaServerOpt);
+    std::shared_ptr<MDSClient> mdsclient = std::make_shared<MDSClient>();
+    mdsclient->Initialize(cc.GetFileServiceOption().metaServerOpt);
 
     FileInstance fileinstance;
-    ASSERT_FALSE(fileinstance.Initialize(filename, &mdsclient, emptyuserinfo,
-                                        cc.GetFileServiceOption()));
-    ASSERT_TRUE(fileinstance.Initialize(filename, &mdsclient, userinfo,
+    ASSERT_FALSE(fileinstance.Initialize(filename, mdsclient, emptyuserinfo,
+                                         cc.GetFileServiceOption()));
+    ASSERT_TRUE(fileinstance.Initialize(filename, mdsclient, userinfo,
                                         cc.GetFileServiceOption()));
 
     // set openfile response
@@ -209,7 +209,6 @@ TEST_F(CurveClientUserAuthFail, CurveClientUserAuthFailTest) {
     ASSERT_EQ(-LIBCURVE_ERROR::AUTHFAIL, fileinstance.Close());
 
     fileinstance.UnInitialize();
-    mdsclient.UnInitialize();
     UnInit();
 }
 

--- a/test/client/copyset_client_test.cpp
+++ b/test/client/copyset_client_test.cpp
@@ -3552,10 +3552,10 @@ TEST(ChunkServerBackwardTest, ChunkServerBackwardTest) {
     UserInfo userinfo;
     userinfo.owner = "userinfo";
 
-    MDSClient mdsclient;
+    std::shared_ptr<MDSClient> mdsclient = std::make_shared<MDSClient>();
     ASSERT_EQ(LIBCURVE_ERROR::OK,
-              mdsclient.Initialize(cc.GetFileServiceOption().metaServerOpt));
-    ASSERT_TRUE(fileinstance.Initialize("/test", &mdsclient, userinfo,
+              mdsclient->Initialize(cc.GetFileServiceOption().metaServerOpt));
+    ASSERT_TRUE(fileinstance.Initialize("/test", mdsclient, userinfo,
                                         cc.GetFileServiceOption()));
 
     // create fake chunkserver service

--- a/test/client/file_instance_test.cpp
+++ b/test/client/file_instance_test.cpp
@@ -29,12 +29,12 @@ namespace client {
 
 TEST(FileInstanceTest, CommonTest) {
     UserInfo userInfo{"test", "passwd"};
-    MDSClient mdsClient;
+    std::shared_ptr<MDSClient> mdsclient = std::make_shared<MDSClient>();
 
     // user info invlaid
     FileInstance fi;
-    ASSERT_FALSE(fi.Initialize(
-        "/test", &mdsClient, UserInfo{}, FileServiceOption{}));
+    ASSERT_FALSE(
+        fi.Initialize("/test", mdsclient, UserInfo{}, FileServiceOption{}));
 
     // mdsclient is nullptr
     FileInstance fi2;
@@ -47,13 +47,12 @@ TEST(FileInstanceTest, CommonTest) {
     opts.ioOpt.taskThreadOpt.isolationTaskQueueCapacity = 0;
     opts.ioOpt.taskThreadOpt.isolationTaskThreadPoolSize = 0;
 
-    ASSERT_FALSE(fi3.Initialize(
-        "/test", &mdsClient, userInfo, opts));
+    ASSERT_FALSE(fi3.Initialize("/test", mdsclient, userInfo, opts));
 
     // readonly
     FileInstance fi4;
-    ASSERT_TRUE(fi4.Initialize(
-        "/test", &mdsClient, userInfo, FileServiceOption{}, true));
+    ASSERT_TRUE(fi4.Initialize("/test", mdsclient, userInfo,
+                               FileServiceOption{}, true));
     ASSERT_EQ(-1, fi4.Write("", 0, 0));
 
     fi4.UnInitialize();
@@ -62,12 +61,12 @@ TEST(FileInstanceTest, CommonTest) {
 TEST(FileInstanceTest, OpenReadonlyAndDiscardTest) {
     FileInstance instance;
     FileServiceOption opt;
-    MDSClient mdsClient;
+    std::shared_ptr<MDSClient> mdsclient = std::make_shared<MDSClient>();
     UserInfo userInfo{"hello", "world"};
 
     ASSERT_TRUE(
         instance.Initialize("/FileInstanceTest-OpenReadonlyAndDiscardTest",
-                            &mdsClient, userInfo, opt, true));
+                            mdsclient, userInfo, opt, true));
 
     ASSERT_EQ(-1, instance.Discard(0, 0));
 

--- a/test/client/libcurve_interface_unittest.cpp
+++ b/test/client/libcurve_interface_unittest.cpp
@@ -652,7 +652,7 @@ TEST(TestLibcurveInterface, UnstableChunkserverTest) {
     std::string filename = "/1_userinfo_";
 
     UserInfo_t userinfo;
-    MDSClient mdsclient_;
+    std::shared_ptr<MDSClient> mdsclient_ = std::make_shared<MDSClient>();
     FileServiceOption fopt;
     FileInstance    fileinstance_;
 
@@ -682,9 +682,9 @@ TEST(TestLibcurveInterface, UnstableChunkserverTest) {
     //     fopt.ioOpt.ioSenderOpt.failRequestOpt);
     LOG(INFO) << "here";
 
-    mdsclient_.Initialize(fopt.metaServerOpt);
+    mdsclient_->Initialize(fopt.metaServerOpt);
     fileinstance_.Initialize(
-        "/UnstableChunkserverTest", &mdsclient_, userinfo, fopt);
+        "/UnstableChunkserverTest", mdsclient_, userinfo, fopt);
 
     // 设置leaderid
     EndPoint ep;
@@ -832,7 +832,6 @@ TEST(TestLibcurveInterface, UnstableChunkserverTest) {
 
     fileinstance_.Close();
     fileinstance_.UnInitialize();
-    mdsclient_.UnInitialize();
     mds.UnInitialize();
     delete[] buffer;
 }
@@ -841,7 +840,7 @@ TEST(TestLibcurveInterface, ResumeTimeoutBackoff) {
     std::string filename = "/1_userinfo_";
 
     UserInfo_t userinfo;
-    MDSClient mdsclient_;
+    std::shared_ptr<MDSClient> mdsclient_ = std::make_shared<MDSClient>();
     FileServiceOption fopt;
     FileInstance    fileinstance_;
 
@@ -867,9 +866,9 @@ TEST(TestLibcurveInterface, ResumeTimeoutBackoff) {
     fopt.leaseOpt.mdsRefreshTimesPerLease = 4;
     fopt.ioOpt.metaCacheOpt.chunkserverUnstableOption.maxStableChunkServerTimeoutTimes = 10;  // NOLINT
 
-    mdsclient_.Initialize(fopt.metaServerOpt);
+    mdsclient_->Initialize(fopt.metaServerOpt);
     fileinstance_.Initialize(
-        "/ResumeTimeoutBackoff", &mdsclient_, userinfo, fopt);
+        "/ResumeTimeoutBackoff", mdsclient_, userinfo, fopt);
 
     // 设置leaderid
     EndPoint ep;
@@ -945,7 +944,6 @@ TEST(TestLibcurveInterface, ResumeTimeoutBackoff) {
 
     fileinstance_.Close();
     fileinstance_.UnInitialize();
-    mdsclient_.UnInitialize();
     mds.UnInitialize();
     delete[] buffer;
 }


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Problem Summary:

After #172 and #209, source volume data of the clone volume can be read within the client through SourceReader, and each source volume was also opened and represented by a FileInstance, but `FileInstance::mdsclient_` points to `FileClient::mdsClient_`, so after FileClient is destroyed, `FileInstance::mdsclient_` becomes dangling pointer.

### What is changed and how it works?

What's Changed:

To fix this problem, we let `FileClient::mdsClient_` be a shared_ptr, and each FileInstance holds ownership of it.

Side effects(Breaking backward compatibility? Performance regression?): 

### Check List

- [x] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license
