### PR TITLE
client: explicit stop LeaseExecutor in FileInstance::UnInitialize

### DIFF
--- a/src/client/copyset_client.cpp
+++ b/src/client/copyset_client.cpp
@@ -54,7 +54,7 @@ int CopysetClient::Init(MetaCache *metaCache,
     iosenderopt_ = ioSenderOpt;
 
     LOG(INFO) << "CopysetClient init success, conf info: "
-              << ", chunkserverOPRetryIntervalUS = "
+                 "chunkserverOPRetryIntervalUS = "
               << iosenderopt_.failRequestOpt.chunkserverOPRetryIntervalUS
               << ", chunkserverOPMaxRetry = "
               << iosenderopt_.failRequestOpt.chunkserverOPMaxRetry

--- a/src/client/file_instance.cpp
+++ b/src/client/file_instance.cpp
@@ -26,13 +26,8 @@
 #include <glog/logging.h>
 #include <utility>
 
-#include "proto/nameserver2.pb.h"
-#include "proto/topology.pb.h"
 #include "src/client/iomanager4file.h"
 #include "src/client/mds_client.h"
-#include "src/client/metacache.h"
-#include "src/client/request_scheduler.h"
-#include "src/client/request_sender_manager.h"
 #include "src/common/timeutility.h"
 
 namespace curve {
@@ -99,6 +94,8 @@ bool FileInstance::Initialize(const std::string& filename,
 }
 
 void FileInstance::UnInitialize() {
+    StopLease();
+
     iomanager4file_.UnInitialize();
 
     // release the ownership of mdsclient
@@ -191,10 +188,7 @@ int FileInstance::Close() {
         return 0;
     }
 
-    if (leaseExecutor_ != nullptr) {
-        leaseExecutor_->Stop();
-        leaseExecutor_.reset();
-    }
+    StopLease();
 
     LIBCURVE_ERROR ret =
         mdsclient_->CloseFile(finfo_.fullPathName, finfo_.userinfo, "");
@@ -252,6 +246,13 @@ FileInstance* FileInstance::Open4Readonly(const FileServiceOption& opt,
     instance->GetIOManager4File()->UpdateFileInfo(fileInfo);
 
     return instance;
+}
+
+void FileInstance::StopLease() {
+    if (leaseExecutor_) {
+        leaseExecutor_->Stop();
+        leaseExecutor_.reset();
+    }
 }
 
 }   // namespace client

--- a/src/client/file_instance.h
+++ b/src/client/file_instance.h
@@ -163,6 +163,9 @@ class CURVE_CACHELINE_ALIGNMENT FileInstance {
                                        const UserInfo& userInfo);
 
  private:
+    void StopLease();
+
+ private:
     // 保存当前file的文件信息
     FInfo_t                 finfo_;
 

--- a/src/client/iomanager4file.cpp
+++ b/src/client/iomanager4file.cpp
@@ -87,7 +87,7 @@ bool IOManager4File::Initialize(const std::string& filename,
     discardTaskManager_.reset(
         new DiscardTaskManager(&(fileMetric_->discardMetric)));
 
-    LOG(INFO) << "iomanager init success! conf info: "
+    LOG(INFO) << "iomanager init success, conf info: "
               << "isolationTaskThreadPoolSize = "
               << ioopt_.taskThreadOpt.isolationTaskThreadPoolSize
               << ", isolationTaskQueueCapacity = "

--- a/src/client/lease_executor.h
+++ b/src/client/lease_executor.h
@@ -70,7 +70,7 @@ class LeaseExecutor {
      * @param: mdsclient是与mds续约的client
      * @param: iomanager会在续约失败或者版本变更的时候进行io调度
      */
-    LeaseExecutor(const LeaseOption& leaseOpt, UserInfo_t userinfo,
+    LeaseExecutor(const LeaseOption& leaseOpt, const UserInfo& userinfo,
                   MDSClient* mdscllent, IOManager4File* iomanager);
 
     ~LeaseExecutor();
@@ -83,11 +83,6 @@ class LeaseExecutor {
      * @return: 成功返回true，否则返回false
      */
     bool Start(const FInfo_t& fi, const LeaseSession_t&  lease);
-
-    /**
-     * 获取当前lease的sessionid信息，外围close文件的时候需要用到
-     */
-    std::string GetLeaseSessionID();
 
     /**
      * 停止续约

--- a/src/client/metacache.cpp
+++ b/src/client/metacache.cpp
@@ -45,8 +45,7 @@ void MetaCache::Init(const MetaCacheOption& metaCacheOpt,
                      MDSClient* mdsclient) {
     mdsclient_ = mdsclient;
     metacacheopt_ = metaCacheOpt;
-    LOG(INFO) << "metacache init success!"
-              << ", get leader retry times = "
+    LOG(INFO) << "metacache init success, get leader retry times = "
               << metacacheopt_.metacacheGetLeaderRetry
               << ", get leader retry interval us = "
               << metacacheopt_.metacacheRPCRetryIntervalUS

--- a/test/client/BUILD
+++ b/test/client/BUILD
@@ -284,6 +284,7 @@ cc_test(
         "//src/client:curve_client",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
+        "//test/client/mock:client_mock_lib",
     ],
 )
 

--- a/test/client/lease_executor_test.cpp
+++ b/test/client/lease_executor_test.cpp
@@ -23,53 +23,158 @@
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 #include <gtest/gtest.h>
+#include <brpc/server.h>
 
-#include "include/client/libcurve.h"
-#include "src/client/client_common.h"
-#include "src/client/config_info.h"
 #include "src/client/iomanager4file.h"
 #include "src/client/lease_executor.h"
-#include "src/client/libcurve_file.h"
 #include "src/client/mds_client.h"
+#include "test/client/mock/mock_namespace_service.h"
 
 namespace curve {
 namespace client {
 
-extern std::string mdsMetaServerAddr;
-extern uint32_t chunk_size;
-extern std::string configpath;
-extern curve::client::FileClient* globalclient;
+using ::testing::_;
+using ::testing::DoAll;
+using ::testing::Invoke;
+using ::testing::Return;
+using ::testing::ReturnArg;
+using ::testing::SaveArg;
+using ::testing::SaveArgPointee;
+using ::testing::SetArgPointee;
 
-using curve::mds::CurveFSService;
-using curve::mds::topology::TopologyService;
-using curve::mds::topology::GetChunkServerListInCopySetsResponse;
+static void MockRefreshSession(::google::protobuf::RpcController* controller,
+                               const curve::mds::ReFreshSessionRequest* request,
+                               curve::mds::ReFreshSessionResponse* response,
+                               ::google::protobuf::Closure* done) {
+    brpc::ClosureGuard guard(done);
 
-TEST(LeaseExecutorBaseTest, test_StartFailed) {
-    UserInfo_t userInfo;
-    MDSClient mdsClient;
-    FInfo fi;
-    fi.fullPathName = "/test_StartFailed";
-    IOManager4File io4File;
+    response->set_statuscode(curve::mds::StatusCode::kOK);
+    response->set_sessionid("");
+}
+
+class LeaseExecutorTest : public ::testing::Test {
+ protected:
+    void SetUp() override {
+        MetaServerOption mdsOpt;
+        mdsOpt.mdsAddrs.push_back(kSvrAddr);
+
+        userInfo_.owner = "test";
+
+        ASSERT_EQ(0, mdsClient_.Initialize(mdsOpt));
+        ASSERT_TRUE(io4File_.Initialize("/test", {}, &mdsClient_));
+        ASSERT_EQ(0, server_.AddService(&curveFsService_,
+                                        brpc::SERVER_DOESNT_OWN_SERVICE));
+        ASSERT_EQ(0, server_.Start(kSvrAddr, nullptr));
+    }
+
+    void TearDown() override {
+        ASSERT_NO_THROW(io4File_.UnInitialize());
+        ASSERT_NO_THROW(mdsClient_.UnInitialize());
+
+        server_.Stop(0);
+        server_.Join();
+    }
+
+    void PrepareMockService() {
+        curve::mds::FileInfo* fileInfo = new curve::mds::FileInfo();
+        fileInfo->set_filestatus(curve::mds::FileStatus::kFileCreated);
+        response_.set_allocated_fileinfo(fileInfo);
+
+        EXPECT_CALL(curveFsService_, RefreshSession(_, _, _, _))
+            .WillRepeatedly(DoAll(SetArgPointee<2>(response_),
+                                  Invoke(MockRefreshSession)));
+    }
+
+ protected:
+    const char* kSvrAddr = "127.0.0.1:21001";
+
+    brpc::Server server_;
+    curve::mds::MockNameService curveFsService_;
+    curve::mds::ReFreshSessionResponse response_;
+
+    MDSClient mdsClient_;
+    IOManager4File io4File_;
+    UserInfo userInfo_;
+    FInfo fi_;
+    LeaseOption leaseOpt_;
+    LeaseSession lease_;
+};
+
+TEST_F(LeaseExecutorTest, TestStartFailed) {
+    fi_.fullPathName = "/TestStartFailed";
 
     {
-        LeaseOption leaseOpt;
-        LeaseExecutor leaseExecutor(leaseOpt, userInfo, &mdsClient, &io4File);
+        leaseOpt_.mdsRefreshTimesPerLease = 100;
+        lease_.leaseTime = 0;
 
-        LeaseSession lease;
-        lease.leaseTime = 0;
-        ASSERT_FALSE(leaseExecutor.Start(fi, lease));
+        LeaseExecutor exec(leaseOpt_, userInfo_, &mdsClient_, &io4File_);
+        ASSERT_FALSE(exec.Start(fi_, lease_));
     }
 
     {
-        LeaseOption leaseOpt;
-        leaseOpt.mdsRefreshTimesPerLease = 0;
+        leaseOpt_.mdsRefreshTimesPerLease = 0;
+        lease_.leaseTime = 1000;
 
-        LeaseExecutor leaseExecutor(leaseOpt, userInfo, &mdsClient, &io4File);
-
-        LeaseSession lease;
-        lease.leaseTime = 1000;
-        ASSERT_FALSE(leaseExecutor.Start(fi, lease));
+        LeaseExecutor exec(leaseOpt_, userInfo_, &mdsClient_, &io4File_);
+        ASSERT_FALSE(exec.Start(fi_, lease_));
     }
+}
+
+TEST_F(LeaseExecutorTest, TestStartStop) {
+    PrepareMockService();
+
+    fi_.fullPathName = "/TestStartStop";
+    fi_.filestatus = FileStatus::Created;
+
+    leaseOpt_.mdsRefreshTimesPerLease = 1;
+    lease_.leaseTime = 5000000;
+
+    LeaseExecutor exec(leaseOpt_, userInfo_, &mdsClient_, &io4File_);
+    ASSERT_TRUE(exec.Start(fi_, lease_));
+
+    std::this_thread::sleep_for(std::chrono::seconds(20));
+
+    ASSERT_NO_FATAL_FAILURE(exec.Stop());
+}
+
+TEST_F(LeaseExecutorTest, TestMultiStop) {
+    PrepareMockService();
+
+    fi_.fullPathName = "/TestMultiStop";
+    fi_.filestatus = FileStatus::Created;
+
+    leaseOpt_.mdsRefreshTimesPerLease = 1;
+    lease_.leaseTime = 5000000;
+
+    LeaseExecutor exec(leaseOpt_, userInfo_, &mdsClient_, &io4File_);
+    ASSERT_TRUE(exec.Start(fi_, lease_));
+
+    std::this_thread::sleep_for(std::chrono::seconds(10));
+
+    ASSERT_NO_FATAL_FAILURE(exec.Stop());
+    ASSERT_NO_FATAL_FAILURE(exec.Stop());
+}
+
+TEST_F(LeaseExecutorTest, TestNoStop) {
+    PrepareMockService();
+
+    fi_.fullPathName = "/TestNoStop";
+    fi_.filestatus = FileStatus::Created;
+
+    leaseOpt_.mdsRefreshTimesPerLease = 1;
+    lease_.leaseTime = 5000000;
+
+    LeaseExecutor exec(leaseOpt_, userInfo_, &mdsClient_, &io4File_);
+    ASSERT_TRUE(exec.Start(fi_, lease_));
+
+    std::this_thread::sleep_for(std::chrono::seconds(10));
+
+    // does not explicit call exec.Stop(),
+    // because LeaseExecutor's destructor will implicit stop,
+    // so this test case will exit success rather than stuck forever
+    // if remove implicit stop in LeaseExecutor's destructor
+    // and uncomment the following code, this test case will stuck here
+    // ASSERT_NO_FATAL_FAILURE(exec.Stop());
 }
 
 }  // namespace client

--- a/test/resources.list
+++ b/test/resources.list
@@ -45,6 +45,8 @@ Used port list:
 
     client_test_unittest: 21000
 
+    lease_executor_test: 21001
+
     use port : 19500 - 19999
 
     mds_client_test : 9600, 9601


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Problem Summary:

When uninit FileClient and some files are not closed, in FileInstance's destructor it will destroy LeaseExecutor, but LeaseExecutor's destructor will wait for backend lease task to stop, so without explicit close a file, thread will be stuck here.

### What is changed and how it works?

What's Changed:

Explicit call `LeaseExecutor::Stop` in `FileInstance::UnInitialize`

Side effects(Breaking backward compatibility? Performance regression?): 

No

### Check List

- [x] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license
