### PR TITLE
curvefs-metaserver: fix restart metaserver lose copyset configuration

### DIFF
--- a/curvefs/src/metaserver/BUILD
+++ b/curvefs/src/metaserver/BUILD
@@ -48,6 +48,7 @@ cc_library(
         "@com_google_absl//absl/cleanup",
         "@com_google_absl//absl/container:btree",
         "@com_google_absl//absl/memory",
+        "@com_google_absl//absl/utility",
     ],
 )
 
@@ -59,10 +60,10 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//curvefs/proto:metaserver_cc_proto",
+        "//curvefs/src/common:curvefs_common",
         "//external:gflags",
         "//external:glog",
         "//src/common:curve_s3_adapter",
-        "//curvefs/src/common:curvefs_common",
     ],
 )
 

--- a/curvefs/src/metaserver/copyset/copyset_node.h
+++ b/curvefs/src/metaserver/copyset/copyset_node.h
@@ -109,7 +109,7 @@ class CopysetNode : public braft::StateMachine {
 
     const std::string& Name() const;
 
-    uint64_t LastSnapshotIndex() const;
+    int64_t LatestLoadSnapshotIndex() const;
 
     int LoadConfEpoch(const std::string& file);
 
@@ -194,7 +194,7 @@ class CopysetNode : public braft::StateMachine {
 
     mutable Mutex confMtx_;
 
-    uint64_t lastSnapshotIndex_;
+    int64_t latestLoadSnapshotIndex_;
 
     std::unique_ptr<OperatorApplyMetric> metric_;
 };
@@ -248,8 +248,8 @@ inline OperatorApplyMetric* CopysetNode::GetMetric() const {
 
 inline const std::string& CopysetNode::Name() const { return name_; }
 
-inline uint64_t CopysetNode::LastSnapshotIndex() const {
-    return lastSnapshotIndex_;
+inline int64_t CopysetNode::LatestLoadSnapshotIndex() const {
+    return latestLoadSnapshotIndex_;
 }
 
 inline const braft::PeerId& CopysetNode::GetPeerId() const { return peerId_; }


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: close #796

Problem Summary:

when metaserver restart, each raft group will reload from snapshot and then
call CopysetNode::on_configuration_committed.

currently, we didn't implement on_configuration_committed, and reset configuration in on_snapshot_load has a bug, so leads to ListPeers return empty configuration.

### What is changed and how it works?

What's Changed:

let on_snapshot_load just recover metastore, and reset copyset configuration in on_configuration_committed.

Side effects(Breaking backward compatibility? Performance regression?): 

### Check List

- [x] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license
