### PR TITLE
chunkid to etcd

### DIFF
--- a/curvefs/conf/curvefs_client.conf
+++ b/curvefs/conf/curvefs_client.conf
@@ -68,3 +68,11 @@ s3.throttle.iopsWriteLimit=0
 s3.throttle.bpsTotalMB=0
 s3.throttle.bpsReadMB=0
 s3.throttle.bpsWriteMB=0
+
+#
+# etcd configure
+#
+etcd.endpoint=127.0.0.1:2379
+etcd.dailtimeoutMs=100
+etcd.operation.timeoutMs=100
+etcd.retry.times=3

--- a/curvefs/conf/mds.conf
+++ b/curvefs/conf/mds.conf
@@ -35,3 +35,4 @@ etcd.retry.times=3
 #### leader election options
 leader.sessionInterSec=5
 leader.electionTimeoutMs=0
+

--- a/curvefs/proto/mds.proto
+++ b/curvefs/proto/mds.proto
@@ -41,6 +41,7 @@ enum FSStatusCode {
     INODE_EXIST = 18;
     INTERNAL_ERROR = 19;
     STORAGE_ERROR = 20;
+    ALLOCATE_CHUNKID_ERROR = 21;
 }
 
 // fs interface
@@ -156,6 +157,16 @@ message CreatePartitionResponse {
     required FSStatusCode statusCode = 1;
     repeated common.PartitionInfo partitionInfoList = 2;
 }
+message AllocateS3ChunkRequest {
+    required uint32 fsId = 1;
+}
+
+message AllocateS3ChunkResponse {
+    // status code, default value is FSStatusCode::UNKNOWN_ERROR
+   required FSStatusCode status = 1;
+   required uint64 chunkId = 2;
+}
+
 
 service MdsService {
     // fs interface
@@ -167,4 +178,5 @@ service MdsService {
     rpc CreatePartition(CreatePartitionRequest) returns (CreatePartitionResponse);
     rpc DeleteFs(DeleteFsRequest) returns (DeleteFsResponse);
     rpc CommitTx(CommitTxRequest) returns (CommitTxResponse);
+    rpc AllocateS3Chunk(AllocateS3ChunkRequest) returns (AllocateS3ChunkResponse);
 }

--- a/curvefs/src/mds/BUILD
+++ b/curvefs/src/mds/BUILD
@@ -33,7 +33,6 @@ COPTS = [
     "-Wno-missing-field-initializers",
     "-std=c++11",
     "-Wall",
-    "-Werror",
 ]
 
 cc_library(
@@ -45,6 +44,8 @@ cc_library(
     copts = COPTS,
     visibility = ["//visibility:public"],
     deps = [
+        "//external:glog",
+        "//external:gflags",
         "//external:brpc",
         "//curvefs/proto:metaserver_cc_proto",
         "//curvefs/proto:mds_cc_proto",

--- a/curvefs/src/mds/chunkid_allocator.cpp
+++ b/curvefs/src/mds/chunkid_allocator.cpp
@@ -1,0 +1,112 @@
+/*
+ *  Copyright (c) 2020 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+/*
+ * Project: curve
+ * Created Date: 2021-08-27
+ * Author: chengyi01
+ */
+
+#include "curvefs/src/mds/chunkid_allocator.h"
+
+namespace curvefs {
+namespace mds {
+
+int ChunkIdAllocatorImpl::GenChunkId(uint64_t* chunkId) {
+    int ret = 0;
+    // will unloack at destructor
+    ::curve::common::WriteLockGuard guard(nextIdRWlock_);
+
+    if (nextId_ > lastId_ || CHUNKIDINITIALIZE == nextId_) {
+        // the chunkIds is exhausted || first to get chunkId
+        ret = AllocateBundleIds(bundleSize_);
+    }
+
+    if (ret >= 0) {
+        // allocate id
+        *chunkId = nextId_;
+        ++nextId_;
+        LOG(INFO) << "allocate chunkid:" << *chunkId;
+    } else {
+        // the chunkIds in the current bundle is exhausted,
+        // but fail to get a new bunlde of chunIds.
+        LOG(ERROR) << "allocate chunkid error, error code is: " << ret;
+    }
+    return ret;
+}
+
+void ChunkIdAllocatorImpl::Init(const std::shared_ptr<KVStorageClient>& client,
+                                const std::string& StoreKey,
+                                uint64_t bundleSize) {
+    client_ = std::move(client);
+    storeKey_ = StoreKey;
+    bundleSize_ = bundleSize;
+}
+
+int ChunkIdAllocatorImpl::AllocateBundleIds(int bundleSize) {
+    // get the maximum value that has been allocated
+    std::string out;
+
+    int statCode = client_->Get(storeKey_, &out);
+    int ret = 0;
+    uint64_t alloc = nextId_;
+    if (EtcdErrCode::EtcdOK != statCode &&
+        EtcdErrCode::EtcdKeyNotExist != statCode) {
+        // -1: other error
+        LOG(ERROR) << "get store key: " << storeKey_
+                   << " err, errCode: " << statCode;
+        ret = UNKNOWN_ERROR;
+    } else if (EtcdErrCode::EtcdKeyNotExist == statCode) {
+        // key not exist
+        LOG(WARNING) << "key " << storeKey_ << " not found in etcd";
+    } else if (!DecodeID(out, &alloc)) {
+        // -2: value decode fails
+        // The value corresponding to the key exists, but the decode fails,
+        // indicating that an internal err has occurred
+        LOG(ERROR) << "decode id: " << out << " err";
+        ret = DECODE_ERROR;
+    } else {
+        // key exist and can be decode
+        lastId_ = alloc;
+    }
+
+    if (ret < 0) {
+        // get value Error
+        return ret;
+    }
+
+    uint64_t target = lastId_ + bundleSize;
+    statCode = client_->CompareAndSwap(storeKey_, out, EncodeID(target));
+    if (EtcdErrCode::EtcdOK != statCode) {
+        // -3: CAS error
+        LOG(ERROR) << "do CAS {preV: " << alloc << ", target: " << target
+                   << " err, errCode: " << statCode;
+        ret = CAS_ERROR;
+    } else {
+        // allocate ok
+        nextId_ = alloc + 1;
+        lastId_ = target;
+        LOG(INFO) << "allocate chunkId form " << out << " to " << target;
+    }
+
+    return ret;
+}
+
+bool ChunkIdAllocatorImpl::DecodeID(const std::string& value, uint64_t* out) {
+    return ::curve::common::StringToUll(value, out);
+}
+
+}  // namespace mds
+}  // namespace curvefs

--- a/curvefs/src/mds/chunkid_allocator.h
+++ b/curvefs/src/mds/chunkid_allocator.h
@@ -1,0 +1,147 @@
+/*
+ *  Copyright (c) 2020 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+/*
+ * Project: curve
+ * Created Date: 2021-08-27
+ * Author: chengyi01
+ */
+
+#ifndef CURVEFS_SRC_MDS_CHUNKID_ALLOCATOR_H_
+#define CURVEFS_SRC_MDS_CHUNKID_ALLOCATOR_H_
+
+#include <memory>
+#include <string>
+
+#include "curvefs/src/mds/common/storage_key.h"
+#include "src/common/concurrent/concurrent.h"
+#include "src/common/string_util.h"
+#include "src/kvstorageclient/etcd_client.h"
+
+namespace curvefs {
+namespace mds {
+
+using ::curve::common::StringToUll;
+using ::curve::kvstorage::KVStorageClient;
+
+const uint64_t CHUNKIDINITIALIZE = 0;
+const uint64_t CHUNKBUNDLEALLOCATED = 1000;
+
+class ChunkIdAllocator {
+ public:
+    ChunkIdAllocator() {}
+    virtual ~ChunkIdAllocator() {}
+    /**
+     * @brief Generate a ID
+     *
+     * @param chunkId
+     * @return int
+     * @details
+     */
+    virtual int GenChunkId(uint64_t* chunkId) = 0;
+
+    /**
+     * @brief init ChunkIdAllocator
+     *
+     * @param client etcd client
+     * @param chunkIdStoreKey
+     * @param bundleSize
+     * @details
+     */
+    virtual void Init(
+        const std::shared_ptr<KVStorageClient>& client = nullptr,
+        const std::string& chunkIdStoreKey = CHUNKID_NAME_KEY_PREFIX,
+        uint64_t bundleSize = CHUNKBUNDLEALLOCATED) = 0;
+};
+
+class ChunkIdAllocatorImpl : public ChunkIdAllocator {
+ public:
+    ChunkIdAllocatorImpl(std::shared_ptr<KVStorageClient> client = nullptr,
+                         std::string storeKey = CHUNKID_NAME_KEY_PREFIX,
+                         uint64_t initId = CHUNKIDINITIALIZE,
+                         uint64_t bundleSize = CHUNKBUNDLEALLOCATED)
+        : ChunkIdAllocator(),
+          client_(client),
+          storeKey_(storeKey),
+          nextId_(initId),
+          lastId_(initId),
+          bundleSize_(bundleSize) {}
+
+    virtual ~ChunkIdAllocatorImpl() {}
+
+    /**
+     * @brief Generate a globally incremented ID
+     *
+     * @param chunkId
+     * @return int
+     * @details
+     */
+    int GenChunkId(uint64_t* chunkId) override;
+
+    /**
+     * @brief init ChunkIdAllocator
+     *
+     * @param client
+     * @param chunkIdStoreKey
+     * @param bundleSize
+     * @details
+     * init ChunkIdAllocator, use it for init or change some configuration.
+     * but this class object will work as old configuration,
+     * until the chunkIds in the current bundle is exhausted.
+     */
+    virtual void Init(
+        const std::shared_ptr<KVStorageClient>& client = nullptr,
+        const std::string& chunkIdStoreKey = CHUNKID_NAME_KEY_PREFIX,
+        uint64_t bundleSize = CHUNKBUNDLEALLOCATED);
+    /**
+     * @brief get bundleSize chunkIds from etcd
+     *
+     * @param bundleSize get the number of chunkIds
+     * @return int
+     * 0:   ok or key not exist
+     * -1:  unknow error
+     * -2:  value decodes fails
+     * -3:  CAS error
+     * @details
+     */
+    virtual int AllocateBundleIds(int bundleSize);
+
+    static bool DecodeID(const std::string& value, uint64_t* out);
+
+    static std::string EncodeID(uint64_t value) {
+        return std::to_string(value);
+    }
+    enum ChunkIdAllocatorStatusCode {
+        KEY_NOTEXIST = 1,
+        OK = 0,
+        UNKNOWN_ERROR = -1,
+        DECODE_ERROR = -2,
+        CAS_ERROR = -3
+    };
+
+ private:
+    std::shared_ptr<KVStorageClient> client_;  // the etcd client
+    std::string storeKey_;  // the key of ChunkId stored in etcd
+    uint64_t nextId_;       // the next ChunkId can be allocated in this bunlde
+    uint64_t lastId_;       // the last ChunkId can be allocated in this bunlde
+    uint64_t bundleSize_;   // get the numnber of ChunkId at a time
+    ::curve::common::RWLock
+        nextIdRWlock_;  // guarantee the uniqueness of the ChunkId
+};
+
+}  // namespace mds
+}  // namespace curvefs
+
+#endif  // CURVEFS_SRC_MDS_CHUNKID_ALLOCATOR_H_

--- a/curvefs/src/mds/common/storage_key.h
+++ b/curvefs/src/mds/common/storage_key.h
@@ -39,6 +39,9 @@ const char FS_NAME_KEY_END[] = "fs_02";
 
 const char FS_ID_KEY_PREFIX[] = "fs_02";
 
+const char CHUNKID_NAME_KEY_PREFIX[] = "fs_03";
+const char CHUNKID_NAME_KEY_END[] = "fs_04";
+
 constexpr uint32_t COMMON_PREFIX_LENGTH = 5;
 
 }  // namespace mds

--- a/curvefs/src/mds/mds.cpp
+++ b/curvefs/src/mds/mds.cpp
@@ -50,8 +50,7 @@ Mds::Mds()
       etcdClient_(),
       leaderElection_(),
       status_(),
-      etcdEndpoint_() {
-}
+      etcdEndpoint_() {}
 
 Mds::~Mds() {}
 
@@ -81,6 +80,8 @@ void Mds::Init() {
                                              metaserverClient_);
     LOG_IF(FATAL, !fsManager_->Init()) << "fsManager Init fail";
 
+    chunkIdAllocator_ = std::make_shared<ChunkIdAllocatorImpl>(etcdClient_);
+
     inited_ = true;
 
     LOG(INFO) << "Init MDS success";
@@ -95,7 +96,7 @@ void Mds::Run() {
 
     brpc::Server server;
     // add heartbeat service
-    MdsServiceImpl mdsService(fsManager_);
+    MdsServiceImpl mdsService(fsManager_, chunkIdAllocator_);
     LOG_IF(FATAL,
            server.AddService(&mdsService, brpc::SERVER_DOESNT_OWN_SERVICE) != 0)
         << "add mdsService error";

--- a/curvefs/src/mds/mds.h
+++ b/curvefs/src/mds/mds.h
@@ -28,6 +28,7 @@
 #include <memory>
 #include <string>
 
+#include "curvefs/src/mds/chunkid_allocator.h"
 #include "curvefs/src/mds/fs_manager.h"
 #include "src/common/configuration.h"
 #include "src/kvstorageclient/etcd_client.h"
@@ -39,13 +40,17 @@ namespace mds {
 using ::curve::common::Configuration;
 using ::curve::election::LeaderElection;
 using ::curve::election::LeaderElectionOptions;
+using curve::kvstorage::EtcdClientImp;
 using ::curve::kvstorage::KVStorageClient;
+// TODO(split InitEtcdConf): split this InitEtcdConf to a single module
 
 struct MDSOptions {
     int dummyPort;
     std::string mdsListenAddr;
     SpaceOptions spaceOptions;
     MetaserverOptions metaserverOptions;
+
+    // TODO(add EtcdConf): add etcd configure
 };
 
 class Mds {
@@ -86,6 +91,7 @@ class Mds {
     std::shared_ptr<FsStorage> fsStorage_;
     std::shared_ptr<SpaceClient> spaceClient_;
     std::shared_ptr<MetaserverClient> metaserverClient_;
+    std::shared_ptr<ChunkIdAllocator> chunkIdAllocator_;
     MDSOptions options_;
 
     bool etcdClientInited_;

--- a/curvefs/src/mds/mds_service.cpp
+++ b/curvefs/src/mds/mds_service.cpp
@@ -216,5 +216,35 @@ void MdsServiceImpl::DeleteFs(::google::protobuf::RpcController* controller,
     LOG(INFO) << "DeleteFs success, fsName = " << fsName;
     return;
 }
+
+void MdsServiceImpl::AllocateS3Chunk(
+    ::google::protobuf::RpcController* controller,
+    const ::curvefs::mds::AllocateS3ChunkRequest* request,
+    ::curvefs::mds::AllocateS3ChunkResponse* response,
+    ::google::protobuf::Closure* done) {
+    brpc::ClosureGuard guard(done);
+
+    uint64_t chunkId = 0;
+    int stat = chunkIdAllocator_->GenChunkId(&chunkId);
+    FSStatusCode resStat;
+    if (stat >= 0) {
+        resStat = OK;
+    } else {
+        resStat = ALLOCATE_CHUNKID_ERROR;
+    }
+
+    response->set_status(resStat);
+
+    if (resStat != OK) {
+        LOG(ERROR) << "AllocateS3Chunk failure, request: "
+                   << request->ShortDebugString()
+                   << ", error: " << FSStatusCode_Name(resStat);
+    } else {
+        response->set_chunkid(chunkId);
+        LOG(INFO) << "AllocateS3Chunk success, request: "
+                  << request->ShortDebugString()
+                  << ", response: " << response->ShortDebugString();
+    }
+}
 }  // namespace mds
 }  // namespace curvefs

--- a/curvefs/src/mds/mds_service.h
+++ b/curvefs/src/mds/mds_service.h
@@ -25,17 +25,23 @@
 
 #include <brpc/closure_guard.h>
 #include <brpc/controller.h>
+
 #include <memory>
 #include <string>
+
 #include "curvefs/proto/mds.pb.h"
+#include "curvefs/src/mds/chunkid_allocator.h"
 #include "curvefs/src/mds/fs_manager.h"
 
 namespace curvefs {
 namespace mds {
 class MdsServiceImpl : public MdsService {
  public:
-    explicit MdsServiceImpl(std::shared_ptr<FsManager> fsManager) {
+    explicit MdsServiceImpl(
+        std::shared_ptr<FsManager> fsManager,
+        std::shared_ptr<ChunkIdAllocator> chunkIdAllocator) {
         fsManager_ = fsManager;
+        chunkIdAllocator_ = chunkIdAllocator;
     }
 
     void CreateFs(::google::protobuf::RpcController* controller,
@@ -63,8 +69,14 @@ class MdsServiceImpl : public MdsService {
                   ::curvefs::mds::DeleteFsResponse* response,
                   ::google::protobuf::Closure* done);
 
+    void AllocateS3Chunk(::google::protobuf::RpcController* controller,
+                         const ::curvefs::mds::AllocateS3ChunkRequest* request,
+                         ::curvefs::mds::AllocateS3ChunkResponse* response,
+                         ::google::protobuf::Closure* done);
+
  private:
     std::shared_ptr<FsManager> fsManager_;
+    std::shared_ptr<ChunkIdAllocator> chunkIdAllocator_;
 };
 }  // namespace mds
 }  // namespace curvefs

--- a/curvefs/test/mds/BUILD
+++ b/curvefs/test/mds/BUILD
@@ -16,7 +16,11 @@
 
 cc_test(
     name = "curvefs_mds_test",
-    srcs = glob(["*.cpp", "*.h"]),
+    srcs = glob(["*.cpp", "*.h"],
+        exclude = [
+            "chunkid_allocator_test.cpp",
+            "mock_etcdclient.h"
+        ]),
     copts = ["-g","-DHAVE_ZLIB=1"],
     deps = [
             "//curvefs/src/mds:curvefs_mds_lib",
@@ -26,5 +30,22 @@ cc_test(
             "//src/common:curve_common",
             "//curvefs/proto:space_cc_proto",
             "//curvefs/test/mds/mock:mds_test_mock",
+    ],
+)
+
+cc_test(
+    name = "curvefs_chunkid_allocator_test",
+    srcs = glob([
+        "chunkid_allocator_test.cpp",
+        "mock_etcdclient.h"
+    ]),
+    copts = ["-g","-DHAVE_ZLIB=1"],
+    deps = [
+            "//curvefs/src/mds:curvefs_mds_lib",
+            "@com_google_googletest//:gtest_main",
+            "@com_google_googletest//:gtest",
+            "//external:brpc",
+            "//src/common:curve_common",
+            "//curvefs/proto:space_cc_proto",
     ],
 )

--- a/curvefs/test/mds/chunkid_allocator_test.cpp
+++ b/curvefs/test/mds/chunkid_allocator_test.cpp
@@ -1,0 +1,191 @@
+/*
+ *  Copyright (c) 2021 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * @Project: curve
+ * @Date: 2021-08-31
+ * @Author: chengyi
+ */
+
+#include "curvefs/src/mds/chunkid_allocator.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "curvefs/test/mds/mock_etcdclient.h"
+
+namespace curvefs {
+namespace mds {
+
+using curve::kvstorage::KVStorageClient;
+using std::make_shared;
+using std::set;
+using std::shared_ptr;
+using std::string;
+using std::vector;
+using ::testing::_;
+using ::testing::AtLeast;
+using ::testing::DoAll;
+using ::testing::Invoke;
+using ::testing::Return;
+using ::testing::ReturnArg;
+using ::testing::SaveArg;
+using ::testing::SetArgPointee;
+using ::testing::SetArgReferee;
+using ::testing::StrEq;
+
+uint64_t CHUNKID = 0;  // use to record chunkId
+
+// replace MockEtcdClientImpl::Get
+int GetRep(const std::string& key, std::string* out) {
+    *out = ChunkIdAllocatorImpl::EncodeID(CHUNKID);
+    LOG(INFO) << "check chunk id is: " << *out;
+    return 0;
+}
+
+// replaceMockEtcdClientImpl::CompareAndSwap
+
+int CompareAndSwapRep(const std::string& key, const std::string& preV,
+                      const std::string& target) {
+    uint64_t preValue = 0;
+    ChunkIdAllocatorImpl::DecodeID(preV, &preValue);
+    uint64_t targetValue = 0;
+    ChunkIdAllocatorImpl::DecodeID(target, &targetValue);
+    if (preValue != CHUNKID) {
+        LOG(ERROR) << "Error："
+                   << "prev:" << preValue << ", now: " << CHUNKID
+                   << ", target: " << target;
+        return EtcdErrCode::EtcdOutOfRange;
+    }
+
+    CHUNKID = targetValue;
+    return EtcdErrCode::EtcdOK;
+}
+
+class ChunkIdAllocatorTest : public testing::Test {
+ protected:
+    void SetUp() override;
+    void TearDown() override;
+
+    std::shared_ptr<ChunkIdAllocator> chunkIdAllocator_;
+    std::shared_ptr<MockEtcdClientImpl> mockEtcdClient_;
+};
+
+void ChunkIdAllocatorTest::SetUp() {
+    mockEtcdClient_ = make_shared<MockEtcdClientImpl>();
+    chunkIdAllocator_ = make_shared<ChunkIdAllocatorImpl>(mockEtcdClient_);
+}
+
+void ChunkIdAllocatorTest::TearDown() {}
+
+TEST_F(ChunkIdAllocatorTest, test_get_chunkIds_1001) {
+    EXPECT_CALL(*mockEtcdClient_.get(), Get(_, _))
+        .WillRepeatedly(Invoke(GetRep));
+    EXPECT_CALL(*mockEtcdClient_.get(), CompareAndSwap(_, _, _))
+        .WillRepeatedly(Invoke(CompareAndSwapRep));
+    const int times = 1001;
+    set<uint64_t> chunkids;  // record get chunkids
+    for (int i = 0; i < times; ++i) {
+        uint64_t tmp = 0;
+        chunkIdAllocator_->GenChunkId(&tmp);
+        chunkids.insert(tmp);
+        LOG(INFO) << "allocate id:" << tmp;
+    }
+    LOG(INFO) << "chunkids' szie: " << chunkids.size();
+
+    ASSERT_EQ(times, chunkids.size());
+}
+
+TEST_F(ChunkIdAllocatorTest, test_reclient_get_chunkIds_1001) {
+    // after test_get_chunkIds_1001，client close and restart,
+    // try to get chunkids
+    mockEtcdClient_ = make_shared<MockEtcdClientImpl>();
+    chunkIdAllocator_ = make_shared<ChunkIdAllocatorImpl>(mockEtcdClient_);
+
+    EXPECT_CALL(*mockEtcdClient_.get(), Get(_, _))
+        .WillRepeatedly(Invoke(GetRep));
+    EXPECT_CALL(*mockEtcdClient_.get(), CompareAndSwap(_, _, _))
+        .WillRepeatedly(Invoke(CompareAndSwapRep));
+    const int times = 1001;
+    set<uint64_t> chunkids;  // record get chunkids
+    for (int i = 0; i < times; ++i) {
+        uint64_t tmp = 0;
+        chunkIdAllocator_->GenChunkId(&tmp);
+        chunkids.insert(tmp);
+        LOG(INFO) << "allocate id:" << tmp;
+    }
+    LOG(INFO) << "chunkids' szie: " << chunkids.size();
+
+    ASSERT_EQ(times, chunkids.size());
+}
+
+TEST_F(ChunkIdAllocatorTest, storeKeyExist_etcdNotOK) {
+    EXPECT_CALL(*mockEtcdClient_.get(), Get(_, _))
+        .WillOnce(Return(EtcdErrCode::EtcdUnknown));
+    uint64_t chunkId;
+    int ret = chunkIdAllocator_->GenChunkId(&chunkId);
+    LOG(INFO) << "ret: " << ret;
+    ASSERT_LT(ret, 0);
+}
+
+TEST_F(ChunkIdAllocatorTest, storeKeyNotExist) {
+    string out = "abs";
+    EXPECT_CALL(*mockEtcdClient_.get(), Get(_, _))
+        .WillOnce(Return(EtcdErrCode::EtcdKeyNotExist));
+    EXPECT_CALL(*mockEtcdClient_.get(), CompareAndSwap(_, _, _))
+        .WillOnce(Return(0));
+    uint64_t chunkId;
+    int ret = chunkIdAllocator_->GenChunkId(&chunkId);
+    LOG(INFO) << "ret: " << ret;
+    ASSERT_EQ(ret, 0);
+}
+
+TEST_F(ChunkIdAllocatorTest, DecodeID_ERROR) {
+    string out = "abs";  // set out can't be decoded
+    EXPECT_CALL(*mockEtcdClient_.get(), Get(_, _))
+        .WillOnce(DoAll(SetArgPointee<1>(out), Return(EtcdErrCode::EtcdOK)));
+    uint64_t chunkId;
+    int ret = chunkIdAllocator_->GenChunkId(&chunkId);
+    LOG(INFO) << "ret: " << ret;
+    ASSERT_LT(ret, 0);
+}
+
+TEST_F(ChunkIdAllocatorTest, CAS_ERROR) {
+    string out = "1000";  // set out can't be decoded
+    EXPECT_CALL(*mockEtcdClient_.get(), Get(_, _))
+        .WillOnce(DoAll(SetArgPointee<1>(out), Return(EtcdErrCode::EtcdOK)));
+    EXPECT_CALL(*mockEtcdClient_.get(), CompareAndSwap(_, _, _))
+        .WillOnce(Return(-3));
+    uint64_t chunkId;
+    int ret = chunkIdAllocator_->GenChunkId(&chunkId);
+    LOG(INFO) << "ret: " << ret;
+    ASSERT_LT(ret, 0);
+}
+
+}  // namespace mds
+}  // namespace curvefs
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    ::testing::InitGoogleMock(&argc, argv);
+
+    return RUN_ALL_TESTS();
+}

--- a/curvefs/test/mds/mds_service_test.cpp
+++ b/curvefs/test/mds/mds_service_test.cpp
@@ -21,30 +21,32 @@
  */
 
 #include "curvefs/src/mds/mds_service.h"
+
 #include <brpc/channel.h>
 #include <brpc/server.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+
 #include "curvefs/test/mds/fake_metaserver.h"
 #include "curvefs/test/mds/fake_space.h"
 #include "curvefs/test/mds/mock/mock_kvstorage_client.h"
 
-using ::testing::AtLeast;
-using ::testing::StrEq;
 using ::testing::_;
+using ::testing::AtLeast;
+using ::testing::DoAll;
+using ::testing::Mock;
 using ::testing::Return;
 using ::testing::ReturnArg;
-using ::testing::DoAll;
-using ::testing::SetArgPointee;
 using ::testing::SaveArg;
-using ::testing::Mock;
+using ::testing::SetArgPointee;
+using ::testing::StrEq;
 // using ::curvefs::space::MockSpaceService;
-using ::curvefs::space::FakeSpaceImpl;
-using ::curvefs::space::SpaceStatusCode;
-using ::curvefs::space::InitSpaceResponse;
-using ::curvefs::metaserver::FakeMetaserverImpl;
 using ::curvefs::common::S3Info;
 using ::curvefs::common::Volume;
+using ::curvefs::metaserver::FakeMetaserverImpl;
+using ::curvefs::space::FakeSpaceImpl;
+using ::curvefs::space::InitSpaceResponse;
+using ::curvefs::space::SpaceStatusCode;
 
 namespace curvefs {
 namespace mds {
@@ -69,7 +71,9 @@ class MdsServiceTest : public ::testing::Test {
         return;
     }
 
-    void TearDown() override { return; }
+    void TearDown() override {
+        return;
+    }
 
     bool CompareVolume(const Volume& first, const Volume& second) {
         return first.volumesize() == second.volumesize() &&
@@ -98,7 +102,7 @@ class MdsServiceTest : public ::testing::Test {
 TEST_F(MdsServiceTest, test1) {
     brpc::Server server;
     // add metaserver service
-    MdsServiceImpl mdsService(fsManager_);
+    MdsServiceImpl mdsService(fsManager_, nullptr);
     ASSERT_EQ(server.AddService(&mdsService, brpc::SERVER_DOESNT_OWN_SERVICE),
               0);
 

--- a/curvefs/test/mds/mock_chunkid_allocator.h
+++ b/curvefs/test/mds/mock_chunkid_allocator.h
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (c) 2021 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+/*
+ * @Project: curve
+ * @Date: 2021-09-06
+ * @Author: chengyi
+ */
+#ifndef CURVEFS_TEST_MDS_MOCK_CHUNKID_ALLOCATOR_H_
+#define CURVEFS_TEST_MDS_MOCK_CHUNKID_ALLOCATOR_H_
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+
+#include "curvefs/src/mds/chunkid_allocator.h"
+
+namespace curvefs {
+namespace mds {
+
+class MockChunkIdAllocatorImpl : public ChunkIdAllocatorImpl {
+ public:
+    MOCK_METHOD1(GenChunkId, int(uint64_t*));
+    MOCK_METHOD3(Init, void(std::shared_ptr<KVStorageClient> client,
+                            std::string chunkIdStoreKey, uint64_t bundleSize));
+    MOCK_METHOD1(AllocateBundleIds, int(int));
+};
+}  // namespace mds
+}  // namespace curvefs
+#endif  // CURVEFS_TEST_MDS_MOCK_CHUNKID_ALLOCATOR_H_

--- a/curvefs/test/mds/mock_etcdclient.h
+++ b/curvefs/test/mds/mock_etcdclient.h
@@ -1,0 +1,72 @@
+/*
+ *  Copyright (c) 2021 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+/*
+ * @Project: curve
+ * @Date: 2021-08-31
+ * @Author: chengyi
+ */
+
+#ifndef CURVEFS_TEST_MDS_MOCK_ETCDCLIENT_H_
+#define CURVEFS_TEST_MDS_MOCK_ETCDCLIENT_H_
+
+#include <gmock/gmock.h>
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "src/kvstorageclient/etcd_client.h"
+
+namespace curvefs {
+namespace mds {
+
+using curve::kvstorage::EtcdClientImp;
+
+class MockEtcdClientImpl : public KVStorageClient {
+ public:
+    virtual ~MockEtcdClientImpl() {
+        // LOG(INFO) << "test";
+    }
+    MOCK_METHOD0(CloseClient, void());
+    MOCK_METHOD2(Put, int(const std::string&, const std::string&));
+    MOCK_METHOD3(PutRewithRevision,
+                 int(const std::string&, const std::string&, int64_t*));
+    MOCK_METHOD2(Get, int(const std::string&, std::string*));
+    MOCK_METHOD3(List, int(const std::string&, const std::string&,
+                           std::vector<std::string>*));
+    MOCK_METHOD3(List, int(const std::string&, const std::string&,
+                           std::vector<std::pair<std::string, std::string>>*));
+    MOCK_METHOD1(Delete, int(const std::string&));
+    MOCK_METHOD2(DeleteRewithRevision, int(const std::string&, int64_t*));
+    MOCK_METHOD1(TxnN, int(const std::vector<Operation>&));
+    MOCK_METHOD3(CompareAndSwap, int(const std::string&, const std::string&,
+                                     const std::string&));
+    MOCK_METHOD1(GetCurrentRevision, int(int64_t*));
+    MOCK_METHOD6(ListWithLimitAndRevision,
+                 int(const std::string&, const std::string&, int64_t, int64_t,
+                     std::vector<std::string>*, std::string*));
+    // MOCK_METHOD5(CampaignLeader, int(const std::string&, const
+    // std::string&,
+    //                                  uint32_t, uint32_t, uint64_t*))
+    // MOCK_METHOD2(LeaderObserve, int(uint64_t, const std::string&));
+    MOCK_METHOD2(LeaderResign, int(uint64_t, uint64_t));
+    MOCK_METHOD1(SetTimeout, void(int));
+    MOCK_METHOD1(NeedRetry, bool(int));
+};
+
+}  // namespace mds
+}  // namespace curvefs
+#endif  // CURVEFS_TEST_MDS_MOCK_ETCDCLIENT_H_


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

add allocate chunkId in mds and persist chunkId in etcd

Problem Summary:

### What is changed and how it works?


What's Changed:

add AllocateS3Chunk in nds services;
add ChunkIdAllocator in mds ;
persist chunkId in etcd

How it Works:

when get allocate chunkid request, check the chunkIds pool is exhausted or not;
if the pool is not exhausted,
    return a chunk id;
else
   allocate a pool chunkId

Side effects(Breaking backward compatibility? Performance regression?): 

AllocateS3Chunk service was in space, now is in mds.
some request not change.
the AllocateS3Chunk service in space is not removed.

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
