### PR TITLE
curvefs/metasever: correct misunderstood of index in s3objname

### DIFF
--- a/curvefs/conf/metaserver.conf
+++ b/curvefs/conf/metaserver.conf
@@ -35,7 +35,8 @@ s3compactwq.queue_size=5
 s3compactwq.fragment_threshold=20
 # max chunks to process per compact task
 s3compactwq.max_chunks_per_compact=10
-s3compactwq.enqueue_sleep_ms=100
+# roughly control the compact freq
+s3compactwq.enqueue_sleep_ms=1000
 s3compactwq.s3infocache_size=100
 
 # metaserver listen ip and port

--- a/curvefs/src/metaserver/inode_storage.cpp
+++ b/curvefs/src/metaserver/inode_storage.cpp
@@ -85,6 +85,11 @@ InodeStorage::ContainerType* MemoryInodeStorage::GetContainer() {
     return &inodeMap_;
 }
 
+InodeStorage::ContainerType MemoryInodeStorage::GetContainerData() {
+    ReadLockGuard readLockGuard(rwLock_);
+    return inodeMap_;
+}
+
 void MemoryInodeStorage::MergeTwoS3ChunkInfoMap(
     const ::google::protobuf::Map<uint64_t, S3ChunkInfoList>& mapA,
     const ::google::protobuf::Map<uint64_t, S3ChunkInfoList>& mapB,

--- a/curvefs/src/metaserver/inode_storage.h
+++ b/curvefs/src/metaserver/inode_storage.h
@@ -68,6 +68,7 @@ class InodeStorage {
     virtual MetaStatusCode Update(const Inode &inode) = 0;
     virtual int Count() = 0;
     virtual ContainerType* GetContainer() = 0;
+    virtual ContainerType GetContainerData() = 0;
     virtual ~InodeStorage() = default;
 };
 
@@ -118,6 +119,8 @@ class MemoryInodeStorage : public InodeStorage {
      * @return Inode container, here returns inodeMap_ pointer
      */
     ContainerType* GetContainer() override;
+    ContainerType GetContainerData() override;
+
 
  private:
     RWLock rwLock_;

--- a/curvefs/src/metaserver/s3compact_manager.cpp
+++ b/curvefs/src/metaserver/s3compact_manager.cpp
@@ -198,7 +198,7 @@ void S3CompactManager::Enqueue() {
             pinfo.poolid(), pinfo.copysetid());
         // traverse inode container
         auto inodeStorage = s3compact->GetMutableInodeStorage();
-        InodeStorage::ContainerType inodes(*(inodeStorage->GetContainer()));
+        InodeStorage::ContainerType inodes(inodeStorage->GetContainerData());
         if (inodes.empty()) {
             sleeper_.wait_for(std::chrono::milliseconds(opts_.enqueueSleepMS));
             continue;
@@ -207,7 +207,7 @@ void S3CompactManager::Enqueue() {
             sleeper_.wait_for(std::chrono::milliseconds(opts_.enqueueSleepMS));
             s3compactworkqueueImpl_->Enqueue(inodeStorage,
                                              InodeKey(item.second),
-                                             std::move(pinfo), copysetNode);
+                                             pinfo, copysetNode);
         }
     }
 }

--- a/curvefs/src/metaserver/s3compact_wq_impl.h
+++ b/curvefs/src/metaserver/s3compact_wq_impl.h
@@ -94,14 +94,17 @@ class S3CompactWorkQueueImpl : public TaskThreadPool<> {
         uint64_t chunkid;
         uint64_t compaction;
         uint64_t chunkoff;
+        uint64_t chunklen;
         bool zero;
         Node(uint64_t begin, uint64_t end, uint64_t chunkid,
-             uint64_t compaction, uint64_t chunkoff, bool zero)
+             uint64_t compaction, uint64_t chunkoff, uint64_t chunklen,
+             bool zero)
             : begin(begin),
               end(end),
               chunkid(chunkid),
               compaction(compaction),
               chunkoff(chunkoff),
+              chunklen(chunklen),
               zero(zero) {}
     };
     // closure for updating inode, simply wait
@@ -132,16 +135,16 @@ class S3CompactWorkQueueImpl : public TaskThreadPool<> {
     std::list<struct Node> BuildValidList(
         const S3ChunkInfoList& s3chunkinfolist, uint64_t inodeLen);
     int ReadFullChunk(const std::list<struct Node>& validList, uint64_t fsId,
-                      uint64_t inodeId, uint64_t blockSize,
+                      uint64_t inodeId, uint64_t blockSize, uint64_t chunkSize,
                       std::string* fullChunk, uint64_t* newChunkId,
                       uint64_t* newCompaction, S3Adapter* s3adapter);
     virtual MetaStatusCode UpdateInode(CopysetNode* copysetNode,
                                        const PartitionInfo& pinfo,
                                        const Inode& inode);
     int WriteFullChunk(const std::string& fullChunk, uint64_t fsId,
-                       uint64_t inodeId, uint64_t blockSize,
+                       uint64_t inodeId, uint64_t blockSize, uint64_t chunkSize,
                        uint64_t newChunkid, uint64_t newCompaction,
-                       std::vector<std::string>* objsAdded,
+                       uint64_t newOff, std::vector<std::string>* objsAdded,
                        S3Adapter* s3adapter);
     // func bind with task
     void CompactChunks(std::shared_ptr<InodeStorage> inodeStorage,

--- a/curvefs/src/metaserver/s3infocache.cpp
+++ b/curvefs/src/metaserver/s3infocache.cpp
@@ -124,10 +124,12 @@ int S3InfoCache::GetS3Info(uint64_t fsid, S3Info* s3info) {
 
 void S3InfoCache::InvalidateS3Info(uint64_t fsid) {
     std::lock_guard<std::mutex> lock(mtx_);
-    auto iter = pos_[fsid];
-    recent_.erase(iter);
-    pos_.erase(fsid);
-    cache_.erase(fsid);
+    if (pos_.find(fsid) != pos_.end()) {
+        auto iter = pos_[fsid];
+        recent_.erase(iter);
+        pos_.erase(fsid);
+        cache_.erase(fsid);
+    }
 }
 
 }  // namespace metaserver

--- a/curvefs/src/metaserver/s3infocache.h
+++ b/curvefs/src/metaserver/s3infocache.h
@@ -43,7 +43,6 @@ using curvefs::common::S3Info;
 
 class S3InfoCache {
  private:
-    enum class RequestStatusCode { SUCCESS, NOS3INFO, RPCFAILURE };
     std::mutex mtx_;
     uint64_t capacity_;
     std::vector<std::string> mdsAddrs_;
@@ -57,9 +56,9 @@ class S3InfoCache {
     void UpdateRecent(uint64_t fsid);
     S3Info Get(uint64_t fsid);
     void Put(uint64_t fsid, const S3Info& s3info);
-    RequestStatusCode RequestS3Info(uint64_t fsid, S3Info* s3info);
 
  public:
+    enum class RequestStatusCode { SUCCESS, NOS3INFO, RPCFAILURE };
     explicit S3InfoCache(uint64_t capacity,
                          const std::vector<std::string>& mdsAddrs,
                          butil::EndPoint metaserverAddr)
@@ -68,6 +67,7 @@ class S3InfoCache {
           mdsIndex_(0),
           metaserverAddr_(metaserverAddr) {}
     virtual ~S3InfoCache() {}
+    virtual RequestStatusCode RequestS3Info(uint64_t fsid, S3Info* s3info);
     virtual int GetS3Info(uint64_t fsid, S3Info* s3info);
     virtual void InvalidateS3Info(uint64_t fsid);
 };

--- a/curvefs/test/metaserver/inode_storage_test.cpp
+++ b/curvefs/test/metaserver/inode_storage_test.cpp
@@ -99,9 +99,14 @@ TEST_F(InodeStorageTest, test1) {
     ASSERT_TRUE(CompareInode(newInode, inode2));
 
     // GetInodeContainer
-    auto map = storage.GetContainer();
-    ASSERT_TRUE(CompareInode((*map)[InodeKey(inode2)], inode2));
-    ASSERT_TRUE(CompareInode((*map)[InodeKey(inode3)], inode3));
+    auto mapPtr = storage.GetContainer();
+    ASSERT_TRUE(CompareInode((*mapPtr)[InodeKey(inode2)], inode2));
+    ASSERT_TRUE(CompareInode((*mapPtr)[InodeKey(inode3)], inode3));
+
+    // GetInodeContainerData
+    auto mapData = storage.GetContainerData();
+    ASSERT_TRUE(CompareInode(mapData[InodeKey(inode2)], inode2));
+    ASSERT_TRUE(CompareInode(mapData[InodeKey(inode3)], inode3));
 }
 }  // namespace metaserver
 }  // namespace curvefs

--- a/curvefs/test/metaserver/mock_inode_storage.h
+++ b/curvefs/test/metaserver/mock_inode_storage.h
@@ -41,6 +41,7 @@ class MockInodeStorage : public InodeStorage {
     MOCK_METHOD1(Update, MetaStatusCode(const Inode &inode));
     MOCK_METHOD0(Count, int());
     MOCK_METHOD0(GetContainer, InodeStorage::ContainerType*());
+    MOCK_METHOD0(GetContainerData, InodeStorage::ContainerType());
 };
 
 

--- a/curvefs/test/metaserver/mock_s3infocache.h
+++ b/curvefs/test/metaserver/mock_s3infocache.h
@@ -32,6 +32,7 @@
 
 #include "curvefs/src/metaserver/s3infocache.h"
 
+using ::testing::Invoke;
 using ::testing::Return;
 
 namespace curvefs {
@@ -43,6 +44,9 @@ class MockS3InfoCache : public S3InfoCache {
                     butil::EndPoint metaserverAddr)
         : S3InfoCache(capacity, mdsAddrs, metaserverAddr) {}
     ~MockS3InfoCache() {}
+    MOCK_METHOD2(RequestS3Info,
+                 S3InfoCache::S3InfoCache::RequestStatusCode(uint64_t,
+                                                             S3Info*));
     MOCK_METHOD2(GetS3Info, int(uint64_t, S3Info*));
     MOCK_METHOD1(InvalidateS3Info, void(uint64_t));
 };


### PR DESCRIPTION
current mapping from (off, len) to objname is wrong, index in s3objname is wrong.

wrong understanding: a s3chunk(chunkid) is split in to several fixed sized s3objs, and index them from 0
correct understanding: index = offset_in_a_chunkindex/s3_object_max_size
