### PR TITLE
curvefs/client: fix umount bug

### DIFF
--- a/curvefs/src/client/s3/disk_cache_manager.cpp
+++ b/curvefs/src/client/s3/disk_cache_manager.cpp
@@ -104,8 +104,8 @@ int DiskCacheManager::UmountDiskCache() {
     ret = cacheWrite_->UploadAllCacheWriteFile();
     if (ret < 0) {
         LOG(ERROR) << "umount disk cache error.";
-        return -1;
     }
+    cacheWrite_->AsyncUploadStop();
     TrimStop();
     LOG(INFO) << "umount disk cache end.";
     return 0;

--- a/curvefs/test/client/test_disk_cache_manager_impl.cpp
+++ b/curvefs/test/client/test_disk_cache_manager_impl.cpp
@@ -224,7 +224,7 @@ TEST_F(TestDiskCacheManagerImpl, UmountDiskCache) {
     EXPECT_CALL(*diskCacheWrite_, UploadAllCacheWriteFile())
           .WillOnce(Return(-1));
     int ret = diskCacheManagerImpl_->UmountDiskCache();
-    ASSERT_EQ(-1, ret);
+    ASSERT_EQ(0, ret);
 
     EXPECT_CALL(*diskCacheWrite_, UploadAllCacheWriteFile())
           .WillOnce(Return(0));


### PR DESCRIPTION
before upload success, the s3 is disable, then the thread will block

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: close #709 <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?): 

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
