### PR TITLE
curve_ops_tool: adapt to user-defined root user and password

### DIFF
--- a/conf/tools.conf
+++ b/conf/tools.conf
@@ -14,3 +14,5 @@ etcdAddr=127.0.0.1:2379
 snapshotCloneAddr=127.0.0.1:5555
 # snapshot clone server dummy port
 snapshotCloneDummyPort=8081
+rootUserName=root
+rootUserPassword=root_password

--- a/curve-ansible/roles/generate_config/templates/tools.conf.j2
+++ b/curve-ansible/roles/generate_config/templates/tools.conf.j2
@@ -33,4 +33,6 @@ etcdAddr={{ etcd_address | join(',') }}
 snapshotCloneAddr={{ snap_address | join(',') }}
 # snapshot clone server dummy port
 snapshotCloneDummyPort={{ hostvars[groups.snapshotclone[0]].snapshot_dummy_port }}
+rootUserName={{ curve_root_username }}
+rootUserPassword={{ curve_root_password }}
 {% endif -%}

--- a/src/tools/curve_tool_define.h
+++ b/src/tools/curve_tool_define.h
@@ -35,6 +35,8 @@ DECLARE_uint64(rpcConcurrentNum);
 DECLARE_string(snapshotCloneAddr);
 DECLARE_string(snapshotCloneDummyPort);
 DECLARE_uint64(chunkSize);
+DECLARE_string(userName);
+DECLARE_string(password);
 
 namespace curve {
 namespace tool {

--- a/src/tools/mds_client.cpp
+++ b/src/tools/mds_client.cpp
@@ -27,6 +27,9 @@ DECLARE_uint64(rpcRetryTimes);
 namespace curve {
 namespace tool {
 
+std::string rootUserName;      // NOLINT
+std::string rootUserPassword;  // NOLINT
+
 int MDSClient::Init(const std::string& mdsAddr) {
     return Init(mdsAddr, std::to_string(kDefaultMdsDummyPort));
 }
@@ -1109,12 +1112,11 @@ void MDSClient::FillUserInfo(T* request) {
     request->set_owner(userName_);
     request->set_date(date);
 
-    if (!userName_.compare("root") &&
-        password_.compare("")) {
-        std::string str2sig = Authenticator::GetString2Signature(date,
-                                                                 userName_);
-        std::string sig = Authenticator::CalcString2Signature(str2sig,
-                                                              password_);
+    if (userName_ == rootUserName && !password_.empty()) {
+        std::string str2sig =
+            Authenticator::GetString2Signature(date, userName_);
+        std::string sig =
+            Authenticator::CalcString2Signature(str2sig, password_);
         request->set_signature(sig);
     }
 }

--- a/src/tools/namespace_tool_core.cpp
+++ b/src/tools/namespace_tool_core.cpp
@@ -21,8 +21,8 @@
  */
 #include "src/tools/namespace_tool_core.h"
 
-DEFINE_string(userName, "root", "owner of the file");
-DEFINE_string(password, "root_password", "password of administrator");
+DEFINE_string(userName, "", "owner of the file");
+DEFINE_string(password, "", "password of administrator");
 
 namespace curve {
 namespace tool {


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: close #831

Problem Summary: 

curve_ops_tool uses hard code `root` to check whether a user is root, so when deploying curve with different `curve_root_username` and `curve_root_password`, MDS will report `kOwnerAuthFail`

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?): 

### Check List

- [x] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license
