### PR TITLE
curvefs/client: fix bugs that abort uplaod when read one file failed

### DIFF
--- a/curvefs/src/client/s3/disk_cache_manager.cpp
+++ b/curvefs/src/client/s3/disk_cache_manager.cpp
@@ -39,6 +39,8 @@ DiskCacheManager::DiskCacheManager(std::shared_ptr<PosixWrapper> posixWrapper,
     cacheWrite_ = cacheWrite;
     cacheRead_ = cacheRead;
     isRunning_ = false;
+    fullRatio_ = 0;
+    safeRatio_ = 0;
 }
 
 int DiskCacheManager::Init(S3Client *client,

--- a/curvefs/src/client/s3/disk_cache_write.cpp
+++ b/curvefs/src/client/s3/disk_cache_write.cpp
@@ -243,8 +243,9 @@ int DiskCacheWrite::UploadAllCacheWriteFile() {
         if (doRet < 0 || buffer == nullptr) {
             if (buffer != nullptr)
                 posixWrapper_->free(buffer);
-            LOG(ERROR) << "read file is failed";
-            return -1;
+            LOG(WARNING) << "read failed, file name is: " << *iter;
+            pendingReq.fetch_sub(1, std::memory_order_seq_cst);
+            continue;
         }
         PutObjectAsyncCallBack cb =
         [&](const std::shared_ptr<PutObjectAsyncContext> &context) {

--- a/curvefs/test/client/test_disk_cache_write.cpp
+++ b/curvefs/test/client/test_disk_cache_write.cpp
@@ -343,7 +343,7 @@ TEST_F(TestDiskCacheWrite, UploadAllCacheWriteFile) {
     EXPECT_CALL(*wrapper_, closedir(NotNull()))
         .WillOnce(Return(0));
     ret = diskCacheWrite_->UploadAllCacheWriteFile();
-    ASSERT_EQ(-1, ret);
+    ASSERT_EQ(0, ret);
 }
 
 TEST_F(TestDiskCacheWrite, UploadAllCacheWriteFile_2) {


### PR DESCRIPTION
when read one file from disk write cache failed, continue to upload
other files

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: close #877  <!-- REMOVE this line if no issue to close -->


