### PR TITLE
unittest/metaserver: enlarge default rpc timeout to 10 seconds

### DIFF
--- a/curvefs/test/metaserver/copyset/copyset_service_test.cpp
+++ b/curvefs/test/metaserver/copyset/copyset_service_test.cpp
@@ -76,7 +76,10 @@ class CopysetServiceTest : public testing::Test {
                                         brpc::SERVER_OWNS_SERVICE));
         ASSERT_EQ(0, server_.Start(listenAddr, nullptr));
 
-        ASSERT_EQ(0, channel_.Init(listenAddr, nullptr));
+        brpc::ChannelOptions opts;
+        opts.timeout_ms = 10 * 1000;
+        opts.max_retry = 0;
+        ASSERT_EQ(0, channel_.Init(listenAddr, &opts));
     }
 
     void TearDown() override {


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: close #930 

Problem Summary:

currently, we run all unittests parallelly in a single host,
and most unittests consume lots of CPU, therefore there's a chance that
default rpc timeout 500ms is not enough.

### What is changed and how it works?

What's Changed:

set default rpc timeout to 10 seconds

Side effects(Breaking backward compatibility? Performance regression?): 

### Check List

- [x] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license
