### PR TITLE
curvefs/metaserver: fix metastore reload failed when dentry already exist

### DIFF
--- a/curvefs/proto/metaserver.proto
+++ b/curvefs/proto/metaserver.proto
@@ -58,6 +58,7 @@ message GetDentryRequest {
 enum DentryFlag {
     TYPE_FILE_FLAG = 1;
     DELETE_MARK_FLAG = 2;
+    TRANSACTION_PREPARE_FLAG = 4;
 }
 
 message Dentry {

--- a/curvefs/src/client/client_operator.cpp
+++ b/curvefs/src/client/client_operator.cpp
@@ -157,12 +157,16 @@ CURVEFS_ERROR RenameOperator::PrepareRenameTx(
 CURVEFS_ERROR RenameOperator::PrepareTx() {
     dentry_ = Dentry(srcDentry_);
     dentry_.set_txid(srcTxId_ + 1);
-    dentry_.set_flag(DentryFlag::DELETE_MARK_FLAG);
+    dentry_.set_flag(dentry_.flag() |
+                     DentryFlag::DELETE_MARK_FLAG |
+                     DentryFlag::TRANSACTION_PREPARE_FLAG);
 
     newDentry_ = Dentry(srcDentry_);
     newDentry_.set_parentinodeid(newParentId_);
     newDentry_.set_name(newname_);
     newDentry_.set_txid(dstTxId_ + 1);
+    newDentry_.set_flag(newDentry_.flag() |
+                        DentryFlag::TRANSACTION_PREPARE_FLAG);
 
     CURVEFS_ERROR rc;
     std::vector<Dentry> dentrys{ dentry_ };

--- a/curvefs/src/metaserver/dentry_manager.cpp
+++ b/curvefs/src/metaserver/dentry_manager.cpp
@@ -57,7 +57,14 @@ void DentryManager::Log4Code(const std::string& request, MetaStatusCode rc) {
 
 MetaStatusCode DentryManager::CreateDentry(const Dentry& dentry) {
     Log4Dentry("CreateDentry", dentry);
-    auto rc = dentryStorage_->Insert(dentry);
+    MetaStatusCode rc;
+    // invoke only from snapshot loading
+    if (dentry.flag() & DentryFlag::TRANSACTION_PREPARE_FLAG) {
+        rc = dentryStorage_->HandleTx(DentryStorage::TX_OP_TYPE::PREPARE,
+                                      dentry);
+    } else {
+        rc = dentryStorage_->Insert(dentry);
+    }
     Log4Code("CreateDentry", rc);
     return rc;
 }

--- a/curvefs/test/client/test_fuse_client.cpp
+++ b/curvefs/test/client/test_fuse_client.cpp
@@ -134,6 +134,7 @@ class TestFuseVolumeClient : public ::testing::Test {
 
     static const uint32_t DELETE = DentryFlag::DELETE_MARK_FLAG;
     static const uint32_t FILE = DentryFlag::TYPE_FILE_FLAG;
+    static const uint32_t TX_PREPARE = DentryFlag::TRANSACTION_PREPARE_FLAG;
 };
 
 TEST_F(TestFuseVolumeClient, FuseOpInit_when_fs_exist) {
@@ -991,16 +992,17 @@ TEST_F(TestFuseVolumeClient, FuseOpRenameBasic) {
     // step3: prepare tx
     EXPECT_CALL(*metaClient_, PrepareRenameTx(_))
         .WillOnce(Invoke([&](const std::vector<Dentry>& dentrys) {
-            auto srcDentry =
-                GenDentry(fsId, parent, name, srcTxId + 1, inodeId, DELETE);
+            auto srcDentry = GenDentry(fsId, parent, name,
+                                       srcTxId + 1, inodeId,
+                                       DELETE | TX_PREPARE);
             if (dentrys.size() == 1 && dentrys[0] == srcDentry) {
                 return MetaStatusCode::OK;
             }
             return MetaStatusCode::UNKNOWN_ERROR;
         }))
         .WillOnce(Invoke([&](const std::vector<Dentry>& dentrys) {
-            auto dstDentry =
-                GenDentry(fsId, newparent, newname, dstTxId + 1, inodeId, 0);
+            auto dstDentry = GenDentry(fsId, newparent, newname,
+                                       dstTxId + 1, inodeId, TX_PREPARE);
             if (dentrys.size() == 1 && dentrys[0] == dstDentry) {
                 return MetaStatusCode::OK;
             }
@@ -1024,7 +1026,8 @@ TEST_F(TestFuseVolumeClient, FuseOpRenameBasic) {
     EXPECT_CALL(*dentryManager_, InsertOrReplaceCache(_))
         .WillOnce(Invoke([&](const Dentry& dentry) {
             auto dstDentry =
-                GenDentry(fsId, newparent, newname, dstTxId + 1, inodeId, 0);
+                GenDentry(fsId, newparent, newname,
+                          dstTxId + 1, inodeId, TX_PREPARE);
             ASSERT_TRUE(dentry == dstDentry);
         }));
 
@@ -1059,8 +1062,8 @@ TEST_F(TestFuseVolumeClient, FuseOpRenameOverwrite) {
     // step2: precheck
     // dentry = { fsid, parentid, name, txid, inodeid, DELETE }
     auto srcDentry = GenDentry(fsId, parent, name, txId, inodeId, FILE);
-    auto dstDentry =
-        GenDentry(fsId, newparent, newname, txId, oldInodeId, FILE);
+    auto dstDentry = GenDentry(fsId, newparent, newname,
+                               txId, oldInodeId, FILE);
     EXPECT_CALL(*dentryManager_, GetDentry(parent, name, _))
         .WillOnce(
             DoAll(SetArgPointee<2>(srcDentry), Return(CURVEFS_ERROR::OK)));
@@ -1071,10 +1074,10 @@ TEST_F(TestFuseVolumeClient, FuseOpRenameOverwrite) {
     // step3: prepare tx
     EXPECT_CALL(*metaClient_, PrepareRenameTx(_))
         .WillOnce(Invoke([&](const std::vector<Dentry>& dentrys) {
-            auto srcDentry =
-                GenDentry(fsId, parent, name, txId + 1, inodeId, DELETE);
-            auto dstDentry =
-                GenDentry(fsId, newparent, newname, txId + 1, inodeId, FILE);
+            auto srcDentry = GenDentry(fsId, parent, name, txId + 1,
+                                       inodeId, FILE | DELETE | TX_PREPARE);
+            auto dstDentry = GenDentry(fsId, newparent, newname,
+                                       txId + 1, inodeId, FILE | TX_PREPARE);
             if (dentrys.size() == 2 && dentrys[0] == srcDentry &&
                 dentrys[1] == dstDentry) {
                 return MetaStatusCode::OK;
@@ -1107,8 +1110,8 @@ TEST_F(TestFuseVolumeClient, FuseOpRenameOverwrite) {
     EXPECT_CALL(*dentryManager_, DeleteCache(parent, name)).Times(1);
     EXPECT_CALL(*dentryManager_, InsertOrReplaceCache(_))
         .WillOnce(Invoke([&](const Dentry& dentry) {
-            auto dstDentry =
-                GenDentry(fsId, newparent, newname, txId + 1, inodeId, FILE);
+            auto dstDentry = GenDentry(fsId, newparent, newname,
+                                       txId + 1, inodeId, FILE | TX_PREPARE);
             ASSERT_TRUE(dentry == dstDentry);
         }));
 
@@ -1142,7 +1145,8 @@ TEST_F(TestFuseVolumeClient, FuseOpRenameOverwriteDir) {
     // step2: precheck
     // dentry = { fsid, parentid, name, txid, inodeid, DELETE }
     auto srcDentry = GenDentry(fsId, parent, name, txId, inodeId, FILE);
-    auto dstDentry = GenDentry(fsId, newparent, newname, txId, oldInodeId, 0);
+    auto dstDentry = GenDentry(fsId, newparent, newname,
+                               txId, oldInodeId, 0);
     EXPECT_CALL(*dentryManager_, GetDentry(parent, name, _))
         .WillOnce(
             DoAll(SetArgPointee<2>(srcDentry), Return(CURVEFS_ERROR::OK)));

--- a/curvefs/test/metaserver/dentry_manager_test.cpp
+++ b/curvefs/test/metaserver/dentry_manager_test.cpp
@@ -74,6 +74,14 @@ TEST_F(DentryManagerTest, CreateDentry) {
     ASSERT_EQ(dentryManager_->CreateDentry(dentry2),
               MetaStatusCode::DENTRY_EXIST);
     ASSERT_EQ(dentryStorage_->Size(), 1);
+
+    // CASE 3: CreateDentry: success
+    //   1) invoke from snapshot loading
+    //   2) dentry has TRANSACTION_PREPARE_FLAG flag
+    dentry2.set_txid(1);
+    dentry2.set_flag(DentryFlag::TRANSACTION_PREPARE_FLAG);
+    ASSERT_EQ(dentryManager_->CreateDentry(dentry2), MetaStatusCode::OK);
+    ASSERT_EQ(dentryStorage_->Size(), 2);
 }
 
 TEST_F(DentryManagerTest, DeleteDentry) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #748

Problem Summary: fix metastore reload failed when dentry already exist

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?): 

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
