### PR TITLE
curvefs: rename bazel BUILD binary name

### DIFF
--- a/curvefs/src/mds/BUILD
+++ b/curvefs/src/mds/BUILD
@@ -47,8 +47,8 @@ cc_library(
 )
 
 cc_binary(
-    name = "curvefs_mds",
-    srcs = glob(["main.cpp"]),
+    name = "curvefs-mds",
+    srcs = ["main.cpp"],
     copts = CURVE_DEFAULT_COPTS,
     visibility = ["//visibility:public"],
     deps = [

--- a/curvefs/src/metaserver/BUILD
+++ b/curvefs/src/metaserver/BUILD
@@ -67,7 +67,7 @@ cc_library(
 )
 
 cc_binary(
-    name = "curvefs_metaserver_main",
+    name = "curvefs-metaserver",
     srcs = ["main.cpp"],
     copts = CURVE_DEFAULT_COPTS,
     visibility = ["//visibility:public"],

--- a/curvefs/src/space/BUILD
+++ b/curvefs/src/space/BUILD
@@ -73,10 +73,8 @@ cc_library(
 )
 
 cc_binary(
-    name = "curve_fs_space_main",
-    srcs = [
-        "main.cpp",
-    ],
+    name = "curvefs-space",
+    srcs = ["main.cpp"],
     copts = CURVE_DEFAULT_COPTS + ABSL_COPTS,
     deps = [
         ":curve_fs_space",


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: close #747

### What is changed and how it works?

What's Changed:

rename mds/metaserver/space of curvefs to `curvefs-mds`/`curvefs-metaserver`/`curvefs-space` to consistent with `curve-fuse`

Side effects(Breaking backward compatibility? Performance regression?): 

### Check List

- [x] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license
