### PR TITLE
curve-client: fix an illegal metric name

### DIFF
--- a/src/client/libcurve_file.cpp
+++ b/src/client/libcurve_file.cpp
@@ -108,7 +108,7 @@ FileClient::FileClient()
       clientconfig_(),
       mdsClient_(),
       inited_(false),
-      openedFileNum_(common::ToHexString(this)) {}
+      openedFileNum_("open_file_num_" + common::ToHexString(this)) {}
 
 bool FileClient::CheckAligned(off_t offset, size_t length) const {
     return common::is_aligned(offset, kMinIOAlignment) &&

--- a/src/common/string_util.h
+++ b/src/common/string_util.h
@@ -140,7 +140,7 @@ inline bool StringToTime(const std::string& value, uint64_t* expireTime) {
 
 inline std::string ToHexString(void* p) {
     std::ostringstream oss;
-    oss << "0x" << std::hex << reinterpret_cast<uint64_t>(p);
+    oss << p;
     return oss.str();
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: close #895 

Problem Summary: a metric name is hexstring

### What is changed and how it works?

What's Changed: 

if expose two different metrics with the same name, bvar will complain name is already exposed. so I just use an address to distinguish them, but forget a prefix. In this PR, add back the prefix.

How it Works:

Side effects(Breaking backward compatibility? Performance regression?): 

### Check List

- [x] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license
