### PR TITLE
curvefs/client: fix inconsistent after cache disk has been dropped

### DIFF
--- a/curvefs/src/client/s3/client_s3_cache_manager.cpp
+++ b/curvefs/src/client/s3/client_s3_cache_manager.cpp
@@ -437,12 +437,13 @@ int FileCacheManager::ReadFromS3(const std::vector<S3ReadRequest> &requests,
                     ret = s3ClientAdaptor_->GetS3Client()->Download(
                         name, response.GetDataBuf() + readOffset,
                         blockPos - objectOffset, n);
-                    if (ret < 0) {
-                        LOG(ERROR) << "download name:" << name
-                                   << " offset:" << blockPos << " len:" << n
-                                   << "fail:" << ret;
-                        return ret;
-                    }
+                }
+                if (ret < 0) {
+                    LOG(ERROR) << "get obj failed, name is: " << name
+                               << ", offset is: " << blockPos
+                               << ", objoffset is: " << objectOffset
+                               << ", len: " << n << ", ret is: " << ret;
+                    return ret;
                 }
             }
             len -= n;

--- a/curvefs/src/client/s3/disk_cache_manager_impl.cpp
+++ b/curvefs/src/client/s3/disk_cache_manager_impl.cpp
@@ -124,7 +124,7 @@ int DiskCacheManagerImpl::Read(const std::string name, char *buf,
     }
     // read disk file maybe fail because of disk file has been removed.
     int ret = diskCacheManager_->ReadDiskFile(name, buf, offset, length);
-    if (ret < length) {
+    if (ret < 0 || ret < length) {
         LOG(ERROR) << "read disk file error. readRet = " << ret;
         ret = client_->Download(name, buf, offset, length);
         if (ret < 0) {

--- a/curvefs/src/client/s3/disk_cache_read.cpp
+++ b/curvefs/src/client/s3/disk_cache_read.cpp
@@ -151,7 +151,7 @@ int DiskCacheRead::WriteDiskFile(const std::string fileName,
         return fd;
     }
     ssize_t writeLen = posixWrapper_->write(fd, buf, length);
-    if (writeLen < length) {
+    if (writeLen < 0 || writeLen < length) {
         LOG(ERROR) << "write disk file error. ret = " << writeLen
                    << ", file = " << fileName;
         posixWrapper_->close(fd);


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: close #798  <!-- REMOVE this line if no issue to close -->

Problem Summary:

after cache disk has been dropped, then we must return failed.


