### PR TITLE
curvefs/client: fixed concurrent rename causes txid to be overwritten

### DIFF
--- a/curvefs/src/client/fuse_client.cpp
+++ b/curvefs/src/client/fuse_client.cpp
@@ -549,6 +549,7 @@ CURVEFS_ERROR FuseClient::FuseOpRename(fuse_req_t req, fuse_ino_t parent,
         RenameOperator(fsInfo_->fsid(), parent, name, newparent, newname,
                        dentryManager_, inodeManager_, metaClient_, mdsClient_);
 
+    curve::common::LockGuard lg(renameMutex_);
     CURVEFS_ERROR rc = CURVEFS_ERROR::OK;
     RETURN_IF_UNSUCCESS(GetTxId);
     RETURN_IF_UNSUCCESS(Precheck);

--- a/curvefs/src/client/fuse_client.h
+++ b/curvefs/src/client/fuse_client.h
@@ -269,6 +269,8 @@ class FuseClient {
     InterruptibleSleeper sleeper_;
 
     Thread flushThread_;
+
+    curve::common::Mutex renameMutex_;
 };
 
 }  // namespace client

--- a/curvefs/src/client/s3/disk_cache_manager.cpp
+++ b/curvefs/src/client/s3/disk_cache_manager.cpp
@@ -41,6 +41,9 @@ DiskCacheManager::DiskCacheManager(std::shared_ptr<PosixWrapper> posixWrapper,
     isRunning_ = false;
     usedBytes_ = 0;
     diskFsUsedRatio_ = 0;
+    fullRatio_ = 0;
+    safeRatio_ = 0;
+    maxUsableSpaceBytes_ = 0;
 }
 
 int DiskCacheManager::Init(S3Client *client,


### PR DESCRIPTION
when two rename operators executed in the different diretories at the same time,
the second one maybe get the old txid to prepare, it lets transaction manager
beleive that the previous one is failed and to rollback it, it will causes the
first operation prepare items lost even if itself return success (#855).

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: close #855

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?): 

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
