### PR TITLE
curvefs/client: temporary disable read lru cache

### DIFF
--- a/curvefs/src/client/s3/client_s3_cache_manager.cpp
+++ b/curvefs/src/client/s3/client_s3_cache_manager.cpp
@@ -1162,6 +1162,8 @@ ChunkCacheManager::CreateWriteDataCache(S3ClientAdaptorImpl *s3ClientAdaptor,
 }
 
 void ChunkCacheManager::AddReadDataCache(DataCachePtr dataCache) {
+    return;
+
     uint64_t chunkPos = dataCache->GetChunkPos();
     uint64_t len = dataCache->GetLen();
     WriteLockGuard writeLockGuard(rwLockRead_);


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #684 

Problem Summary: Currently, the solution is not so clear, so just disable it now in order not to affect other tests

### What is changed and how it works?

What's Changed:

*temporarily disable read lru cache*

Side effects(Breaking backward compatibility? Performance regression?): 

*read performance may lower down, but it was not obvious in the test*

### Check List

- [x] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license
