### PR TITLE
metaserver/s3_adaptor: fix delete s3 object error

### DIFF
--- a/curvefs/src/metaserver/s3/metaserver_s3.cpp
+++ b/curvefs/src/metaserver/s3/metaserver_s3.cpp
@@ -37,17 +37,15 @@ void S3ClientImpl::Init(const curve::common::S3AdapterOption& option) {
 int S3ClientImpl::Delete(const std::string& name) {
     int ret = 0;
     const Aws::String aws_key(name.c_str(), name.length());
-    LOG(INFO) << "delete start, aws_key: " << aws_key;
-    if (!s3Adapter_->ObjectExist(aws_key)) {
-        // the aws_key is not exist
-        LOG(INFO) << "delete object error, aws_key: " << aws_key
-                  << " is not exist";
-        return 1;
-    }
     ret = s3Adapter_->DeleteObject(aws_key);
     if (ret < 0) {
         // -1
         LOG(ERROR) << "delete object: " << aws_key << " get error:" << ret;
+        if (!s3Adapter_->ObjectExist(aws_key)) {
+            // the aws_key is not exist
+            // may delete by others
+            ret = 0;
+        }
     } else {
         // 0
         LOG(INFO) << "delete object: " << aws_key << " end, ret:" << ret;

--- a/curvefs/src/metaserver/s3/metaserver_s3_adaptor.cpp
+++ b/curvefs/src/metaserver/s3/metaserver_s3_adaptor.cpp
@@ -71,9 +71,6 @@ int S3ClientAdaptorImpl::DeleteChunk(uint64_t fsId, uint64_t inodeId,
                                      uint64_t chunkPos, uint64_t length) {
     uint64_t blockIndex = chunkPos / blockSize_;
     uint64_t blockPos = chunkPos % blockSize_;
-    VLOG(3) << "delete Chunk start, chunk id: " << chunkId
-            << ", compaction:" << compaction << ", chunkPos: " << chunkPos
-            << ", length: " << length;
     int count = 0;  // blocks' number
     int ret = 0;
     while (length > blockSize_ * count - blockPos || count == 0) {
@@ -90,7 +87,6 @@ int S3ClientAdaptorImpl::DeleteChunk(uint64_t fsId, uint64_t inodeId,
             // 1. overwrite，the object is delete by others
             // 2. last delete failed
             // 3. others
-            VLOG(3) << "object: " << objectName << ", has been deleted.";
             ret = 1;
         }
 

--- a/curvefs/test/metaserver/metaserver_s3_test.cpp
+++ b/curvefs/test/metaserver/metaserver_s3_test.cpp
@@ -61,7 +61,7 @@ class ClientS3Test : public testing::Test {
 TEST_F(ClientS3Test, delete_object_not_exist) {
     EXPECT_CALL(*s3Adapter_, ObjectExist(_)).WillRepeatedly(Return(false));
     int ret = s3Client_->Delete("123");
-    ASSERT_EQ(ret, 1);
+    ASSERT_EQ(ret, 0);
 }
 
 TEST_F(ClientS3Test, delete_error) {


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

When deleting an s3 object, the s3 object is deleted by someone else,
it will return a failed code

Issue Number: close #829 <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

What's Changed:

when delete fail check the s3 object status, if not exist return normal.

How it Works:

Side effects(Breaking backward compatibility? Performance regression?): 

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
