### PR TITLE
make packages include libnebd.h.

### DIFF
--- a/mk-deb.sh
+++ b/mk-deb.sh
@@ -515,6 +515,7 @@ then
 fi
 # step 4.1 prepare for nebd-package
 cp -r nebd/nebd-package build/
+mkdir -p build/nebd-package/usr/include/nebd
 mkdir -p build/nebd-package/usr/bin
 mkdir -p build/nebd-package/usr/lib/nebd
 
@@ -531,6 +532,7 @@ do
     cp -f $i build/k8s-nebd-package/usr/lib/nebd
 done
 
+cp nebd/src/part1/libnebd.h build/nebd-package/usr/include/nebd
 cp bazel-bin/nebd/src/part2/nebd-server build/nebd-package/usr/bin
 cp bazel-bin/nebd/src/part2/nebd-server build/k8s-nebd-package/usr/bin
 

--- a/mk-tar.sh
+++ b/mk-tar.sh
@@ -454,6 +454,7 @@ fi
 echo "end copy"
 
 # step 4.1 prepare for nebd-package
+mkdir -p build/nebd-package/include/nebd
 mkdir -p build/nebd-package/bin
 mkdir -p build/nebd-package/lib/nebd
 
@@ -462,6 +463,7 @@ do
     cp -f $i build/nebd-package/lib/nebd
 done
 
+cp nebd/src/part1/libnebd.h build/nebd-package/include/nebd
 cp bazel-bin/nebd/src/part2/nebd-server build/nebd-package/bin
 
 # step 4.2 prepare for curve-nbd package


### PR DESCRIPTION
After installed these packages, developers no longer need to
make a copy of libnebd.h from curve source repository. This makes
easier for third-party developers, before this, for example,
fio and polarfs etcs are forced to make a copy of the file.

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: ##664

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?): 

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
