### PR TITLE
curvefs/metaserver: fix metastore reload failed when dentry already exists

### DIFF
--- a/curvefs/proto/metaserver.proto
+++ b/curvefs/proto/metaserver.proto
@@ -59,6 +59,7 @@ message GetDentryRequest {
 enum DentryFlag {
     TYPE_FILE_FLAG = 1;
     DELETE_MARK_FLAG = 2;
+    TRANSACTION_PREPARE_FLAG = 4;
 }
 
 message Dentry {

--- a/curvefs/src/client/client_operator.cpp
+++ b/curvefs/src/client/client_operator.cpp
@@ -157,12 +157,16 @@ CURVEFS_ERROR RenameOperator::PrepareRenameTx(
 CURVEFS_ERROR RenameOperator::PrepareTx() {
     dentry_ = Dentry(srcDentry_);
     dentry_.set_txid(srcTxId_ + 1);
-    dentry_.set_flag(DentryFlag::DELETE_MARK_FLAG);
+    dentry_.set_flag(dentry_.flag() |
+                     DentryFlag::DELETE_MARK_FLAG |
+                     DentryFlag::TRANSACTION_PREPARE_FLAG);
 
     newDentry_ = Dentry(srcDentry_);
     newDentry_.set_parentinodeid(newParentId_);
     newDentry_.set_name(newname_);
     newDentry_.set_txid(dstTxId_ + 1);
+    newDentry_.set_flag(newDentry_.flag() |
+                        DentryFlag::TRANSACTION_PREPARE_FLAG);
 
     CURVEFS_ERROR rc;
     std::vector<Dentry> dentrys{ dentry_ };

--- a/curvefs/src/metaserver/dentry_manager.cpp
+++ b/curvefs/src/metaserver/dentry_manager.cpp
@@ -57,7 +57,14 @@ void DentryManager::Log4Code(const std::string& request, MetaStatusCode rc) {
 
 MetaStatusCode DentryManager::CreateDentry(const Dentry& dentry) {
     Log4Dentry("CreateDentry", dentry);
-    auto rc = dentryStorage_->Insert(dentry);
+    MetaStatusCode rc;
+    // invoke only from snapshot loading
+    if (dentry.flag() & DentryFlag::TRANSACTION_PREPARE_FLAG) {
+        rc = dentryStorage_->HandleTx(DentryStorage::TX_OP_TYPE::PREPARE,
+                                      dentry);
+    } else {
+        rc = dentryStorage_->Insert(dentry);
+    }
     Log4Code("CreateDentry", rc);
     return rc;
 }

--- a/curvefs/test/metaserver/dentry_manager_test.cpp
+++ b/curvefs/test/metaserver/dentry_manager_test.cpp
@@ -74,6 +74,14 @@ TEST_F(DentryManagerTest, CreateDentry) {
     ASSERT_EQ(dentryManager_->CreateDentry(dentry2),
               MetaStatusCode::DENTRY_EXIST);
     ASSERT_EQ(dentryStorage_->Size(), 1);
+
+    // CASE 3: CreateDentry: success
+    //   1) invoke from snapshot loading
+    //   2) dentry has TRANSACTION_PREPARE_FLAG flag
+    dentry2.set_txid(1);
+    dentry2.set_flag(DentryFlag::TRANSACTION_PREPARE_FLAG);
+    ASSERT_EQ(dentryManager_->CreateDentry(dentry2), MetaStatusCode::OK);
+    ASSERT_EQ(dentryStorage_->Size(), 2);
 }
 
 TEST_F(DentryManagerTest, DeleteDentry) {


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?): 

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
