### PR TITLE
curvefs_tool: fix curvefs_tool name & fix config

### DIFF
--- a/curvefs/docker/Dockerfile
+++ b/curvefs/docker/Dockerfile
@@ -1,5 +1,6 @@
 FROM opencurvedocker/curve-base:debian9
 RUN mkdir -p /usr/local/curvefs
+RUN mkdir -p /etc/curvefs
 COPY curvefs /usr/local/curvefs
 COPY entrypoint.sh /
 COPY curvefs/tools/sbin/curvefs_tool /usr/bin

--- a/curvefs/src/tools/curvefs_tool_define.h
+++ b/curvefs/src/tools/curvefs_tool_define.h
@@ -39,7 +39,7 @@ namespace tools {
 
 /* command */
 // programe name
-const char kProgrameName[] = "curvefs-tool";
+const char kProgrameName[] = "curvefs_tool";
 // version
 const char kVersionCmd[] = "version";
 // build-topology


### PR DESCRIPTION
1. fix curvefs_tool name error in --example
2. solve the problem of missing curvefs_tool configuration file, mkdir
/etc/curvefs when make docker image and sync conf file when deploy

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: close #729  <!-- REMOVE this line if no issue to close -->

Problem Summary:

The curvefs_tool configuration file is not synchronized

### What is changed and how it works?

What's Changed:

dockerfile 

How it Works:

When building the docker image, create /etc/curvefs,
sync config file when deploy

Side effects(Breaking backward compatibility? Performance regression?): 

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
