### PR TITLE
curvefs/metaserver: fixed metastore reload fail and report INVALID_CHECKSUM

### DIFF
--- a/curvefs/docker/Dockerfile
+++ b/curvefs/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM opencurvedocker/curve-base:debian9
-RUN mkdir -p /usr/local/curvefs
-RUN mkdir -p /etc/curvefs
+ENV TZ=Asia/Shanghai
+RUN mkdir -p /usr/local/curvefs /etc/curvefs
 COPY curvefs /usr/local/curvefs
 COPY entrypoint.sh /
 COPY curvefs/tools/sbin/curvefs_tool /usr/bin

--- a/curvefs/src/metaserver/dumpfile.cpp
+++ b/curvefs/src/metaserver/dumpfile.cpp
@@ -285,12 +285,14 @@ DUMPFILE_ERROR DumpFile::Save(std::shared_ptr<Iterator> iter) {
     RETURN_IF_UNSUCCESS(SaveInt<uint64_t>(iter->Size(), &offset, &checkSum));
 
     // Step2: save key-value pairs
+    uint64_t nPairs = 0;
     for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
         auto key = iter->Key();
         auto value = iter->Value();
 
         RETURN_IF_UNSUCCESS(SaveEntry(key, &offset, &checkSum));
         RETURN_IF_UNSUCCESS(SaveEntry(value, &offset, &checkSum));
+        nPairs++;
     }
 
     // Step3: save checksum
@@ -303,7 +305,9 @@ DUMPFILE_ERROR DumpFile::Save(std::shared_ptr<Iterator> iter) {
         return  DUMPFILE_ERROR::SYNC_FAILED;
     }
 
-    LOG(INFO) << "Save success";
+    LOG(INFO) << "Save success, iterator size = " << iter->Size()
+              << ", number of saved entrys = " << nPairs
+              << ", checksum = " << checkSum;
     return DUMPFILE_ERROR::OK;
 }
 
@@ -515,7 +519,11 @@ void DumpFileIterator::End() {
     double elapsed = (endTime - startTime_) * 1.0 / 1000;
     LOG(INFO) << "Load " << (succ ? "success" : "fail")
               << ", loadStatus = " << status
-              << ", cost " << elapsed << " seconds";
+              << ", cost " << elapsed << " seconds"
+              << ", loaded size = " << size_
+              << ", number of loaded entrys = " << nPairs_
+              << ", loaded checksum = " << crc4load
+              << ", calculate checksum = " << crc4calc;
 
     EXIT_LOAD_IF_UNEXPECT(true, status);
 }

--- a/curvefs/src/metaserver/storage.h
+++ b/curvefs/src/metaserver/storage.h
@@ -164,14 +164,15 @@ class MergeIterator : public Iterator {
  public:
     explicit MergeIterator(
         const std::vector<std::shared_ptr<Iterator>>& children)
-        : size_(0), current_(nullptr), children_(children) {
-        for (const auto& child : children) {
-            size_ += child->Size();
-        }
+        : current_(nullptr), children_(children) {
     }
 
     uint64_t Size() override {
-        return size_;
+        uint64_t size = 0;
+        for (const auto& child : children_) {
+            size += child->Size();
+        }
+        return size;
     }
 
     bool Valid() override {
@@ -219,7 +220,6 @@ class MergeIterator : public Iterator {
     }
 
  private:
-    uint64_t size_;
     std::shared_ptr<Iterator> current_;
     std::vector<std::shared_ptr<Iterator>> children_;
 };

--- a/curvefs/test/metaserver/storage_test.cpp
+++ b/curvefs/test/metaserver/storage_test.cpp
@@ -217,6 +217,25 @@ TEST_F(StorageTest, MergeIterator) {
     });
 }
 
+TEST_F(StorageTest, MergeIteratorSize) {
+    auto hash1 = Hash{ { "A0", "A0" } };
+    auto hash2 = Hash{ { "B0", "B0" } };
+    std::vector<std::shared_ptr<Iterator>> children;
+    children.push_back(std::make_shared<HashIterator>(&hash1));
+    children.push_back(std::make_shared<HashIterator>(&hash2));
+    auto iter = MergeIterator(children);
+    ASSERT_EQ(iter.Size(), 2);
+
+    hash1.emplace(std::make_pair("A1", "A1"));
+    ASSERT_EQ(iter.Size(), 3);
+
+    uint64_t size = 0;
+    for (iter.SeekToFirst(); iter.Valid(); iter.Next()) {
+        size++;
+    }
+    ASSERT_EQ(size, 3);
+}
+
 TEST_F(StorageTest, Storage) {
     // step1: generate merge iterator
     auto dentry = GenDentry();


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: close #803

Problem Summary: metastore reload fail and report INVALID_CHECKUM

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?): 

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
