### PR TITLE
curvefs/metaserver: s3compact add multi s3info support

### DIFF
--- a/curvefs/conf/metaserver.conf
+++ b/curvefs/conf/metaserver.conf
@@ -36,6 +36,7 @@ s3compactwq.fragment_threshold=20
 # max chunks to process per compact task
 s3compactwq.max_chunks_per_compact=10
 s3compactwq.enqueue_sleep_ms=100
+s3compactwq.s3infocache_size=100
 
 # metaserver listen ip and port
 # these two config items ip and port can be replaced by start up options `-ip` and `-port`

--- a/curvefs/src/metaserver/BUILD
+++ b/curvefs/src/metaserver/BUILD
@@ -61,6 +61,7 @@ cc_library(
     deps = [
         "//curvefs/proto:metaserver_cc_proto",
         "//curvefs/src/common:curvefs_common",
+        "//curvefs/proto:mds_cc_proto",
         "//external:gflags",
         "//external:glog",
         "//src/common:curve_s3_adapter",

--- a/curvefs/src/metaserver/s3infocache.cpp
+++ b/curvefs/src/metaserver/s3infocache.cpp
@@ -1,0 +1,134 @@
+/*
+ *  Copyright (c) 2021 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * @Project: curve
+ * @Date: 2021-11-02
+ * @Author: majie1
+ */
+
+#include "curvefs/src/metaserver/s3infocache.h"
+
+#include "curvefs/proto/mds.pb.h"
+
+namespace curvefs {
+namespace metaserver {
+
+void S3InfoCache::UpdateRecent(uint64_t fsid) {
+    if (pos_.find(fsid) != pos_.end()) {
+        recent_.erase(pos_[fsid]);
+    } else if (recent_.size() >= capacity_) {
+        auto old = recent_.back();
+        recent_.pop_back();
+        cache_.erase(old);
+        pos_.erase(old);
+    }
+    recent_.push_front(fsid);
+    pos_[fsid] = recent_.begin();
+}
+
+S3Info S3InfoCache::Get(uint64_t fsid) {
+    UpdateRecent(fsid);
+    return cache_[fsid];
+}
+
+void S3InfoCache::Put(uint64_t fsid, const S3Info& s3info) {
+    UpdateRecent(fsid);
+    cache_[fsid] = s3info;
+}
+
+S3InfoCache::RequestStatusCode S3InfoCache::RequestS3Info(uint64_t fsid,
+                                                          S3Info* s3info) {
+    // send GetFsInfoRequest to mds
+    curvefs::mds::GetFsInfoRequest request;
+    curvefs::mds::GetFsInfoResponse response;
+    request.set_fsid(fsid);
+    brpc::Channel channel;
+    if (channel.Init(mdsAddrs_[mdsIndex_].c_str(), NULL) != 0) {
+        VLOG(6) << "s3infocache: " << metaserverAddr_.ip << ":"
+                << metaserverAddr_.port << " Fail to init channel to MDS "
+                << mdsAddrs_[mdsIndex_];
+        return RequestStatusCode::RPCFAILURE;
+    }
+
+    curvefs::mds::MdsService_Stub stub(&channel);
+    brpc::Controller cntl;
+    stub.GetFsInfo(&cntl, &request, &response, nullptr);
+    if (cntl.Failed()) {
+        if (cntl.ErrorCode() == EHOSTDOWN || cntl.ErrorCode() == ETIMEDOUT ||
+            cntl.ErrorCode() == brpc::ELOGOFF ||
+            cntl.ErrorCode() == brpc::ERPCTIMEDOUT) {
+            VLOG(6) << "s3infocache: current mds: " << mdsAddrs_[mdsIndex_]
+                    << " is shutdown or going to quit";
+            mdsIndex_ = (mdsIndex_ + 1) % mdsAddrs_.size();
+            VLOG(6) << "s3infocache: next heartbeat switch to "
+                    << mdsAddrs_[mdsIndex_];
+        } else {
+            VLOG(6) << "s3infocache: " << metaserverAddr_.ip << ":"
+                    << metaserverAddr_.port << " Fail to send heartbeat to MDS "
+                    << mdsAddrs_[mdsIndex_] << ","
+                    << " cntl errorCode: " << cntl.ErrorCode()
+                    << " cntl error: " << cntl.ErrorText();
+        }
+        return RequestStatusCode::RPCFAILURE;
+    } else {
+        auto ret = response.statuscode();
+        VLOG(6) << "s3infocache: rpc statuscode " << ret;
+        if (ret == curvefs::mds::FSStatusCode::OK) {
+            const curvefs::mds::FsDetail& fsdetail = response.fsinfo().detail();
+            if (fsdetail.has_s3info()) {
+                *s3info = fsdetail.s3info();
+                return RequestStatusCode::SUCCESS;
+            } else {
+                VLOG(6) << "s3infocache: fsid " << fsid
+                        << "doesn't have s3info " << ret;
+                return RequestStatusCode::NOS3INFO;
+            }
+        } else {
+            return RequestStatusCode::RPCFAILURE;
+        }
+    }
+}
+
+int S3InfoCache::GetS3Info(uint64_t fsid, S3Info* s3info) {
+    std::lock_guard<std::mutex> lock(mtx_);
+    if (cache_.find(fsid) != cache_.end()) {
+        *s3info = Get(fsid);
+        return 0;
+    } else {
+        // request s3info from mds
+        S3Info info;
+        RequestStatusCode ret = RequestS3Info(fsid, &info);
+        if (ret == RequestStatusCode::SUCCESS) {
+            Put(fsid, info);
+            *s3info = info;
+            return 0;
+        } else {
+            return -1;
+        }
+    }
+}
+
+void S3InfoCache::InvalidateS3Info(uint64_t fsid) {
+    std::lock_guard<std::mutex> lock(mtx_);
+    auto iter = pos_[fsid];
+    recent_.erase(iter);
+    pos_.erase(fsid);
+    cache_.erase(fsid);
+}
+
+}  // namespace metaserver
+}  // namespace curvefs

--- a/curvefs/src/metaserver/s3infocache.h
+++ b/curvefs/src/metaserver/s3infocache.h
@@ -1,0 +1,78 @@
+/*
+ *  Copyright (c) 2021 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * @Project: curve
+ * @Date: 2021-11-02
+ * @Author: majie1
+ */
+
+#ifndef CURVEFS_SRC_METASERVER_S3INFOCACHE_H_
+#define CURVEFS_SRC_METASERVER_S3INFOCACHE_H_
+
+#include <braft/closure_helper.h>
+#include <brpc/channel.h>
+#include <brpc/controller.h>
+
+#include <list>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "curvefs/proto/common.pb.h"
+#include "curvefs/src/metaserver/inode_storage.h"
+
+namespace curvefs {
+namespace metaserver {
+
+using curvefs::common::S3Info;
+
+class S3InfoCache {
+ private:
+    enum class RequestStatusCode { SUCCESS, NOS3INFO, RPCFAILURE };
+    std::mutex mtx_;
+    uint64_t capacity_;
+    std::vector<std::string> mdsAddrs_;
+    uint64_t mdsIndex_;
+    butil::EndPoint metaserverAddr_;
+    // lru cache
+    std::unordered_map<uint64_t, S3Info> cache_;
+    std::list<uint64_t> recent_;
+    std::unordered_map<uint64_t, std::list<uint64_t>::iterator> pos_;
+
+    void UpdateRecent(uint64_t fsid);
+    S3Info Get(uint64_t fsid);
+    void Put(uint64_t fsid, const S3Info& s3info);
+    RequestStatusCode RequestS3Info(uint64_t fsid, S3Info* s3info);
+
+ public:
+    explicit S3InfoCache(uint64_t capacity,
+                         const std::vector<std::string>& mdsAddrs,
+                         butil::EndPoint metaserverAddr)
+        : capacity_(capacity),
+          mdsAddrs_(mdsAddrs),
+          mdsIndex_(0),
+          metaserverAddr_(metaserverAddr) {}
+    virtual ~S3InfoCache() {}
+    virtual int GetS3Info(uint64_t fsid, S3Info* s3info);
+    virtual void InvalidateS3Info(uint64_t fsid);
+};
+
+}  // namespace metaserver
+}  // namespace curvefs
+
+#endif  // CURVEFS_SRC_METASERVER_S3INFOCACHE_H_

--- a/curvefs/test/metaserver/BUILD
+++ b/curvefs/test/metaserver/BUILD
@@ -32,7 +32,7 @@ cc_test(
             "metaserver_s3_test.cpp",
             "mock_s3compactwq_impl.h",
             "s3compactwq_test.cpp",
-           "mock_s3_adapter.h"
+            "mock_s3_adapter.h"
         ],
     ),
     copts = CURVE_TEST_COPTS,
@@ -125,7 +125,8 @@ cc_test(
     srcs = glob(
                [ "s3compactwq_test.cpp",
                  "mock_s3compactwq_impl.h",
-                 "mock_s3_adapter.h"]
+                 "mock_s3_adapter.h",
+                 "mock_s3infocache.h"]
                ),
     copts = CURVE_TEST_COPTS,
     defines = ["UNIT_TEST"],

--- a/curvefs/test/metaserver/mock_s3_adapter.h
+++ b/curvefs/test/metaserver/mock_s3_adapter.h
@@ -28,7 +28,9 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 
+#include "curvefs/src/metaserver/s3compact_manager.h"
 #include "src/common/s3_adapter.h"
 
 using ::curve::common::S3Adapter;
@@ -37,6 +39,16 @@ using ::testing::Return;
 namespace curvefs {
 namespace metaserver {
 
+class MockS3AdapterManager : public S3AdapterManager {
+ public:
+    MockS3AdapterManager(uint64_t size, const S3AdapterOption& opts)
+        : S3AdapterManager(size, opts) {}
+    ~MockS3AdapterManager() {}
+    MOCK_METHOD0(Init, void());
+    MOCK_METHOD0(GetS3Adapter, std::pair<uint64_t, S3Adapter*>());
+    MOCK_METHOD1(ReleaseS3Adapter, void(uint64_t));
+};
+
 class MockS3Adapter : public S3Adapter {
  public:
     MockS3Adapter() {}
@@ -44,6 +56,12 @@ class MockS3Adapter : public S3Adapter {
 
     MOCK_METHOD1(Init, void(const std::string&));
     MOCK_METHOD0(Deinit, void());
+    MOCK_METHOD4(Reinit, void(const std::string&, const std::string&,
+                              const std::string&, S3AdapterOption opt));
+    MOCK_METHOD0(GetS3Ak, std::string());
+    MOCK_METHOD0(GetS3Sk, std::string());
+    MOCK_METHOD0(GetS3Endpoint, std::string());
+    MOCK_METHOD0(GetBucketName, std::string());
     MOCK_METHOD2(PutObject, int(const Aws::String&, const std::string&));
     MOCK_METHOD2(GetObject, int(const Aws::String&, std::string*));
     MOCK_METHOD1(DeleteObject, int(const Aws::String&));

--- a/curvefs/test/metaserver/mock_s3compactwq_impl.h
+++ b/curvefs/test/metaserver/mock_s3compactwq_impl.h
@@ -30,6 +30,7 @@
 #include <string>
 
 #include "curvefs/src/metaserver/s3compact_wq_impl.h"
+#include "curvefs/test/metaserver/mock_s3infocache.h"
 
 using curve::common::S3Adapter;
 using curvefs::metaserver::copyset::CopysetNode;
@@ -40,9 +41,11 @@ namespace metaserver {
 
 class MockS3CompactWorkQueueImpl : public S3CompactWorkQueueImpl {
  public:
-    MockS3CompactWorkQueueImpl(std::shared_ptr<S3Adapter> s3Adapter,
-                               const S3CompactWorkQueueOption& opts)
-        : S3CompactWorkQueueImpl(s3Adapter, opts) {}
+    MockS3CompactWorkQueueImpl(
+        std::shared_ptr<S3AdapterManager> s3AdapterManager,
+        std::shared_ptr<S3InfoCache> s3infoCache,
+        const S3CompactWorkQueueOption& opts)
+        : S3CompactWorkQueueImpl(s3AdapterManager, s3infoCache, opts) {}
     MOCK_METHOD3(UpdateInode, MetaStatusCode(CopysetNode*, const PartitionInfo&,
                                              const Inode&));
 };
@@ -51,6 +54,7 @@ class MockCopysetNodeWrapper : public CopysetNodeWrapper {
  public:
     MockCopysetNodeWrapper() : CopysetNodeWrapper(nullptr) {}
     MOCK_METHOD0(IsLeaderTerm, bool());
+    MOCK_METHOD0(IsValid, bool());
 };
 
 }  // namespace metaserver

--- a/curvefs/test/metaserver/mock_s3infocache.h
+++ b/curvefs/test/metaserver/mock_s3infocache.h
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (c) 2021 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*************************************************************************
+> File Name: mock_s3infocache.h
+> Author:
+> Created Time: Thu 4 Nov 2021
+ ************************************************************************/
+
+#ifndef CURVEFS_TEST_METASERVER_MOCK_S3INFOCACHE_H_
+#define CURVEFS_TEST_METASERVER_MOCK_S3INFOCACHE_H_
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "curvefs/src/metaserver/s3infocache.h"
+
+using ::testing::Return;
+
+namespace curvefs {
+namespace metaserver {
+
+class MockS3InfoCache : public S3InfoCache {
+ public:
+    MockS3InfoCache(uint64_t capacity, std::vector<std::string> mdsAddrs,
+                    butil::EndPoint metaserverAddr)
+        : S3InfoCache(capacity, mdsAddrs, metaserverAddr) {}
+    ~MockS3InfoCache() {}
+    MOCK_METHOD2(GetS3Info, int(uint64_t, S3Info*));
+    MOCK_METHOD1(InvalidateS3Info, void(uint64_t));
+};
+
+}  // namespace metaserver
+}  // namespace curvefs
+#endif  // CURVEFS_TEST_METASERVER_MOCK_S3INFOCACHE_H_

--- a/src/common/s3_adapter.cpp
+++ b/src/common/s3_adapter.cpp
@@ -150,6 +150,27 @@ void S3Adapter::Shutdown() {
     std::call_once(S3SHUTDOWN_FLAG, shutdownSDK);
 }
 
+void S3Adapter::Reinit(const std::string& ak, const std::string& sk,
+                       const std::string& endpoint, S3AdapterOption option) {
+    Deinit();
+    option.ak = ak;
+    option.sk = sk;
+    option.s3Address = endpoint;
+    Init(option);
+}
+
+std::string S3Adapter::GetS3Ak() {
+    return std::string(s3Ak_.c_str(), s3Ak_.size());
+}
+
+std::string S3Adapter::GetS3Sk() {
+    return std::string(s3Sk_.c_str(), s3Sk_.c_str());
+}
+
+std::string S3Adapter::GetS3Endpoint() {
+    return std::string(s3Address_.c_str(), s3Address_.c_str());
+}
+
 int S3Adapter::CreateBucket() {
     Aws::S3::Model::CreateBucketRequest request;
     request.SetBucket(bucketName_);

--- a/src/common/s3_adapter.h
+++ b/src/common/s3_adapter.h
@@ -139,6 +139,23 @@ class S3Adapter {
      */
     virtual void Shutdown();
     /**
+     * reinit s3client with new AWSCredentials
+     */
+    virtual void Reinit(const std::string& ak, const std::string& sk,
+                        const std::string& endpoint, S3AdapterOption option);
+    /**
+     * get s3 ak
+     */
+    virtual std::string GetS3Ak();
+    /**
+     * get s3 sk
+     */
+    virtual std::string GetS3Sk();
+    /**
+     * get s3 endpoint
+     */
+    virtual std::string GetS3Endpoint();
+    /**
      * 创建存储快照数据的桶（桶名称由配置文件指定，需要全局唯一）
      * @return: 0 创建成功/ -1 创建失败
      */


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

What's Changed:

prerequisite #678 

add S3InfoCache and S3AdapterManager
when do s3compact, get S3Info from cache or MDS.

How it Works:

Side effects(Breaking backward compatibility? Performance regression?): 

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
