### PR TITLE
curvefs/metaserver: fix s3compact crash when partition have been deleted

### DIFF
--- a/curvefs/src/metaserver/partition.cpp
+++ b/curvefs/src/metaserver/partition.cpp
@@ -50,8 +50,7 @@ Partition::Partition(const PartitionInfo& paritionInfo) {
 
     if (paritionInfo.status() != PartitionStatus::DELETING) {
         TrashManager::GetInstance().Add(paritionInfo.partitionid(), trash_);
-        s3compact_ = std::make_shared<S3Compact>(inodeStorage_,
-                                                 &partitionInfo_);
+        s3compact_ = std::make_shared<S3Compact>(inodeStorage_, partitionInfo_);
         S3CompactManager::GetInstance().RegisterS3Compact(s3compact_);
     }
 }

--- a/curvefs/src/metaserver/s3compact.h
+++ b/curvefs/src/metaserver/s3compact.h
@@ -24,10 +24,9 @@
 #define CURVEFS_SRC_METASERVER_S3COMPACT_H_
 
 #include <memory>
+
 #include "curvefs/proto/common.pb.h"
 #include "curvefs/src/metaserver/inode_storage.h"
-
-
 
 namespace curvefs {
 namespace metaserver {
@@ -37,20 +36,21 @@ using curvefs::common::PartitionInfo;
 class S3Compact {
  public:
     explicit S3Compact(std::shared_ptr<InodeStorage> inodeStorage,
-                       PartitionInfo* partitionInfo)
+                       const PartitionInfo& partitionInfo)
         : inodeStorage_(inodeStorage), partitionInfo_(partitionInfo) {}
 
     std::shared_ptr<InodeStorage> GetMutableInodeStorage() {
         return inodeStorage_;
     }
 
-    PartitionInfo GetPartition() {
-        return *partitionInfo_;
+    PartitionInfo GetPartition() const {
+        return partitionInfo_;
     }
 
  private:
     std::shared_ptr<InodeStorage> inodeStorage_;
-    PartitionInfo* partitionInfo_;
+    // we only need data that will not be changed after being created.
+    const PartitionInfo partitionInfo_;
 };
 
 }  // namespace metaserver

--- a/curvefs/src/metaserver/s3compact_manager.h
+++ b/curvefs/src/metaserver/s3compact_manager.h
@@ -89,7 +89,7 @@ class S3CompactManager {
     std::shared_ptr<S3InfoCache> s3infoCache_;
     std::shared_ptr<S3AdapterManager> s3adapterManager_;
     std::shared_ptr<S3CompactWorkQueueImpl> s3compactworkqueueImpl_;
-    std::vector<std::shared_ptr<S3Compact>> s3compacts_;
+    std::vector<std::weak_ptr<S3Compact>> s3compacts_;
     curve::common::RWLock rwLock_;
     InterruptibleSleeper sleeper_;
     void Enqueue();
@@ -106,7 +106,7 @@ class S3CompactManager {
     }
 
     void Init(std::shared_ptr<Configuration> conf);
-    void RegisterS3Compact(std::shared_ptr<S3Compact>);
+    void RegisterS3Compact(std::weak_ptr<S3Compact>);
     int Run();
     void Stop();
 };


### PR DESCRIPTION
we need erase s3compact from vector when partition is deleted