### PR TITLE
curvefs/client: fix poor random read performance after random write

### DIFF
--- a/curvefs/src/client/fuse_s3_client.cpp
+++ b/curvefs/src/client/fuse_s3_client.cpp
@@ -143,14 +143,14 @@ CURVEFS_ERROR FuseS3Client::FuseOpRead(fuse_req_t req, fuse_ino_t ino,
                    << ", inodeid = " << ino;
         return ret;
     }
-    Inode inode = inodeWrapper->GetInodeLocked();
+    uint64_t fileSize = inodeWrapper->GetLength();
 
     size_t len = 0;
-    if (inode.length() <= off) {
+    if (fileSize <= off) {
         *rSize = 0;
         return CURVEFS_ERROR::OK;
-    } else if (inode.length() < off + size) {
-        len = inode.length() - off;
+    } else if (fileSize < off + size) {
+        len = fileSize - off;
     } else {
         len = size;
     }

--- a/curvefs/src/client/inode_wrapper.h
+++ b/curvefs/src/client/inode_wrapper.h
@@ -90,6 +90,11 @@ class InodeWrapper {
         dirty_ = true;
     }
 
+    uint64_t GetLength() const {
+        curve::common::UniqueLock lg(mtx_);
+        return inode_.length();
+    }
+
     void SetUid(uint32_t uid) {
         inode_.set_uid(uid);
         dirty_ = true;


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?
fix poor random read performance after random write
Through testing and metrices analysis, it is found that the performance bottleneck is mainly in the copy of the inode, and the copy is only to obtain the length, so there is no need
Issue Number: close #809  <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?): 

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
