### PR TITLE
fix out of range of the ChunkServerInfo, maybe chunkserver status is …

### DIFF
--- a/src/tools/status_tool.cpp
+++ b/src/tools/status_tool.cpp
@@ -702,7 +702,8 @@ int CheckUseWalPool(const std::map<PoolIdType, std::vector<ChunkServerInfo>>
                      bool *useChunkFilePoolAsWalPool,
                      std::shared_ptr<MetricClient> metricClient) {
     int ret = 0;
-    if (!poolChunkservers.empty()) {
+    if (!poolChunkservers.empty() &&
+        !poolChunkservers.begin()->second.empty()) {
         ChunkServerInfo chunkserver = poolChunkservers.begin()->second[0];
         std::string csAddr = chunkserver.hostip()
                             + ":" + std::to_string(chunkserver.port());
@@ -917,6 +918,7 @@ void StatusTool::PrintCsLeftSizeStatistics(const std::string& name,
         return;
     }
     for (const auto& leftSize : poolLeftSize) {
+        if (leftSize.second.empty()) continue;
         uint64_t min = leftSize.second[0];
         uint64_t max = leftSize.second[0];
         double sum = 0;


### PR DESCRIPTION
…'RETIRED'

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary: when chunkserver status was 'RETIRED', mdsclient will skip add chunkserverinfo into ChunkServerInfo list. 

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?): 

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
