### PR TITLE
client: fix a bvar name

### DIFF
--- a/src/client/libcurve_file.cpp
+++ b/src/client/libcurve_file.cpp
@@ -108,7 +108,7 @@ FileClient::FileClient()
       clientconfig_(),
       mdsClient_(),
       inited_(false),
-      openedFileNum_(common::ToHexString(this)) {}
+      openedFileNum_("open_file_num_" + common::ToHexString(this)) {}
 
 bool FileClient::CheckAligned(off_t offset, size_t length) const {
     return common::is_aligned(offset, kMinIOAlignment) &&


### PR DESCRIPTION
Prometheus doesn't support metric name like an address "0x556168fe1720"

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?): 

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
