### PR TITLE
curve: support block storage open multiple times

### DIFF
--- a/curve-ansible/roles/install_package/tasks/include/install_nebd.yml
+++ b/curve-ansible/roles/install_package/tasks/include/install_nebd.yml
@@ -64,6 +64,12 @@
         local_file_path: "{{ local_nebd_package_path }}/bin/"
         file_mode: 0755
       include_tasks: copy_file_to_remote.yml
+    - name: install nebd include
+      vars:
+        remote_dir_name: "{{ curve_include_dir }}"
+        local_file_path: "{{ local_nebd_package_path }}/include/"
+        file_mode: 0644
+      include_tasks: copy_file_to_remote.yml
     - name: install nebd lib
       vars:
         remote_dir_name: "{{ curve_lib_dir }}"

--- a/include/client/libcurve.h
+++ b/include/client/libcurve.h
@@ -450,6 +450,12 @@ typedef struct UserInfo {
     }
 } UserInfo_t;
 
+struct OpenFlags {
+    bool exclusive;
+
+    OpenFlags() : exclusive(true) {}
+};
+
 class CurveClient {
  public:
     CurveClient();
@@ -474,7 +480,7 @@ class CurveClient {
      * @return 成功返回fd，失败返回-1
      */
     virtual int Open(const std::string& filename,
-                     std::string* sessionId);
+                     const OpenFlags& openflags);
 
     /**
      * 重新打开文件
@@ -484,8 +490,7 @@ class CurveClient {
      * @return 成功返回fd，失败返回-1
      */
     virtual int ReOpen(const std::string& filename,
-                       const std::string& sessionId,
-                       std::string* newSessionId);
+                       const OpenFlags& openflags);
 
     /**
      * 关闭文件

--- a/nbd/src/ImageInstance.cpp
+++ b/nbd/src/ImageInstance.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "nbd/src/ImageInstance.h"
+
 #include <glog/logging.h>
 
 namespace curve {
@@ -42,7 +43,10 @@ bool ImageInstance::Open() {
         return false;
     }
 
-    ret = nebd_lib_open(imageName_.c_str());
+    NebdOpenFlags flags;
+    nebd_lib_init_open_flags(&flags);
+    flags.exclusive = config_->exclusive ? 1 : 0;
+    ret = nebd_lib_open_with_flags(imageName_.c_str(), &flags);
     if (ret < 0) {
         LOG(ERROR) << "open image failed, ret = " << ret;
         return false;

--- a/nbd/src/define.h
+++ b/nbd/src/define.h
@@ -50,14 +50,6 @@
 #include <sstream>
 #include <string>
 
-namespace std {
-
-inline std::string to_string(const std::string& val) {
-    return val;
-}
-
-}  // namespace std
-
 namespace curve {
 namespace nbd {
 
@@ -87,6 +79,8 @@ struct NBDConfig {
     bool try_netlink = false;
     // 需要映射的后端文件名称
     std::string imgname;
+    // exclusive open image or not
+    bool exclusive = true;
     // 指定需要映射的nbd设备路径
     std::string devpath;
     // force unmap even if the device is mounted
@@ -142,9 +136,16 @@ inline std::string BoolOption(const std::string& name, bool value,
     return opts;
 }
 
+inline std::string to_string(const std::string& val) {
+    return val;
+}
+
 template <typename T>
 inline std::string KeyValueOption(const std::string& optName, const T& value,
                                   const T& defaultValue, bool* firstOpt) {
+    using curve::nbd::to_string;
+    using std::to_string;
+
     std::string opts;
 
     if (value != defaultValue) {
@@ -152,7 +153,7 @@ inline std::string KeyValueOption(const std::string& optName, const T& value,
             opts += ",";
         }
 
-        opts += std::string(optName + "=") + std::to_string(value);
+        opts += std::string(optName + "=") + to_string(value);
         *firstOpt = false;
     }
 
@@ -171,6 +172,7 @@ inline std::string NBDConfig::MapOptions() const {
     opts.append(KeyValueOption("timeout", timeout, 3600, &firstOpt));
     opts.append(KeyValueOption("block-size", block_size, 4096, &firstOpt));
     opts.append(KeyValueOption("nebd-conf", nebd_conf, {}, &firstOpt));
+    opts.append(BoolOption("no-exclusive", !exclusive, &firstOpt));
 
     return opts.empty() ? "defaults" : opts;
 }

--- a/nbd/src/main.cpp
+++ b/nbd/src/main.cpp
@@ -89,6 +89,8 @@ static void Usage() {
         << "  --try-netlink           Use the nbd netlink interface\n"
         << "  --block-size            NBD Devices's block size, default is 4096, support 512 and 4096\n"  // NOLINT
         << "  --nebd-conf             LibNebd config file\n"
+        << "  --no-exclusive          Map image non exclusive\n"
+        << "\n"
         << "Unmap options:\n"
         << "  -f, --force                 Force unmap even if the device is mounted\n"              // NOLINT
         << "  --retry_times <limit>       The number of retries waiting for the process to exit\n"  // NOLINT
@@ -103,7 +105,8 @@ static int AddRecord(int flag) {
     std::string record;
     int fd = open(CURVETAB_PATH, O_WRONLY | O_APPEND);
     if (fd < 0) {
-        std::cerr << "curve-nbd: open curvetab file failed.";
+        std::cerr << "curve-nbd: open curvetab file failed, error: "
+                  << strerror(errno);
         return -EINVAL;
     }
     if (1 == flag) {

--- a/nbd/test/nbd_tool_test.cpp
+++ b/nbd/test/nbd_tool_test.cpp
@@ -77,6 +77,8 @@ class NBDToolTest : public ::testing::Test {
         NebdClientAioContext aioCtx;
         EXPECT_CALL(*image_, AioRead(_))
             .WillRepeatedly(Invoke([](NebdClientAioContext* context){
+                memset(context->buf, 0, context->length);
+                context->ret = 0;
                 context->cb(context);
             }));
         nbdThread_ = std::thread(task, config, &isRunning_, &tool_);
@@ -91,10 +93,13 @@ class NBDToolTest : public ::testing::Test {
         EXPECT_CALL(*image_, AioWrite(_))
             .WillOnce(Invoke([&](NebdClientAioContext* context){
                 tempContext = *context;
+                memset(context->buf, 0, context->length);
+                context->ret = 0;
                 context->cb(context);
             }));
         EXPECT_CALL(*image_, Flush(_))
             .WillOnce(Invoke([](NebdClientAioContext* context){
+                context->ret = 0;
                 context->cb(context);
             }));
 
@@ -143,6 +148,7 @@ class NBDToolTest : public ::testing::Test {
 
 TEST_F(NBDToolTest, ioctl_connect_test) {
     NBDConfig config;
+    config.devpath = "/dev/nbd10";
     config.imgname = kTestImage;
     StartInAnotherThread(&config);
     ASSERT_TRUE(isRunning_);
@@ -154,6 +160,7 @@ TEST_F(NBDToolTest, ioctl_connect_test) {
 
 TEST_F(NBDToolTest, netlink_connect_test) {
     NBDConfig config;
+    config.devpath = "/dev/nbd10";
     config.imgname = kTestImage;
     config.try_netlink = true;
     StartInAnotherThread(&config);
@@ -165,6 +172,7 @@ TEST_F(NBDToolTest, netlink_connect_test) {
 
 TEST_F(NBDToolTest, readonly_test) {
     NBDConfig config;
+    config.devpath = "/dev/nbd10";
     config.imgname = kTestImage;
     config.readonly = true;
     StartInAnotherThread(&config);
@@ -177,6 +185,7 @@ TEST_F(NBDToolTest, readonly_test) {
 
 TEST_F(NBDToolTest, timeout_test) {
     NBDConfig config;
+    config.devpath = "/dev/nbd10";
     config.imgname = kTestImage;
     config.timeout = 3;
     StartInAnotherThread(&config);

--- a/nebd/proto/client.proto
+++ b/nebd/proto/client.proto
@@ -21,9 +21,15 @@ package nebd.client;
 
 option cc_generic_services = true;
 
+message ProtoOpenFlags {
+   required bool exclusive = 1;
+}
+
 message OpenFileRequest {
    required string fileName = 1;
+   optional ProtoOpenFlags flags = 2;
 }
+
 message OpenFileResponse {
    required RetCode retCode = 1;
    optional string retMsg = 2;

--- a/nebd/src/part1/libnebd.cpp
+++ b/nebd/src/part1/libnebd.cpp
@@ -68,7 +68,11 @@ int nebd_lib_uninit() {
 }
 
 int nebd_lib_open(const char* filename) {
-    return Open4Nebd(filename);
+    return Open4Nebd(filename, nullptr);
+}
+
+int nebd_lib_open_with_flags(const char* filename, const NebdOpenFlags* flags) {
+    return Open4Nebd(filename, flags);
 }
 
 int nebd_lib_close(int fd) {
@@ -119,6 +123,10 @@ int64_t nebd_lib_getinfo(int fd) {
 
 int nebd_lib_invalidcache(int fd) {
     return InvalidCache4Nebd(fd);
+}
+
+void nebd_lib_init_open_flags(NebdOpenFlags* flags) {
+    flags->exclusive = 1;
 }
 
 }  // extern "C"

--- a/nebd/src/part1/libnebd.h
+++ b/nebd/src/part1/libnebd.h
@@ -47,6 +47,12 @@ typedef enum LIBAIO_OP {
     LIBAIO_OP_FLUSH,
 } LIBAIO_OP;
 
+typedef struct NebdOpenFlags {
+    int exclusive;
+} NebdOpenFlags;
+
+void nebd_lib_init_open_flags(NebdOpenFlags* flags);
+
 struct NebdClientAioContext;
 
 // nebd回调函数的类型
@@ -85,6 +91,8 @@ int nebd_lib_uninit(void);
  *  @return 成功返回文件fd，失败返回错误码
  */
 int nebd_lib_open(const char* filename);
+int nebd_lib_open_with_flags(const char* filename,
+                             const NebdOpenFlags* openflags);
 
 /**
  *  @brief close文件

--- a/nebd/src/part1/libnebd_file.cpp
+++ b/nebd/src/part1/libnebd_file.cpp
@@ -35,8 +35,8 @@ void Uninit4Nebd() {
     return;
 }
 
-int Open4Nebd(const char* filename) {
-    return nebd::client::nebdClient.Open(filename);
+int Open4Nebd(const char* filename, const NebdOpenFlags* openflags) {
+    return nebd::client::nebdClient.Open(filename, openflags);
 }
 
 int Close4Nebd(int fd) {

--- a/nebd/src/part1/libnebd_file.h
+++ b/nebd/src/part1/libnebd_file.h
@@ -42,7 +42,7 @@ void Uninit4Nebd();
  *  @param filename：文件名
  *  @return 成功返回文件fd，失败返回错误码
  */
-int Open4Nebd(const char* filename);
+int Open4Nebd(const char* filename, const NebdOpenFlags* flags);
 /**
  *  @brief close文件
  *  @param fd：文件的fd

--- a/nebd/src/part1/nebd_client.h
+++ b/nebd/src/part1/nebd_client.h
@@ -76,7 +76,7 @@ class NebdClient {
      *  @param filename：文件名
      *  @return 成功返回文件fd，失败返回错误码
      */
-    int Open(const char* filename);
+    int Open(const char* filename, const NebdOpenFlags* flags);
 
     /**
      *  @brief close文件

--- a/nebd/src/part2/file_entity.h
+++ b/nebd/src/part2/file_entity.h
@@ -38,6 +38,7 @@
 #include "nebd/src/part2/util.h"
 #include "nebd/src/part2/request_executor.h"
 #include "nebd/src/part2/metafile_manager.h"
+#include "nebd/proto/client.pb.h"
 
 namespace nebd {
 namespace server {
@@ -46,6 +47,7 @@ using nebd::common::BthreadRWLock;
 using nebd::common::WriteLockGuard;
 using nebd::common::ReadLockGuard;
 using nebd::common::TimeUtility;
+using OpenFlags = nebd::client::ProtoOpenFlags;
 
 class NebdFileInstance;
 class NebdRequestExecutor;
@@ -103,7 +105,7 @@ class NebdFileEntity : public std::enable_shared_from_this<NebdFileEntity> {
      * 打开文件
      * @return 成功返回fd，失败返回-1
      */
-    virtual int Open();
+    virtual int Open(const OpenFlags* openflags);
     /**
      * 重新open文件，如果之前的后端存储的连接还存在则复用之前的连接
      * 否则与后端存储建立新的连接
@@ -212,6 +214,7 @@ class NebdFileEntity : public std::enable_shared_from_this<NebdFileEntity> {
     int fd_;
     // 文件名称
     std::string fileName_;
+    std::unique_ptr<OpenFlags> openFlags_;
     // 文件当前状态，opened表示文件已打开，closed表示文件已关闭
     std::atomic<NebdFileStatus> status_;
     // 该文件上一次收到心跳时的时间戳

--- a/nebd/src/part2/file_manager.h
+++ b/nebd/src/part2/file_manager.h
@@ -46,6 +46,7 @@ using nebd::common::NameLock;
 using nebd::common::NameLockGuard;
 using nebd::common::WriteLockGuard;
 using nebd::common::ReadLockGuard;
+using OpenFlags = nebd::client::ProtoOpenFlags;
 
 using FileEntityMap = std::unordered_map<int, NebdFileEntityPtr>;
 class NebdFileManager {
@@ -67,7 +68,7 @@ class NebdFileManager {
      * @param filename: 文件的filename
      * @return 成功返回fd，失败返回-1
      */
-    virtual int Open(const std::string& filename);
+    virtual int Open(const std::string& filename, const OpenFlags* flags);
     /**
      * 关闭文件
      * @param fd: 文件的fd

--- a/nebd/src/part2/file_service.cpp
+++ b/nebd/src/part2/file_service.cpp
@@ -31,6 +31,7 @@ namespace nebd {
 namespace server {
 
 using nebd::client::RetCode;
+using OpenFlags = nebd::client::ProtoOpenFlags;
 
 /**
  * use curl -L clientIp:nebd-serverPort/flags/dropRpc?setvalue=true
@@ -120,7 +121,10 @@ void NebdFileServiceImpl::OpenFile(
     brpc::ClosureGuard doneGuard(done);
     response->set_retcode(RetCode::kNoOK);
 
-    int fd = fileManager_->Open(request->filename());
+    int fd =
+        fileManager_->Open(request->filename(),
+                           request->has_flags() ? &request->flags() : nullptr);
+
     if (fd > 0) {
         response->set_retcode(RetCode::kOK);
         response->set_fd(fd);

--- a/nebd/src/part2/request_executor.h
+++ b/nebd/src/part2/request_executor.h
@@ -29,9 +29,17 @@
 #include "nebd/src/part2/define.h"
 
 namespace nebd {
+namespace client {
+class ProtoOpenFlags;
+}  // namespace client
+}  // namespace nebd
+
+namespace nebd {
 namespace server {
 
 class CurveRequestExecutor;
+
+using OpenFlags = nebd::client::ProtoOpenFlags;
 
 // 具体RequestExecutor中会用到的文件实例上下文信息
 // RequestExecutor需要用到的文件上下文信息都记录到FileInstance内
@@ -48,7 +56,8 @@ class NebdRequestExecutor {
  public:
     NebdRequestExecutor() {}
     virtual ~NebdRequestExecutor() {}
-    virtual std::shared_ptr<NebdFileInstance> Open(const std::string& filename) = 0;  // NOLINT
+    virtual std::shared_ptr<NebdFileInstance> Open(
+        const std::string& filename, const OpenFlags* openflags) = 0;
     virtual std::shared_ptr<NebdFileInstance> Reopen(
         const std::string& filename, const ExtendAttribute& xattr) = 0;
     virtual int Close(NebdFileInstance* fd) = 0;

--- a/nebd/src/part2/request_executor_curve.h
+++ b/nebd/src/part2/request_executor_curve.h
@@ -71,7 +71,8 @@ class CurveRequestExecutor : public NebdRequestExecutor {
     }
     ~CurveRequestExecutor() {}
     void Init(const std::shared_ptr<CurveClient> &client);
-    std::shared_ptr<NebdFileInstance> Open(const std::string& filename) override;  // NOLINT
+    std::shared_ptr<NebdFileInstance> Open(const std::string& filename,
+                                           const OpenFlags* openflags) override;
     std::shared_ptr<NebdFileInstance> Reopen(
         const std::string& filename, const ExtendAttribute& xattr) override;
     int Close(NebdFileInstance* fd) override;

--- a/nebd/test/part1/nebd_client_unittest.cpp
+++ b/nebd/test/part1/nebd_client_unittest.cpp
@@ -259,7 +259,7 @@ TEST_F(NebdFileClientTest, NoNebdServerTest) {
 
     {
         auto start = std::chrono::system_clock::now();
-        ASSERT_EQ(-1, Open4Nebd(kFileName));
+        ASSERT_EQ(-1, Open4Nebd(kFileName, nullptr));
         auto end = std::chrono::system_clock::now();
         auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
             end - start).count();
@@ -282,10 +282,10 @@ TEST_F(NebdFileClientTest, CommonTest) {
 
     ASSERT_EQ(0, Init4Nebd(kNebdClientConf));
 
-    int fd = Open4Nebd(kFileName);
+    int fd = Open4Nebd(kFileName, nullptr);
     ASSERT_GE(fd, 0);
 
-    int fd2 = Open4Nebd(kFileNameWithSlash);
+    int fd2 = Open4Nebd(kFileNameWithSlash, nullptr);
     ASSERT_GE(fd2, 0);
     ASSERT_EQ(0, Close4Nebd(fd2));
 
@@ -375,16 +375,16 @@ TEST_F(NebdFileClientTest, ReOpenTest) {
 
     ASSERT_EQ(0, Init4Nebd(kNebdClientConf));
 
-    int fd = Open4Nebd(kFileName);
+    int fd = Open4Nebd(kFileName, nullptr);
     ASSERT_GT(fd, 0);
 
     // 文件已经被打开，并占用文件锁
     // 再次打开时，获取文件锁失败，直接返回
-    ASSERT_EQ(-1, Open4Nebd(kFileName));
+    ASSERT_EQ(-1, Open4Nebd(kFileName, nullptr));
 
     ASSERT_EQ(0, Close4Nebd(fd));
 
-    fd = Open4Nebd(kFileName);
+    fd = Open4Nebd(kFileName, nullptr);
     ASSERT_GT(fd, 0);
     ASSERT_EQ(0, Close4Nebd(fd));
 
@@ -407,7 +407,7 @@ TEST_F(NebdFileClientTest, ResponseFailTest) {
             .WillOnce(DoAll(
                 SetArgPointee<2>(response),
                 Invoke(MockClientFunc<OpenFileRequest, OpenFileResponse>)));  // NOLINT
-        ASSERT_EQ(-1, Open4Nebd(kFileName));
+        ASSERT_EQ(-1, Open4Nebd(kFileName, nullptr));
     }
 
     {

--- a/nebd/test/part2/metafile_manager_test.cpp
+++ b/nebd/test/part2/metafile_manager_test.cpp
@@ -275,6 +275,5 @@ TEST(MetaFileParserTest, Parse) {
 
 int main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);
-    RUN_ALL_TESTS();
-    return 0;
+    return RUN_ALL_TESTS();
 }

--- a/nebd/test/part2/mock_curve_client.h
+++ b/nebd/test/part2/mock_curve_client.h
@@ -35,9 +35,10 @@ class MockCurveClient : public ::curve::client::CurveClient {
     ~MockCurveClient() {}
     MOCK_METHOD1(Init, int(const std::string&));
     MOCK_METHOD0(UnInit, void());
-    MOCK_METHOD2(Open, int(const std::string&, std::string*));
-    MOCK_METHOD3(ReOpen, int(
-        const std::string&, const std::string&, std::string*));
+    MOCK_METHOD2(Open,
+                 int(const std::string&, const ::curve::client::OpenFlags&));
+    MOCK_METHOD2(ReOpen,
+                 int(const std::string&, const ::curve::client::OpenFlags&));
     MOCK_METHOD1(Close, int(int));
     MOCK_METHOD2(Extend, int(const std::string&, int64_t));
     MOCK_METHOD1(StatFile, int64_t(const std::string&));

--- a/nebd/test/part2/mock_file_manager.h
+++ b/nebd/test/part2/mock_file_manager.h
@@ -39,7 +39,7 @@ class MockFileManager : public NebdFileManager {
 
     MOCK_METHOD0(Fini, int());
     MOCK_METHOD0(Run, int());
-    MOCK_METHOD1(Open, int(const std::string&));
+    MOCK_METHOD2(Open, int(const std::string&, const OpenFlags*));
     MOCK_METHOD2(Close, int(int, bool));
     MOCK_METHOD2(Extend, int(int, int64_t));
     MOCK_METHOD2(GetInfo, int(int, NebdFileInfo*));

--- a/nebd/test/part2/mock_request_executor.h
+++ b/nebd/test/part2/mock_request_executor.h
@@ -44,7 +44,8 @@ class MockRequestExecutor : public NebdRequestExecutor {
     MockRequestExecutor() {}
     ~MockRequestExecutor() {}
 
-    MOCK_METHOD1(Open, std::shared_ptr<NebdFileInstance>(const std::string&));
+    MOCK_METHOD2(Open, std::shared_ptr<NebdFileInstance>(const std::string&,
+                                                         const OpenFlags*));
     MOCK_METHOD2(Reopen, std::shared_ptr<NebdFileInstance>(
         const std::string&, const ExtendAttribute&));
     MOCK_METHOD1(Close, int(NebdFileInstance*));

--- a/nebd/test/part2/test_nebd_server.cpp
+++ b/nebd/test/part2/test_nebd_server.cpp
@@ -44,6 +44,7 @@ TEST(TestNebdServer, test_Init_Run_Fini) {
     // 2. 配置文件存在, 监听端口未设置
     confPath = "./nebd/test/part2/nebd-server-err.conf";
     Configuration conf;
+    conf.SetBoolValue("response.returnRpcWhenIoError", false);
     conf.SetConfigPath(confPath);
     conf.SaveConfig();
     ASSERT_EQ(-1, server.Init(confPath));
@@ -106,6 +107,5 @@ TEST(TestNebdServer, test_Init_Run_Fini) {
 
 int main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);
-    RUN_ALL_TESTS();
-    return 0;
+    return RUN_ALL_TESTS();
 }

--- a/nebd/test/part2/test_request_executor_curve.cpp
+++ b/nebd/test/part2/test_request_executor_curve.cpp
@@ -80,29 +80,32 @@ TEST_F(TestReuqestExecutorCurve, test_Open) {
     {
         std::string errFileName("cbd:pool1/:");
         EXPECT_CALL(*curveClient_, Open(fileName, _)).Times(0);
-        std::shared_ptr<NebdFileInstance> ret = executor.Open(errFileName);
+        std::shared_ptr<NebdFileInstance> ret =
+            executor.Open(errFileName, nullptr);
         ASSERT_TRUE(nullptr == ret);
     }
 
     // 2. curveclient open失败
     {
         EXPECT_CALL(*curveClient_, Open(curveFileName, _))
-            .WillOnce(DoAll(SetArgPointee<1>(""), Return(-1)));
-        std::shared_ptr<NebdFileInstance> ret = executor.Open(fileName);
+            .WillOnce(Return(-1));
+        std::shared_ptr<NebdFileInstance> ret =
+            executor.Open(fileName, nullptr);
         ASSERT_TRUE(nullptr == ret);
     }
 
     // 3. open成功
     {
         EXPECT_CALL(*curveClient_, Open(curveFileName, _))
-            .WillOnce(DoAll(SetArgPointee<1>("abc"), Return(1)));
-        std::shared_ptr<NebdFileInstance> ret = executor.Open(fileName);
+            .WillOnce(Return(1));
+        std::shared_ptr<NebdFileInstance> ret =
+            executor.Open(fileName, nullptr);
         ASSERT_TRUE(nullptr != ret);
         auto *curveIns = dynamic_cast<CurveFileInstance *>(ret.get());
         ASSERT_TRUE(nullptr != curveIns);
         ASSERT_EQ(curveFileName, curveIns->fileName);
         ASSERT_EQ(1, curveIns->fd);
-        ASSERT_EQ("abc", curveIns->xattr["session"]);
+        ASSERT_EQ("", curveIns->xattr["session"]);
     }
 }
 
@@ -124,8 +127,8 @@ TEST_F(TestReuqestExecutorCurve, test_ReOpen) {
 
     // 2. repoen失败
     {
-        EXPECT_CALL(*curveClient_, ReOpen(curveFileName, xattr["session"], _))
-            .WillOnce(DoAll(SetArgPointee<2>(""), Return(-1)));
+        EXPECT_CALL(*curveClient_, ReOpen(curveFileName, _))
+            .WillOnce(Return(-1));
         std::shared_ptr<NebdFileInstance> ret =
             executor.Reopen(fileName, xattr);
         ASSERT_TRUE(nullptr == ret);
@@ -133,8 +136,8 @@ TEST_F(TestReuqestExecutorCurve, test_ReOpen) {
 
     // 3. reopen成功
     {
-        EXPECT_CALL(*curveClient_, ReOpen(curveFileName, xattr["session"], _))
-            .WillOnce(DoAll(SetArgPointee<2>("bcd"), Return(1)));
+        EXPECT_CALL(*curveClient_, ReOpen(curveFileName, _))
+            .WillOnce(Return(1));
          std::shared_ptr<NebdFileInstance> ret =
             executor.Reopen(fileName, xattr);
         ASSERT_TRUE(nullptr != ret);
@@ -142,7 +145,7 @@ TEST_F(TestReuqestExecutorCurve, test_ReOpen) {
         ASSERT_TRUE(nullptr != curveIns);
         ASSERT_EQ(curveFileName, curveIns->fileName);
         ASSERT_EQ(1, curveIns->fd);
-        ASSERT_EQ("bcd", curveIns->xattr["session"]);
+        ASSERT_EQ("", curveIns->xattr["session"]);
     }
 }
 

--- a/proto/nameserver2.proto
+++ b/proto/nameserver2.proto
@@ -442,6 +442,9 @@ message CloseFileRequest {
     required string     owner = 3;
     optional string     signature = 4;
     required uint64     date = 5;
+
+    optional string     clientIP = 6;
+    optional uint32     clientPort = 7;
 };
 
 // statusCode返回值，详见StatusCode定义:
@@ -554,7 +557,7 @@ message FindFileMountPointRequest {
 
 message FindFileMountPointResponse {
     required StatusCode statusCode = 1;
-    optional ClientInfo clientInfo = 2;
+    repeated ClientInfo clientInfo = 2;
 }
 
 message ListVolumesOnCopysetsRequest {

--- a/src/client/client_common.cpp
+++ b/src/client/client_common.cpp
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (c) 2021 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * Project: curve
+ * Date: Thursday Dec 09 21:18:37 CST 2021
+ * Author: wuhanqing
+ */
+
+#include "src/client/client_common.h"
+
+#include <mutex>
+
+namespace curve {
+namespace client {
+
+OpenFlags DefaultReadonlyOpenFlags() {
+    static OpenFlags readonlyFlags;
+    static std::once_flag onceFlag;
+
+    std::call_once(onceFlag, []() { readonlyFlags.exclusive = false; });
+
+    return readonlyFlags;
+}
+
+}  // namespace client
+}  // namespace curve

--- a/src/client/client_common.h
+++ b/src/client/client_common.h
@@ -91,9 +91,6 @@ typedef struct ChunkIDInfo {
     ChunkIDInfo(ChunkID cid, LogicPoolID lpid, CopysetID cpid)
         : cid_(cid), cpid_(cpid), lpid_(lpid) {}
 
-    ChunkIDInfo(const ChunkIDInfo& chunkinfo) = default;
-    ChunkIDInfo& operator=(const ChunkIDInfo& chunkinfo) = default;
-
     bool Valid() const {
         return lpid_ > 0 && cpid_ > 0;
     }
@@ -138,12 +135,6 @@ struct CloneSourceInfo {
 
     CloneSourceInfo() = default;
 
-    CloneSourceInfo(const CloneSourceInfo& other)
-        : name(other.name),
-          length(other.length),
-          segmentSize(other.segmentSize),
-          allocatedSegmentOffsets(other.allocatedSegmentOffsets) {}
-
     bool IsSegmentAllocated(uint64_t offset) const;
 };
 
@@ -170,6 +161,7 @@ typedef struct FInfo {
     uint64_t        stripeUnit;
     uint64_t        stripeCount;
 
+    OpenFlags       openflags;
     common::ReadWriteThrottleParams throttleParams;
 
     FInfo() {
@@ -285,7 +277,7 @@ class ClientDummyServerInfo {
         localIP_ = ip;
     }
 
-    const std::string& GetIP() const {
+    std::string GetIP() const {
         return localIP_;
     }
 
@@ -314,7 +306,7 @@ class ClientDummyServerInfo {
     bool register_ = false;
 };
 
-inline void TrivialDeleter(void* ptr) {}
+inline void TrivialDeleter(void*) {}
 
 inline const char* FileStatusToName(FileStatus status) {
     switch (status) {
@@ -343,6 +335,15 @@ inline bool CloneSourceInfo::IsSegmentAllocated(uint64_t offset) const {
     uint64_t segmentOffset = offset / segmentSize * segmentSize;
     return allocatedSegmentOffsets.count(segmentOffset) != 0;
 }
+
+inline std::ostream& operator<<(std::ostream& os, const OpenFlags& flags) {
+    os << "[exclusive: " << std::boolalpha << flags.exclusive << "]";
+
+    return os;
+}
+
+// default flags for readonly open
+OpenFlags DefaultReadonlyOpenFlags();
 
 }   // namespace client
 }   // namespace curve

--- a/src/client/file_instance.cpp
+++ b/src/client/file_instance.cpp
@@ -49,6 +49,7 @@ FileInstance::FileInstance()
 bool FileInstance::Initialize(const std::string& filename,
                               std::shared_ptr<MDSClient> mdsclient,
                               const UserInfo_t& userinfo,
+                              const OpenFlags& openflags,
                               const FileServiceOption& fileservicopt,
                               bool readonly) {
     readonly_ = readonly;
@@ -65,6 +66,7 @@ bool FileInstance::Initialize(const std::string& filename,
             break;
         }
 
+        finfo_.openflags = openflags;
         finfo_.userinfo = userinfo;
         mdsclient_ = std::move(mdsclient);
 
@@ -213,6 +215,7 @@ FileInstance* FileInstance::NewInitedFileInstance(
     std::shared_ptr<MDSClient> mdsClient,
     const std::string& filename,
     const UserInfo& userInfo,
+    const OpenFlags& openflags,  // TODO(all): maybe we can put userinfo and readonly into openflags  // NOLINT
     bool readonly) {
     FileInstance* instance = new (std::nothrow) FileInstance();
     if (instance == nullptr) {
@@ -221,11 +224,11 @@ FileInstance* FileInstance::NewInitedFileInstance(
     }
 
     bool ret = instance->Initialize(filename, std::move(mdsClient), userInfo,
-                                    fileServiceOption, readonly);
+                                    openflags, fileServiceOption, readonly);
     if (!ret) {
         LOG(ERROR) << "FileInstance initialize failed"
                    << ", filename = " << filename
-                   << ", ower = " << userInfo.owner
+                   << ", owner = " << userInfo.owner
                    << ", readonly = " << readonly;
         delete instance;
         return nullptr;
@@ -237,9 +240,10 @@ FileInstance* FileInstance::NewInitedFileInstance(
 FileInstance* FileInstance::Open4Readonly(const FileServiceOption& opt,
                                           std::shared_ptr<MDSClient> mdsclient,
                                           const std::string& filename,
-                                          const UserInfo& userInfo) {
+                                          const UserInfo& userInfo,
+                                          const OpenFlags& openflags) {
     FileInstance* instance = FileInstance::NewInitedFileInstance(
-        opt, std::move(mdsclient), filename, userInfo, true);
+        opt, std::move(mdsclient), filename, userInfo, openflags, true);
     if (instance == nullptr) {
         LOG(ERROR) << "NewInitedFileInstance failed, filename = " << filename;
         return nullptr;
@@ -254,6 +258,7 @@ FileInstance* FileInstance::Open4Readonly(const FileServiceOption& opt,
         return nullptr;
     }
 
+    fileInfo.openflags = openflags;
     fileInfo.userinfo = userInfo;
     fileInfo.fullPathName = filename;
     instance->GetIOManager4File()->UpdateFileInfo(fileInfo);

--- a/src/client/file_instance.h
+++ b/src/client/file_instance.h
@@ -54,6 +54,7 @@ class CURVE_CACHELINE_ALIGNMENT FileInstance {
     bool Initialize(const std::string& filename,
                     std::shared_ptr<MDSClient> mdsclient,
                     const UserInfo_t& userinfo,
+                    const OpenFlags& openflags,
                     const FileServiceOption& fileservicopt,
                     bool readonly = false);
     /**
@@ -155,12 +156,13 @@ class CURVE_CACHELINE_ALIGNMENT FileInstance {
         std::shared_ptr<MDSClient> mdsClient,
         const std::string& filename,
         const UserInfo& userInfo,
+        const OpenFlags& openflags,
         bool readonly);
 
-    static FileInstance* Open4Readonly(const FileServiceOption& opt,
-                                       std::shared_ptr<MDSClient> mdsclient,
-                                       const std::string& filename,
-                                       const UserInfo& userInfo);
+    static FileInstance* Open4Readonly(
+        const FileServiceOption& opt, std::shared_ptr<MDSClient> mdsclient,
+        const std::string& filename, const UserInfo& userInfo,
+        const OpenFlags& openflags = DefaultReadonlyOpenFlags());
 
  private:
     void StopLease();

--- a/src/client/libcurve_client.cpp
+++ b/src/client/libcurve_client.cpp
@@ -43,7 +43,7 @@ void CurveClient::UnInit() {
 }
 
 int CurveClient::Open(const std::string& filename,
-                      std::string* sessionId) {
+                      const OpenFlags& openflags) {
     curve::client::UserInfo userInfo;
     std::string realFileName;
     bool ret = curve::client::ServiceHelper::GetUserInfoFromFilename(
@@ -54,24 +54,12 @@ int CurveClient::Open(const std::string& filename,
         return -LIBCURVE_ERROR::FAILED;
     }
 
-    return fileClient_->Open(realFileName, userInfo, sessionId);
+    return fileClient_->Open(realFileName, userInfo, openflags);
 }
 
 int CurveClient::ReOpen(const std::string& filename,
-                        const std::string& sessionId,
-                        std::string* newSessionId) {
-    curve::client::UserInfo userInfo;
-    std::string realFileName;
-    bool ret = curve::client::ServiceHelper::GetUserInfoFromFilename(
-        filename, &realFileName, &userInfo.owner);
-
-    if (!ret) {
-        LOG(ERROR) << "Get User Info from filename failed!";
-        return -LIBCURVE_ERROR::FAILED;
-    }
-
-    return fileClient_->ReOpen(realFileName, sessionId,
-                               userInfo, newSessionId);
+                        const OpenFlags& openflags) {
+    return Open(filename, openflags);
 }
 
 int CurveClient::Close(int fd) {

--- a/src/client/libcurve_file.h
+++ b/src/client/libcurve_file.h
@@ -75,20 +75,7 @@ class FileClient {
      */
     virtual int Open(const std::string& filename,
                      const UserInfo_t& userinfo,
-                     std::string* sessionId = nullptr);
-
-    /**
-     * 重新打开文件
-     * @param: filename文件名
-     * @param: sessionId是上次打开该文件时返回的sessionId
-     * @param: userInfo是操作文件的用户信息
-     * @return: 返回文件fd
-     */
-
-    virtual int ReOpen(const std::string& filename,
-                       const std::string& sessionId,
-                       const UserInfo& userInfo,
-                       std::string* newSessionId);
+                     const OpenFlags& openflags = {});
 
     /**
      * 打开文件，这个打开只是创建了一个fd，并不与mds交互，没有session续约

--- a/src/client/mds_client_base.cpp
+++ b/src/client/mds_client_base.cpp
@@ -32,6 +32,16 @@ using curve::common::Authenticator;
 
 const char* kRootUserName = "root";
 
+template <typename T>
+void FillClienIpPortIfRegistered(T* request) {
+    auto& clientinfo = ClientDummyServerInfo::GetInstance();
+
+    if (clientinfo.GetRegister()) {
+        request->set_clientip(clientinfo.GetIP());
+        request->set_clientport(clientinfo.GetPort());
+    }
+}
+
 void MDSClientBase::OpenFile(const std::string& filename,
                              const UserInfo_t& userinfo,
                              OpenFileResponse* response,
@@ -74,7 +84,7 @@ void MDSClientBase::CreateFile(const std::string& filename,
 
     LOG(INFO) << "CreateFile: filename = " << filename
                 << ", owner = " << userinfo.owner
-                << ", is nomalfile: " << normalFile
+                << ", is normalfile: " << normalFile
                 << ", log id = " << cntl->log_id()
                 << ", stripeUnit = " << stripeUnit
                 << ", stripeCount = " << stripeCount;
@@ -93,6 +103,7 @@ void MDSClientBase::CloseFile(const std::string& filename,
     request.set_filename(filename);
     request.set_sessionid(sessionid);
     FillUserInfo(&request, userinfo);
+    FillClienIpPortIfRegistered(&request);
 
     LOG(INFO) << "CloseFile: filename = " << filename
                 << ", owner = " << userinfo.owner
@@ -222,16 +233,8 @@ void MDSClientBase::RefreshSession(const std::string& filename,
     request.set_filename(filename);
     request.set_sessionid(sessionid);
     request.set_clientversion(curve::common::CurveVersion());
-
-    static ClientDummyServerInfo& clientInfo =
-        ClientDummyServerInfo::GetInstance();
-
-    if (clientInfo.GetRegister()) {
-        request.set_clientip(clientInfo.GetIP());
-        request.set_clientport(clientInfo.GetPort());
-    }
-
     FillUserInfo(&request, userinfo);
+    FillClienIpPortIfRegistered(&request);
 
     LOG_EVERY_N(INFO, 10) << "RefreshSession: filename = " << filename
                           << ", owner = " << userinfo.owner

--- a/src/client/splitor.cpp
+++ b/src/client/splitor.cpp
@@ -166,10 +166,8 @@ bool Splitor::AssignInternal(IOTracker* iotracker, MetaCache* metaCache,
     MetaCacheErrorType errCode =
         metaCache->GetChunkInfoByIndex(chunkidx, &chunkIdInfo);
 
-
-    if (errCode == MetaCacheErrorType::CHUNKINFO_NOT_FOUND ||
-       (errCode == MetaCacheErrorType::OK && !chunkIdInfo.chunkExist &&
-       iotracker->Optype() == OpType::WRITE)) {
+    if (NeedGetOrAllocateSegment(errCode, iotracker->Optype(), chunkIdInfo,
+                                 metaCache)) {
         bool isAllocateSegment =
             iotracker->Optype() == OpType::READ ? false : true;
         if (false == GetOrAllocateSegment(
@@ -467,6 +465,20 @@ RequestSourceInfo Splitor::CalcRequestSourceInfo(IOTracker* ioTracker,
     }
 
     return {};
+}
+
+bool Splitor::NeedGetOrAllocateSegment(MetaCacheErrorType error, OpType opType,
+                                       const ChunkIDInfo& chunkInfo,
+                                       const MetaCache* metaCache) {
+    if (error == MetaCacheErrorType::CHUNKINFO_NOT_FOUND) {
+        return true;
+    } else if (error == MetaCacheErrorType::OK && !chunkInfo.chunkExist) {
+        return (opType == OpType::WRITE) ||
+               (opType == OpType::READ &&
+                !metaCache->GetFileInfo()->openflags.exclusive);
+    }
+
+    return false;
 }
 
 }   // namespace client

--- a/src/client/splitor.h
+++ b/src/client/splitor.h
@@ -29,12 +29,12 @@
 
 #include "src/client/client_common.h"
 #include "src/client/config_info.h"
+#include "src/client/metacache.h"
 #include "src/client/request_context.h"
 
 namespace curve {
 namespace client {
 
-class MetaCache;
 class MDSClient;
 class IOTracker;
 class FileSegment;
@@ -93,6 +93,11 @@ class Splitor {
     static RequestSourceInfo CalcRequestSourceInfo(IOTracker* ioTracker,
                                                    MetaCache* metaCache,
                                                    ChunkIndex chunkIdx);
+
+    static bool NeedGetOrAllocateSegment(MetaCacheErrorType error,
+                                         OpType opType,
+                                         const ChunkIDInfo& chunkInfo,
+                                         const MetaCache* metaCache);
 
  private:
     /**

--- a/src/common/string_util.h
+++ b/src/common/string_util.h
@@ -40,7 +40,7 @@
 namespace curve {
 namespace common {
 
-static void SplitString(const std::string& full,
+inline void SplitString(const std::string& full,
                                const std::string& delim,
                                std::vector<std::string>* result) {
     result->clear();
@@ -69,7 +69,7 @@ static void SplitString(const std::string& full,
     }
 }
 
-static bool StringToUll(const std::string &value, uint64_t *out) {
+inline bool StringToUll(const std::string &value, uint64_t *out) {
     try {
         *out = std::stoull(value);
         return true;
@@ -84,7 +84,7 @@ static bool StringToUll(const std::string &value, uint64_t *out) {
     }
 }
 
-static bool StringToInt(const std::string &value, int32_t *out) {
+inline bool StringToInt(const std::string &value, int32_t *out) {
     try {
         *out = std::stoi(value);
         return true;
@@ -99,19 +99,19 @@ static bool StringToInt(const std::string &value, int32_t *out) {
     }
 }
 
-static bool StringStartWith(const std::string& value,
+inline bool StringStartWith(const std::string& value,
                             const std::string& starting) {
     return value.rfind(starting, 0) == 0;
 }
 
-static bool StringEndsWith(const std::string& value,
+inline bool StringEndsWith(const std::string& value,
                            const std::string& ending) {
     if (ending.size() > value.size())
         return false;
     return std::equal(ending.rbegin(), ending.rend(), value.rbegin());
 }
 
-static bool StringToTime(const std::string& value, uint64_t* expireTime) {
+inline bool StringToTime(const std::string& value, uint64_t* expireTime) {
     *expireTime = 0;
     auto length = value.length();
     if (0 == length) {

--- a/src/mds/nameserver2/curvefs.cpp
+++ b/src/mds/nameserver2/curvefs.cpp
@@ -44,6 +44,14 @@ using curve::mds::topology::CopySetIdType;
 namespace curve {
 namespace mds {
 
+ClientInfo EndPointToClientInfo(const butil::EndPoint& ep) {
+    ClientInfo info;
+    info.set_ip(butil::ip2str(ep.ip).c_str());
+    info.set_port(ep.port);
+
+    return info;
+}
+
 inline bool CurveFS::CheckSegmentOffset(const FileInfo& fileInfo,
                                         uint64_t offset) const {
     if (offset % fileInfo.segmentsize() != 0) {
@@ -566,7 +574,7 @@ StatusCode CurveFS::IsSnapshotAllowed(const std::string &fileName) {
 
     // the client version satisfies the conditions
     std::string clientVersion;
-    bool exist = fileRecordManager_->GetFileClientVersion(
+    bool exist = fileRecordManager_->GetMinimumFileClientVersion(
         fileName, &clientVersion);
     if (!exist) {
         return StatusCode::kOK;
@@ -874,10 +882,11 @@ StatusCode CurveFS::CheckFileCanChange(const std::string &fileName,
         return StatusCode::kNotSupported;
     }
 
-    ClientIpPortType mountPoint;
-    if (fileRecordManager_->FindFileMountPoint(fileName, &mountPoint)) {
-        LOG(WARNING) << fileName << " is mounting on " << mountPoint.first
-                     << ":" << mountPoint.second;
+    std::vector<butil::EndPoint> endPoints;
+    if (fileRecordManager_->FindFileMountPoint(fileName, &endPoints) &&
+        !endPoints.empty()) {
+        LOG(WARNING) << fileName << " has " << endPoints.size()
+                     << " mount points";
         return StatusCode::kFileOccupied;
     }
 
@@ -1620,7 +1629,9 @@ StatusCode CurveFS::OpenFile(const std::string &fileName,
 }
 
 StatusCode CurveFS::CloseFile(const std::string &fileName,
-                              const std::string &sessionID) {
+                              const std::string &sessionID,
+                              const std::string &clientIP,
+                              uint32_t clientPort) {
     // check the existence of the file
     FileInfo  fileInfo;
     StatusCode ret;
@@ -1640,7 +1651,7 @@ StatusCode CurveFS::CloseFile(const std::string &fileName,
     }
 
     // remove file record
-    fileRecordManager_->RemoveFileRecord(fileName);
+    fileRecordManager_->RemoveFileRecord(fileName, clientIP, clientPort);
 
     return StatusCode::kOK;
 }
@@ -2138,14 +2149,10 @@ bool CurveFS::CheckSignature(const std::string& owner,
 
 StatusCode CurveFS::ListClient(bool listAllClient,
                                std::vector<ClientInfo>* clientInfos) {
-    std::set<ClientIpPortType> allClients = fileRecordManager_->ListAllClient();
+    std::set<butil::EndPoint> allClients = fileRecordManager_->ListAllClient();
 
-    for (const auto& c : allClients) {
-        ClientInfo info;
-        info.set_ip(c.first);
-        info.set_port(c.second);
-
-        clientInfos->emplace_back(std::move(info));
+    for (const auto &c : allClients) {
+        clientInfos->emplace_back(EndPointToClientInfo(c));
     }
 
     return StatusCode::kOK;
@@ -2251,15 +2258,16 @@ StatusCode CurveFS::ListCloneSourceFileSegments(
     return StatusCode::kOK;
 }
 
-StatusCode CurveFS::FindFileMountPoint(
-    const std::string& fileName,
-    ClientInfo* clientInfo) {
-    ClientIpPortType clientIpPort;
-    auto res = fileRecordManager_->FindFileMountPoint(fileName, &clientIpPort);
+StatusCode CurveFS::FindFileMountPoint(const std::string& fileName,
+                                       std::vector<ClientInfo>* clientInfos) {
+    std::vector<butil::EndPoint> mps;
+    auto res = fileRecordManager_->FindFileMountPoint(fileName, &mps);
 
     if (res) {
-        clientInfo->set_ip(clientIpPort.first);
-        clientInfo->set_port(clientIpPort.second);
+        clientInfos->reserve(mps.size());
+        for (auto& mp : mps) {
+            clientInfos->emplace_back(EndPointToClientInfo(mp));
+        }
         return StatusCode::kOK;
     }
 

--- a/src/mds/nameserver2/curvefs.h
+++ b/src/mds/nameserver2/curvefs.h
@@ -378,7 +378,8 @@ class CurveFS {
      *  @return StatusCode::kOK if succeeded
      */
     StatusCode CloseFile(const std::string &fileName,
-                         const std::string &sessionID);
+                         const std::string &sessionID,
+                         const std::string &clientIP, uint32_t clientPort);
 
     /**
      *  @brief update the valid period of the session
@@ -526,7 +527,7 @@ class CurveFS {
      * @return StatusCode::kOK if succeeded, StatusCode::kFileNotExists if failed //NOLINT
      */
     StatusCode FindFileMountPoint(const std::string& fileName,
-                                  ClientInfo* clientInfo);
+                                  std::vector<ClientInfo>* clientInfos);
 
     /**
      * @brief List volumes on copysets

--- a/src/mds/nameserver2/namespace_service.cpp
+++ b/src/mds/nameserver2/namespace_service.cpp
@@ -24,6 +24,7 @@
 #include <vector>
 #include <string>
 #include <memory>
+#include <utility>
 #include "src/mds/nameserver2/curvefs.h"
 #include "src/mds/nameserver2/file_lock.h"
 #include "src/common/string_util.h"
@@ -1495,7 +1496,10 @@ void NameSpaceService::CloseFile(::google::protobuf::RpcController* controller,
         return;
     }
 
-    retCode = kCurveFS.CloseFile(request->filename(), request->sessionid());
+    retCode = kCurveFS.CloseFile(
+        request->filename(), request->sessionid(),
+        request->has_clientip() ? request->clientip() : clientIP,
+        request->has_clientport() ? request->clientport() : kInvalidPort);
     if (retCode != StatusCode::kOK)  {
         response->set_statuscode(retCode);
         if (google::ERROR != GetMdsLogLevel(retCode)) {
@@ -1974,9 +1978,9 @@ void NameSpaceService::FindFileMountPoint(
               << request->filename();
 
     StatusCode retCode;
-    std::unique_ptr<ClientInfo> clientInfo(new ClientInfo());
+    std::vector<ClientInfo> infos;
     retCode =
-        kCurveFS.FindFileMountPoint(request->filename(), clientInfo.get());
+        kCurveFS.FindFileMountPoint(request->filename(), &infos);
 
     if (retCode != StatusCode::kOK) {
         response->set_statuscode(retCode);
@@ -1987,13 +1991,14 @@ void NameSpaceService::FindFileMountPoint(
                    << ", cost " << expiredTime.ExpiredMs() << " ms";
         return;
     } else {
+        response->set_statuscode(StatusCode::kOK);
+        for (auto& info : infos) {
+            *response->add_clientinfo() = std::move(info);
+        }
         LOG(INFO) << "logid = " << cntl->log_id()
                   << ", FindFileMountPoint ok, fileName = "
-                  << request->filename() << ", client info = "
-                  << response->clientinfo().ShortDebugString()
-                  << ", cost " << expiredTime.ExpiredMs() << " ms";
-        response->set_statuscode(StatusCode::kOK);
-        response->set_allocated_clientinfo(clientInfo.release());
+                  << request->filename() << ", cost " << expiredTime.ExpiredMs()
+                  << " ms";
     }
     return;
 }

--- a/src/mds/server/mds.cpp
+++ b/src/mds/server/mds.cpp
@@ -238,7 +238,7 @@ void MDS::InitEtcdClient(const EtcdConf& etcdConf,
     auto res = etcdClient_->Init(etcdConf, etcdTimeout, retryTimes);
     LOG_IF(FATAL, res != EtcdErrCode::EtcdOK)
         << "init etcd client err! "
-        << "etcdaddr: " << etcdConf.Endpoints
+        << "etcdaddr: " << std::string{etcdConf.Endpoints, etcdConf.len}
         << ", etcdaddr len: " << etcdConf.len
         << ", etcdtimeout: " << etcdConf.DialTimeout
         << ", operation timeout: " << etcdTimeout
@@ -252,7 +252,7 @@ void MDS::InitEtcdClient(const EtcdConf& etcdConf,
         << "Run mds err. Check if etcd is running.";
 
     LOG(INFO) << "init etcd client ok! "
-            << "etcdaddr: " << etcdConf.Endpoints
+            << "etcdaddr: " << std::string{etcdConf.Endpoints, etcdConf.len}
             << ", etcdaddr len: " << etcdConf.len
             << ", etcdtimeout: " << etcdConf.DialTimeout
             << ", operation timeout: " << etcdTimeout

--- a/test/client/client_metric_test.cpp
+++ b/test/client/client_metric_test.cpp
@@ -101,7 +101,7 @@ TEST(MetricTest, ChunkServer_MetricTest) {
     auto opt = cc.GetFileServiceOption();
 
     FileInstance fi;
-    ASSERT_TRUE(fi.Initialize(filename.c_str(), mdsclient, userinfo, opt));
+    ASSERT_TRUE(fi.Initialize(filename, mdsclient, userinfo, OpenFlags{}, opt));
 
     FileMetric* fm = fi.GetIOManager4File()->GetMetric();
 
@@ -216,7 +216,7 @@ TEST(MetricTest, SuspendRPC_MetricTest) {
     ioSenderOpt.failRequestOpt.chunkserverMaxRPCTimeoutMS = 50;
 
     FileInstance fi;
-    ASSERT_TRUE(fi.Initialize(filename.c_str(), mdsclient, userinfo, opt));
+    ASSERT_TRUE(fi.Initialize(filename, mdsclient, userinfo, OpenFlags{}, opt));
 
     FileMetric* fm = fi.GetIOManager4File()->GetMetric();
 

--- a/test/client/client_session_unittest.cpp
+++ b/test/client/client_session_unittest.cpp
@@ -96,8 +96,8 @@ TEST(ClientSession, LeaseTaskTest) {
 
     std::shared_ptr<MDSClient> mdsclient = std::make_shared<MDSClient>();
     mdsclient->Initialize(cc.GetFileServiceOption().metaServerOpt);
-    ASSERT_TRUE(fileinstance.Initialize(filename, mdsclient, userinfo,
-                                        cc.GetFileServiceOption()));
+    ASSERT_TRUE(fileinstance.Initialize(
+        filename, mdsclient, userinfo, OpenFlags{}, cc.GetFileServiceOption()));
 
     brpc::Server server;
     FakeMDSCurveFSService* curvefsservice = mds.GetMDSService();

--- a/test/client/client_userinfo_unittest.cpp
+++ b/test/client/client_userinfo_unittest.cpp
@@ -99,9 +99,10 @@ TEST_F(CurveClientUserAuthFail, CurveClientUserAuthFailTest) {
 
     FileInstance fileinstance;
     ASSERT_FALSE(fileinstance.Initialize(filename, mdsclient, emptyuserinfo,
+                                         OpenFlags{},
                                          cc.GetFileServiceOption()));
-    ASSERT_TRUE(fileinstance.Initialize(filename, mdsclient, userinfo,
-                                        cc.GetFileServiceOption()));
+    ASSERT_TRUE(fileinstance.Initialize(
+        filename, mdsclient, userinfo, OpenFlags{}, cc.GetFileServiceOption()));
 
     // set openfile response
     ::curve::mds::OpenFileResponse openresponse;

--- a/test/client/copyset_client_test.cpp
+++ b/test/client/copyset_client_test.cpp
@@ -3561,8 +3561,8 @@ TEST(ChunkServerBackwardTest, ChunkServerBackwardTest) {
     std::shared_ptr<MDSClient> mdsclient = std::make_shared<MDSClient>();
     ASSERT_EQ(LIBCURVE_ERROR::OK,
               mdsclient->Initialize(cc.GetFileServiceOption().metaServerOpt));
-    ASSERT_TRUE(fileinstance.Initialize("/test", mdsclient, userinfo,
-                                        cc.GetFileServiceOption()));
+    ASSERT_TRUE(fileinstance.Initialize(
+        "/test", mdsclient, userinfo, OpenFlags{}, cc.GetFileServiceOption()));
 
     // create fake chunkserver service
     FakeChunkServerService fakechunkservice;

--- a/test/client/file_instance_test.cpp
+++ b/test/client/file_instance_test.cpp
@@ -33,13 +33,13 @@ TEST(FileInstanceTest, CommonTest) {
 
     // user info invlaid
     FileInstance fi;
-    ASSERT_FALSE(
-        fi.Initialize("/test", mdsclient, UserInfo{}, FileServiceOption{}));
+    ASSERT_FALSE(fi.Initialize("/test", mdsclient, UserInfo{}, OpenFlags{},
+                               FileServiceOption{}));
 
     // mdsclient is nullptr
     FileInstance fi2;
-    ASSERT_FALSE(fi2.Initialize(
-        "/test", nullptr, userInfo, FileServiceOption{}));
+    ASSERT_FALSE(fi2.Initialize("/test", nullptr, userInfo, OpenFlags{},
+                                FileServiceOption{}));
 
     // iomanager4file init failed
     FileInstance fi3;
@@ -47,11 +47,12 @@ TEST(FileInstanceTest, CommonTest) {
     opts.ioOpt.taskThreadOpt.isolationTaskQueueCapacity = 0;
     opts.ioOpt.taskThreadOpt.isolationTaskThreadPoolSize = 0;
 
-    ASSERT_FALSE(fi3.Initialize("/test", mdsclient, userInfo, opts));
+    ASSERT_FALSE(
+        fi3.Initialize("/test", mdsclient, userInfo, OpenFlags{}, opts));
 
     // readonly
     FileInstance fi4;
-    ASSERT_TRUE(fi4.Initialize("/test", mdsclient, userInfo,
+    ASSERT_TRUE(fi4.Initialize("/test", mdsclient, userInfo, OpenFlags{},
                                FileServiceOption{}, true));
     ASSERT_EQ(-1, fi4.Write("", 0, 0));
 
@@ -66,7 +67,7 @@ TEST(FileInstanceTest, OpenReadonlyAndDiscardTest) {
 
     ASSERT_TRUE(
         instance.Initialize("/FileInstanceTest-OpenReadonlyAndDiscardTest",
-                            mdsclient, userInfo, opt, true));
+                            mdsclient, userInfo, OpenFlags{}, opt, true));
 
     ASSERT_EQ(-1, instance.Discard(0, 0));
 

--- a/test/client/iotracker_splitor_unittest.cpp
+++ b/test/client/iotracker_splitor_unittest.cpp
@@ -107,7 +107,8 @@ class IOTrackerSplitorTest : public ::testing::Test {
 
         mdsclient_ = std::make_shared<MDSClient>();
         mdsclient_->Initialize(fopt.metaServerOpt);
-        fileinstance_->Initialize("/test", mdsclient_, userinfo, fopt);
+        fileinstance_->Initialize("/test", mdsclient_, userinfo, OpenFlags{},
+                                  fopt);
         InsertMetaCache();
 
         SourceReader::GetInstance().SetOption(fopt);
@@ -732,7 +733,8 @@ TEST_F(IOTrackerSplitorTest, ExceptionTest_TEST) {
     rootuserinfo.owner = "root";
     rootuserinfo.password = "root_password";
 
-    ASSERT_TRUE(fileserv->Initialize("/test", mdsclient_, rootuserinfo, fopt));
+    ASSERT_TRUE(fileserv->Initialize("/test", mdsclient_, rootuserinfo,
+                                     OpenFlags{}, fopt));
     ASSERT_EQ(LIBCURVE_ERROR::OK, fileserv->Open("1_userinfo_.txt", userinfo));
     curve::client::IOManager4File* iomana = fileserv->GetIOManager4File();
     MetaCache* mc = fileserv->GetIOManager4File()->GetMetaCache();
@@ -1315,7 +1317,8 @@ TEST_F(IOTrackerSplitorTest, StartReadNotAllocateSegmentFromOrigin) {
     userinfo.owner = "cloneuser-test1";
     userinfo.password = "12345";
     mdsclient_->Initialize(fopt.metaServerOpt);
-    fileinstance2->Initialize("/clonesource", mdsclient_, userinfo, fopt);
+    fileinstance2->Initialize("/clonesource", mdsclient_, userinfo, OpenFlags{},
+                              fopt);
 
     MockRequestScheduler* mockschuler2 = new MockRequestScheduler;
     mockschuler2->DelegateToFake();
@@ -1389,7 +1392,8 @@ TEST_F(IOTrackerSplitorTest, AsyncStartReadNotAllocateSegmentFromOrigin) {
     userinfo.owner = "cloneuser-test2";
     userinfo.password = "12345";
     mdsclient_->Initialize(fopt.metaServerOpt);
-    fileinstance2->Initialize("/clonesource", mdsclient_, userinfo, fopt);
+    fileinstance2->Initialize("/clonesource", mdsclient_, userinfo, OpenFlags{},
+                              fopt);
 
     MockRequestScheduler* mockschuler2 = new MockRequestScheduler;
     mockschuler2->DelegateToFake();

--- a/test/client/libcurve_client_unittest.cpp
+++ b/test/client/libcurve_client_unittest.cpp
@@ -87,7 +87,7 @@ TEST_F(CurveClientTest, TestOpen) {
             .Times(0);
 
         ASSERT_EQ(-LIBCURVE_ERROR::FAILED,
-                  client_.Open(kWrongFileName, nullptr));
+                  client_.Open(kWrongFileName, {}));
     }
 
     // open success
@@ -95,26 +95,7 @@ TEST_F(CurveClientTest, TestOpen) {
         EXPECT_CALL(*mockFileClient_, Open(_, _, _))
             .WillOnce(Return(1));
 
-        ASSERT_EQ(1, client_.Open(kValidFileName, nullptr));
-    }
-}
-
-TEST_F(CurveClientTest, TestReOpen) {
-    // parse filename and user info failed
-    {
-        EXPECT_CALL(*mockFileClient_, ReOpen(_, _, _, _))
-            .Times(0);
-
-        ASSERT_EQ(-LIBCURVE_ERROR::FAILED,
-                  client_.ReOpen(kWrongFileName, "xxxx", nullptr));
-    }
-
-    // reopen success
-    {
-        EXPECT_CALL(*mockFileClient_, ReOpen(_, _, _, _))
-            .WillOnce(Return(1));
-
-        ASSERT_EQ(1, client_.ReOpen(kValidFileName, "xxxx", nullptr));
+        ASSERT_EQ(1, client_.Open(kValidFileName, {}));
     }
 }
 

--- a/test/client/libcurve_interface_unittest.cpp
+++ b/test/client/libcurve_interface_unittest.cpp
@@ -684,7 +684,7 @@ TEST(TestLibcurveInterface, UnstableChunkserverTest) {
 
     mdsclient_->Initialize(fopt.metaServerOpt);
     fileinstance_.Initialize(
-        "/UnstableChunkserverTest", mdsclient_, userinfo, fopt);
+        "/UnstableChunkserverTest", mdsclient_, userinfo, OpenFlags{}, fopt);
 
     // 设置leaderid
     EndPoint ep;
@@ -867,8 +867,8 @@ TEST(TestLibcurveInterface, ResumeTimeoutBackoff) {
     fopt.ioOpt.metaCacheOpt.chunkserverUnstableOption.maxStableChunkServerTimeoutTimes = 10;  // NOLINT
 
     mdsclient_->Initialize(fopt.metaServerOpt);
-    fileinstance_.Initialize(
-        "/ResumeTimeoutBackoff", mdsclient_, userinfo, fopt);
+    fileinstance_.Initialize("/ResumeTimeoutBackoff", mdsclient_, userinfo,
+                             OpenFlags{}, fopt);
 
     // 设置leaderid
     EndPoint ep;

--- a/test/client/mock/mock_file_client.h
+++ b/test/client/mock/mock_file_client.h
@@ -39,7 +39,8 @@ class MockFileClient : public FileClient {
 
     MOCK_METHOD1(Init, int(const std::string&));
     MOCK_METHOD0(UnInit, void());
-    MOCK_METHOD3(Open, int(const std::string&, const UserInfo&, std::string*));
+    MOCK_METHOD3(Open,
+                 int(const std::string&, const UserInfo&, const OpenFlags&));
     MOCK_METHOD3(Open4ReadOnly,
                  int(const std::string&, const UserInfo_t&, bool));
     MOCK_METHOD4(Read, int(int, char*, off_t, size_t));

--- a/test/client/splitor_test2.cpp
+++ b/test/client/splitor_test2.cpp
@@ -1,0 +1,66 @@
+/*
+ *  Copyright (c) 2021 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * Project: curve
+ * Date: Thursday Dec 09 19:59:06 CST 2021
+ * Author: wuhanqing
+ */
+
+#include <gtest/gtest.h>
+
+#include "src/client/client_common.h"
+#include "src/client/splitor.h"
+
+namespace curve {
+namespace client {
+
+TEST(SplitorTest, NeedGetOrAllocateSegmentTest_ChunkNotAllocated) {
+    MetaCache metaCache;
+
+    EXPECT_TRUE(Splitor::NeedGetOrAllocateSegment(
+        MetaCacheErrorType::CHUNKINFO_NOT_FOUND, OpType::READ, {}, &metaCache));
+    EXPECT_TRUE(Splitor::NeedGetOrAllocateSegment(
+        MetaCacheErrorType::CHUNKINFO_NOT_FOUND, OpType::WRITE, {},
+        &metaCache));
+}
+
+TEST(SplitorTest, NeedGetOrAllocateSegmentTest_ChunkAllocatedButInvalid) {
+    MetaCache metaCache;
+
+    ChunkIDInfo chunkInfo;
+    chunkInfo.chunkExist = false;
+
+    // write request always return true
+    EXPECT_TRUE(Splitor::NeedGetOrAllocateSegment(
+        MetaCacheErrorType::OK, OpType::WRITE, chunkInfo, &metaCache));
+
+    // read request with exclusive open return false
+    FInfo finfo;
+    finfo.openflags.exclusive = true;
+    metaCache.UpdateFileInfo(finfo);
+    EXPECT_FALSE(Splitor::NeedGetOrAllocateSegment(
+        MetaCacheErrorType::OK, OpType::READ, chunkInfo, &metaCache));
+
+    // read request with non-exclusive open return false
+    finfo.openflags.exclusive = false;
+    metaCache.UpdateFileInfo(finfo);
+    EXPECT_TRUE(Splitor::NeedGetOrAllocateSegment(
+        MetaCacheErrorType::OK, OpType::READ, chunkInfo, &metaCache));
+}
+
+}  // namespace client
+}  // namespace curve

--- a/test/mds/nameserver2/curvefs_test.cpp
+++ b/test/mds/nameserver2/curvefs_test.cpp
@@ -959,9 +959,11 @@ TEST_F(CurveFSTest, testDeleteFile) {
             .Times(1)
             .WillOnce(Return(1ul));
 
-        ClientIpPortType mountPoint("127.0.0.1", 12345);
+        // ClientIpPortType mountPoint("127.0.0.1", 12345);
+        std::vector<butil::EndPoint> mps;
+        mps.emplace_back(butil::EndPoint{});
         EXPECT_CALL(*fileRecordManager_, FindFileMountPoint(_, _))
-            .WillOnce(DoAll(SetArgPointee<1>(mountPoint), Return(true)));
+            .WillOnce(DoAll(SetArgPointee<1>(mps), Return(true)));
 
         ASSERT_EQ(curvefs_->DeleteFile("/file1", kUnitializedFileID, false),
                   StatusCode::kFileOccupied);
@@ -1738,11 +1740,13 @@ TEST_F(CurveFSTest, testRenameFile) {
             .Times(2)
             .WillRepeatedly(Return(1ul));
 
-        ClientIpPortType mountPoint("127.0.0.1", 12345);
+        // ClientIpPortType mountPoint("127.0.0.1", 12345);
+        std::vector<butil::EndPoint> mps;
+        mps.emplace_back(butil::EndPoint{});
         EXPECT_CALL(*fileRecordManager_, FindFileMountPoint(_, _))
             .Times(2)
             .WillOnce(Return(false))
-            .WillOnce(DoAll(SetArgPointee<1>(mountPoint), Return(true)));
+            .WillOnce(DoAll(SetArgPointee<1>(mps), Return(true)));
 
         EXPECT_CALL(*storage_, ListSnapshotFile(_, _, _))
             .Times(2)
@@ -2145,9 +2149,11 @@ TEST_F(CurveFSTest, testChangeOwner) {
             .Times(1)
             .WillOnce(Return(StoreStatus::KeyNotExist));
 
-        ClientIpPortType mountPoint("127.0.0.1", 12345);
+        // ClientIpPortType mountPoint("127.0.0.1", 12345);
+        std::vector<butil::EndPoint> mps;
+        mps.emplace_back(butil::EndPoint{});
         EXPECT_CALL(*fileRecordManager_, FindFileMountPoint(_, _))
-            .WillOnce(DoAll(SetArgPointee<1>(mountPoint), Return(true)));
+            .WillOnce(DoAll(SetArgPointee<1>(mps), Return(true)));
 
         ASSERT_EQ(curvefs_->ChangeOwner("/file1", "owner2"),
                   StatusCode::kFileOccupied);
@@ -2609,8 +2615,8 @@ TEST_F(CurveFSTest, testCreateSnapshotFile) {
 
         FileInfo info;
         ASSERT_EQ(StatusCode::kOK,
-            curvefs_->RefreshSession(
-                fileName, "", 0 , "", "",  1234, "0.0.5", &info));
+                  curvefs_->RefreshSession(fileName, "", 0, "", "127.0.0.1",
+                                           1234, "0.0.5", &info));
 
         FileInfo snapShotFileInfoRet;
         ASSERT_EQ(curvefs_->CreateSnapShotFile(
@@ -2637,7 +2643,7 @@ TEST_F(CurveFSTest, testCreateSnapshotFile) {
         FileInfo info;
         ASSERT_EQ(StatusCode::kOK,
             curvefs_->RefreshSession(
-                fileName, "", 0 , "", "",  1234, "", &info));
+                fileName, "", 0 , "", "127.0.0.1",  1234, "", &info));
 
         FileInfo snapShotFileInfoRet;
         ASSERT_EQ(curvefs_->CreateSnapShotFile(
@@ -3717,7 +3723,8 @@ TEST_F(CurveFSTest, testCloseFile) {
             .Times(1)
             .WillOnce(Return(StoreStatus::OK));
 
-        ASSERT_EQ(curvefs_->CloseFile("/file1", protoSession.sessionid()),
+        ASSERT_EQ(curvefs_->CloseFile("/file1", protoSession.sessionid(), "",
+                                      kInvalidPort),
                   StatusCode::kOK);
     }
 }

--- a/test/mds/nameserver2/file_record_test.cpp
+++ b/test/mds/nameserver2/file_record_test.cpp
@@ -34,8 +34,11 @@ namespace curve {
 namespace mds {
 
 TEST(FileRecordTest, timeout_test) {
+    butil::EndPoint ep;
+    butil::str2endpoint("127.0.0.1:1111", &ep);
+
     // 设置有效时间为1ms
-    FileRecord record(1 * 1000, "0.0.6", "127.0.0.1", 1111);
+    FileRecord record(1 * 1000, "0.0.6", ep);
 
     // 判断超时
     ASSERT_EQ(false, record.IsTimeout());
@@ -46,9 +49,11 @@ TEST(FileRecordTest, timeout_test) {
     std::this_thread::sleep_for(std::chrono::milliseconds(15));
     ASSERT_EQ(true, record.IsTimeout());
 
-    auto clientIpPort = record.GetClientIpPort();
-    ASSERT_EQ(clientIpPort.first, "127.0.0.1");
-    ASSERT_EQ(clientIpPort.second, 1111);
+    auto clientIpPort = record.GetClientEndPoint();
+    // ASSERT_EQ(clientIpPort.first, "127.0.0.1");
+    // ASSERT_EQ(clientIpPort.second, 1111);
+    ASSERT_EQ(butil::endpoint2str(clientIpPort).c_str(),
+              std::string("127.0.0.1:1111"));
 }
 
 TEST(FileRecordManagerTest, normal_test) {
@@ -68,16 +73,16 @@ TEST(FileRecordManagerTest, normal_test) {
     fileRecordManager.UpdateFileRecord("file2", "0.0.5", "127.0.0.1", 1235);
     ASSERT_EQ(2, fileRecordManager.GetOpenFileNum());
     std::string v;
-    ASSERT_TRUE(fileRecordManager.GetFileClientVersion("file1", &v));
+    ASSERT_TRUE(fileRecordManager.GetMinimumFileClientVersion("file1", &v));
     ASSERT_EQ("", v);
-    ASSERT_TRUE(fileRecordManager.GetFileClientVersion("file2", &v));
+    ASSERT_TRUE(fileRecordManager.GetMinimumFileClientVersion("file2", &v));
     ASSERT_EQ("0.0.5", v);
-    ASSERT_FALSE(fileRecordManager.GetFileClientVersion("file3", &v));
+    ASSERT_FALSE(fileRecordManager.GetMinimumFileClientVersion("file3", &v));
 
     fileRecordManager.UpdateFileRecord("file2", "0.0.6", "127.0.0.1", 1235);
     ASSERT_EQ(2, fileRecordManager.GetOpenFileNum());
-    ASSERT_TRUE(fileRecordManager.GetFileClientVersion("file1", &v));
-    ASSERT_TRUE(fileRecordManager.GetFileClientVersion("file2", &v));
+    ASSERT_TRUE(fileRecordManager.GetMinimumFileClientVersion("file1", &v));
+    ASSERT_TRUE(fileRecordManager.GetMinimumFileClientVersion("file2", &v));
     ASSERT_EQ("0.0.6", v);
 
     fileRecordManager.UpdateFileRecord("file3", "0.0.6", "127.0.0.1",
@@ -89,17 +94,24 @@ TEST(FileRecordManagerTest, normal_test) {
     // 其中两个文件打开的client ip port相同
     ASSERT_EQ(2, fileRecordManager.ListAllClient().size());
 
-    ClientIpPortType clientIpPort;
-    ASSERT_TRUE(fileRecordManager.FindFileMountPoint("file1", &clientIpPort));
-    ASSERT_EQ(clientIpPort.first, "127.0.0.1");
-    ASSERT_EQ(clientIpPort.second, 1234);
+    // ClientIpPortType clientIpPort;
+    std::vector<butil::EndPoint> clients;
+    ASSERT_TRUE(fileRecordManager.FindFileMountPoint("file1", &clients));
+    ASSERT_EQ(1, clients.size());
+    // ASSERT_EQ(butil::end, std::string("127.0.0.1"));
+    // ASSERT_EQ(clientIpPort.second, 1234);
+    ASSERT_EQ(std::string("127.0.0.1:1234"),
+              butil::endpoint2str(clients[0]).c_str());
 
-    ASSERT_TRUE(fileRecordManager.FindFileMountPoint("file2", &clientIpPort));
-    ASSERT_EQ(clientIpPort.first, "127.0.0.1");
-    ASSERT_EQ(clientIpPort.second, 1235);
+    clients.clear();
 
+    ASSERT_TRUE(fileRecordManager.FindFileMountPoint("file2", &clients));
+    ASSERT_EQ(std::string("127.0.0.1:1235"),
+              butil::endpoint2str(clients[0]).c_str());
+
+    clients.clear();
     ASSERT_FALSE(
-        fileRecordManager.FindFileMountPoint("file100", &clientIpPort));
+        fileRecordManager.FindFileMountPoint("file100", &clients));
 
     fileRecordManager.Stop();
 }
@@ -116,13 +128,13 @@ TEST(FileRecordManagerTest, open_file_num_test) {
     ASSERT_EQ(0, fileRecordManager.GetOpenFileNum());
 
     // 插入两个记录
-    fileRecordManager.UpdateFileRecord("file1", "", "", 0);
-    fileRecordManager.UpdateFileRecord("file2", "", "", 0);
+    fileRecordManager.UpdateFileRecord("file1", "", "127.0.0.1", 0);
+    fileRecordManager.UpdateFileRecord("file2", "", "127.0.0.1", 0);
 
     bool running = true;
     auto task = [&](const std::string& filename) {
         while (running) {
-            fileRecordManager.UpdateFileRecord(filename, "", "", 1234);
+            fileRecordManager.UpdateFileRecord(filename, "", "127.0.0.1", 1234);
         }
     };
 

--- a/test/mds/nameserver2/mock/mock_file_record_manager.h
+++ b/test/mds/nameserver2/mock/mock_file_record_manager.h
@@ -26,6 +26,7 @@
 #include <gmock/gmock.h>
 
 #include <string>
+#include <vector>
 
 #include "src/mds/nameserver2/file_record.h"
 
@@ -39,7 +40,7 @@ class MockFileRecordManager : public FileRecordManager {
 
     MOCK_CONST_METHOD0(GetFileRecordExpiredTimeUs, uint32_t());
     MOCK_CONST_METHOD2(FindFileMountPoint,
-                       bool(const std::string&, ClientIpPortType*));
+                       bool(const std::string&, std::vector<butil::EndPoint>*));
 };
 
 }  // namespace mds

--- a/test/mds/nameserver2/namespace_service_test.cpp
+++ b/test/mds/nameserver2/namespace_service_test.cpp
@@ -1989,6 +1989,8 @@ TEST_F(NameSpaceServiceTest, FindFileMountPointTest) {
     std::string testFileName = "/test_filename";
     std::string testClientIP = "127.0.0.1";
     uint32_t testClientPort = 1234;
+    std::string testClientIP2 = "127.0.0.1";
+    uint32_t testClientPort2 = 1235;
 
     // start server
     NameSpaceService namespaceService(new FileLockManager(8));
@@ -2006,6 +2008,8 @@ TEST_F(NameSpaceServiceTest, FindFileMountPointTest) {
 
     fileRecordManager_->UpdateFileRecord(testFileName, "0.0.6", testClientIP,
                                          testClientPort);
+    fileRecordManager_->UpdateFileRecord(testFileName, "1.0.0", testClientIP2,
+                                         testClientPort2);
 
     CurveFSService_Stub stub(&channel);
 
@@ -2019,9 +2023,12 @@ TEST_F(NameSpaceServiceTest, FindFileMountPointTest) {
     stub.FindFileMountPoint(&cntl, &request, &response, NULL);
     if (!cntl.Failed()) {
         ASSERT_EQ(response.statuscode(), StatusCode::kOK);
+        ASSERT_EQ(2, response.clientinfo_size());
 
-        ASSERT_EQ(response.clientinfo().ip(), testClientIP);
-        ASSERT_EQ(response.clientinfo().port(), testClientPort);
+        ASSERT_EQ(response.clientinfo(0).ip(), testClientIP);
+        ASSERT_EQ(response.clientinfo(0).port(), testClientPort);
+        ASSERT_EQ(response.clientinfo(1).ip(), testClientIP2);
+        ASSERT_EQ(response.clientinfo(1).port(), testClientPort2);
     } else {
         LOG(INFO) << cntl.ErrorText();
         ASSERT_TRUE(false);


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: close #856

### What is changed and how it works?

What's Changed:

support block storage open multiple times
e.g., a single file/image can be mapped multiple times on different hosts by
curve-nbd with extra option `--no-exclusive'

limitations:
1. provided as a shared disk/device WITHOUT data consistent guarantee,
   so it's users' responsibility to deal with this problem.
2. each file/image can only open once on each host.



Side effects(Breaking backward compatibility? Performance regression?): 

### Check List

- [x] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license
