### PR TITLE
curve: make s3sdk init/shutdown only be called once

### DIFF
--- a/src/common/s3_adapter.h
+++ b/src/common/s3_adapter.h
@@ -57,6 +57,10 @@
 namespace curve {
 namespace common {
 
+extern std::once_flag S3INIT_FLAG;
+extern std::once_flag S3SHUTDOWN_FLAG;
+extern Aws::SDKOptions AWS_SDK_OPTIONS;
+
 struct GetObjectAsyncContext;
 struct PutObjectAsyncContext;
 class S3Adapter;
@@ -130,6 +134,10 @@ class S3Adapter {
      * 释放S3Adapter资源
      */
     virtual void Deinit();
+    /**
+     *  call aws sdk shutdown api
+     */
+    virtual void Shutdown();
     /**
      * 创建存储快照数据的桶（桶名称由配置文件指定，需要全局唯一）
      * @return: 0 创建成功/ -1 创建失败
@@ -287,7 +295,6 @@ class S3Adapter {
     // 对象的桶名，根据配置文件指定
     Aws::String bucketName_;
     // aws sdk的配置，同样由配置文件指定
-    Aws::SDKOptions *options_;
     Aws::Client::ClientConfiguration *clientCfg_;
     Aws::S3::S3Client *s3Client_;
     Configuration conf_;


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: close #686 

Problem Summary:

AWS SDK initapi/shutdownapi should be only called once in one program.
Multi s3adapter in a program will cause problem. Seperate shutdown from deinit function.

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?): 

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
