### PR TITLE
curvefs client,metaserver: fix dir size & trash dtime bug

### DIFF
--- a/curvefs/src/client/fuse_client.cpp
+++ b/curvefs/src/client/fuse_client.cpp
@@ -322,7 +322,11 @@ CURVEFS_ERROR FuseClient::MakeNode(fuse_req_t req, fuse_ino_t parent,
     const struct fuse_ctx *ctx = fuse_req_ctx(req);
     InodeParam param;
     param.fsId = fsInfo_->fsid();
-    param.length = 0;
+    if (FsFileType::TYPE_DIRECTORY == type) {
+        param.length = 4096;
+    } else {
+        param.length = 0;
+    }
     param.uid = ctx->uid;
     param.gid = ctx->gid;
     param.mode = mode;

--- a/curvefs/src/client/inode_wrapper.h
+++ b/curvefs/src/client/inode_wrapper.h
@@ -138,7 +138,6 @@ class InodeWrapper {
         attr->st_uid = inode_.uid();
         attr->st_gid = inode_.gid();
         attr->st_size = inode_.length();
-        attr->st_blocks = (inode_.length() + 511) / 512;
         attr->st_rdev = inode_.rdev();
         attr->st_atim.tv_sec = inode_.atime();
         attr->st_atim.tv_nsec = inode_.atime_ns();
@@ -147,6 +146,16 @@ class InodeWrapper {
         attr->st_ctim.tv_sec = inode_.ctime();
         attr->st_ctim.tv_nsec = inode_.ctime_ns();
         attr->st_blksize = kOptimalIOBlockSize;
+
+        switch (inode_.type()) {
+            case metaserver::TYPE_S3:
+                attr->st_blocks = (inode_.length() + 511) / 512;
+                break;
+            default:
+                attr->st_blocks = 0;
+                break;
+        }
+
         VLOG(6) << "GetInodeAttr attr =  " << *attr
                 << ", inodeid = " << inode_.inodeid();
         return;

--- a/curvefs/src/metaserver/trash.cpp
+++ b/curvefs/src/metaserver/trash.cpp
@@ -42,7 +42,7 @@ void TrashImpl::Add(uint32_t fsId, uint64_t inodeId, uint32_t dtime) {
     TrashItem item;
     item.fsId = fsId;
     item.inodeId = inodeId;
-    item.dtime = TimeUtility::GetTimeofDayMs();
+    item.dtime = dtime;
 
     LockGuard lg(itemsMutex_);
     trashItems_.push_back(item);


### PR DESCRIPTION
1. default dir size to 4096
2. fix a trash dtime setting bug, otherwize tash will not keep 7 days

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: close #795，#827 <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?): 

### Check List

- [x] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license
