### PR TITLE
 curvefs/client: fix readCacheMaxByte is zero, curve-fuse is segment fault.

### DIFF
--- a/curvefs/src/client/s3/client_s3_cache_manager.h
+++ b/curvefs/src/client/s3/client_s3_cache_manager.h
@@ -313,7 +313,8 @@ class FsCacheManager {
                                                      uint64_t inodeId);
     void ReleaseFileCacheManager(uint64_t inodeId);
 
-    std::list<DataCachePtr>::iterator Set(DataCachePtr dataCache);
+    bool Set(DataCachePtr dataCache,
+             std::list<DataCachePtr>::iterator *outIter);
     void Delete(std::list<DataCachePtr>::iterator iter);
     void Get(std::list<DataCachePtr>::iterator iter);
 

--- a/curvefs/test/client/fs_cache_manager_test.cpp
+++ b/curvefs/test/client/fs_cache_manager_test.cpp
@@ -53,14 +53,15 @@ TEST(FsCacheManagerTest, test_read_lru_cache_size) {
     FsCacheManager manager(s3ClientAdaptor_, maxReadCacheByte,
                            maxWriteCacheByte);
     auto mockCacheMgr = std::make_shared<MockChunkCacheManager>();
-
+    std::list<DataCachePtr>::iterator outIter;
     {
         EXPECT_CALL(*mockCacheMgr, ReleaseReadDataCache(_)).Times(0);
 
         for (size_t i = 0; i < maxReadCacheByte / smallDataCacheByte; ++i) {
             manager.Set(std::make_shared<DataCache>(s3ClientAdaptor_,
                                                     mockCacheMgr.get(), 0,
-                                                    smallDataCacheByte, buf));
+                                                    smallDataCacheByte, buf),
+                        &outIter);
         }
     }
 
@@ -71,8 +72,10 @@ TEST(FsCacheManagerTest, test_read_lru_cache_size) {
         EXPECT_CALL(*mockCacheMgr, ReleaseReadDataCache(_))
             .Times(expectCallTimes)
             .WillRepeatedly(Invoke([&counter](uint64_t) { counter.Signal(); }));
-        manager.Set(std::make_shared<DataCache>(
-            s3ClientAdaptor_, mockCacheMgr.get(), 0, dataCacheByte, buf));
+        manager.Set(std::make_shared<DataCache>(s3ClientAdaptor_,
+                                                mockCacheMgr.get(), 0,
+                                                dataCacheByte, buf),
+                    &outIter);
 
         counter.Wait();
     }
@@ -85,8 +88,10 @@ TEST(FsCacheManagerTest, test_read_lru_cache_size) {
             .Times(expectCallTimes)
             .WillRepeatedly(Invoke([&counter](uint64_t) { counter.Signal(); }));
 
-        manager.Set(std::make_shared<DataCache>(
-            s3ClientAdaptor_, mockCacheMgr.get(), 0, dataCacheByte, buf));
+        manager.Set(std::make_shared<DataCache>(s3ClientAdaptor_,
+                                                mockCacheMgr.get(), 0,
+                                                dataCacheByte, buf),
+                    &outIter);
         counter.Wait();
     }
 }


### PR DESCRIPTION


<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?
fix readCacheMaxByte is zero, curve-fuse is segment fault.
Issue Number: close #857  <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?): 

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
