### PR TITLE
curvefs/client: fix vdbench fuse to appear coredump

### DIFF
--- a/curvefs/src/client/s3/client_s3.cpp
+++ b/curvefs/src/client/s3/client_s3.cpp
@@ -28,6 +28,10 @@ void S3ClientImpl::Init(const curve::common::S3AdapterOption &option) {
     s3Adapter_->Init(option);
 }
 
+void S3ClientImpl::Deinit() {
+    s3Adapter_->Deinit();
+}
+
 int S3ClientImpl::Upload(const std::string &name, const char *buf,
                          uint64_t length) {
     int ret = 0;

--- a/curvefs/src/client/s3/client_s3.h
+++ b/curvefs/src/client/s3/client_s3.h
@@ -36,6 +36,7 @@ class S3Client {
     S3Client() {}
     virtual ~S3Client() {}
     virtual void Init(const curve::common::S3AdapterOption& option) = 0;
+    virtual void Deinit() = 0;
     virtual int Upload(const std::string& name, const char* buf,
                        uint64_t length) = 0;
     virtual void UploadAsync(
@@ -53,6 +54,7 @@ class S3ClientImpl : public S3Client {
     }
     virtual ~S3ClientImpl() {}
     void Init(const curve::common::S3AdapterOption& option);
+    void Deinit();
     int Upload(const std::string& name, const char* buf, uint64_t length);
     void UploadAsync(std::shared_ptr<PutObjectAsyncContext> context);
     int Download(const std::string& name, char* buf, uint64_t offset,

--- a/curvefs/src/client/s3/client_s3_adaptor.cpp
+++ b/curvefs/src/client/s3/client_s3_adaptor.cpp
@@ -276,7 +276,6 @@ int S3ClientAdaptorImpl::Stop() {
     toStop_.store(true, std::memory_order_release);
     FsSyncSignal();
     bgFlushThread_.join();
-
     if (HasDiskCache()) {
         for (auto& q : downloadTaskQueues_) {
             bthread::execution_queue_stop(q);
@@ -284,6 +283,7 @@ int S3ClientAdaptorImpl::Stop() {
         }
         diskCacheManagerImpl_->UmountDiskCache();
     }
+    client_->Deinit();
     LOG(INFO) << "Stopping S3ClientAdaptor success";
     return 0;
 }

--- a/curvefs/src/client/s3/client_s3_cache_manager.cpp
+++ b/curvefs/src/client/s3/client_s3_cache_manager.cpp
@@ -1373,7 +1373,6 @@ void DataCache::Write(uint64_t chunkPos, uint64_t len, const char *data,
         */
         if (chunkPos + len <= chunkPos_ + len_) {
             memcpy(data_ + chunkPos - chunkPos_, data, len);
-            chunkCacheManager_->UpdateWriteCacheMap(chunkPos_, this);
             return;
         } else {
             std::vector<DataCachePtr>::const_iterator iter =
@@ -1399,7 +1398,6 @@ void DataCache::Write(uint64_t chunkPos, uint64_t len, const char *data,
                            (*iter)->GetChunkPos() + (*iter)->GetLen() -
                                chunkPos - len);
                     Swap(newDatabuf, totalSize);
-                    chunkCacheManager_->UpdateWriteCacheMap(chunkPos_, this);
                     return;
                 }
             }
@@ -1414,7 +1412,6 @@ void DataCache::Write(uint64_t chunkPos, uint64_t len, const char *data,
             memcpy(newDatabuf, data_, chunkPos - chunkPos_);
             memcpy(newDatabuf + chunkPos - chunkPos_, data, len);
             Swap(newDatabuf, totalSize);
-            chunkCacheManager_->UpdateWriteCacheMap(chunkPos_, this);
             return;
         }
     }

--- a/curvefs/test/client/mock_client_s3.h
+++ b/curvefs/test/client/mock_client_s3.h
@@ -41,6 +41,7 @@ class MockS3Client : public S3Client {
     ~MockS3Client() {}
 
     MOCK_METHOD1(Init, void(const curve::common::S3AdapterOption& options));
+    MOCK_METHOD0(Deinit, void());
     MOCK_METHOD3(Upload, int(const std::string& name,
                              const char* buf, uint64_t length));
     MOCK_METHOD1(UploadAsync, void(


### PR DESCRIPTION
When the background is flush copy dataWCacheMap_, the write thread may modify dataWCacheMap_ without locking.
It has been confirmed that UpdateWriteCacheMap is not required

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?
When the background is flush copy dataWCacheMap_, the write thread may modify dataWCacheMap_ without locking.
It has been confirmed that UpdateWriteCacheMap is not required
Issue Number: close #739  <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?): 

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
