### PR TITLE
curvefs-mds/curvefs-metaserver: install SIGTERM handler

### DIFF
--- a/curvefs/src/mds/mds.cpp
+++ b/curvefs/src/mds/mds.cpp
@@ -30,6 +30,10 @@
 
 #include "curvefs/src/mds/mds_service.h"
 
+namespace brpc {
+DECLARE_bool(graceful_quit_on_sigterm);
+}  // namespace brpc
+
 namespace curvefs {
 namespace mds {
 
@@ -190,8 +194,7 @@ void MDS::Run() {
         << "start brpc server error";
     running_ = true;
 
-    // To achieve the graceful exit of SIGTERM, you need to specify parameters
-    // when starting the process: --graceful_quit_on_sigterm
+    brpc::FLAGS_graceful_quit_on_sigterm = true;
     server.RunUntilAskedToQuit();
 }
 

--- a/curvefs/src/metaserver/metaserver.cpp
+++ b/curvefs/src/metaserver/metaserver.cpp
@@ -45,6 +45,10 @@ DECLARE_int32(raft_max_install_snapshot_tasks_num);
 
 }  // namespace braft
 
+namespace brpc {
+DECLARE_bool(graceful_quit_on_sigterm);
+}  // namespace brpc
+
 namespace curvefs {
 namespace metaserver {
 
@@ -184,8 +188,7 @@ void Metaserver::Run() {
     LOG_IF(FATAL, !copysetNodeManager_->Start())
         << "Failed to start copyset node manager";
 
-    // To achieve the graceful exit of SIGTERM, you need to specify parameters
-    // when starting the process: --graceful_quit_on_sigterm
+    brpc::FLAGS_graceful_quit_on_sigterm = true;
     server_->RunUntilAskedToQuit();
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: close #804 

Problem Summary:

Leader observation is handled in another detached thread,
and when observe leader failed, it raises a SIGTERM in the detached thread.

By default, we didn't register handler for SIGTERM, so the process should exit directly.
But, in current scenario, it seems the SIGTERM signal is ignored.


### What is changed and how it works?

What's Changed:

To avoid this problem, register handler for SIGTERM through brpc's flags graceful_quit_on_sigterm

Side effects(Breaking backward compatibility? Performance regression?): 

### Check List

- [x] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license
