### PR TITLE
curvefs/client: fix problem that after disk cache full, obj forget to upload

### DIFF
--- a/curvefs/src/client/s3/client_s3_cache_manager.cpp
+++ b/curvefs/src/client/s3/client_s3_cache_manager.cpp
@@ -1843,7 +1843,7 @@ CURVEFS_ERROR DataCache::Flush(uint64_t inodeId, bool force) {
             writeOffset += n;
             blockPos = (blockPos + n) % blockSize;
         }
-        if (!s3ClientAdaptor_->IsReadWriteCache()) {
+        if (!useDiskCache) {
             pendingReq.fetch_add(uploadTasks.size(), std::memory_order_seq_cst);
             VLOG(9) << "pendingReq init: " << pendingReq;
             for (auto iter = uploadTasks.begin(); iter != uploadTasks.end();

--- a/curvefs/src/client/s3/disk_cache_manager_impl.cpp
+++ b/curvefs/src/client/s3/disk_cache_manager_impl.cpp
@@ -61,11 +61,6 @@ int DiskCacheManagerImpl::Write(const std::string name, const char *buf,
             LOG(ERROR) << "upload object fail. object: " << name;
             return -1;
         }
-        ret = WriteReadDirect(name, buf, length);
-        if (ret < 0) {
-            LOG(ERROR) << "write object fail. object: " << name;
-            return -1;
-        }
     }
     VLOG(9) << "write success, write name = " << name;
     return 0;

--- a/curvefs/test/client/test_disk_cache_manager_impl.cpp
+++ b/curvefs/test/client/test_disk_cache_manager_impl.cpp
@@ -154,24 +154,8 @@ TEST_F(TestDiskCacheManagerImpl, Write) {
     ASSERT_EQ(0, ret);
 
     EXPECT_CALL(*diskCacheManager_, IsDiskCacheFull())
-        .Times(2)
-        .WillOnce(Return(true))
-        .WillOnce(Return(false));
+        .WillOnce(Return(true));
     EXPECT_CALL(*client_, Upload(_, _, _))
-        .WillOnce(Return(0));
-    EXPECT_CALL(*diskCacheManager_, WriteReadDirect(_, _, _))
-        .WillOnce(Return(-1));
-    ret = diskCacheManagerImpl_->Write(fileName,
-            const_cast<char*>(buf.c_str()), 10);
-    ASSERT_EQ(-1, ret);
-
-    EXPECT_CALL(*diskCacheManager_, IsDiskCacheFull())
-        .Times(2)
-        .WillOnce(Return(true))
-        .WillOnce(Return(false));
-    EXPECT_CALL(*client_, Upload(_, _, _))
-        .WillOnce(Return(0));
-    EXPECT_CALL(*diskCacheManager_, WriteReadDirect(_, _, _))
         .WillOnce(Return(0));
     ret = diskCacheManagerImpl_->Write(fileName,
             const_cast<char*>(buf.c_str()), 10);


### PR DESCRIPTION
Fixs: https://github.com/opencurve/curve/issues/750

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: close #750  <!-- REMOVE this line if no issue to close -->

Problem Summary: when use disk cache and disk cache is full, we forget to upload obj to s3

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?): 

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
