### PR TITLE
curvefs/client: retry ReadFromS3 when needed

### DIFF
--- a/curvefs/src/client/s3/client_s3.cpp
+++ b/curvefs/src/client/s3/client_s3.cpp
@@ -63,6 +63,11 @@ int S3ClientImpl::Download(const std::string &name, char *buf, uint64_t offset,
             << ",length:" << length;
     ret = s3Adapter_->GetObject(name, buf, offset, length);
     if (ret < 0) {
+        const Aws::String aws_key(name.c_str(), name.size());
+        if (!s3Adapter_->ObjectExist(aws_key)) {
+            LOG(INFO) << "obj " << name << " seems not exist";
+            ret = -2;
+        }
         LOG(ERROR) << "download error:" << ret;
     }
 

--- a/curvefs/src/client/s3/client_s3_cache_manager.cpp
+++ b/curvefs/src/client/s3/client_s3_cache_manager.cpp
@@ -275,67 +275,95 @@ int FileCacheManager::Read(uint64_t inodeId, uint64_t offset, uint64_t length,
         return readOffset;
     }
 
-    std::vector<S3ReadRequest> totalS3Requests;
-    auto iter = totalRequests.begin();
-    uint64_t fileLen;
     {
+        unsigned int maxRetry = 3;  // hardcode, fixme
+        unsigned int retry = 0;
         std::shared_ptr<InodeWrapper> inodeWrapper;
-        CURVEFS_ERROR ret = s3ClientAdaptor_->GetInodeCacheManager()->GetInode(
-            inodeId, inodeWrapper);
-        if (ret != CURVEFS_ERROR::OK) {
+        auto inodeManager = s3ClientAdaptor_->GetInodeCacheManager();
+        CURVEFS_ERROR r = inodeManager->GetInode(inodeId, inodeWrapper);
+        if (r != CURVEFS_ERROR::OK) {
             LOG(WARNING) << "get inode fail, ret:" << ret;
             return -1;
         }
-        ::curve::common::UniqueLock lgGuard = inodeWrapper->GetUniqueLock();
-        Inode *inode = inodeWrapper->GetMutableInodeUnlocked();
-        fileLen = inode->length();
-        for (; iter != totalRequests.end(); iter++) {
-            VLOG(6) << "ReadRequest index:" << iter->index
-                    << ",chunkPos:" << iter->chunkPos << ",len:" << iter->len
-                    << ",bufOffset:" << iter->bufOffset;
-            auto s3InfoListIter = inode->s3chunkinfomap().find(iter->index);
-            if (s3InfoListIter == inode->s3chunkinfomap().end()) {
-                VLOG(6) << "s3infolist is not found.index:" << iter->index;
-                memset(dataBuf + iter->bufOffset, 0, iter->len);
-                continue;
+        std::vector<S3ReadResponse> responses;
+        while (retry < maxRetry) {
+            std::vector<S3ReadRequest> totalS3Requests;
+            auto iter = totalRequests.begin();
+            uint64_t fileLen;
+            {
+                ::curve::common::UniqueLock lgGuard =
+                    inodeWrapper->GetUniqueLock();
+                Inode* inode = inodeWrapper->GetMutableInodeUnlocked();
+                fileLen = inode->length();
+                for (; iter != totalRequests.end(); iter++) {
+                    VLOG(6) << "ReadRequest index:" << iter->index
+                            << ",chunkPos:" << iter->chunkPos
+                            << ",len:" << iter->len
+                            << ",bufOffset:" << iter->bufOffset;
+                    auto s3InfoListIter =
+                        inode->s3chunkinfomap().find(iter->index);
+                    if (s3InfoListIter == inode->s3chunkinfomap().end()) {
+                        VLOG(6)
+                            << "s3infolist is not found.index:" << iter->index;
+                        memset(dataBuf + iter->bufOffset, 0, iter->len);
+                        continue;
+                    }
+                    std::vector<S3ReadRequest> s3Requests;
+                    GenerateS3Request(*iter, s3InfoListIter->second, dataBuf,
+                                      &s3Requests, inode->fsid(),
+                                      inode->inodeid());
+                    totalS3Requests.insert(totalS3Requests.end(),
+                                           s3Requests.begin(),
+                                           s3Requests.end());
+                }
             }
-            std::vector<S3ReadRequest> s3Requests;
-            GenerateS3Request(*iter, s3InfoListIter->second, dataBuf,
-                              &s3Requests, inode->fsid(), inode->inodeid());
-            totalS3Requests.insert(totalS3Requests.end(), s3Requests.begin(),
-                                   s3Requests.end());
+            if (totalS3Requests.empty()) {
+                VLOG(6) << "s3 has not data to read.";
+                return readOffset;
+            }
+
+            uint32_t i;
+            for (i = 0; i < totalS3Requests.size(); i++) {
+                S3ReadRequest& tmp_req = totalS3Requests[i];
+                VLOG(9) << "S3ReadRequest chunkid:" << tmp_req.chunkId
+                        << ",offset:" << tmp_req.offset
+                        << ",len:" << tmp_req.len
+                        << ",objectOffset:" << tmp_req.objectOffset
+                        << ",readOffset:" << tmp_req.readOffset
+                        << ",compaction:" << tmp_req.compaction
+                        << ",fsid:" << tmp_req.fsId
+                        << ",inodeId:" << tmp_req.inodeId;
+            }
+
+            ret = ReadFromS3(totalS3Requests, &responses, fileLen);
+            if (ret < 0) {
+                retry++;
+                responses.clear();
+                if (ret != -2 || retry == maxRetry) {
+                    LOG(ERROR) << "read from s3 failed. ret:" << ret;
+                    return ret;
+                } else {
+                    // ret -2 refs s3obj not exist
+                    // clear inodecache && get again
+                    LOG(INFO) << "inode cache maybe steal, try to get latest";
+                    inodeManager->ClearInodeCache(inodeId);
+                    auto r = inodeManager->GetInode(inodeId, inodeWrapper);
+                    if (r != CURVEFS_ERROR::OK) {
+                        LOG(WARNING) << "get inode fail, ret:" << ret;
+                        return -1;
+                    }
+                }
+            } else {
+                break;
+            }
         }
-    }
-    if (totalS3Requests.empty()) {
-        VLOG(6) << "s3 has not data to read.";
-        return readOffset;
-    }
-
-    uint32_t i;
-    for (i = 0; i < totalS3Requests.size(); i++) {
-        S3ReadRequest &tmp_req = totalS3Requests[i];
-        VLOG(9) << "S3ReadRequest chunkid:" << tmp_req.chunkId
-                << ",offset:" << tmp_req.offset << ",len:" << tmp_req.len
-                << ",objectOffset:" << tmp_req.objectOffset
-                << ",readOffset:" << tmp_req.readOffset
-                << ",compaction:" << tmp_req.compaction
-                << ",fsid:" << tmp_req.fsId << ",inodeId:" << tmp_req.inodeId;
-    }
-
-    std::vector<S3ReadResponse> responses;
-
-    ret = ReadFromS3(totalS3Requests, &responses, fileLen);
-    if (ret < 0) {
-        LOG(ERROR) << "read from s3 failed. ret:" << ret;
-        return ret;
-    }
-
-    auto repIter = responses.begin();
-    for (; repIter != responses.end(); repIter++) {
-        VLOG(6) << "readOffset:" << repIter->GetReadOffset()
-                << ",bufLen:" << repIter->GetBufLen();
-        memcpy(dataBuf + repIter->GetReadOffset(), repIter->GetDataBuf(),
-               repIter->GetBufLen());
+        auto repIter = responses.begin();
+        for (; repIter != responses.end(); repIter++) {
+            VLOG(6) << "readOffset:" << repIter->GetReadOffset()
+                    << ",bufLen:" << repIter->GetBufLen();
+            memcpy(dataBuf + repIter->GetReadOffset(),
+                repIter->GetDataBuf(), repIter->GetBufLen());
+        }
     }
 
     return readOffset;

--- a/curvefs/test/client/client_s3_test.cpp
+++ b/curvefs/test/client/client_s3_test.cpp
@@ -79,11 +79,17 @@ TEST_F(ClientS3Test, download) {
     char* buf = new char[len];
 
     EXPECT_CALL(*s3Client_, GetObject(_, _, _, _))
-        .Times(2)
+        .Times(3)
         .WillOnce(Return(0))
+        .WillOnce(Return(-1))
         .WillOnce(Return(-1));
+    EXPECT_CALL(*s3Client_, ObjectExist(_))
+        .Times(2)
+        .WillOnce(Return(true))
+        .WillOnce(Return(false));
     ASSERT_EQ(0, client_->Download(obj, buf, offset, len));
     ASSERT_EQ(-1, client_->Download(obj, buf, offset, len));
+    ASSERT_EQ(-2, client_->Download(obj, buf, offset, len));
     delete buf;
 }
 

--- a/curvefs/test/client/mock_s3_adapter.h
+++ b/curvefs/test/client/mock_s3_adapter.h
@@ -47,6 +47,7 @@ class MockS3Adapter : public curve::common::S3Adapter {
     MOCK_METHOD1(PutObjectAsync, void(std::shared_ptr<PutObjectAsyncContext>));
     MOCK_METHOD4(GetObject, int(const std::string&, char*, off_t, size_t));
     MOCK_METHOD1(GetObjectAsync, void(std::shared_ptr<GetObjectAsyncContext>));
+    MOCK_METHOD1(ObjectExist, bool(const Aws::String &key));
 };
 }  // namespace client
 }  // namespace curvefs


### PR DESCRIPTION
    curvefs/client: update inode cache and retry ReadFromS3 when obj does not
    exist. because objs may be deleted by s3compact, client inode cache is
    stale.