### PR TITLE
curvefs/metaserver: support config change

### DIFF
--- a/curvefs/proto/cli2.proto
+++ b/curvefs/proto/cli2.proto
@@ -30,6 +30,51 @@ message GetLeaderResponse2 {
     required common.Peer leader = 1;
 }
 
+message AddPeerRequest2 {
+    required uint32 poolId = 1;
+    required uint32 copysetId = 2;
+    required common.Peer addPeer = 3;
+}
+
+message AddPeerResponse2 {
+    repeated common.Peer oldPeers = 1;
+    repeated common.Peer newPeers = 2;
+}
+
+message RemovePeerRequest2 {
+    required uint32 poolId = 1;
+    required uint32 copysetId = 2;
+    required common.Peer removePeer = 3;
+}
+
+message RemovePeerResponse2 {
+    repeated common.Peer oldPeers = 1;
+    repeated common.Peer newPeers = 2;
+}
+
+message ChangePeersRequest2 {
+    required uint32 poolId = 1;
+    required uint32 copysetId = 2;
+    repeated common.Peer newPeers = 3;
+}
+
+message ChangePeersResponse2 {
+    repeated common.Peer oldPeers = 1;
+    repeated common.Peer newPeers = 2;
+}
+
+message TransferLeaderRequest2 {
+    required uint32 poolId = 1;
+    required uint32 copysetId = 2;
+    required common.Peer transferee = 3;
+}
+
+message TransferLeaderResponse2 {}
+
 service CliService2 {
     rpc GetLeader(GetLeaderRequest2) returns (GetLeaderResponse2);
+    rpc AddPeer(AddPeerRequest2) returns (AddPeerResponse2);
+    rpc RemovePeer(RemovePeerRequest2) returns (RemovePeerResponse2);
+    rpc ChangePeers(ChangePeersRequest2) returns (ChangePeersResponse2);
+    rpc TransferLeader(TransferLeaderRequest2) returns (TransferLeaderResponse2);
 };

--- a/curvefs/src/metaserver/copyset/copyset_conf_change.cpp
+++ b/curvefs/src/metaserver/copyset/copyset_conf_change.cpp
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (c) 2021 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * Project: curve
+ * Date: Tuesday Nov 23 11:20:12 CST 2021
+ * Author: wuhanqing
+ */
+
+#include "curvefs/src/metaserver/copyset/copyset_conf_change.h"
+
+#include "curvefs/src/metaserver/copyset/copyset_node.h"
+
+namespace curvefs {
+namespace metaserver {
+namespace copyset {
+
+void OnConfChangeDone::Run() {
+    node_->OnConfChangeComplete();
+
+    LOG_IF(WARNING, !status().ok())
+        << "Copyset: " << node_->Name() << " "
+        << curve::mds::heartbeat::ConfigChangeType_Name(confChange_.type)
+        << " failed";
+
+    if (done_) {
+        done_->status() = status();
+        done_->Run();
+    }
+
+    delete this;
+}
+
+}  // namespace copyset
+}  // namespace metaserver
+}  // namespace curvefs

--- a/curvefs/src/metaserver/copyset/copyset_conf_change.h
+++ b/curvefs/src/metaserver/copyset/copyset_conf_change.h
@@ -1,0 +1,83 @@
+/*
+ *  Copyright (c) 2021 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * Project: curve
+ * Date: Tuesday Nov 23 11:20:08 CST 2021
+ * Author: wuhanqing
+ */
+
+#ifndef CURVEFS_SRC_METASERVER_COPYSET_COPYSET_CONF_CHANGE_H_
+#define CURVEFS_SRC_METASERVER_COPYSET_COPYSET_CONF_CHANGE_H_
+
+#include <braft/raft.h>
+
+#include <utility>
+
+#include "curvefs/proto/common.pb.h"
+#include "curvefs/proto/heartbeat.pb.h"
+#include "curvefs/src/metaserver/copyset/types.h"
+
+namespace curvefs {
+namespace metaserver {
+namespace copyset {
+
+using ::curve::mds::heartbeat::ConfigChangeType;
+using ::curvefs::common::Peer;
+
+struct OngoingConfChange {
+    OngoingConfChange() : type(ConfigChangeType::NONE), alterPeer() {}
+
+    OngoingConfChange(ConfigChangeType type, const Peer& peer)
+        : type(type), alterPeer(peer) {}
+
+    OngoingConfChange(ConfigChangeType type, Peer&& peer)
+        : type(type), alterPeer(std::move(peer)) {}
+
+    bool HasConfChange() const {
+        return type != ConfigChangeType::NONE && alterPeer.has_address();
+    }
+
+    void Reset() {
+        type = ConfigChangeType::NONE;
+        alterPeer.clear_address();
+    }
+
+    ConfigChangeType type;
+    Peer alterPeer;
+};
+
+class CopysetNode;
+
+class OnConfChangeDone : public braft::Closure {
+ public:
+    OnConfChangeDone(CopysetNode* node, braft::Closure* done,
+                     const OngoingConfChange& confChange)
+        : node_(node), done_(done), confChange_(confChange) {}
+
+    void Run() override;
+
+ private:
+    CopysetNode* node_;
+    braft::Closure* done_;
+    OngoingConfChange confChange_;
+};
+
+}  // namespace copyset
+}  // namespace metaserver
+}  // namespace curvefs
+
+#endif  // CURVEFS_SRC_METASERVER_COPYSET_COPYSET_CONF_CHANGE_H_

--- a/curvefs/src/metaserver/copyset/copyset_node_manager.cpp
+++ b/curvefs/src/metaserver/copyset/copyset_node_manager.cpp
@@ -180,7 +180,7 @@ bool CopysetNodeManager::CreateCopysetNode(PoolId poolId, CopysetId copysetId,
         return false;
     }
 
-    copysetNode = absl::make_unique<CopysetNode>(poolId, copysetId, conf);
+    copysetNode = absl::make_unique<CopysetNode>(poolId, copysetId, conf, this);
     if (!copysetNode->Init(options_)) {
         LOG(ERROR) << "Copyset " << ToGroupIdString(poolId, copysetId)
                    << "init failed";
@@ -216,7 +216,7 @@ void CopysetNodeManager::AddService(brpc::Server* server,
     // remote braft CliService and add our implemented cli service
     auto* service = server->FindServiceByName("CliService");
     LOG_IF(FATAL, 0 != server->RemoveService(service));
-    LOG_IF(FATAL, 0 != server->AddService(new RaftCliService2(),
+    LOG_IF(FATAL, 0 != server->AddService(new RaftCliService2(this),
                                           brpc::SERVER_OWNS_SERVICE));
 }
 

--- a/curvefs/src/metaserver/copyset/copyset_node_manager.h
+++ b/curvefs/src/metaserver/copyset/copyset_node_manager.h
@@ -55,7 +55,7 @@ class CopysetNodeManager {
 
     bool Stop();
 
-    CopysetNode* GetCopysetNode(PoolId poolId, CopysetId copysetId);
+    virtual CopysetNode* GetCopysetNode(PoolId poolId, CopysetId copysetId);
 
     bool IsCopysetNodeExist(PoolId poolId, CopysetId copysetId);
 
@@ -65,11 +65,11 @@ class CopysetNodeManager {
 
     bool DeleteCopysetNode(PoolId poolId, CopysetId copysetId);
 
-    bool PurgeCopysetNode(PoolId poolId, CopysetId copysetId);
+    virtual bool PurgeCopysetNode(PoolId poolId, CopysetId copysetId);
 
     void GetAllCopysets(std::vector<CopysetNode*>* nodes) const;
 
-    bool IsLoadFinished() const;
+    virtual bool IsLoadFinished() const;
 
  public:
     CopysetNodeManager();

--- a/curvefs/src/metaserver/copyset/copyset_reloader.cpp
+++ b/curvefs/src/metaserver/copyset/copyset_reloader.cpp
@@ -128,9 +128,9 @@ void CopysetReloader::LoadCopyset(PoolId poolId, CopysetId copysetId) {
 
     bool success =
         nodeManager_->CreateCopysetNode(poolId, copysetId, conf, false);
-    if (success) {
-        LOG(INFO) << "Failed to create copyset "
-                  << ToGroupIdString(poolId, copysetId);
+    if (!success) {
+        LOG(WARNING) << "Failed to create copyset "
+                     << ToGroupIdString(poolId, copysetId);
         return;
     }
 

--- a/curvefs/src/metaserver/copyset/raft_cli_service2.cpp
+++ b/curvefs/src/metaserver/copyset/raft_cli_service2.cpp
@@ -38,9 +38,13 @@
 
 #include "curvefs/src/metaserver/copyset/raft_cli_service2.h"
 
+#include <braft/closure_helper.h>
 #include <braft/node_manager.h>
+#include <butil/errno.h>
+#include <google/protobuf/util/message_differencer.h>
 
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "curvefs/src/metaserver/copyset/types.h"
@@ -50,11 +54,124 @@ namespace curvefs {
 namespace metaserver {
 namespace copyset {
 
-void RaftCliService2::GetLeader(
-    ::google::protobuf::RpcController* controller,
-    const ::curvefs::metaserver::copyset::GetLeaderRequest2* request,
-    ::curvefs::metaserver::copyset::GetLeaderResponse2* response,
-    ::google::protobuf::Closure* done) {
+namespace {
+
+using ::google::protobuf::util::MessageDifferencer;
+
+struct OnAddPeerReturned : public braft::Closure {
+    OnAddPeerReturned(brpc::Controller* cntl, const AddPeerRequest2* request,
+                      AddPeerResponse2* response, std::vector<Peer>&& oldPeers,
+                      google::protobuf::Closure* done)
+        : cntl(cntl),
+          request(request),
+          response(response),
+          oldPeers(std::move(oldPeers)),
+          done(done) {}
+
+    void Run() {
+        brpc::ClosureGuard doneGuard(done);
+        if (!status().ok()) {
+            cntl->SetFailed(status().error_code(), "%s", status().error_cstr());
+            return;
+        }
+
+        *response->mutable_oldpeers() = {oldPeers.begin(), oldPeers.end()};
+        *response->mutable_newpeers() = {oldPeers.begin(), oldPeers.end()};
+
+        auto iter = std::find_if(
+            oldPeers.begin(), oldPeers.end(), [this](const Peer& p) {
+                return MessageDifferencer::Equals(request->addpeer(), p);
+            });
+
+        if (iter == oldPeers.end()) {
+            *response->add_newpeers() = request->addpeer();
+        }
+    }
+
+    brpc::Controller* cntl;
+    const AddPeerRequest2* request;
+    AddPeerResponse2* response;
+    std::vector<Peer> oldPeers;
+    google::protobuf::Closure* done;
+};
+
+struct OnRemovePeerReturned : public braft::Closure {
+    OnRemovePeerReturned(brpc::Controller* cntl,
+                         const RemovePeerRequest2* request,
+                         RemovePeerResponse2* response,
+                         std::vector<Peer>&& oldPeers,
+                         google::protobuf::Closure* done)
+        : cntl(cntl),
+          request(request),
+          response(response),
+          oldPeers(std::move(oldPeers)),
+          done(done) {}
+
+    void Run() override {
+        brpc::ClosureGuard doneGuard(done);
+        if (!status().ok()) {
+            cntl->SetFailed(status().error_code(), "%s", status().error_cstr());
+            return;
+        }
+
+        for (size_t i = 0; i < oldPeers.size(); ++i) {
+            *response->add_oldpeers() = oldPeers[i];
+            if (!MessageDifferencer::Equals(oldPeers[i],
+                                            request->removepeer())) {
+                *response->add_newpeers() = oldPeers[i];
+            }
+        }
+    }
+
+    brpc::Controller* cntl;
+    const RemovePeerRequest2* request;
+    RemovePeerResponse2* response;
+    std::vector<Peer> oldPeers;
+    google::protobuf::Closure* done;
+};
+
+struct OnChangePeersReturned : public braft::Closure {
+    OnChangePeersReturned(brpc::Controller* cntl,
+                          const ChangePeersRequest2* request,
+                          ChangePeersResponse2* response,
+                          std::vector<Peer>&& oldPeers,
+                          const std::vector<Peer>& newPeers,
+                          google::protobuf::Closure* done)
+        : cntl(cntl),
+          request(request),
+          response(response),
+          oldPeers(std::move(oldPeers)),
+          newPeers(newPeers),
+          done(done) {}
+
+    void Run() override {
+        brpc::ClosureGuard doneGuard(done);
+        if (!status().ok()) {
+            cntl->SetFailed(status().error_code(), "%s", status().error_cstr());
+            return;
+        }
+
+        *response->mutable_oldpeers() = {oldPeers.begin(), oldPeers.end()};
+        *response->mutable_newpeers() = {newPeers.begin(), newPeers.end()};
+    }
+
+    brpc::Controller* cntl;
+    const ChangePeersRequest2* request;
+    ChangePeersResponse2* response;
+    std::vector<Peer> oldPeers;
+    std::vector<Peer> newPeers;
+    google::protobuf::Closure* done;
+};
+
+}  // namespace
+
+RaftCliService2::RaftCliService2(CopysetNodeManager* nodeManager)
+    : nodeManager_(nodeManager) {}
+
+void RaftCliService2::GetLeader(google::protobuf::RpcController* controller,
+                                const GetLeaderRequest2* request,
+                                GetLeaderResponse2* response,
+                                google::protobuf::Closure* done) {
     brpc::ClosureGuard doneGuard(done);
     brpc::Controller* cntl = static_cast<brpc::Controller*>(controller);
 
@@ -77,6 +194,109 @@ void RaftCliService2::GetLeader(
     }
 
     cntl->SetFailed(EAGAIN, "Unknown leader");
+}
+
+void RaftCliService2::AddPeer(google::protobuf::RpcController* controller,
+                              const AddPeerRequest2* request,
+                              AddPeerResponse2* response,
+                              google::protobuf::Closure* done) {
+    brpc::ClosureGuard doneGuard(done);
+    brpc::Controller* cntl = static_cast<brpc::Controller*>(controller);
+
+    auto* node =
+        nodeManager_->GetCopysetNode(request->poolid(), request->copysetid());
+    if (!node) {
+        cntl->SetFailed(
+            ENOENT, "Copyset %s not found",
+            ToGroupIdString(request->poolid(), request->copysetid()).c_str());
+        return;
+    }
+
+    std::vector<Peer> oldPeers;
+    node->ListPeers(&oldPeers);
+
+    auto* addPeerDone = new OnAddPeerReturned(
+        cntl, request, response, std::move(oldPeers), doneGuard.release());
+    return node->AddPeer(request->addpeer(), addPeerDone);
+}
+
+void RaftCliService2::RemovePeer(google::protobuf::RpcController* controller,
+                                 const RemovePeerRequest2* request,
+                                 RemovePeerResponse2* response,
+                                 google::protobuf::Closure* done) {
+    brpc::ClosureGuard doneGuard(done);
+    brpc::Controller* cntl = static_cast<brpc::Controller*>(controller);
+
+    auto* node =
+        nodeManager_->GetCopysetNode(request->poolid(), request->copysetid());
+    if (!node) {
+        cntl->SetFailed(
+            ENOENT, "Copyset %s not found",
+            ToGroupIdString(request->poolid(), request->copysetid()).c_str());
+        return;
+    }
+
+    std::vector<Peer> oldPeers;
+    node->ListPeers(&oldPeers);
+
+    auto* removePeerDone = new OnRemovePeerReturned(
+        cntl, request, response, std::move(oldPeers), doneGuard.release());
+    return node->RemovePeer(request->removepeer(), removePeerDone);
+}
+
+void RaftCliService2::ChangePeers(google::protobuf::RpcController* controller,
+                                  const ChangePeersRequest2* request,
+                                  ChangePeersResponse2* response,
+                                  google::protobuf::Closure* done) {
+    brpc::ClosureGuard doneGuard(done);
+    brpc::Controller* cntl = static_cast<brpc::Controller*>(controller);
+
+    auto* node =
+        nodeManager_->GetCopysetNode(request->poolid(), request->copysetid());
+    if (!node) {
+        cntl->SetFailed(
+            ENOENT, "Copyset %s not found",
+            ToGroupIdString(request->poolid(), request->copysetid()).c_str());
+        return;
+    }
+
+    std::vector<Peer> oldPeers;
+    node->ListPeers(&oldPeers);
+
+    std::vector<Peer> newPeers{request->newpeers().begin(),
+                               request->newpeers().end()};
+
+    auto* changePeerDone =
+        new OnChangePeersReturned(cntl, request, response, std::move(oldPeers),
+                                  newPeers, doneGuard.release());
+    return node->ChangePeers(newPeers, changePeerDone);
+}
+
+void RaftCliService2::TransferLeader(
+    google::protobuf::RpcController* controller,
+    const TransferLeaderRequest2* request,
+    TransferLeaderResponse2* /* response */, google::protobuf::Closure* done) {
+    brpc::ClosureGuard doneGuard(done);
+    brpc::Controller* cntl = static_cast<brpc::Controller*>(controller);
+
+    auto* node =
+        nodeManager_->GetCopysetNode(request->poolid(), request->copysetid());
+    if (!node) {
+        cntl->SetFailed(
+            ENOENT, "Copyset %s not found",
+            ToGroupIdString(request->poolid(), request->copysetid()).c_str());
+        return;
+    }
+
+    auto st = node->TransferLeader(request->transferee());
+    if (!st.ok()) {
+        cntl->SetFailed(
+            st.error_code(),
+            "Fail to TransferLeader to %s, copyset %s, error: %s",
+            request->transferee().ShortDebugString().c_str(),
+            ToGroupIdString(request->poolid(), request->copysetid()).c_str(),
+            st.error_cstr());
+    }
 }
 
 butil::Status RaftCliService2::GetNode(scoped_refptr<braft::NodeImpl>* node,

--- a/curvefs/src/metaserver/copyset/raft_cli_service2.h
+++ b/curvefs/src/metaserver/copyset/raft_cli_service2.h
@@ -31,6 +31,7 @@
 
 #include "curvefs/proto/cli2.pb.h"
 #include "curvefs/src/metaserver/common/types.h"
+#include "curvefs/src/metaserver/copyset/copyset_node_manager.h"
 
 namespace curvefs {
 namespace metaserver {
@@ -38,15 +39,38 @@ namespace copyset {
 
 class RaftCliService2 : public CliService2 {
  public:
-    void GetLeader(
-        ::google::protobuf::RpcController* controller,
-        const ::curvefs::metaserver::copyset::GetLeaderRequest2* request,
-        ::curvefs::metaserver::copyset::GetLeaderResponse2* response,
-        ::google::protobuf::Closure* done);
+    explicit RaftCliService2(CopysetNodeManager* manager);
+
+    void GetLeader(google::protobuf::RpcController* controller,
+                   const GetLeaderRequest2* request,
+                   GetLeaderResponse2* response,
+                   google::protobuf::Closure* done) override;
+
+    void AddPeer(google::protobuf::RpcController* controller,
+                 const AddPeerRequest2* request, AddPeerResponse2* response,
+                 google::protobuf::Closure* done) override;
+
+    void RemovePeer(google::protobuf::RpcController* controller,
+                    const RemovePeerRequest2* request,
+                    RemovePeerResponse2* response,
+                    google::protobuf::Closure* done) override;
+
+    void ChangePeers(google::protobuf::RpcController* controller,
+                     const ChangePeersRequest2* request,
+                     ChangePeersResponse2* response,
+                     google::protobuf::Closure* done) override;
+
+    void TransferLeader(google::protobuf::RpcController* controller,
+                        const TransferLeaderRequest2* request,
+                        TransferLeaderResponse2* response,
+                        google::protobuf::Closure* done) override;
 
  private:
     butil::Status GetNode(scoped_refptr<braft::NodeImpl>* node, PoolId poolId,
                           CopysetId copysetId, const std::string& peerId);
+
+ private:
+    CopysetNodeManager* nodeManager_;
 };
 
 }  // namespace copyset

--- a/curvefs/test/metaserver/BUILD
+++ b/curvefs/test/metaserver/BUILD
@@ -42,6 +42,7 @@ cc_test(
             "@com_google_googletest//:gtest",
             "//external:brpc",
             "//curvefs/proto:curvefs_topology_cc_proto",
+            "//curvefs/test/metaserver/copyset/mock:metaserver_copyset_test_mock",
     ],
 )
 

--- a/curvefs/test/metaserver/copyset/copyset_node_conf_change_test.cpp
+++ b/curvefs/test/metaserver/copyset/copyset_node_conf_change_test.cpp
@@ -1,0 +1,662 @@
+/*
+ *  Copyright (c) 2021 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * Project: curve
+ * Date: Friday Nov 26 16:55:39 CST 2021
+ * Author: wuhanqing
+ */
+
+#include <brpc/server.h>
+#include <gmock/gmock.h>
+#include <google/protobuf/util/message_differencer.h>
+#include <gtest/gtest.h>
+
+#include "curvefs/src/metaserver/copyset/copyset_node.h"
+#include "curvefs/test/metaserver/copyset/mock/mock_copyset_node_manager.h"
+#include "curvefs/test/metaserver/copyset/mock/mock_copyset_service.h"
+#include "curvefs/test/metaserver/copyset/mock/mock_raft_node.h"
+
+namespace curvefs {
+namespace metaserver {
+namespace copyset {
+
+using ::google::protobuf::util::MessageDifferencer;
+using ::testing::_;
+using ::testing::Invoke;
+using ::testing::Return;
+using ::testing::SaveArgPointee;
+
+class CopysetNodeConfChangeTest : public testing::Test {
+ protected:
+    void SetUp() override {
+        unsigned int seed = reinterpret_cast<uint64_t>(this);
+        poolId_ = rand_r(&seed) % 12345;
+        copysetId_ = time(nullptr) % 54321;
+
+        conf_.parse_from(
+            "127.0.0.1:29960:0,127.0.0.1:29961:0,127.0.0.1:29962:0");
+
+        options_.dataUri = "local:///data/";
+        options_.ip = "127.0.0.1";
+        options_.port = 29960;
+
+        ON_CALL(mockNodeManager_, IsLoadFinished())
+            .WillByDefault(Return(true));
+    }
+
+    void TearDown() override {
+        if (server_) {
+            server_->Stop(0);
+            server_->Join();
+        }
+    }
+
+    void StartMockCopysetService(butil::EndPoint listenAddr) {
+        server_ = absl::make_unique<brpc::Server>();
+        mockCopysetService_ = absl::make_unique<MockCopysetService>();
+
+        ASSERT_EQ(0, server_->AddService(mockCopysetService_.get(),
+                                         brpc::SERVER_DOESNT_OWN_SERVICE));
+
+        ASSERT_EQ(0, server_->Start(listenAddr, nullptr));
+    }
+
+ protected:
+    PoolId poolId_;
+    CopysetId copysetId_;
+    braft::Configuration conf_;
+    CopysetNodeOptions options_;
+    MockCopysetNodeManager mockNodeManager_;
+
+    std::unique_ptr<brpc::Server> server_;
+    std::unique_ptr<MockCopysetService> mockCopysetService_;
+};
+
+namespace {
+
+struct FakeClosure : public braft::Closure {
+    std::mutex mtx;
+    std::condition_variable cond;
+    bool runned{false};
+    std::atomic<uint32_t> count{0};
+
+    void Run() override {
+        std::unique_lock<std::mutex> lk(mtx);
+        runned = true;
+        cond.notify_one();
+    }
+
+    void Wait() {
+        std::unique_lock<std::mutex> lk(mtx);
+        cond.wait(lk, [this]() { return runned; });
+    }
+};
+
+}  // namespace
+
+TEST_F(CopysetNodeConfChangeTest, GetConfTest_NoConfChange) {
+    CopysetNode node(poolId_, copysetId_, conf_, &mockNodeManager_);
+    EXPECT_TRUE(node.Init(options_));
+
+    ConfigChangeType type;
+    Configuration oldConf;
+    Peer alterPeer;
+
+    node.GetConfChange(&type, &alterPeer);
+    EXPECT_EQ(ConfigChangeType::NONE, type);
+    EXPECT_FALSE(alterPeer.has_address());
+    EXPECT_FALSE(alterPeer.has_id());
+}
+
+TEST_F(CopysetNodeConfChangeTest, TestTransferLeader) {
+    // target peer is invalid
+    {
+        CopysetNode node(poolId_, copysetId_, conf_, &mockNodeManager_);
+        EXPECT_TRUE(node.Init(options_));
+
+        Peer peer;
+        peer.set_address("127.0.0.1:xxxx:0");
+
+        auto st = node.TransferLeader(peer);
+        EXPECT_EQ(EINVAL, st.error_code());
+    }
+
+    // no a leader
+    {
+        CopysetNode node(poolId_, copysetId_, conf_, &mockNodeManager_);
+        EXPECT_TRUE(node.Init(options_));
+
+        Peer peer;
+        peer.set_address("127.0.0.1:29960:0");
+
+        auto st = node.TransferLeader(peer);
+        EXPECT_EQ(EPERM, st.error_code());
+    }
+
+    // transfer to self
+    {
+        CopysetNode node(poolId_, copysetId_, conf_, &mockNodeManager_);
+        EXPECT_TRUE(node.Init(options_));
+
+        auto* raftNode = new MockRaftNode();
+        node.SetRaftNode(raftNode);
+        node.on_leader_start(100);
+
+        Peer peer;
+        peer.set_address("127.0.0.1:29960:0");
+
+        EXPECT_CALL(*raftNode, leader_id()).WillOnce(Invoke([peer]() {
+            braft::PeerId peerId(peer.address());
+            return peerId;
+        }));
+
+        auto st = node.TransferLeader(peer);
+        EXPECT_EQ(0, st.error_code());
+    }
+
+    // raft node return ENOENT
+    {
+        CopysetNode node(poolId_, copysetId_, conf_, &mockNodeManager_);
+        EXPECT_TRUE(node.Init(options_));
+
+        auto* raftNode = new MockRaftNode();
+        node.SetRaftNode(raftNode);
+        node.on_leader_start(100);
+
+        Peer peer;
+        peer.set_address("127.0.0.1:29961:0");
+
+        EXPECT_CALL(*raftNode, leader_id()).WillOnce(Invoke([peer]() {
+            braft::PeerId peerId("127.0.0.1:29960:0");
+            return peerId;
+        }));
+
+        EXPECT_CALL(*raftNode, transfer_leadership_to(_))
+            .WillOnce(Return(ENOENT));
+
+        auto st = node.TransferLeader(peer);
+        EXPECT_EQ(ENOENT, st.error_code());
+    }
+
+    // raft node return OK
+    {
+        CopysetNode node(poolId_, copysetId_, conf_, &mockNodeManager_);
+        EXPECT_TRUE(node.Init(options_));
+
+        auto* raftNode = new MockRaftNode();
+        node.SetRaftNode(raftNode);
+        node.on_leader_start(100);
+
+        Peer peer;
+        peer.set_address("127.0.0.1:29961:0");
+
+        EXPECT_CALL(*raftNode, leader_id()).WillOnce(Invoke([peer]() {
+            braft::PeerId peerId("127.0.0.1:29960:0");
+            return peerId;
+        }));
+
+        EXPECT_CALL(*raftNode, transfer_leadership_to(_)).WillOnce(Return(OK));
+
+        auto st = node.TransferLeader(peer);
+        EXPECT_EQ(OK, st.error_code());
+
+        // get conf change
+        ConfigChangeType type;
+        Peer alterPeer;
+
+        EXPECT_CALL(*raftNode, get_status(_))
+            .WillOnce(Invoke([](braft::NodeStatus* status) {
+                status->state = braft::State::STATE_TRANSFERRING;
+                return;
+            }));
+
+        node.GetConfChange(&type, &alterPeer);
+        EXPECT_EQ(ConfigChangeType::TRANSFER_LEADER, type);
+        EXPECT_TRUE(MessageDifferencer::Equals(peer, alterPeer));
+    }
+}
+
+TEST_F(CopysetNodeConfChangeTest, TestTransferLeader_CopysetsStillLoading) {
+    CopysetNode node(poolId_, copysetId_, conf_, &mockNodeManager_);
+    EXPECT_TRUE(node.Init(options_));
+
+    EXPECT_CALL(mockNodeManager_, IsLoadFinished())
+        .WillOnce(Return(false));
+
+    Peer peer;
+    peer.set_address("127.0.0.1:29960:0");
+
+    auto st = node.TransferLeader(peer);
+    EXPECT_EQ(EBUSY, st.error_code());
+}
+
+TEST_F(CopysetNodeConfChangeTest, TestAddPeer) {
+    // add peer already exists
+    {
+        CopysetNode node(poolId_, copysetId_, conf_, &mockNodeManager_);
+        EXPECT_TRUE(node.Init(options_));
+
+        node.on_leader_start(100);
+
+        Peer peer;
+        peer.set_address("127.0.0.1:29960:0");
+
+        FakeClosure done;
+        node.AddPeer(peer, &done);
+        done.Wait();
+        EXPECT_EQ(EEXIST, done.status().error_code());
+    }
+
+    // add peer is invalid
+    {
+        CopysetNode node(poolId_, copysetId_, conf_, &mockNodeManager_);
+        EXPECT_TRUE(node.Init(options_));
+
+        node.on_leader_start(100);
+
+        Peer peer;
+        peer.set_address("127.0.0.1:xxxx:0");
+
+        FakeClosure done;
+        node.AddPeer(peer, &done);
+        done.Wait();
+        EXPECT_EQ(EINVAL, done.status().error_code());
+    }
+
+    // not a leader
+    {
+        CopysetNode node(poolId_, copysetId_, conf_, &mockNodeManager_);
+        EXPECT_TRUE(node.Init(options_));
+
+        Peer peer;
+        peer.set_address("127.0.0.1:29963:0");
+
+        FakeClosure done;
+        node.AddPeer(peer, &done);
+        done.Wait();
+        EXPECT_EQ(EPERM, done.status().error_code());
+    }
+
+    // raft node return EBUSY
+    {
+        CopysetNode node(poolId_, copysetId_, conf_, &mockNodeManager_);
+        EXPECT_TRUE(node.Init(options_));
+
+        node.on_leader_start(100);
+
+        auto* raftNode = new MockRaftNode();
+        node.SetRaftNode(raftNode);
+
+        Peer peer;
+        peer.set_address("127.0.0.1:29963:0");
+
+        EXPECT_CALL(*raftNode, add_peer(_, _))
+            .WillOnce(
+                Invoke([](const braft::PeerId& peer, braft::Closure* done) {
+                    braft::AsyncClosureGuard guard(done);
+                    done->status().set_error(EBUSY, "busy");
+                }));
+
+        FakeClosure done;
+        node.AddPeer(peer, &done);
+        done.Wait();
+        EXPECT_EQ(EBUSY, done.status().error_code());
+    }
+
+    // raft node succeeded
+    {
+        CopysetNode node(poolId_, copysetId_, conf_, &mockNodeManager_);
+        EXPECT_TRUE(node.Init(options_));
+
+        node.on_leader_start(100);
+
+        auto* raftNode = new MockRaftNode();
+        node.SetRaftNode(raftNode);
+
+        Peer peer;
+        peer.set_address("127.0.0.1:29963:0");
+
+        EXPECT_CALL(*raftNode, add_peer(_, _))
+            .WillOnce(Invoke([](const braft::PeerId&, braft::Closure* done) {
+                braft::AsyncClosureGuard guard(done);
+                done->status() = butil::Status::OK();
+            }));
+
+        FakeClosure done;
+        node.AddPeer(peer, &done);
+        done.Wait();
+        EXPECT_TRUE(done.status().ok());
+
+        // get conf change
+        ConfigChangeType type;
+        Peer alterPeer;
+
+        node.GetConfChange(&type, &alterPeer);
+        EXPECT_EQ(ConfigChangeType::NONE, type);
+    }
+}
+
+TEST_F(CopysetNodeConfChangeTest, TestRemovePeer) {
+    // remove peer don't exists
+    {
+        CopysetNode node(poolId_, copysetId_, conf_, &mockNodeManager_);
+        EXPECT_TRUE(node.Init(options_));
+
+        node.on_leader_start(100);
+
+        Peer peer;
+        peer.set_address("127.0.0.1:29970:0");
+
+        FakeClosure done;
+        node.RemovePeer(peer, &done);
+        done.Wait();
+        EXPECT_EQ(ENOENT, done.status().error_code());
+    }
+
+    // remove peer is invalid
+    {
+        CopysetNode node(poolId_, copysetId_, conf_, &mockNodeManager_);
+        EXPECT_TRUE(node.Init(options_));
+
+        node.on_leader_start(100);
+
+        Peer peer;
+        peer.set_address("127.0.0.1:xxx:0");
+
+        FakeClosure done;
+        node.RemovePeer(peer, &done);
+        done.Wait();
+        EXPECT_EQ(EINVAL, done.status().error_code());
+    }
+
+    // not a leader
+    {
+        CopysetNode node(poolId_, copysetId_, conf_, &mockNodeManager_);
+        EXPECT_TRUE(node.Init(options_));
+
+        Peer peer;
+        peer.set_address("127.0.0.1:29962:0");
+
+        FakeClosure done;
+        node.RemovePeer(peer, &done);
+        done.Wait();
+        EXPECT_EQ(EPERM, done.status().error_code());
+    }
+
+    // raft node return EBUSY
+    {
+        CopysetNode node(poolId_, copysetId_, conf_, &mockNodeManager_);
+        EXPECT_TRUE(node.Init(options_));
+
+        node.on_leader_start(100);
+
+        auto* raftNode = new MockRaftNode();
+        node.SetRaftNode(raftNode);
+
+        Peer peer;
+        peer.set_address("127.0.0.1:29962:0");
+
+        EXPECT_CALL(*raftNode, remove_peer(_, _))
+            .WillOnce(
+                Invoke([](const braft::PeerId& peer, braft::Closure* done) {
+                    braft::AsyncClosureGuard guard(done);
+                    done->status().set_error(EBUSY, "busy");
+                }));
+
+        FakeClosure done;
+        node.RemovePeer(peer, &done);
+        done.Wait();
+        LOG(INFO) << "done: " << &done
+                  << ", status: " << done.status().error_str();
+        EXPECT_EQ(EBUSY, done.status().error_code());
+    }
+
+    // raft node succeeded
+    {
+        CopysetNode node(poolId_, copysetId_, conf_, &mockNodeManager_);
+        EXPECT_TRUE(node.Init(options_));
+
+        node.on_leader_start(100);
+
+        auto* raftNode = new MockRaftNode();
+        node.SetRaftNode(raftNode);
+
+        Peer peer;
+        peer.set_address("127.0.0.1:29962:0");
+
+        EXPECT_CALL(*raftNode, remove_peer(_, _))
+            .WillOnce(
+                Invoke([](const braft::PeerId& peer, braft::Closure* done) {
+                    braft::AsyncClosureGuard guard(done);
+                    done->status() = butil::Status::OK();
+                }));
+
+        FakeClosure done;
+        node.RemovePeer(peer, &done);
+        done.Wait();
+        EXPECT_TRUE(done.status().ok());
+
+        // get conf change
+        ConfigChangeType type;
+        Peer alterPeer;
+
+        node.GetConfChange(&type, &alterPeer);
+        EXPECT_EQ(ConfigChangeType::NONE, type);
+    }
+}
+
+TEST_F(CopysetNodeConfChangeTest, TestChangePeer) {
+    // not a leader
+    {
+        CopysetNode node(poolId_, copysetId_, conf_, &mockNodeManager_);
+        EXPECT_TRUE(node.Init(options_));
+
+        Peer peer;
+        std::vector<Peer> newPeers;
+
+        peer.set_address("127.0.0.1:29961:0");
+        newPeers.emplace_back(peer);
+        peer.set_address("127.0.0.1:29962:0");
+        newPeers.emplace_back(peer);
+        peer.set_address("127.0.0.1:29963:0");
+        newPeers.emplace_back(peer);
+
+        FakeClosure done;
+        node.ChangePeers(newPeers, &done);
+        done.Wait();
+        EXPECT_EQ(EPERM, done.status().error_code());
+    }
+
+    // adding or removing more than one peers
+    {
+        CopysetNode node(poolId_, copysetId_, conf_, &mockNodeManager_);
+        EXPECT_TRUE(node.Init(options_));
+
+        node.on_leader_start(100);
+
+        Peer peer;
+        std::vector<Peer> newPeers;
+
+        peer.set_address("127.0.0.1:29962:0");
+        newPeers.emplace_back(peer);
+        peer.set_address("127.0.0.1:29963:0");
+        newPeers.emplace_back(peer);
+        peer.set_address("127.0.0.1:29964:0");
+        newPeers.emplace_back(peer);
+
+        FakeClosure done;
+        node.ChangePeers(newPeers, &done);
+        done.Wait();
+        EXPECT_EQ(EPERM, done.status().error_code());
+    }
+
+    // raft node return EBUSY
+    {
+        CopysetNode node(poolId_, copysetId_, conf_, &mockNodeManager_);
+        EXPECT_TRUE(node.Init(options_));
+
+        node.on_leader_start(100);
+
+        auto* raftNode = new MockRaftNode();
+        node.SetRaftNode(raftNode);
+
+        Peer peer;
+        std::vector<Peer> newPeers;
+
+        peer.set_address("127.0.0.1:29961:0");
+        newPeers.emplace_back(peer);
+        peer.set_address("127.0.0.1:29962:0");
+        newPeers.emplace_back(peer);
+        peer.set_address("127.0.0.1:29963:0");
+        newPeers.emplace_back(peer);
+
+        EXPECT_CALL(*raftNode, change_peers(_, _))
+            .WillOnce(Invoke([](const braft::Configuration& new_peers,
+                                braft::Closure* done) {
+                braft::AsyncClosureGuard guard(done);
+                done->status().set_error(EBUSY, "busy");
+            }));
+
+        FakeClosure done;
+        node.ChangePeers(newPeers, &done);
+        done.Wait();
+        EXPECT_EQ(EBUSY, done.status().error_code());
+    }
+
+    // raft node succeeded
+    {
+        CopysetNode node(poolId_, copysetId_, conf_, &mockNodeManager_);
+        EXPECT_TRUE(node.Init(options_));
+
+        node.on_leader_start(100);
+
+        auto* raftNode = new MockRaftNode();
+        node.SetRaftNode(raftNode);
+
+        Peer peer;
+        std::vector<Peer> newPeers;
+
+        peer.set_address("127.0.0.1:29961:0");
+        newPeers.emplace_back(peer);
+        peer.set_address("127.0.0.1:29962:0");
+        newPeers.emplace_back(peer);
+        peer.set_address("127.0.0.1:29963:0");
+        newPeers.emplace_back(peer);
+
+        EXPECT_CALL(*raftNode, change_peers(_, _))
+            .WillOnce(Invoke([](const braft::Configuration& new_peers,
+                                braft::Closure* done) {
+                braft::AsyncClosureGuard guard(done);
+                done->status() = butil::Status::OK();
+            }));
+
+        FakeClosure done;
+        node.ChangePeers(newPeers, &done);
+        done.Wait();
+        EXPECT_TRUE(done.status().ok());
+
+        // get conf change
+        ConfigChangeType type;
+        Peer alterPeer;
+
+        node.GetConfChange(&type, &alterPeer);
+        EXPECT_EQ(ConfigChangeType::NONE, type);
+    }
+}
+
+TEST_F(CopysetNodeConfChangeTest, RejectConfChangeIfPreviousNotComplete) {
+    CopysetNode node(poolId_, copysetId_, conf_, &mockNodeManager_);
+    EXPECT_TRUE(node.Init(options_));
+
+    node.on_leader_start(100);
+
+    auto* raftNode = new MockRaftNode();
+    node.SetRaftNode(raftNode);
+
+    // issue add peer
+    Peer peerToAdd;
+    peerToAdd.set_address("127.0.0.1:29963:0");
+
+    braft::Closure* addPeerDone;
+    EXPECT_CALL(*raftNode, add_peer(_, _))
+        .WillOnce(
+            Invoke([&addPeerDone](const braft::PeerId&, braft::Closure* done) {
+                addPeerDone = done;
+            }));
+
+    FakeClosure onAddPeerDone;
+    node.AddPeer(peerToAdd, &onAddPeerDone);
+
+    // issue remove peer
+    Peer peerToRemove;
+    peerToRemove.set_address("127.0.0.1:29960:0");
+
+    EXPECT_CALL(*raftNode, remove_peer(_, _)).Times(0);
+
+    FakeClosure onRemovePeerDone;
+    node.RemovePeer(peerToRemove, &onRemovePeerDone);
+    onRemovePeerDone.Wait();
+    EXPECT_EQ(EBUSY, onRemovePeerDone.status().error_code());
+
+    // let add peer complete
+    addPeerDone->status() = butil::Status::OK();
+    addPeerDone->Run();
+}
+
+TEST_F(CopysetNodeConfChangeTest, UpdateTransferLeaderStateWhenGetConfChange) {
+    // issue a transfer leader request
+    CopysetNode node(poolId_, copysetId_, conf_, &mockNodeManager_);
+    EXPECT_TRUE(node.Init(options_));
+
+    auto* raftNode = new MockRaftNode();
+    node.SetRaftNode(raftNode);
+    node.on_leader_start(100);
+
+    Peer peer;
+    peer.set_address("127.0.0.1:29961:0");
+
+    EXPECT_CALL(*raftNode, leader_id()).WillOnce(Invoke([]() {
+        braft::PeerId peerId("127.0.0.1:29960:0");
+        return peerId;
+    }));
+
+    EXPECT_CALL(*raftNode, transfer_leadership_to(_)).WillOnce(Return(OK));
+
+    auto st = node.TransferLeader(peer);
+    EXPECT_EQ(OK, st.error_code());
+
+    // get conf change
+    ConfigChangeType type;
+    Peer alterPeer;
+
+    EXPECT_CALL(*raftNode, get_status(_))
+        .WillOnce(Invoke([](braft::NodeStatus* status) {
+            status->state = braft::State::STATE_FOLLOWER;
+            return;
+        }));
+
+    node.GetConfChange(&type, &alterPeer);
+    EXPECT_EQ(ConfigChangeType::NONE, type);
+
+    // later get conf change won't call raft node get_status
+    node.GetConfChange(&type, &alterPeer);
+    EXPECT_EQ(ConfigChangeType::NONE, type);
+}
+
+}  // namespace copyset
+}  // namespace metaserver
+}  // namespace curvefs

--- a/curvefs/test/metaserver/copyset/copyset_node_snapshot_test.cpp
+++ b/curvefs/test/metaserver/copyset/copyset_node_snapshot_test.cpp
@@ -325,10 +325,11 @@ TEST_F(CopysetNodeRaftSnapshotTest,
     EXPECT_EQ(0, node->on_snapshot_load(&reader));
     EXPECT_EQ(100, node->LatestLoadSnapshotIndex());
 
-    // load snapshot doesn't change configuration
+    // load snapshot doesn't change configuration and epoch
     std::vector<Peer> peers;
     node->ListPeers(&peers);
     EXPECT_EQ(3, peers.size());
+    auto epochBefore = node->GetConfEpoch();
 
     braft::Configuration conf;
     for (int i = 0; i < meta.peers_size(); ++i) {
@@ -338,7 +339,8 @@ TEST_F(CopysetNodeRaftSnapshotTest,
     node->on_configuration_committed(conf, meta.last_included_index());
     peers.clear();
     node->ListPeers(&peers);
-    EXPECT_EQ(1, peers.size());
+    EXPECT_EQ(3, peers.size());
+    EXPECT_EQ(epochBefore, node->GetConfEpoch());
 }
 
 TEST_F(CopysetNodeRaftSnapshotTest, SnapshotLoadTest_MetaStoreLoadFailed) {

--- a/curvefs/test/metaserver/copyset/meta_operator_test.cpp
+++ b/curvefs/test/metaserver/copyset/meta_operator_test.cpp
@@ -30,6 +30,7 @@
 #include <regex>
 
 #include "absl/memory/memory.h"
+#include "curvefs/test/metaserver/copyset/mock/mock_copyset_node_manager.h"
 #include "curvefs/test/metaserver/copyset/mock/mock_raft_node.h"
 #include "curvefs/test/metaserver/mock/mock_metastore.h"
 #include "curvefs/test/utils/protobuf_message_utils.h"
@@ -113,6 +114,9 @@ class MetaOperatorTest : public testing::Test {
 
         return std::stoull(match[2].str()) == expectValue;
     }
+
+ protected:
+    MockCopysetNodeManager mockNodeManager_;
 };
 
 TEST_F(MetaOperatorTest, OperatorTypeTest) {
@@ -145,7 +149,7 @@ TEST_F(MetaOperatorTest, OnApplyErrorTest) {
     CopysetId copysetId = 100;
     braft::Configuration conf;
 
-    CopysetNode node(poolId, copysetId, conf);
+    CopysetNode node(poolId, copysetId, conf, &mockNodeManager_);
     mock::MockMetaStore* mockMetaStore = new mock::MockMetaStore();
     node.SetMetaStore(mockMetaStore);
 
@@ -247,7 +251,7 @@ TEST_F(MetaOperatorTest, OnApplyFromLogErrorTest) {
     CopysetId copysetId = 100;
     braft::Configuration conf;
 
-    CopysetNode node(poolId, copysetId, conf);
+    CopysetNode node(poolId, copysetId, conf, &mockNodeManager_);
     mock::MockMetaStore* mockMetaStore = new mock::MockMetaStore();
     node.SetMetaStore(mockMetaStore);
 
@@ -344,7 +348,7 @@ TEST_F(MetaOperatorTest, PropostTest_IsNotLeader) {
 
     butil::Status status;
     status.set_error(EINVAL, "invalid");
-    CopysetNode node(poolId, copysetId, conf);
+    CopysetNode node(poolId, copysetId, conf, &mockNodeManager_);
     node.on_leader_stop(status);
 
     CreateInodeRequest request;
@@ -361,7 +365,7 @@ TEST_F(MetaOperatorTest, PropostTest_RequestCanBypassProcess) {
     CopysetId copysetId = 100;
     braft::Configuration conf;
 
-    CopysetNode node(poolId, copysetId, conf);
+    CopysetNode node(poolId, copysetId, conf, &mockNodeManager_);
     CopysetNodeOptions options;
     options.dataUri = "local:///mnt/data";
 
@@ -404,7 +408,7 @@ TEST_F(MetaOperatorTest, PropostTest_PropostTaskFailed) {
     CopysetId copysetId = 100;
     braft::Configuration conf;
 
-    CopysetNode node(poolId, copysetId, conf);
+    CopysetNode node(poolId, copysetId, conf, &mockNodeManager_);
 
     node.on_leader_start(1);
     node.UpdateAppliedIndex(101);

--- a/curvefs/test/metaserver/copyset/mock/mock_copyset_node.h
+++ b/curvefs/test/metaserver/copyset/mock/mock_copyset_node.h
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (c) 2021 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * Project: curve
+ * Date: Wednesday Dec 01 19:37:04 CST 2021
+ * Author: wuhanqing
+ */
+
+#ifndef CURVEFS_TEST_METASERVER_COPYSET_MOCK_MOCK_COPYSET_NODE_H_
+#define CURVEFS_TEST_METASERVER_COPYSET_MOCK_MOCK_COPYSET_NODE_H_
+
+#include <gmock/gmock.h>
+
+#include <vector>
+
+#include "curvefs/src/metaserver/copyset/copyset_node.h"
+
+namespace curvefs {
+namespace metaserver {
+namespace copyset {
+
+class MockCopysetNode : public CopysetNode {
+ public:
+    MockCopysetNode() : CopysetNode(0, 0, {}, nullptr) {}
+
+    MOCK_CONST_METHOD0(GetConfEpoch, uint64_t());
+    MOCK_METHOD1(TransferLeader, butil::Status(const Peer&));
+    MOCK_METHOD2(AddPeer, void(const Peer&, braft::Closure*));
+    MOCK_METHOD2(RemovePeer, void(const Peer&, braft::Closure*));
+    MOCK_METHOD2(ChangePeers, void(const std::vector<Peer>&, braft::Closure*));
+    MOCK_CONST_METHOD1(ListPeers, void(std::vector<Peer>*));
+};
+
+}  // namespace copyset
+}  // namespace metaserver
+}  // namespace curvefs
+
+#endif  // CURVEFS_TEST_METASERVER_COPYSET_MOCK_MOCK_COPYSET_NODE_H_

--- a/curvefs/test/metaserver/copyset/mock/mock_copyset_node_manager.h
+++ b/curvefs/test/metaserver/copyset/mock/mock_copyset_node_manager.h
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (c) 2021 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * Project: curve
+ * Date: Wednesday Dec 01 19:30:09 CST 2021
+ * Author: wuhanqing
+ */
+
+#ifndef CURVEFS_TEST_METASERVER_COPYSET_MOCK_MOCK_COPYSET_NODE_MANAGER_H_
+#define CURVEFS_TEST_METASERVER_COPYSET_MOCK_MOCK_COPYSET_NODE_MANAGER_H_
+
+#include <gmock/gmock.h>
+
+#include "curvefs/src/metaserver/copyset/copyset_node_manager.h"
+
+namespace curvefs {
+namespace metaserver {
+namespace copyset {
+
+class MockCopysetNodeManager : public CopysetNodeManager {
+ public:
+    MOCK_METHOD2(GetCopysetNode, CopysetNode*(PoolId, CopysetId));
+    MOCK_METHOD2(PurgeCopysetNode, bool(PoolId, CopysetId));
+    MOCK_CONST_METHOD0(IsLoadFinished, bool());
+};
+
+}  // namespace copyset
+}  // namespace metaserver
+}  // namespace curvefs
+
+#endif  // CURVEFS_TEST_METASERVER_COPYSET_MOCK_MOCK_COPYSET_NODE_MANAGER_H_

--- a/curvefs/test/metaserver/copyset/raft_cli_servic2_conf_change_test.cpp
+++ b/curvefs/test/metaserver/copyset/raft_cli_servic2_conf_change_test.cpp
@@ -1,0 +1,450 @@
+/*
+ *  Copyright (c) 2021 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * Project: curve
+ * Date: Wed Dec 15 14:11:10 CST 2021
+ * Author: wuhanqing
+ */
+
+#include <brpc/server.h>
+#include <butil/endpoint.h>
+#include <butil/status.h>
+#include <gflags/gflags.h>
+#include <gtest/gtest.h>
+
+#include <utility>
+
+#include "curvefs/src/metaserver/copyset/raft_cli_service2.h"
+#include "curvefs/test/metaserver/copyset/mock/mock_copyset_node.h"
+#include "curvefs/test/metaserver/copyset/mock/mock_copyset_node_manager.h"
+
+namespace curvefs {
+namespace metaserver {
+namespace copyset {
+
+using ::testing::_;
+using ::testing::DoAll;
+using ::testing::Invoke;
+using ::testing::Return;
+using ::testing::SaveArg;
+using ::testing::SetArgumentPointee;
+
+const char* kServerAddress = "127.0.0.1:29919";
+
+class RaftCliService2ConfChangeTest : public testing::Test {
+ protected:
+    void SetUp() override {
+        mockNodeManager_ = absl::make_unique<MockCopysetNodeManager>();
+        service_ = absl::make_unique<RaftCliService2>(mockNodeManager_.get());
+        server_ = absl::make_unique<brpc::Server>();
+
+        ASSERT_EQ(0, server_->AddService(service_.get(),
+                                         brpc::SERVER_DOESNT_OWN_SERVICE));
+        ASSERT_EQ(0, server_->Start(kServerAddress, nullptr));
+    }
+
+    void TearDown() override {
+        if (server_) {
+            server_->Stop(0);
+            server_->Join();
+        }
+    }
+
+ protected:
+    std::unique_ptr<MockCopysetNodeManager> mockNodeManager_;
+    std::unique_ptr<RaftCliService2> service_;
+    std::unique_ptr<brpc::Server> server_;
+};
+
+TEST_F(RaftCliService2ConfChangeTest, TransferLeaderTest) {
+    std::string targetPeer = kServerAddress + std::string(":0");
+
+    brpc::Channel channel;
+    ASSERT_EQ(0, channel.Init(kServerAddress, nullptr));
+
+    TransferLeaderRequest2 request;
+    TransferLeaderResponse2 response;
+    request.set_poolid(1);
+    request.set_copysetid(1);
+    auto* peer = request.mutable_transferee();
+    peer->set_address(targetPeer);
+
+    // pool or copyset is not exists
+    {
+        EXPECT_CALL(*mockNodeManager_, GetCopysetNode(_, _))
+            .WillOnce(Return(nullptr));
+
+        brpc::Controller cntl;
+        cntl.set_max_retry(0);
+        CliService2_Stub stub(&channel);
+        stub.TransferLeader(&cntl, &request, &response, nullptr);
+        ASSERT_TRUE(cntl.Failed());
+        ASSERT_EQ(ENOENT, cntl.ErrorCode());
+    }
+
+    // copyset node return error
+    {
+        auto mockNode = absl::make_unique<MockCopysetNode>();
+        EXPECT_CALL(*mockNodeManager_, GetCopysetNode(_, _))
+            .WillOnce(Return(mockNode.get()));
+        EXPECT_CALL(*mockNode, TransferLeader(_))
+            .WillOnce(Return(butil::Status(EPERM, "%s", "dummy")));
+
+        brpc::Controller cntl;
+        cntl.set_max_retry(0);
+        CliService2_Stub stub(&channel);
+        stub.TransferLeader(&cntl, &request, &response, nullptr);
+        ASSERT_TRUE(cntl.Failed());
+        ASSERT_EQ(EPERM, cntl.ErrorCode());
+    }
+}
+
+TEST_F(RaftCliService2ConfChangeTest, AddPeerTest) {
+    std::string targetPeer = kServerAddress + std::string(":0");
+
+    std::vector<Peer> peers;
+    Peer peer;
+    peer.set_address("127.0.0.1:29910:0");
+    peers.push_back(peer);
+    peer.set_address("127.0.0.1:29911:0");
+    peers.push_back(peer);
+    peer.set_address("127.0.0.1:29912:0");
+    peers.push_back(peer);
+
+    brpc::Channel channel;
+    ASSERT_EQ(0, channel.Init(kServerAddress, nullptr));
+
+    AddPeerRequest2 request;
+    AddPeerResponse2 response;
+    request.set_poolid(1);
+    request.set_copysetid(1);
+    auto* p = request.mutable_addpeer();
+    p->set_address(targetPeer);
+
+    // pool or copyset not found
+    {
+        EXPECT_CALL(*mockNodeManager_, GetCopysetNode(_, _))
+            .WillOnce(Return(nullptr));
+
+        brpc::Controller cntl;
+        cntl.set_max_retry(0);
+
+        CliService2_Stub stub(&channel);
+        stub.AddPeer(&cntl, &request, &response, nullptr);
+        ASSERT_TRUE(cntl.Failed());
+        ASSERT_EQ(ENOENT, cntl.ErrorCode());
+    }
+
+    // add peer fail
+    {
+        auto mockNode = absl::make_unique<MockCopysetNode>();
+        EXPECT_CALL(*mockNodeManager_, GetCopysetNode(_, _))
+            .WillOnce(Return(mockNode.get()));
+
+        EXPECT_CALL(*mockNode, ListPeers(_))
+            .WillOnce(SetArgumentPointee<0>(peers));
+
+        EXPECT_CALL(*mockNode, AddPeer(_, _))
+            .WillOnce(Invoke([](const Peer& peer, braft::Closure* done) {
+                done->status() = butil::Status(EPERM, "%s", "dummy");
+                done->Run();
+            }));
+
+        brpc::Controller cntl;
+        cntl.set_max_retry(0);
+
+        CliService2_Stub stub(&channel);
+        stub.AddPeer(&cntl, &request, &response, nullptr);
+        ASSERT_TRUE(cntl.Failed());
+        ASSERT_EQ(EPERM, cntl.ErrorCode());
+    }
+
+    // add peer success
+    {
+        auto mockNode = absl::make_unique<MockCopysetNode>();
+        EXPECT_CALL(*mockNodeManager_, GetCopysetNode(_, _))
+            .WillOnce(Return(mockNode.get()));
+
+        EXPECT_CALL(*mockNode, ListPeers(_))
+            .WillOnce(SetArgumentPointee<0>(peers));
+
+        EXPECT_CALL(*mockNode, AddPeer(_, _))
+            .WillOnce(Invoke([](const Peer& peer, braft::Closure* done) {
+                done->status() = butil::Status::OK();
+                done->Run();
+            }));
+
+        brpc::Controller cntl;
+        cntl.set_max_retry(0);
+
+        CliService2_Stub stub(&channel);
+        stub.AddPeer(&cntl, &request, &response, nullptr);
+        ASSERT_FALSE(cntl.Failed());
+        ASSERT_EQ(3, response.oldpeers_size());
+        ASSERT_EQ(4, response.newpeers_size());
+    }
+
+    // add peer already exists
+    {
+        AddPeerRequest2 request;
+        AddPeerResponse2 response;
+        request.set_poolid(1);
+        request.set_copysetid(1);
+        auto* peer = request.mutable_addpeer();
+        peer->set_address(peers[0].address());
+
+        auto mockNode = absl::make_unique<MockCopysetNode>();
+        EXPECT_CALL(*mockNodeManager_, GetCopysetNode(_, _))
+            .WillOnce(Return(mockNode.get()));
+
+        EXPECT_CALL(*mockNode, ListPeers(_))
+            .WillOnce(SetArgumentPointee<0>(peers));
+
+        EXPECT_CALL(*mockNode, AddPeer(_, _))
+            .WillOnce(Invoke([](const Peer& peer, braft::Closure* done) {
+                done->status() = butil::Status::OK();
+                done->Run();
+            }));
+
+        brpc::Controller cntl;
+        cntl.set_max_retry(0);
+
+        CliService2_Stub stub(&channel);
+        stub.AddPeer(&cntl, &request, &response, nullptr);
+        ASSERT_FALSE(cntl.Failed());
+        ASSERT_EQ(3, response.oldpeers_size());
+        ASSERT_EQ(3, response.newpeers_size());
+    }
+}
+
+TEST_F(RaftCliService2ConfChangeTest, RemovePeerTest) {
+    std::vector<Peer> peers;
+    Peer peer;
+    peer.set_address("127.0.0.1:29910:0");
+    peers.push_back(peer);
+    peer.set_address("127.0.0.1:29911:0");
+    peers.push_back(peer);
+    peer.set_address("127.0.0.1:29912:0");
+    peers.push_back(peer);
+
+    std::string targetPeer{peers[0].address()};
+
+    brpc::Channel channel;
+    ASSERT_EQ(0, channel.Init(kServerAddress, nullptr));
+
+    RemovePeerRequest2 request;
+    RemovePeerResponse2 response;
+    request.set_poolid(1);
+    request.set_copysetid(1);
+    auto* p = request.mutable_removepeer();
+    p->set_address(targetPeer);
+
+    // pool or copyset not found
+    {
+        EXPECT_CALL(*mockNodeManager_, GetCopysetNode(_, _))
+            .WillOnce(Return(nullptr));
+
+        brpc::Controller cntl;
+        cntl.set_max_retry(0);
+
+        CliService2_Stub stub(&channel);
+        stub.RemovePeer(&cntl, &request, &response, nullptr);
+        ASSERT_TRUE(cntl.Failed());
+        ASSERT_EQ(ENOENT, cntl.ErrorCode());
+    }
+
+    // remove peer fail
+    {
+        auto mockNode = absl::make_unique<MockCopysetNode>();
+        EXPECT_CALL(*mockNodeManager_, GetCopysetNode(_, _))
+            .WillOnce(Return(mockNode.get()));
+
+        EXPECT_CALL(*mockNode, ListPeers(_))
+            .WillOnce(SetArgumentPointee<0>(peers));
+
+        EXPECT_CALL(*mockNode, RemovePeer(_, _))
+            .WillOnce(Invoke([](const Peer& peer, braft::Closure* done) {
+                done->status() = butil::Status(EPERM, "%s", "dummy");
+                done->Run();
+            }));
+
+        brpc::Controller cntl;
+        cntl.set_max_retry(0);
+
+        CliService2_Stub stub(&channel);
+        stub.RemovePeer(&cntl, &request, &response, nullptr);
+        ASSERT_TRUE(cntl.Failed());
+        ASSERT_EQ(EPERM, cntl.ErrorCode());
+    }
+
+    // remove peer success
+    {
+        auto mockNode = absl::make_unique<MockCopysetNode>();
+        EXPECT_CALL(*mockNodeManager_, GetCopysetNode(_, _))
+            .WillOnce(Return(mockNode.get()));
+
+        EXPECT_CALL(*mockNode, ListPeers(_))
+            .WillOnce(SetArgumentPointee<0>(peers));
+
+        EXPECT_CALL(*mockNode, RemovePeer(_, _))
+            .WillOnce(Invoke([](const Peer& peer, braft::Closure* done) {
+                done->status() = butil::Status::OK();
+                done->Run();
+            }));
+
+        brpc::Controller cntl;
+        cntl.set_max_retry(0);
+
+        CliService2_Stub stub(&channel);
+        stub.RemovePeer(&cntl, &request, &response, nullptr);
+        ASSERT_FALSE(cntl.Failed());
+        ASSERT_EQ(3, response.oldpeers_size());
+        ASSERT_EQ(2, response.newpeers_size());
+    }
+
+    // remove peer not exists
+    {
+        RemovePeerRequest2 request;
+        RemovePeerResponse2 response;
+        request.set_poolid(1);
+        request.set_copysetid(1);
+        auto* peer = request.mutable_removepeer();
+        peer->set_address(kServerAddress + std::string(":0"));
+
+        auto mockNode = absl::make_unique<MockCopysetNode>();
+        EXPECT_CALL(*mockNodeManager_, GetCopysetNode(_, _))
+            .WillOnce(Return(mockNode.get()));
+
+        EXPECT_CALL(*mockNode, ListPeers(_))
+            .WillOnce(SetArgumentPointee<0>(peers));
+
+        EXPECT_CALL(*mockNode, RemovePeer(_, _))
+            .WillOnce(Invoke([](const Peer& peer, braft::Closure* done) {
+                done->status() = butil::Status::OK();
+                done->Run();
+            }));
+
+        brpc::Controller cntl;
+        cntl.set_max_retry(0);
+
+        CliService2_Stub stub(&channel);
+        stub.RemovePeer(&cntl, &request, &response, nullptr);
+        ASSERT_FALSE(cntl.Failed());
+        ASSERT_EQ(3, response.oldpeers_size());
+        ASSERT_EQ(3, response.newpeers_size());
+    }
+}
+
+TEST_F(RaftCliService2ConfChangeTest, ChangePeersTest) {
+    std::vector<Peer> peers;
+    Peer peer;
+    peer.set_address("127.0.0.1:29910:0");
+    peers.push_back(peer);
+    peer.set_address("127.0.0.1:29911:0");
+    peers.push_back(peer);
+    peer.set_address("127.0.0.1:29912:0");
+    peers.push_back(peer);
+
+    std::vector<Peer> newPeers;
+    peer.set_address("127.0.0.1:29911:0");
+    newPeers.push_back(peer);
+    peer.set_address("127.0.0.1:29912:0");
+    newPeers.push_back(peer);
+    peer.set_address("127.0.0.1:29913:0");
+    newPeers.push_back(peer);
+
+    brpc::Channel channel;
+    ASSERT_EQ(0, channel.Init(kServerAddress, nullptr));
+
+    ChangePeersRequest2 request;
+    ChangePeersResponse2 response;
+    request.set_poolid(1);
+    request.set_copysetid(1);
+    for (auto& peer : newPeers) {
+        auto* p = request.add_newpeers();
+        p->CopyFrom(peer);
+    }
+
+    // pool or copyset not found
+    {
+        EXPECT_CALL(*mockNodeManager_, GetCopysetNode(_, _))
+            .WillOnce(Return(nullptr));
+
+        brpc::Controller cntl;
+        cntl.set_max_retry(0);
+
+        CliService2_Stub stub(&channel);
+        stub.ChangePeers(&cntl, &request, &response, nullptr);
+        ASSERT_TRUE(cntl.Failed());
+        ASSERT_EQ(ENOENT, cntl.ErrorCode());
+    }
+
+    // change peers fail
+    {
+        auto mockNode = absl::make_unique<MockCopysetNode>();
+        EXPECT_CALL(*mockNodeManager_, GetCopysetNode(_, _))
+            .WillOnce(Return(mockNode.get()));
+
+        EXPECT_CALL(*mockNode, ListPeers(_))
+            .WillOnce(SetArgumentPointee<0>(peers));
+
+        EXPECT_CALL(*mockNode, ChangePeers(_, _))
+            .WillOnce(Invoke(
+                [](const std::vector<Peer>& peers, braft::Closure* done) {
+                    done->status() = butil::Status(EPERM, "%s", "dummy");
+                    done->Run();
+                }));
+
+        brpc::Controller cntl;
+        cntl.set_max_retry(0);
+
+        CliService2_Stub stub(&channel);
+        stub.ChangePeers(&cntl, &request, &response, nullptr);
+        ASSERT_TRUE(cntl.Failed());
+        ASSERT_EQ(EPERM, cntl.ErrorCode());
+    }
+
+    // change peers success
+    {
+        auto mockNode = absl::make_unique<MockCopysetNode>();
+        EXPECT_CALL(*mockNodeManager_, GetCopysetNode(_, _))
+            .WillOnce(Return(mockNode.get()));
+
+        EXPECT_CALL(*mockNode, ListPeers(_))
+            .WillOnce(SetArgumentPointee<0>(peers));
+
+        EXPECT_CALL(*mockNode, ChangePeers(_, _))
+            .WillOnce(Invoke(
+                [](const std::vector<Peer>& peers, braft::Closure* done) {
+                    done->status() = butil::Status::OK();
+                    done->Run();
+                }));
+
+        brpc::Controller cntl;
+        cntl.set_max_retry(0);
+
+        CliService2_Stub stub(&channel);
+        stub.ChangePeers(&cntl, &request, &response, nullptr);
+        ASSERT_FALSE(cntl.Failed());
+        ASSERT_EQ(3, response.oldpeers_size());
+        ASSERT_EQ(3, response.newpeers_size());
+    }
+}
+
+}  // namespace copyset
+}  // namespace metaserver
+}  // namespace curvefs

--- a/curvefs/test/metaserver/copyset/raft_cli_servic2_test.cpp
+++ b/curvefs/test/metaserver/copyset/raft_cli_servic2_test.cpp
@@ -23,7 +23,9 @@
 #include <brpc/server.h>
 #include <butil/endpoint.h>
 #include <butil/status.h>
+#include <gflags/gflags.h>
 #include <glog/logging.h>
+#include <google/protobuf/util/message_differencer.h>
 #include <gtest/gtest.h>
 
 #include <utility>
@@ -42,61 +44,78 @@ using ::curve::common::UUIDGenerator;
 using ::curve::fs::FileSystemType;
 using ::curve::fs::LocalFileSystem;
 using ::curve::fs::LocalFsFactory;
+using ::google::protobuf::util::MessageDifferencer;
 
 const char* kInitConf = "127.0.0.1:29910:0,127.0.0.1:29911:0,127.0.0.1:29912:0";
-
 const int kElectionTimeoutMs = 3000;
-
 const PoolId kPoolId = 1234;
 const CopysetId kCopysetId = 1234;
 
 class RaftCliService2Test : public testing::Test {
  protected:
+    void SetUp() override {}
+
+    void TearDown() override {}
+
     static void SetUpTestCase() {
         LOG(INFO) << "BraftCliServiceTest SetUpTestCase";
+
+        StartOneCopysetGroup();
+        StartOneStandByMetaserver("127.0.0.1", 29913, "127.0.0.1:29913:0");
+        StartOneStandByMetaserver("127.0.0.1", 29914, "127.0.0.1:29914:0");
     }
 
     static void TearDownTestCase() {
         LOG(INFO) << "BraftCliServiceTest TearDownTestCase";
-    }
 
-    void SetUp() override {}
-
-    void TearDown() override {
         for (auto& s : servers_) {
-            kill(s.first, SIGTERM);
-            ::system(std::string("rm -rf " + s.second).c_str());
+            kill(s.first, SIGKILL);
+            int wstatus;
+            wait(&wstatus);
+            system(std::string("rm -rf " + s.second).c_str());
         }
     }
 
-    void StartThreeMetaserver() {
-        UUIDGenerator uuid;
+    static void StartOneCopysetGroup() {
+        std::string copysetDir = "./runlog/" + uuid_.GenerateUUID();
+        pid_t pid = StartOneFakeMetaserver(
+            "127.0.0.1", 29910, "local://" + copysetDir, kInitConf);
 
-        std::string copysetDir = "./runlog/" + uuid.GenerateUUID();
-        pid_t pid = StartFakeMetaserver("127.0.0.1", 29910,
-                                        "local://" + copysetDir, kInitConf);
-        ASSERT_GE(pid, 0);
+        CHECK_GE(pid, 0);
         servers_.emplace_back(pid, copysetDir);
         usleep(kElectionTimeoutMs * 1000);
 
-        copysetDir = "./runlog/" + uuid.GenerateUUID();
-        pid = StartFakeMetaserver("127.0.0.1", 29911, "local://" + copysetDir,
-                                  kInitConf);
-        ASSERT_GE(pid, 0);
+        copysetDir = "./runlog/" + uuid_.GenerateUUID();
+        pid = StartOneFakeMetaserver("127.0.0.1", 29911,
+                                     "local://" + copysetDir, kInitConf);
+        CHECK_GE(pid, 0);
         servers_.emplace_back(pid, copysetDir);
         usleep(kElectionTimeoutMs * 1000);
 
-        copysetDir = "./runlog/" + uuid.GenerateUUID();
-        pid = StartFakeMetaserver("127.0.0.1", 29912, "local://" + copysetDir,
-                                  kInitConf);
-        ASSERT_GE(pid, 0);
+        copysetDir = "./runlog/" + uuid_.GenerateUUID();
+        pid = StartOneFakeMetaserver("127.0.0.1", 29912,
+                                     "local://" + copysetDir, kInitConf);
+        CHECK_GE(pid, 0);
         servers_.emplace_back(pid, copysetDir);
         usleep(kElectionTimeoutMs * 1000 * 2);
+
+        CHECK_EQ(0, conf_.parse_from(kInitConf));
     }
 
-    static pid_t StartFakeMetaserver(const char* ip, int port,
-                                     const std::string& copysetDir,
-                                     const std::string& initConf) {
+    static void StartOneStandByMetaserver(const char* ip, int port,
+                                          const std::string& initConf) {
+        std::string copysetDir = "./runlog/" + uuid_.GenerateUUID();
+        pid_t pid =
+            StartOneFakeMetaserver(ip, port, "local://" + copysetDir, initConf);
+        ASSERT_GE(pid, 0);
+
+        servers_.emplace_back(pid, copysetDir);
+        usleep(kElectionTimeoutMs * 1000);
+    }
+
+    static pid_t StartOneFakeMetaserver(const char* ip, int port,
+                                        const std::string& copysetDir,
+                                        const std::string& initConf) {
         LOG(INFO) << "Going to start metaserver on " << ip << ":" << port;
 
         pid_t pid = fork();
@@ -149,12 +168,13 @@ class RaftCliService2Test : public testing::Test {
         exit(0);
     }
 
-    bool WaitLeader(int retryTimes, braft::PeerId* leaderId) {
-        braft::Configuration conf;
-        conf.parse_from(kInitConf);
+    static bool GetCurrentLeader(braft::PeerId* leaderId) {
+        return WaitLeader(1, leaderId);
+    }
 
+    static bool WaitLeader(int retryTimes, braft::PeerId* leaderId) {
         for (int i = 0; i < retryTimes; ++i) {
-            auto status = GetLeader(kPoolId, kCopysetId, conf, leaderId);
+            auto status = GetLeader(kPoolId, kCopysetId, conf_, leaderId);
             if (status.ok()) {
                 usleep(kElectionTimeoutMs * 1000);
                 return true;
@@ -167,13 +187,68 @@ class RaftCliService2Test : public testing::Test {
         return false;
     }
 
+    static Peer RandomSelectOnePeer() {
+        std::vector<braft::PeerId> peers;
+        conf_.list_peers(&peers);
+
+        int idx = rand() % peers.size();  // NOLINT
+        Peer peer;
+        peer.set_address(peers[idx].to_string());
+        return peer;
+    }
+
+    static Peer RandomSelectOneFollower(const braft::PeerId& leader) {
+        std::vector<braft::PeerId> peers;
+        conf_.list_peers(&peers);
+
+        Peer follower;
+
+        while (true) {
+            int idx = rand() % peers.size();  // NOLINT
+            if (leader != peers[idx]) {
+                follower.set_address(peers[idx].to_string());
+                break;
+            }
+        }
+
+        return follower;
+    }
+
+    template <typename Request>
+    static void SetRequestPoolAndCopysetId(Request* request,
+                                           bool random = false) {
+        if (random) {
+            request->set_poolid(kPoolId + rand() % kPoolId + 1);  // NOLINT
+            request->set_copysetid(kCopysetId + rand() % kCopysetId + 1);  // NOLINT
+        } else {
+            request->set_poolid(kPoolId);
+            request->set_copysetid(kCopysetId);
+        }
+    }
+
+    static void UpdateConfigurations(
+        const google::protobuf::RepeatedPtrField<curvefs::common::Peer>&
+            peers) {
+        conf_.reset();
+
+        for (auto& peer : peers) {
+            braft::PeerId pid;
+            CHECK_EQ(0, pid.parse(peer.address()));
+            conf_.add_peer(pid);
+        }
+    }
+
  protected:
-    std::vector<std::pair<pid_t, std::string>> servers_;
+    static std::vector<std::pair<pid_t, std::string>> servers_;
+    static UUIDGenerator uuid_;
+    static braft::Configuration conf_;
 };
 
-TEST_F(RaftCliService2Test, GetLeaderTest) {
-    StartThreeMetaserver();
+std::vector<std::pair<pid_t, std::string>> RaftCliService2Test::servers_;
+UUIDGenerator RaftCliService2Test::uuid_;
+braft::Configuration RaftCliService2Test::conf_;
 
+TEST_F(RaftCliService2Test, GetLeaderTest) {
     braft::PeerId leaderId;
     ASSERT_TRUE(WaitLeader(10, &leaderId));
     ASSERT_FALSE(leaderId.is_empty());
@@ -185,8 +260,7 @@ TEST_F(RaftCliService2Test, GetLeaderTest) {
 
         GetLeaderRequest2 request;
         GetLeaderResponse2 response;
-        request.set_poolid(1);
-        request.set_copysetid(1);
+        SetRequestPoolAndCopysetId(&request, true);
 
         brpc::Controller cntl;
         CliService2_Stub stub(&channel);
@@ -195,20 +269,268 @@ TEST_F(RaftCliService2Test, GetLeaderTest) {
         ASSERT_EQ(ENOENT, cntl.ErrorCode());
     }
 
+    // succeeded
     {
         brpc::Channel channel;
         ASSERT_EQ(0, channel.Init(leaderId.addr, nullptr));
 
         GetLeaderRequest2 request;
         GetLeaderResponse2 response;
-        request.set_poolid(kPoolId);
-        request.set_copysetid(kCopysetId);
+        SetRequestPoolAndCopysetId(&request, false);
 
         brpc::Controller cntl;
         CliService2_Stub stub(&channel);
         stub.GetLeader(&cntl, &request, &response, nullptr);
         ASSERT_FALSE(cntl.Failed());
         ASSERT_EQ(leaderId.to_string(), response.leader().address());
+    }
+}
+
+TEST_F(RaftCliService2Test, TransferLeaderTest) {
+    braft::PeerId leaderId;
+    ASSERT_TRUE(WaitLeader(10, &leaderId));
+    ASSERT_FALSE(leaderId.is_empty());
+
+    // pool or copyset is not exists
+    {
+        brpc::Channel channel;
+        ASSERT_EQ(0, channel.Init(leaderId.addr, nullptr));
+
+        TransferLeaderRequest2 request;
+        TransferLeaderResponse2 response;
+        SetRequestPoolAndCopysetId(&request, true);
+        auto* peer = request.mutable_transferee();
+        *peer = RandomSelectOneFollower(leaderId);
+
+        brpc::Controller cntl;
+        CliService2_Stub stub(&channel);
+        stub.TransferLeader(&cntl, &request, &response, nullptr);
+        ASSERT_TRUE(cntl.Failed());
+        ASSERT_EQ(ENOENT, cntl.ErrorCode());
+    }
+
+    // send to follower
+    {
+        TransferLeaderRequest2 request;
+        TransferLeaderResponse2 response;
+        SetRequestPoolAndCopysetId(&request);
+        auto* peer = request.mutable_transferee();
+        *peer = RandomSelectOneFollower(leaderId);
+
+        braft::PeerId follower(peer->address());
+
+        brpc::Channel channel;
+        ASSERT_EQ(0, channel.Init(follower.addr, nullptr));
+
+        brpc::Controller cntl;
+        CliService2_Stub stub(&channel);
+        stub.TransferLeader(&cntl, &request, &response, nullptr);
+        ASSERT_TRUE(cntl.Failed());
+        ASSERT_EQ(EPERM, cntl.ErrorCode());
+    }
+
+    // getleader after transfer succeeded
+    {
+        brpc::Channel channel;
+        ASSERT_EQ(0, channel.Init(leaderId.addr, nullptr));
+
+        TransferLeaderRequest2 request;
+        TransferLeaderResponse2 response;
+        SetRequestPoolAndCopysetId(&request);
+        auto* peer = request.mutable_transferee();
+        *peer = RandomSelectOneFollower(leaderId);
+
+        brpc::Controller cntl;
+        CliService2_Stub stub(&channel);
+        stub.TransferLeader(&cntl, &request, &response, nullptr);
+        ASSERT_FALSE(cntl.Failed());
+
+        braft::PeerId current;
+        braft::PeerId expected(peer->address());
+
+        while (true) {
+            bool rc = GetCurrentLeader(&current);
+            if (!rc) {
+                continue;
+            } else if (current == leaderId) {
+                continue;
+            } else {
+                break;
+            }
+        }
+
+        EXPECT_EQ(current, expected);
+    }
+}
+
+TEST_F(RaftCliService2Test, AddPeerTest) {
+    braft::PeerId leaderId;
+    ASSERT_TRUE(WaitLeader(10, &leaderId));
+    ASSERT_FALSE(leaderId.is_empty());
+
+    // pool or copyset not exists
+    {
+        brpc::Channel channel;
+        ASSERT_EQ(0, channel.Init(leaderId.addr, nullptr));
+
+        AddPeerRequest2 request;
+        AddPeerResponse2 response;
+        SetRequestPoolAndCopysetId(&request, true);
+        auto* peer = request.mutable_addpeer();
+        peer->set_address("127.0.0.1:29913:0");
+
+        brpc::Controller cntl;
+        CliService2_Stub stub(&channel);
+        stub.AddPeer(&cntl, &request, &response, nullptr);
+        ASSERT_TRUE(cntl.Failed());
+        ASSERT_EQ(ENOENT, cntl.ErrorCode());
+    }
+
+    // add peer succeeded
+    {
+        brpc::Channel channel;
+        ASSERT_EQ(0, channel.Init(leaderId.addr, nullptr));
+
+        AddPeerRequest2 request;
+        AddPeerResponse2 response;
+        SetRequestPoolAndCopysetId(&request);
+        auto* peerToAdd = request.mutable_addpeer();
+        peerToAdd->set_address("127.0.0.1:29913:0");
+
+        brpc::Controller cntl;
+        cntl.set_timeout_ms(5 * 1000);
+        CliService2_Stub stub(&channel);
+        stub.AddPeer(&cntl, &request, &response, nullptr);
+        ASSERT_FALSE(cntl.Failed()) << cntl.ErrorText();
+
+        // check response
+        ASSERT_EQ(3, response.oldpeers_size());
+        ASSERT_EQ(4, response.newpeers_size());
+        bool found = false;
+        for (auto& peer : response.newpeers()) {
+            if (MessageDifferencer::Equals(peer, *peerToAdd)) {
+                found = true;
+            }
+        }
+        ASSERT_TRUE(found);
+
+        UpdateConfigurations(response.newpeers());
+    }
+}
+
+TEST_F(RaftCliService2Test, RemovePeerTest) {
+    braft::PeerId leaderId;
+    ASSERT_TRUE(WaitLeader(10, &leaderId));
+    ASSERT_FALSE(leaderId.is_empty());
+
+    // pool or copyset not exists
+    {
+        brpc::Channel channel;
+        ASSERT_EQ(0, channel.Init(leaderId.addr, nullptr));
+
+        RemovePeerRequest2 request;
+        RemovePeerResponse2 response;
+        SetRequestPoolAndCopysetId(&request, true);
+        auto* peer = request.mutable_removepeer();
+        peer->set_address("127.0.0.1:29912:0");
+
+        brpc::Controller cntl;
+        CliService2_Stub stub(&channel);
+        stub.RemovePeer(&cntl, &request, &response, nullptr);
+        ASSERT_TRUE(cntl.Failed()) << cntl.ErrorText();
+        ASSERT_EQ(ENOENT, cntl.ErrorCode());
+    }
+
+    // remove peer succeeded
+    {
+        brpc::Channel channel;
+        ASSERT_EQ(0, channel.Init(leaderId.addr, nullptr));
+
+        RemovePeerRequest2 request;
+        RemovePeerResponse2 response;
+        SetRequestPoolAndCopysetId(&request);
+
+        auto* peerToRemove = request.mutable_removepeer();
+        *peerToRemove = RandomSelectOnePeer();
+
+        LOG(INFO) << "Remove peer: " << peerToRemove->address();
+
+        brpc::Controller cntl;
+        CliService2_Stub stub(&channel);
+        stub.RemovePeer(&cntl, &request, &response, nullptr);
+        ASSERT_FALSE(cntl.Failed());
+
+        // check response
+        EXPECT_EQ(4, response.oldpeers_size());
+        EXPECT_EQ(3, response.newpeers_size());
+        for (auto& peer : response.newpeers()) {
+            EXPECT_FALSE(MessageDifferencer::Equals(peer, *peerToRemove));
+        }
+
+        UpdateConfigurations(response.newpeers());
+    }
+}
+
+TEST_F(RaftCliService2Test, ChangePeerTest) {
+    braft::PeerId leaderId;
+    ASSERT_TRUE(WaitLeader(10, &leaderId));
+    ASSERT_FALSE(leaderId.is_empty());
+
+    // pool or copyset is not exists
+    {
+        brpc::Channel channel;
+        ASSERT_EQ(0, channel.Init(leaderId.addr, nullptr));
+
+        ChangePeersRequest2 request;
+        ChangePeersResponse2 response;
+        SetRequestPoolAndCopysetId(&request, true);
+
+        auto* peer = request.add_newpeers();
+        peer->set_address("127.0.0.1:29911:0");
+        peer = request.add_newpeers();
+        peer->set_address("127.0.0.1:29912:0");
+        peer = request.add_newpeers();
+        peer->set_address("127.0.0.1:29913:0");
+
+        brpc::Controller cntl;
+        CliService2_Stub stub(&channel);
+        stub.ChangePeers(&cntl, &request, &response, nullptr);
+        ASSERT_TRUE(cntl.Failed());
+        ASSERT_EQ(ENOENT, cntl.ErrorCode());
+    }
+
+    // change peer succeed
+    {
+        brpc::Channel channel;
+        ASSERT_EQ(0, channel.Init(leaderId.addr, nullptr));
+
+        ChangePeersRequest2 request;
+        ChangePeersResponse2 response;
+        SetRequestPoolAndCopysetId(&request);
+
+        // remove one from current conf, and add 29914
+        Peer peerToRemove = RandomSelectOnePeer();
+        std::vector<braft::PeerId> peers;
+        conf_.list_peers(&peers);
+        for (auto& peer : peers) {
+            if (peer.to_string() != peerToRemove.address()) {
+                auto* add = request.add_newpeers();
+                add->set_address(peer.to_string());
+            }
+        }
+
+        Peer peerToAdd;
+        peerToAdd.set_address("127.0.0.1:29914:0");
+        *request.add_newpeers() = peerToAdd;
+
+        brpc::Controller cntl;
+        CliService2_Stub stub(&channel);
+        stub.ChangePeers(&cntl, &request, &response, nullptr);
+        ASSERT_FALSE(cntl.Failed());
+
+        // check response
+        ASSERT_EQ(3, response.oldpeers_size());
+        ASSERT_EQ(3, response.newpeers_size());
     }
 }
 

--- a/curvefs/test/metaserver/heartbeat_task_executor_test.cpp
+++ b/curvefs/test/metaserver/heartbeat_task_executor_test.cpp
@@ -1,0 +1,298 @@
+/*
+ *  Copyright (c) 2021 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * Project: curve
+ * Date: Wednesday Dec 01 19:13:53 CST 2021
+ * Author: wuhanqing
+ */
+
+#include <brpc/server.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "curvefs/src/metaserver/heartbeat.h"
+#include "curvefs/test/metaserver/copyset/mock/mock_copyset_node.h"
+#include "curvefs/test/metaserver/copyset/mock/mock_copyset_node_manager.h"
+#include "curvefs/test/metaserver/copyset/mock/mock_copyset_service.h"
+
+namespace curvefs {
+namespace metaserver {
+
+using ::curvefs::metaserver::copyset::MockCopysetNode;
+using ::curvefs::metaserver::copyset::MockCopysetNodeManager;
+using ::curvefs::metaserver::copyset::MockCopysetService;
+using ::testing::_;
+using ::testing::DoAll;
+using ::testing::Invoke;
+using ::testing::Return;
+using ::testing::Test;
+
+class HeartbeatTaskExecutorTest : public testing::Test {
+ protected:
+    void SetUp() override {
+        butil::EndPoint ep;
+        ASSERT_EQ(0, butil::str2endpoint(current_.c_str(), &ep));
+
+        executor_.reset(new HeartbeatTaskExecutor(&mockCopysetMgr_, ep));
+    }
+
+    void TearDown() override {
+        if (server_) {
+            server_->Stop(0);
+            server_->Join();
+        }
+    }
+
+    void StartFakeCopysetService(const std::string& ipport) {
+        service_.reset(new MockCopysetService());
+        server_.reset(new brpc::Server());
+        ASSERT_EQ(0, server_->AddService(service_.get(),
+                                         brpc::SERVER_DOESNT_OWN_SERVICE));
+        ASSERT_EQ(0, server_->Start(ipport.c_str(), nullptr));
+    }
+
+ protected:
+    const std::string current_{"127.0.0.1:6701"};
+    const std::string confChangeTarget_{"127.0.0.1:6702"};
+
+    MockCopysetNodeManager mockCopysetMgr_;
+    MockCopysetNode mockCopysetNode_;
+
+    std::unique_ptr<HeartbeatTaskExecutor> executor_;
+    std::unique_ptr<brpc::Server> server_;
+    std::unique_ptr<MockCopysetService> service_;
+};
+
+TEST_F(HeartbeatTaskExecutorTest, CopysetNotFound) {
+    EXPECT_CALL(mockCopysetMgr_, GetCopysetNode(_, _))
+        .WillOnce(Return(nullptr));
+
+    HeartbeatResponse response;
+    auto* conf = response.add_needupdatecopysets();
+    conf->set_poolid(1);
+    conf->set_copysetid(1);
+
+    ASSERT_NO_FATAL_FAILURE(executor_->ExecTasks(response));
+}
+
+TEST_F(HeartbeatTaskExecutorTest, NeedPurge_EpochIsZeroAndConfIsEmpty) {
+    EXPECT_CALL(mockCopysetMgr_, GetCopysetNode(_, _))
+        .WillOnce(Return(&mockCopysetNode_));
+
+    EXPECT_CALL(mockCopysetMgr_, PurgeCopysetNode(_, _))
+        .Times(1);
+
+    HeartbeatResponse response;
+    auto* conf = response.add_needupdatecopysets();
+    conf->set_poolid(1);
+    conf->set_copysetid(1);
+    conf->set_epoch(0);
+    conf->mutable_peers()->Clear();
+
+    executor_->ExecTasks(response);
+}
+
+TEST_F(HeartbeatTaskExecutorTest, NeedPurge_ConfDoesnotContainCurrentServer) {
+    EXPECT_CALL(mockCopysetMgr_, GetCopysetNode(_, _))
+        .WillOnce(Return(&mockCopysetNode_));
+
+    EXPECT_CALL(mockCopysetMgr_, PurgeCopysetNode(_, _)).Times(1);
+
+    HeartbeatResponse response;
+    auto* conf = response.add_needupdatecopysets();
+    conf->set_poolid(1);
+    conf->set_copysetid(1);
+    conf->set_epoch(1);
+    auto* peer = conf->add_peers();
+    peer->set_address("1.2.3.4:1234:0");
+
+    executor_->ExecTasks(response);
+}
+
+TEST_F(HeartbeatTaskExecutorTest, EpochMismatch) {
+    EXPECT_CALL(mockCopysetMgr_, GetCopysetNode(_, _))
+        .WillOnce(Return(&mockCopysetNode_));
+
+    EXPECT_CALL(mockCopysetMgr_, PurgeCopysetNode(_, _))
+        .Times(0);
+
+    EXPECT_CALL(mockCopysetNode_, GetConfEpoch())
+        .WillOnce(Return(100));
+
+    EXPECT_CALL(mockCopysetNode_, TransferLeader(_))
+        .Times(0);
+    EXPECT_CALL(mockCopysetNode_, AddPeer(_, _))
+        .Times(0);
+    EXPECT_CALL(mockCopysetNode_, RemovePeer(_, _))
+        .Times(0);
+    EXPECT_CALL(mockCopysetNode_, ChangePeers(_, _))
+        .Times(0);
+
+    HeartbeatResponse response;
+    auto* conf = response.add_needupdatecopysets();
+    conf->set_poolid(1);
+    conf->set_copysetid(1);
+    conf->set_epoch(1);
+    auto* peer = conf->add_peers();
+    peer->set_address(current_ + ":0");
+
+    executor_->ExecTasks(response);
+}
+
+TEST_F(HeartbeatTaskExecutorTest, HasNoConfChangeType) {
+    EXPECT_CALL(mockCopysetMgr_, GetCopysetNode(_, _))
+        .WillOnce(Return(&mockCopysetNode_));
+
+    EXPECT_CALL(mockCopysetMgr_, PurgeCopysetNode(_, _))
+        .Times(0);
+
+    EXPECT_CALL(mockCopysetNode_, GetConfEpoch())
+        .WillOnce(Return(100));
+
+    EXPECT_CALL(mockCopysetNode_, TransferLeader(_))
+        .Times(0);
+    EXPECT_CALL(mockCopysetNode_, AddPeer(_, _))
+        .Times(0);
+    EXPECT_CALL(mockCopysetNode_, RemovePeer(_, _))
+        .Times(0);
+    EXPECT_CALL(mockCopysetNode_, ChangePeers(_, _))
+        .Times(0);
+
+    HeartbeatResponse response;
+    auto* conf = response.add_needupdatecopysets();
+    conf->set_poolid(1);
+    conf->set_copysetid(1);
+    conf->set_epoch(100);
+    auto* peer = conf->add_peers();
+    peer->set_address(current_ + ":0");
+
+    executor_->ExecTasks(response);
+}
+
+TEST_F(HeartbeatTaskExecutorTest, TransferLeader_Success) {
+    StartFakeCopysetService(confChangeTarget_);
+
+    EXPECT_CALL(mockCopysetMgr_, GetCopysetNode(_, _))
+        .WillOnce(Return(&mockCopysetNode_));
+
+    EXPECT_CALL(mockCopysetMgr_, PurgeCopysetNode(_, _))
+        .Times(0);
+
+    EXPECT_CALL(mockCopysetNode_, GetConfEpoch())
+        .WillOnce(Return(1));
+
+    EXPECT_CALL(mockCopysetNode_, TransferLeader(_))
+        .WillOnce(Return(butil::Status::OK()));
+
+    HeartbeatResponse response;
+    auto* conf = response.add_needupdatecopysets();
+    conf->set_poolid(1);
+    conf->set_copysetid(1);
+    conf->set_epoch(1);
+    conf->set_type(curve::mds::heartbeat::ConfigChangeType::TRANSFER_LEADER);
+    auto* peer = conf->add_peers();
+    peer->set_address(current_ + ":0");
+
+    conf->mutable_configchangeitem()->set_address(confChangeTarget_ + ":0");
+
+    executor_->ExecTasks(response);
+}
+
+TEST_F(HeartbeatTaskExecutorTest, AddPeer_Success) {
+    EXPECT_CALL(mockCopysetMgr_, GetCopysetNode(_, _))
+        .WillOnce(Return(&mockCopysetNode_));
+
+    EXPECT_CALL(mockCopysetMgr_, PurgeCopysetNode(_, _))
+        .Times(0);
+
+    EXPECT_CALL(mockCopysetNode_, GetConfEpoch())
+        .WillOnce(Return(1));
+
+    EXPECT_CALL(mockCopysetNode_, AddPeer(_, _))
+        .Times(1);
+
+    HeartbeatResponse response;
+    auto* conf = response.add_needupdatecopysets();
+    conf->set_poolid(1);
+    conf->set_copysetid(1);
+    conf->set_epoch(1);
+    conf->set_type(curve::mds::heartbeat::ConfigChangeType::ADD_PEER);
+    auto* peer = conf->add_peers();
+    peer->set_address(current_ + ":0");
+
+    conf->mutable_configchangeitem()->set_address(confChangeTarget_ + ":0");
+
+    executor_->ExecTasks(response);
+}
+
+TEST_F(HeartbeatTaskExecutorTest, RemovePeer_Success) {
+    EXPECT_CALL(mockCopysetMgr_, GetCopysetNode(_, _))
+        .WillOnce(Return(&mockCopysetNode_));
+
+    EXPECT_CALL(mockCopysetMgr_, PurgeCopysetNode(_, _))
+        .Times(0);
+
+    EXPECT_CALL(mockCopysetNode_, GetConfEpoch())
+        .WillOnce(Return(1));
+
+    EXPECT_CALL(mockCopysetNode_, RemovePeer(_, _))
+        .Times(1);
+
+    HeartbeatResponse response;
+    auto* conf = response.add_needupdatecopysets();
+    conf->set_poolid(1);
+    conf->set_copysetid(1);
+    conf->set_epoch(1);
+    conf->set_type(curve::mds::heartbeat::ConfigChangeType::REMOVE_PEER);
+    auto* peer = conf->add_peers();
+    peer->set_address(current_ + ":0");
+
+    conf->mutable_configchangeitem()->set_address(confChangeTarget_ + ":0");
+
+    executor_->ExecTasks(response);
+}
+
+TEST_F(HeartbeatTaskExecutorTest, ChangePeer_Success) {
+    EXPECT_CALL(mockCopysetMgr_, GetCopysetNode(_, _))
+        .WillOnce(Return(&mockCopysetNode_));
+
+    EXPECT_CALL(mockCopysetMgr_, PurgeCopysetNode(_, _))
+        .Times(0);
+
+    EXPECT_CALL(mockCopysetNode_, GetConfEpoch())
+        .WillOnce(Return(1));
+
+    EXPECT_CALL(mockCopysetNode_, ChangePeers(_, _))
+        .Times(1);
+
+    HeartbeatResponse response;
+    auto* conf = response.add_needupdatecopysets();
+    conf->set_poolid(1);
+    conf->set_copysetid(1);
+    conf->set_epoch(1);
+    conf->set_type(curve::mds::heartbeat::ConfigChangeType::CHANGE_PEER);
+    auto* peer = conf->add_peers();
+    peer->set_address(current_ + ":0");
+
+    conf->mutable_oldpeer()->set_address("127.0.0.1:6700:0");
+    conf->mutable_configchangeitem()->set_address(confChangeTarget_ + ":0");
+
+    executor_->ExecTasks(response);
+}
+
+}  // namespace metaserver
+}  // namespace curvefs

--- a/src/fs/local_filesystem.h
+++ b/src/fs/local_filesystem.h
@@ -207,9 +207,9 @@ class LocalFileSystem {
     virtual int Fsync(int fd) = 0;
 
  private:
-    virtual int DoRename(const string& oldPath,
-                         const string& newPath,
-                         unsigned int flags) { return -1; }
+    virtual int DoRename(const string& /* oldPath */,
+                         const string& /* newPath */,
+                         unsigned int /* flags */) { return -1; }
 };
 
 


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: close https://github.com/opencurve/curve/issues/763

### What is changed and how it works?

What's Changed:

This PR makes metaserver support configuration changes and executes configuration changes issued by MDS.

How it Works:

Overall approaches are similar to ChunkServer, but have a few modifications.
e.g.,
- add a mutex to protect ongoing configuration change
- raft cli service2 handles TransferLeader/AddPeer/RemovePeer/ChangePeer requests by calling the corresponding copyset node rather than the internal raft node, otherwise, CopysetNode's GetConfChange can't catch this configuration change.
- ...

Side effects(Breaking backward compatibility? Performance regression?): 

### Check List

- [x] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license
