### PR TITLE
curvefs/metaserver: fix crash when first write of s3 inode

### DIFF
--- a/curvefs/src/metaserver/inode_storage.cpp
+++ b/curvefs/src/metaserver/inode_storage.cpp
@@ -62,7 +62,7 @@ MetaStatusCode MemoryInodeStorage::Update(const Inode &inode) {
     if (it == inodeMap_.end()) {
         return MetaStatusCode::NOT_FOUND;
     }
-    if (inode.s3chunkinfomap().empty()) {
+    if (inode.s3chunkinfomap().empty() || it->second.s3chunkinfomap().empty()) {
         inodeMap_[InodeKey(inode)] = inode;
     } else {
         ::google::protobuf::Map<uint64_t, S3ChunkInfoList> result;


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:
when first write s3type inode, update inode will crash in the empty assert in "void MemoryInodeStorage::MergeTwoS3ChunkInfoMap"

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?): 

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
