### PR TITLE
Fs metaserver delete

### DIFF
--- a/curvefs/src/mds/metaserver_client.h
+++ b/curvefs/src/mds/metaserver_client.h
@@ -25,6 +25,7 @@
 
 #include <brpc/channel.h>
 #include <string>
+
 #include "curvefs/proto/mds.pb.h"
 #include "curvefs/proto/metaserver.pb.h"
 
@@ -39,7 +40,7 @@ struct MetaserverOptions {
 
 class MetaserverClient {
  public:
-    explicit MetaserverClient(const MetaserverOptions& option) {
+    explicit MetaserverClient(const MetaserverOptions &option) {
         options_ = option;
     }
 
@@ -59,4 +60,5 @@ class MetaserverClient {
 };
 }  // namespace mds
 }  // namespace curvefs
+
 #endif  // CURVEFS_SRC_MDS_METASERVER_CLIENT_H_

--- a/curvefs/src/metaserver/BUILD
+++ b/curvefs/src/metaserver/BUILD
@@ -53,6 +53,21 @@ cc_library(
     ],
 )
 
+cc_library(
+    name="metaserver_s3_lib",
+        hdrs=glob(["s3/*.h"]),
+        srcs=glob(["s3/*.cpp"]),
+        copts = COPTS,
+        visibility = ["//visibility:public"],
+        deps = [
+            "//external:glog",
+            "//external:gflags",
+            "//curvefs/proto:metaserver_cc_proto",
+            "//src/common:curve_s3_adapter",
+        ],
+        linkopts = ["-lpthread", "-L/usr/local/lib/x86_64-linux-gnu"],
+)
+
 cc_binary(
     name = "curvefs_metaserver",
     srcs = glob([

--- a/curvefs/src/metaserver/s3/metaserver_s3.cpp
+++ b/curvefs/src/metaserver/s3/metaserver_s3.cpp
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (c) 2020 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * Project: curve
+ * Created Date: 2021-8-13
+ * Author: chengyi
+ */
+
+#include "curvefs/src/metaserver/s3/metaserver_s3.h"
+
+namespace curvefs {
+namespace metaserver {
+void S3ClientImpl::Init(const curve::common::S3AdapterOption& option) {
+    s3Adapter_.Init(option);
+}
+
+int S3ClientImpl::Delete(const std::string& name) {
+    int ret = 0;
+    const Aws::String aws_key(name.c_str(), name.length());
+    LOG(INFO) << "delete start, aws_key: " << aws_key;
+    if (!s3Adapter_.ObjectExist(aws_key)) {
+        // the aws_key is not exist
+        LOG(INFO) << "delete object error, aws_key: " << aws_key
+                  << " is not exist";
+        return 1;
+    }
+    ret = s3Adapter_.DeleteObject(aws_key);
+    if (ret < 0) {
+        // -1
+        LOG(ERROR) << "delete object: " << aws_key << " get error:" << ret;
+    } else {
+        // 0
+        LOG(INFO) << "delete object: " << aws_key << " end, ret:" << ret;
+    }
+
+    return ret;
+}
+}  // namespace metaserver
+}  // namespace curvefs

--- a/curvefs/src/metaserver/s3/metaserver_s3.h
+++ b/curvefs/src/metaserver/s3/metaserver_s3.h
@@ -1,0 +1,63 @@
+/*
+ *  Copyright (c) 2020 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+/*
+ * Project: curve
+ * Created Date: 2021-8-13
+ * Author: chengyi
+ */
+
+#ifndef CURVEFS_SRC_METASERVER_S3_METASERVER_S3_H_
+#define CURVEFS_SRC_METASERVER_S3_METASERVER_S3_H_
+
+#include <string>
+
+#include "src/common/s3_adapter.h"
+
+namespace curvefs {
+namespace metaserver {
+class S3Client {
+ public:
+    S3Client() {}
+    virtual ~S3Client() {}
+    virtual void Init(const curve::common::S3AdapterOption &option) = 0;
+    virtual int Delete(const std::string &name) = 0;
+};
+
+class S3ClientImpl : public S3Client {
+ public:
+    S3ClientImpl() : S3Client() {}
+    virtual ~S3ClientImpl() {}
+
+    void Init(const curve::common::S3AdapterOption &option) override;
+    /**
+     * @brief
+     *
+     * @param name object_key
+     * @return int
+     *  1:  object is not exist
+     *  0:  delete sucess
+     *  -1: delete fail
+     * @details
+     */
+    int Delete(const std::string &name) override;
+
+ private:
+    curve::common::S3Adapter s3Adapter_;
+};
+}  // namespace metaserver
+}  // namespace curvefs
+
+#endif  // CURVEFS_SRC_METASERVER_S3_METASERVER_S3_H_

--- a/curvefs/src/metaserver/s3/metaserver_s3_adaptor.cpp
+++ b/curvefs/src/metaserver/s3/metaserver_s3_adaptor.cpp
@@ -1,0 +1,100 @@
+/*
+ *  Copyright (c) 2020 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * Project: curve
+ * Created Date: 2021-8-13
+ * Author: chengyi
+ */
+
+#include "curvefs/src/metaserver/s3/metaserver_s3_adaptor.h"
+
+namespace curvefs {
+namespace metaserver {
+void S3ClientAdaptorImpl::Init(const S3ClientAdaptorOption& option,
+                               S3Client* client) {
+    blockSize_ = option.blockSize;
+    chunkSize_ = option.chunkSize;
+    client_ = client;
+}
+
+int S3ClientAdaptorImpl::Delete(const Inode& inode) {
+    const S3ChunkInfoList& s3ChunkInfolist = inode.s3chunkinfolist();
+    LOG(INFO) << "delete data, inode id: " << inode.inodeid()
+              << ", len:" << inode.length();
+
+    int ret = 0;
+    for (int i = 0; i < s3ChunkInfolist.s3chunks_size(); ++i) {
+        // traverse chunks to delete blocks
+        S3ChunkInfo chunkInfo = s3ChunkInfolist.s3chunks(i);
+        // delete chunkInfo from client
+        uint64_t chunkId = chunkInfo.chunkid();
+        uint64_t version = chunkInfo.version();
+        uint64_t chunkPos = chunkInfo.offset() % chunkSize_;
+        uint64_t length = chunkInfo.len();
+        int delStat = DeleteChunk(chunkId, version, chunkPos, length);
+        if (delStat < 0) {
+            LOG(ERROR) << "delete chunk failed, status code is: " << delStat
+                       << " , chunkId is " << chunkId;
+            ret = -1;
+        }
+    }
+    return ret;
+}
+
+int S3ClientAdaptorImpl::DeleteChunk(uint64_t chunkId, uint64_t version,
+                                     uint64_t chunkPos, uint64_t length) {
+    uint64_t blockIndex = chunkPos / blockSize_;
+    uint64_t blockPos = chunkPos % blockSize_;
+    LOG(INFO) << "delete Chunk start, chunk id: " << chunkId
+              << ", verison: " << version << ", chunkPos: " << chunkPos
+              << ", length: " << length;
+    int count = 0;  // blocks' number
+    int ret = 0;
+    while (length > blockSize_ * count - blockPos || count == 0) {
+        // divide chunks to blocks, and delete these blocks
+        std::string objectName =
+            GenerateObjectName(chunkId, blockIndex, version);
+        int delStat = client_->Delete(objectName);
+        if (delStat < 0) {
+            // fail
+            LOG(ERROR) << "delete object fail. object: " << objectName;
+            ret = -1;
+        } else if (delStat > 0) {  // delSat == 1
+            // object is not exist
+            // 1. overwrite，the object is delete by others
+            // 2. last delete failed
+            // 3. others
+            LOG(INFO) << "object: " << objectName << ", has been deleted.";
+            ret = 1;
+        }
+
+        ++blockIndex;
+        ++count;
+    }
+
+    return ret;
+}
+
+std::string S3ClientAdaptorImpl::GenerateObjectName(uint64_t chunkId,
+                                                    uint64_t blockIndex,
+                                                    uint64_t version) {
+    std::ostringstream oss;
+    oss << chunkId << "_" << blockIndex << "_" << version;
+    return oss.str();
+}
+}  // namespace metaserver
+}  // namespace curvefs

--- a/curvefs/src/metaserver/s3/metaserver_s3_adaptor.h
+++ b/curvefs/src/metaserver/s3/metaserver_s3_adaptor.h
@@ -1,0 +1,109 @@
+#ifndef CURVEFS_SRC_METASERVER_S3_METASERVER_S3_ADAPTOR_H_
+#define CURVEFS_SRC_METASERVER_S3_METASERVER_S3_ADAPTOR_H_
+
+/*
+ *  Copyright (c) 2020 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * Project: curve
+ * Created Date: 2021-8-13
+ * Author: chengyi
+ */
+#include <string>
+
+#include "curvefs/proto/metaserver.pb.h"
+#include "curvefs/src/metaserver/s3/metaserver_s3.h"
+
+namespace curvefs {
+namespace metaserver {
+
+struct S3ClientAdaptorOption {
+    uint64_t blockSize;
+    uint64_t chunkSize;
+};
+
+class S3ClientAdaptor {
+ public:
+    S3ClientAdaptor() {}
+    virtual ~S3ClientAdaptor() {}
+
+    /**
+     * @brief Initialize s3 client
+     * @param[in] options the options for s3 client
+     */
+    virtual void Init(const S3ClientAdaptorOption& option,
+                      S3Client* client) = 0;
+
+    /**
+     * @brief delete inode from s3
+     * @param inode
+     * @return int
+     *  0   : delete sucess
+     *  -1  : delete fail
+     * @details
+     * Step.1 get indoe' s3chunkInfoList
+     * Step.2 delete chunk from s3 client
+     */
+    virtual int Delete(const Inode& inode) = 0;
+};
+
+class S3ClientAdaptorImpl : public S3ClientAdaptor {
+ public:
+    S3ClientAdaptorImpl() {}
+    ~S3ClientAdaptorImpl() {
+        if (client_ != nullptr) {
+            delete client_;
+            client_ = nullptr;
+        }
+    }
+
+    /**
+     * @brief Initialize s3 client
+     * @param[in] options the options for s3 client
+     */
+    void Init(const S3ClientAdaptorOption& option, S3Client* client) override;
+
+    /**
+     * @brief delete inode from s3
+     * @param inode
+     * @return int
+     * @details
+     * Step.1 get indoe' s3chunkInfoList
+     * Step.2 delete chunk from s3 client
+     */
+    int Delete(const Inode& inode) override;
+
+ private:
+    /**
+     * @brief  delete chunk from client
+     * @return int
+     *  0   : delete sucess or some objects are not exist
+     *  -1  : some objects delete fail
+     * @param[in] options the options for s3 client
+     */
+    int DeleteChunk(uint64_t chunkId, uint64_t version, uint64_t chunkPos,
+                    uint64_t length);
+    std::string GenerateObjectName(uint64_t chunkId, uint64_t blockIndex,
+                                   uint64_t version);
+
+    S3Client* client_;
+    uint64_t blockSize_;
+    uint64_t chunkSize_;
+};
+}  // namespace metaserver
+}  // namespace curvefs
+
+#endif  // CURVEFS_SRC_METASERVER_S3_METASERVER_S3_ADAPTOR_H_

--- a/curvefs/test/client/BUILD
+++ b/curvefs/test/client/BUILD
@@ -56,6 +56,26 @@ cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
+cc_library(
+    name = "client_s3_test_lib",
+    srcs = glob([
+        "mock_client_s3.h",
+        "mock_metaserver_service.h",
+        "mock_spacealloc_service.h",
+    ]),
+    copts = COPTS,
+    defines = ["UNIT_TEST"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//external:gtest",
+         "//curvefs/src/client:fuse_client_lib",
+        "//curvefs/proto:metaserver_cc_proto",
+        "//curvefs/proto:mds_cc_proto",
+        "//curvefs/proto:space_cc_proto",
+    ],
+    linkopts = ["-lpthread",
+                "-L/usr/local/lib/x86_64-linux-gnu"],
+)
 
 cc_binary(
     name = "client_s3_test",
@@ -73,6 +93,7 @@ cc_binary(
         "//curvefs/proto:metaserver_cc_proto",
         "//curvefs/proto:mds_cc_proto",
         "//curvefs/proto:space_cc_proto",
+        "//test/client/mock:client_mock_lib",
     ],
     linkopts = ["-lpthread",
                 "-L/usr/local/lib/x86_64-linux-gnu"],

--- a/curvefs/test/metaserver/BUILD
+++ b/curvefs/test/metaserver/BUILD
@@ -46,7 +46,13 @@ cc_test(
         exclude = [
             "dumpfile_test.cpp",
             "storage_test.cpp",
-            "metastore_test.cpp"
+            "metastore_test.cpp",
+            "mock_client_s3.h",
+            "mock_metaserver_s3.h",
+            "metaserver_s3_adaptor_test.h",
+            "metaserver_s3_adaptor_test.cpp",
+            "mock_metaserver_s3_adaptor.h"
+            
         ],
     ),
     copts = ["-g","-DHAVE_ZLIB=1"],
@@ -55,6 +61,40 @@ cc_test(
             "@com_google_googletest//:gtest_main",
             "@com_google_googletest//:gtest",
             "//external:brpc",
+    ],
+)
+
+# s3 adaptor
+cc_test(
+    name = "metaserver_s3_adaptor_test",
+    srcs = glob([
+        "mock_metaserver_s3.h",
+        "metaserver_s3_adaptor_test.h",
+        "metaserver_s3_adaptor_test.cpp",
+        "curvefs/test/client/mock_client_s3.h",
+        "mock_metaserver_s3_adaptor.h",
+    ]),
+    copts = COPTS,
+    defines = ["UNIT_TEST"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+        "//external:brpc",
+        "//external:glog",
+        "//external:gflags",
+        "//include/client:include_client",
+        "//src/common:curve_s3_adapter",
+        "//src/client:curve_client",
+        "//curvefs/src/client:fuse_client_lib",
+        "//curvefs/src/metaserver:metaserver_s3_lib",
+        "//curvefs/test/client:client_s3_test_lib",
+        "//test/client/mock:client_mock_lib",
+    ],
+    linkopts = [
+        "-lfuse3",
+        "-lpthread",
+        "-L/usr/local/lib/x86_64-linux-gnu",
     ],
 )
 

--- a/curvefs/test/metaserver/metaserver_s3_adaptor_test.cpp
+++ b/curvefs/test/metaserver/metaserver_s3_adaptor_test.cpp
@@ -1,0 +1,353 @@
+/*
+ *  Copyright (c) 2020 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+/*
+ * Project: curve
+ * Created Date: 2021-8-13
+ * Author: chengyi
+ */
+
+#include "curvefs/test/metaserver/metaserver_s3_adaptor_test.h"
+
+namespace curvefs {
+namespace metaserver {
+
+class MetaserverS3AdaptorTest : public testing::Test {
+ protected:
+    void SetUp() override {
+        ASSERT_EQ(0, server_.AddService(&mockMetaServerService_,
+                                        brpc::SERVER_DOESNT_OWN_SERVICE));
+        ASSERT_EQ(0, server_.AddService(&mockSpaceAllocService_,
+                                        brpc::SERVER_DOESNT_OWN_SERVICE));
+        ASSERT_EQ(0, server_.Start(addr_.c_str(), nullptr));
+
+        S3ClientAdaptorOption option;
+        option.blockSize = 1 * 1024 * 1024;
+        option.chunkSize = 4 * 1024 * 1024;
+        metaserverS3ClientAdaptor_ = new S3ClientAdaptorImpl();
+        metaserverS3ClientAdaptor_->Init(option, &mockMetaserverS3Client_);
+
+        client::S3ClientAdaptorOption option_client;
+        option_client.blockSize = 1 * 1024 * 1024;
+        option_client.chunkSize = 4 * 1024 * 1024;
+        option_client.metaServerEps = addr_;
+        option_client.allocateServerEps = addr_;
+        clientS3ClientAdaptor_ = new client::S3ClientAdaptorImpl();
+        clientS3ClientAdaptor_->Init(option_client, &mockClientS3Client_);
+    }
+
+    void TearDown() override {
+        server_.Stop(0);
+        server_.Join();
+        if (metaserverS3ClientAdaptor_ != nullptr) {
+            delete metaserverS3ClientAdaptor_;
+        }
+    }
+
+ protected:
+    S3ClientAdaptor* metaserverS3ClientAdaptor_;
+    client::S3ClientAdaptor* clientS3ClientAdaptor_;
+    MockS3Client mockMetaserverS3Client_;
+    client::MockS3Client mockClientS3Client_;
+
+    client::MockMetaServerService mockMetaServerService_;
+    client::MockSpaceAllocService mockSpaceAllocService_;
+    std::string addr_ = "127.0.0.1:5629";
+    brpc::Server server_;
+};
+
+void InitInode(Inode* inode) {
+    inode->set_inodeid(1);
+    inode->set_fsid(2);
+    inode->set_length(0);
+    inode->set_ctime(1623835517);
+    inode->set_mtime(1623835517);
+    inode->set_atime(1623835517);
+    inode->set_uid(1);
+    inode->set_gid(1);
+    inode->set_mode(1);
+    inode->set_nlink(1);
+    inode->set_type(curvefs::metaserver::FsFileType::TYPE_S3);
+}
+
+// delete chunks
+TEST_F(MetaserverS3AdaptorTest, test_delete_chunks) {
+    // Init
+    curvefs::metaserver::Inode inode;
+    InitInode(&inode);
+
+    /*
+    1. write 3MB+1 from 0; (write)
+    2. write 2MB+1 from 2MB+2; (overwrite）
+    3. write 1MB+1 from 4MB+3; (append)
+    */
+    const uint64_t FileLen = 5 * 1024 * 1024 + 4;
+    inode.set_length(FileLen);
+    S3ChunkInfoList* s3ChunkInfoList = new S3ChunkInfoList();
+    // 1. 1_0_0 1_1_0 1_2_0 1_3_0
+    S3ChunkInfo* s3ChunkInfo1 = s3ChunkInfoList->add_s3chunks();
+    s3ChunkInfo1->set_chunkid(1);
+    s3ChunkInfo1->set_version(0);
+    s3ChunkInfo1->set_offset(0);
+    const uint64_t first_len = 3 * 1024 * 1024 + 1;
+    s3ChunkInfo1->set_len(first_len);
+    s3ChunkInfo1->set_size(first_len);
+    // 2. 1_2_1 1_3_1  2_0_1
+    S3ChunkInfo* s3ChunkInfo2 = s3ChunkInfoList->add_s3chunks();
+    s3ChunkInfo2->set_chunkid(1);
+    s3ChunkInfo2->set_version(1);
+    s3ChunkInfo2->set_offset(2 * 1024 * 1024 + 2);
+    s3ChunkInfo2->set_len(4 * 1024 * 1024 - 2 * 1024 * 1024 - 2);
+    s3ChunkInfo2->set_size(4 * 1024 * 1024 - 2 * 1024 * 1024 - 2);
+    S3ChunkInfo* s3ChunkInfo3 = s3ChunkInfoList->add_s3chunks();
+    s3ChunkInfo3->set_chunkid(2);
+    s3ChunkInfo3->set_version(1);
+    s3ChunkInfo3->set_offset(4 * 1024 * 1024);
+    s3ChunkInfo3->set_len(3);
+    s3ChunkInfo3->set_size(3);
+    // 3. 2_0_1 2_1_1
+    S3ChunkInfo* s3ChunkInfo4 = s3ChunkInfoList->add_s3chunks();
+    s3ChunkInfo4->set_chunkid(2);
+    s3ChunkInfo4->set_version(1);
+    s3ChunkInfo4->set_offset(4 * 1024 * 1024 + 3);
+    s3ChunkInfo4->set_len(1 * 1024 * 1024 + 1);
+    s3ChunkInfo4->set_size(1 * 1024 * 1024 + 1);
+
+    inode.set_allocated_s3chunkinfolist(s3ChunkInfoList);
+
+    // replace s3 delete
+    std::function<int(std::string)> delete_object = [](std::string name) {
+        LOG(INFO) << "delete object, name:" << name;
+        return 0;
+    };
+    EXPECT_CALL(mockMetaserverS3Client_, Delete(_))
+        .Times(9)
+        .WillRepeatedly(Invoke(delete_object));
+    int ret = metaserverS3ClientAdaptor_->Delete(inode);
+    ASSERT_EQ(ret, 0);
+}
+
+// write and delete
+TEST_F(MetaserverS3AdaptorTest, test_write_delete_chunks) {
+    // write first
+
+    // init
+    global_chunk_id_ = global_version_ = 0;
+    ::curvefs::space::AllocateS3ChunkResponse resp_alloc;
+    resp_alloc.set_status(::curvefs::space::SpaceStatusCode::SPACE_OK);
+    EXPECT_CALL(mockSpaceAllocService_, AllocateS3Chunk(_, _, _, _))
+        .WillRepeatedly(DoAll(
+            SetArgPointee<2>(resp_alloc),
+            Invoke(S3RpcService_ChunkId<space::AllocateS3ChunkRequest,
+                                        space::AllocateS3ChunkResponse>)));
+
+    ::curvefs::metaserver::UpdateInodeS3VersionResponse resp_version;
+    resp_version.set_statuscode(::curvefs::metaserver::MetaStatusCode::OK);
+    EXPECT_CALL(mockMetaServerService_, UpdateInodeS3Version(_, _, _, _))
+        .WillRepeatedly(
+            DoAll(SetArgPointee<2>(resp_version),
+                  Invoke(S3RpcService_Version<UpdateInodeS3VersionRequest,
+                                              UpdateInodeS3VersionResponse>)));
+    std::set<std::string> uploadObject;
+    std::function<int(std::string, const char*, uint64_t)> upload_object =
+        [&uploadObject](std::string name, const char* buf, uint64_t length) {
+            LOG(INFO) << "upload object, name:" << name;
+            uploadObject.insert(name);
+            std::string data(buf, length);
+            return data.length();
+        };
+    std::function<int(std::string, const char*, uint64_t)> append_object =
+        [&uploadObject](std::string name, const char* buf, uint64_t length) {
+            LOG(INFO) << "append object, name:" << name;
+            uploadObject.insert(name);
+            std::string data(buf, length);
+            return data.length();
+        };
+    EXPECT_CALL(mockClientS3Client_, Upload(_, _, _))
+        .WillRepeatedly(Invoke(upload_object));
+    EXPECT_CALL(mockClientS3Client_, Append(_, _, _))
+        .WillRepeatedly(Invoke(append_object));
+
+    // replace s3 delete
+    std::set<std::string> deleteObject;
+    std::function<int(std::string)> delete_object =
+        [&deleteObject](std::string name) {
+            LOG(INFO) << "delete object, name:" << name;
+            deleteObject.insert(name);
+            return 0;
+        };
+    EXPECT_CALL(mockMetaserverS3Client_, Delete(_))
+        .WillRepeatedly(Invoke(delete_object));
+
+    curvefs::metaserver::Inode inode;
+    InitInode(&inode);
+
+    /*
+    1. write 3MB+1 from 0; (write)
+    2. write 2MB+1 from 2MB+2; (overwrite）
+    3. write 1MB+1 from 4MB+3; (append)
+  */
+    char* buf;
+    uint64_t offset = 0;
+    uint64_t fileLen = 3 * 1024 * 1024 + 1;
+    buf = new char[fileLen];
+    memset(buf, 'a', fileLen);
+    clientS3ClientAdaptor_->Write(&inode, offset, fileLen - offset, buf);
+    inode.set_length(fileLen);
+    delete[] buf;
+
+    offset = 2 * 1024 * 1024 + 2;
+    fileLen = 2 * 1024 * 1024 + 2 + 2 * 1024 * 1024 + 1;
+    buf = new char[fileLen];
+    memset(buf, 'b', fileLen);
+    clientS3ClientAdaptor_->Write(&inode, offset, fileLen - offset, buf);
+    inode.set_length(fileLen);
+    delete[] buf;
+
+    offset = 4 * 1024 * 1024 + 3;
+    fileLen = 4 * 1024 * 1024 + 3 + 1 * 1024 * 1024 + 1;
+    buf = new char[fileLen];
+    memset(buf, 'c', fileLen);
+    clientS3ClientAdaptor_->Write(&inode, offset, fileLen - offset, buf);
+    inode.set_length(fileLen);
+    delete[] buf;
+
+    /*
+    1. write 3MB+1 from 0; (write)
+    2. write 2MB+1 from 2MB+2; (overwrite）
+    3. write 1MB+1 from 4MB+3; (append)
+    */
+
+    int ret = metaserverS3ClientAdaptor_->Delete(inode);
+    ASSERT_EQ(ret, 0);
+    ASSERT_EQ(uploadObject, deleteObject);
+}
+
+// an idempotence test
+TEST_F(MetaserverS3AdaptorTest, test_delete_idempotence) {
+    // init
+    global_chunk_id_ = global_version_ = 0;
+    ::curvefs::space::AllocateS3ChunkResponse resp_alloc;
+    resp_alloc.set_status(::curvefs::space::SpaceStatusCode::SPACE_OK);
+    EXPECT_CALL(mockSpaceAllocService_, AllocateS3Chunk(_, _, _, _))
+        .WillRepeatedly(DoAll(
+            SetArgPointee<2>(resp_alloc),
+            Invoke(S3RpcService_ChunkId<space::AllocateS3ChunkRequest,
+                                        space::AllocateS3ChunkResponse>)));
+
+    ::curvefs::metaserver::UpdateInodeS3VersionResponse resp_version;
+    resp_version.set_statuscode(::curvefs::metaserver::MetaStatusCode::OK);
+    EXPECT_CALL(mockMetaServerService_, UpdateInodeS3Version(_, _, _, _))
+        .WillRepeatedly(
+            DoAll(SetArgPointee<2>(resp_version),
+                  Invoke(S3RpcService_Version<UpdateInodeS3VersionRequest,
+                                              UpdateInodeS3VersionResponse>)));
+    std::set<std::string> uploadObject;
+    std::function<int(std::string, const char*, uint64_t)> upload_object =
+        [&uploadObject](std::string name, const char* buf, uint64_t length) {
+            LOG(INFO) << "upload object, name:" << name;
+            uploadObject.insert(name);
+            std::string data(buf, length);
+            return data.length();
+        };
+    std::function<int(std::string, const char*, uint64_t)> append_object =
+        [&uploadObject](std::string name, const char* buf, uint64_t length) {
+            LOG(INFO) << "append object, name:" << name;
+            uploadObject.insert(name);
+            std::string data(buf, length);
+            return data.length();
+        };
+    EXPECT_CALL(mockClientS3Client_, Upload(_, _, _))
+        .WillRepeatedly(Invoke(upload_object));
+    EXPECT_CALL(mockClientS3Client_, Append(_, _, _))
+        .WillRepeatedly(Invoke(append_object));
+
+    // replace s3 delete
+    // when name == fail_del_name, should be delete or not
+    const std::string fail_del_name = "2_0_1";
+    bool deleted = true;
+    std::set<std::string> deleteObject;
+    std::function<int(std::string)> delete_object =
+        [&deleteObject, fail_del_name, &deleted](std::string name) {
+            int ret = 0;
+            if (deleted && fail_del_name == name) {
+                LOG(INFO) << "delete object fail, name: " << name;
+                deleted = false;
+                ret = -1;
+            } else {
+                LOG(INFO) << "delete object sucess, name: " << name;
+                deleteObject.insert(name);
+            }
+            return ret;
+        };
+    EXPECT_CALL(mockMetaserverS3Client_, Delete(_))
+        .WillRepeatedly(Invoke(delete_object));
+
+    curvefs::metaserver::Inode inode;
+    InitInode(&inode);
+
+    /*
+    1. write 3MB+1 from 0; (write)
+    2. write 2MB+1 from 2MB+2; (overwrite）
+    3. write 1MB+1 from 4MB+3; (append)
+  */
+    char* buf;
+    uint64_t offset = 0;
+    uint64_t fileLen = 3 * 1024 * 1024 + 1;
+    buf = new char[fileLen];
+    memset(buf, 'a', fileLen);
+    clientS3ClientAdaptor_->Write(&inode, offset, fileLen - offset, buf);
+    inode.set_length(fileLen);
+    delete[] buf;
+
+    offset = 2 * 1024 * 1024 + 2;
+    fileLen = 2 * 1024 * 1024 + 2 + 2 * 1024 * 1024 + 1;
+    buf = new char[fileLen];
+    memset(buf, 'b', fileLen);
+    clientS3ClientAdaptor_->Write(&inode, offset, fileLen - offset, buf);
+    inode.set_length(fileLen);
+    delete[] buf;
+
+    offset = 4 * 1024 * 1024 + 3;
+    fileLen = 4 * 1024 * 1024 + 3 + 1 * 1024 * 1024 + 1;
+    buf = new char[fileLen];
+    memset(buf, 'c', fileLen);
+    clientS3ClientAdaptor_->Write(&inode, offset, fileLen - offset, buf);
+    inode.set_length(fileLen);
+    delete[] buf;
+
+    /*
+    1. write 3MB+1 from 0; (write)
+    2. write 2MB+1 from 2MB+2; (overwrite）
+    3. write 1MB+1 from 4MB+3; (append)
+    */
+    int ret = 0;
+    do {
+        ret = metaserverS3ClientAdaptor_->Delete(inode);
+    } while (ret < 0);
+
+    ASSERT_EQ(ret, 0);
+    ASSERT_EQ(uploadObject, deleteObject);
+}
+
+}  // namespace metaserver
+}  // namespace curvefs
+
+int main(int argc, char** argv) {
+    testing::InitGoogleTest(&argc, argv);
+    google::ParseCommandLineFlags(&argc, &argv, false);
+
+    return RUN_ALL_TESTS();
+}

--- a/curvefs/test/metaserver/metaserver_s3_adaptor_test.h
+++ b/curvefs/test/metaserver/metaserver_s3_adaptor_test.h
@@ -1,0 +1,98 @@
+/*
+ *  Copyright (c) 2020 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+/*
+ * Project: curve
+ * Created Date: 2021-8-13
+ * Author: chengyi
+ */
+#ifndef CURVEFS_TEST_METASERVER_METASERVER_S3_ADAPTOR_TEST_H_
+#define CURVEFS_TEST_METASERVER_METASERVER_S3_ADAPTOR_TEST_H_
+
+#include <brpc/server.h>
+#include <google/protobuf/util/message_differencer.h>
+#include <gtest/gtest.h>
+
+#include <functional>
+#include <set>
+#include <string>
+
+#include "curvefs/src/client/s3/client_s3_adaptor.h"
+#include "curvefs/src/metaserver/s3/metaserver_s3_adaptor.h"
+#include "curvefs/test/client/mock_client_s3.h"
+#include "curvefs/test/client/mock_metaserver_service.h"
+#include "curvefs/test/client/mock_spacealloc_service.h"
+#include "curvefs/test/metaserver/mock_metaserver_s3.h"
+
+namespace curvefs {
+namespace metaserver {
+
+using ::testing::_;
+using ::testing::DoAll;
+using ::testing::Invoke;
+using ::testing::Return;
+using ::testing::SetArgPointee;
+
+template <typename RpcRequestType, typename RpcResponseType,
+          bool RpcFailed = false>
+void S3RpcService(google::protobuf::RpcController* cntl_base,
+                  const RpcRequestType* request, RpcResponseType* response,
+                  google::protobuf::Closure* done) {
+    if (RpcFailed) {
+        brpc::Controller* cntl = static_cast<brpc::Controller*>(cntl_base);
+        cntl->SetFailed(112, "Not connected to");
+    }
+    LOG(INFO) << "run s3 prc service, response.chunkid:" << response->chunkid();
+    done->Run();
+}
+
+// use global_chunk_id_ to record chunk id
+uint64_t global_chunk_id_ = 0;
+template <typename RpcRequestType, typename RpcResponseType,
+          bool RpcFailed = false>
+void S3RpcService_ChunkId(google::protobuf::RpcController* cntl_base,
+                          const RpcRequestType* request,
+                          RpcResponseType* response,
+                          google::protobuf::Closure* done) {
+    if (RpcFailed) {
+        brpc::Controller* cntl = static_cast<brpc::Controller*>(cntl_base);
+        cntl->SetFailed(112, "Not connected to");
+    }
+    response->set_chunkid(++global_chunk_id_);
+    LOG(INFO) << "run s3 prc service, response.chunkid: "
+              << response->chunkid();
+    done->Run();
+}
+
+// use global_version_ to record version
+uint64_t global_version_ = 0;
+template <typename RpcRequestType, typename RpcResponseType,
+          bool RpcFailed = false>
+void S3RpcService_Version(google::protobuf::RpcController* cntl_base,
+                          const RpcRequestType* request,
+                          RpcResponseType* response,
+                          google::protobuf::Closure* done) {
+    if (RpcFailed) {
+        brpc::Controller* cntl = static_cast<brpc::Controller*>(cntl_base);
+        cntl->SetFailed(112, "Not connected to");
+    }
+    response->set_version(++global_version_);
+    LOG(INFO) << "run s3 prc service, response.version:" << response->version();
+    done->Run();
+}
+
+}  // namespace metaserver
+}  // namespace curvefs
+#endif  // CURVEFS_TEST_METASERVER_METASERVER_S3_ADAPTOR_TEST_H_

--- a/curvefs/test/metaserver/moc_metaserver_s3_adaptor.h
+++ b/curvefs/test/metaserver/moc_metaserver_s3_adaptor.h
@@ -16,17 +16,16 @@
 
 /*
  * Project: curve
- * Created Date: Thur May 27 2021
- * Author: xuchaojie
+ * Created Date: 2021-8-16
+ * Author: chengyi
  */
+#ifndef CURVEFS_TEST_METASERVER_MOC_METASERVER_S3_ADAPTOR_H_
+#define CURVEFS_TEST_METASERVER_MOC_METASERVER_S3_ADAPTOR_H_
 
-#ifndef CURVEFS_TEST_CLIENT_MOCK_CLIENT_S3_ADAPTOR_H_
-#define CURVEFS_TEST_CLIENT_MOCK_CLIENT_S3_ADAPTOR_H_
-
-#include "curvefs/src/client/s3/client_s3_adaptor.h"
+#include "curvefs/src/metaserver/s3/client_s3_adaptor.h"
 
 namespace curvefs {
-namespace client {
+namespace metaserver {
 
 class MockS3ClientAdaptor : public S3ClientAdaptor {
  public:
@@ -34,17 +33,11 @@ class MockS3ClientAdaptor : public S3ClientAdaptor {
     ~MockS3ClientAdaptor() {}
 
     MOCK_METHOD2(Init,
-                 void(const S3ClientAdaptorOption& option, S3Client* client));
-
-    MOCK_METHOD4(Write, int(Inode* inode, uint64_t offset, uint64_t length,
-                            const char* buf));
-
-    MOCK_METHOD4(Read, int(Inode* inode, uint64_t offset, uint64_t length,
-                           char* buf));
-    MOCK_METHOD2(Truncate, int(Inode* inode, uint64_t length));
+                 void(const S3ClientAdaptorOption option, S3Client *client));
+    MOCK_METHOD1(Delete, int(Inode *inode));
 };
 
-}  // namespace client
+}  // namespace metaserver
 }  // namespace curvefs
 
-#endif  // CURVEFS_TEST_CLIENT_MOCK_CLIENT_S3_ADAPTOR_H_
+#endif  // CURVEFS_TEST_METASERVER_MOC_METASERVER_S3_ADAPTOR_H_

--- a/curvefs/test/metaserver/mock_metaserver_s3.h
+++ b/curvefs/test/metaserver/mock_metaserver_s3.h
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (c) 2020 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * Project: curve
+ * Created Date: 2021-8-13
+ * Author: chengyi
+ */
+
+#ifndef CURVEFS_TEST_METASERVER_MOCK_METASERVER_S3_H_
+#define CURVEFS_TEST_METASERVER_MOCK_METASERVER_S3_H_
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <string>
+
+#include "curvefs/src/metaserver/s3/metaserver_s3.h"
+
+using ::testing::_;
+using ::testing::Return;
+
+namespace curvefs {
+namespace metaserver {
+class MockS3Client : public S3Client {
+ public:
+    MockS3Client() {}
+    ~MockS3Client() {}
+
+    MOCK_METHOD1(Init, void(const curve::common::S3AdapterOption &options));
+    MOCK_METHOD1(Delete, int(const std::string &name));
+};
+}  // namespace metaserver
+}  // namespace curvefs
+
+#endif  // CURVEFS_TEST_METASERVER_MOCK_METASERVER_S3_H_


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Problem Summary:

metaserver deletes objects from S3,  thses objects belong to inode

### What is changed and how it works?

use delete(inode) function. 

What's Changed:
curvefs/src/metaserver/s3/metaserver_s3_adaptor.h
curvefs/src/metaserver/s3/metaserver_s3_adaptor.cpp
curvefs/src/metaserver/s3/metaserver_s3.cpp
curvefs/src/metaserver/s3/metaserver_s3.h

How it Works:

Side effects(Breaking backward compatibility? Performance regression?): 

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
