### PR TITLE
curvefs/mds:fix delete fs

### DIFF
--- a/curvefs/conf/metaserver.conf
+++ b/curvefs/conf/metaserver.conf
@@ -5,8 +5,8 @@ trash.scanPeriodSec=600
 trash.expiredAfterSec=604800
 
 # s3
-s3.blocksize=1048576
-s3.chunksize=4194304
+s3.blocksize=4194304
+s3.chunksize=67108864
 # if s3.enableDeleteObjects set True, batch size limit the object num of delete count per delete request
 s3.batchsize=100
 # if s3 sdk support batch delete objects, set True; other set False

--- a/curvefs/src/mds/fs_manager.h
+++ b/curvefs/src/mds/fs_manager.h
@@ -176,9 +176,16 @@ class FsManager {
                                         FSType fsType, uint64_t blocksize,
                                         const FsDetail& detail);
 
+    // send request to metaserver to DeletePartition, if response returns
+    // FSStatusCode::OK or FSStatusCode::UNDER_DELETING, returns true;
+    // else returns false
+    bool DeletePartiton(std::string fsName, const PartitionInfo& partition);
+
+    // set partition status to DELETING in topology
+    bool SetPartitionToDeleting(const PartitionInfo& partition);
+
  private:
     uint64_t GetRootId();
-    FSStatusCode CleanFsInodeAndDentry(uint32_t fsId);
 
  private:
     std::shared_ptr<FsStorage> fsStorage_;

--- a/curvefs/src/mds/topology/topology.cpp
+++ b/curvefs/src/mds/topology/topology.cpp
@@ -588,6 +588,24 @@ TopoStatusCode TopologyImpl::UpdatePartitionStatistic(
     }
 }
 
+
+TopoStatusCode TopologyImpl::UpdatePartitionStatus(PartitionIdType partitionId,
+                                                   PartitionStatus status) {
+    WriteLockGuard wlockPartition(partitionMutex_);
+    auto it = partitionMap_.find(partitionId);
+    if (it != partitionMap_.end()) {
+        Partition temp = it->second;
+        temp.SetStatus(status);
+        if (!storage_->UpdatePartition(temp)) {
+            return TopoStatusCode::TOPO_STORGE_FAIL;
+        }
+        it->second = std::move(temp);
+        return TopoStatusCode::TOPO_OK;
+    } else {
+        return TopoStatusCode::TOPO_PARTITION_NOT_FOUND;
+    }
+}
+
 bool TopologyImpl::GetPartition(PartitionIdType partitionId, Partition *out) {
     ReadLockGuard rlockPartition(partitionMutex_);
     auto it = partitionMap_.find(partitionId);

--- a/curvefs/src/mds/topology/topology.h
+++ b/curvefs/src/mds/topology/topology.h
@@ -103,6 +103,8 @@ class Topology {
         uint32_t partitionId, PartitionStatistic statistic) = 0;
     virtual TopoStatusCode UpdatePartitionTxIds(
         std::vector<PartitionTxId> txIds) = 0;
+    virtual TopoStatusCode UpdatePartitionStatus(PartitionIdType partitionId,
+                                                 PartitionStatus status) = 0;
 
     virtual TopoStatusCode SetCopySetAvalFlag(const CopySetKey &key,
                                               bool aval) = 0;
@@ -290,6 +292,8 @@ class TopologyImpl : public Topology {
         uint32_t partitionId, PartitionStatistic statistic) override;
     TopoStatusCode UpdatePartitionTxIds(
         std::vector<PartitionTxId> txIds) override;
+    TopoStatusCode UpdatePartitionStatus(PartitionIdType partitionId,
+        PartitionStatus status) override;
 
     PoolIdType FindPool(const std::string &poolName) const override;
     ZoneIdType FindZone(const std::string &zoneName,

--- a/curvefs/src/mds/topology/topology_manager.cpp
+++ b/curvefs/src/mds/topology/topology_manager.cpp
@@ -1157,6 +1157,11 @@ void TopologyManager::ListMetaserverOfCluster(
     }
 }
 
+TopoStatusCode TopologyManager::UpdatePartitionStatus(
+    PartitionIdType partitionId, PartitionStatus status) {
+    return topology_->UpdatePartitionStatus(partitionId, status);
+}
+
 }  // namespace topology
 }  // namespace mds
 }  // namespace curvefs

--- a/curvefs/src/mds/topology/topology_manager.h
+++ b/curvefs/src/mds/topology/topology_manager.h
@@ -125,6 +125,9 @@ class TopologyManager {
     virtual void ListPartitionOfFs(FsIdType fsId,
                                    std::list<PartitionInfo>* list);
 
+    virtual TopoStatusCode UpdatePartitionStatus(PartitionIdType partitionId,
+                                                 PartitionStatus status);
+
     virtual void GetCopysetOfPartition(
         const GetCopysetOfPartitionRequest *request,
         GetCopysetOfPartitionResponse *response);

--- a/curvefs/src/metaserver/metastore.cpp
+++ b/curvefs/src/metaserver/metastore.cpp
@@ -278,6 +278,7 @@ MetaStatusCode MetaStoreImpl::DeletePartition(
                   << ", partitionId = " <<  partitionId;
         TrashManager::GetInstance().Remove(partitionId);
         it->second->ClearS3Compact();
+        PartitionCleanManager::GetInstance().Remove(partitionId);
         partitionMap_.erase(it);
         response->set_statuscode(MetaStatusCode::OK);
         return MetaStatusCode::OK;

--- a/curvefs/src/metaserver/partition.cpp
+++ b/curvefs/src/metaserver/partition.cpp
@@ -220,10 +220,6 @@ MetaStatusCode Partition::GetInode(uint32_t fsId, uint64_t inodeId,
         return MetaStatusCode::PARTITION_ID_MISSMATCH;
     }
 
-    if (GetStatus() == PartitionStatus::DELETING) {
-        return MetaStatusCode::PARTITION_DELETING;
-    }
-
     return inodeManager_->GetInode(fsId, inodeId, inode);
 }
 
@@ -296,10 +292,18 @@ bool Partition::IsDeletable() {
 
 bool Partition::IsInodeBelongs(uint32_t fsId, uint64_t inodeId) {
     if (fsId != partitionInfo_.fsid()) {
+        LOG(WARNING) << "partition fsid mismatch, fsId = " << fsId
+                     << ", inodeId = " << inodeId
+                     << ", partition fsId = " << partitionInfo_.fsid();
         return false;
     }
 
     if (inodeId < partitionInfo_.start() || inodeId > partitionInfo_.end()) {
+        LOG(WARNING) << "partition inode mismatch, fsId = " << fsId
+                     << ", inodeId = " << inodeId
+                     << ", partition fsId = " << partitionInfo_.fsid()
+                     << ", partition starst = " << partitionInfo_.start()
+                     << ", partition end = " << partitionInfo_.end();
         return false;
     }
 

--- a/curvefs/src/metaserver/s3/metaserver_s3_adaptor.cpp
+++ b/curvefs/src/metaserver/s3/metaserver_s3_adaptor.cpp
@@ -179,7 +179,8 @@ void S3ClientAdaptorImpl::GenObjNameListForChunkInfo(
     uint64_t length = chunkInfo.len();
     uint64_t blockIndex = chunkPos / blockSize_;
     uint64_t blockPos = chunkPos % blockSize_;
-    VLOG(3) << "delete Chunk start, chunk id: " << chunkId
+    VLOG(3) << "delete Chunk start, fsId = "<< fsId << ", inodeId = " << inodeId
+            << ", chunk id: " << chunkId
             << ", compaction:" << compaction << ", chunkPos: " << chunkPos
             << ", length: " << length;
     int count = (length + blockPos + blockSize_ - 1) / blockSize_;

--- a/curvefs/test/mds/mock/mock_topology.h
+++ b/curvefs/test/mds/mock/mock_topology.h
@@ -321,16 +321,16 @@ class MockTopology : public TopologyImpl {
     MOCK_CONST_METHOD4(
         ChooseRecoveredMetaServer,
         TopoStatusCode(PoolIdType poolId,
-        const std::set<ZoneIdType> &unavailableZones,
-        const std::set<MetaServerIdType> &unavailableMs,
-        MetaServerIdType *target));
+                       const std::set<ZoneIdType> &unavailableZones,
+                       const std::set<MetaServerIdType> &unavailableMs,
+                       MetaServerIdType *target));
 
     MOCK_METHOD2(ChooseAvailableMetaServers,
-                TopoStatusCode(std::set<MetaServerIdType> *metaServers,
-                PoolIdType *poolId));
+                 TopoStatusCode(std::set<MetaServerIdType> *metaServers,
+                                PoolIdType *poolId));
 
-    MOCK_CONST_METHOD1(GetPartitionInfosInCopyset, std::list<Partition>(
-                       CopySetIdType copysetId));
+    MOCK_CONST_METHOD1(GetPartitionInfosInCopyset,
+                       std::list<Partition>(CopySetIdType copysetId));
 };
 
 class MockTopologyManager : public TopologyManager {
@@ -405,8 +405,12 @@ class MockTopologyManager : public TopologyManager {
     MOCK_METHOD2(ListPartition, void(const ListPartitionRequest *request,
                                      ListPartitionResponse *response));
 
-    MOCK_METHOD2(ListPartitionOfFs, void(FsIdType fsId,
-                                         std::list<PartitionInfo>* list));
+    MOCK_METHOD2(ListPartitionOfFs,
+                 void(FsIdType fsId, std::list<PartitionInfo> *list));
+
+    MOCK_METHOD2(UpdatePartitionStatus,
+                 TopoStatusCode(PartitionIdType partitionId,
+                                PartitionStatus status));
 
     MOCK_METHOD2(GetCopysetOfPartition,
                  void(const GetCopysetOfPartitionRequest *request,

--- a/curvefs/test/metaserver/partition_clean_test.cpp
+++ b/curvefs/test/metaserver/partition_clean_test.cpp
@@ -81,17 +81,17 @@ TEST_F(PartitionCleanManagerTest, test1) {
 
     EXPECT_CALL(copysetNode, Propose(_))
         .WillOnce(Invoke([partition, fsId](const braft::Task& task) {
-            ASSERT_EQ(partition->DeleteInode(fsId, ROOTINODEID),
-                      MetaStatusCode::OK);
-            LOG(INFO) << "Partition DeleteInode, fsId = " << fsId
-                      << ", inodeId = " << ROOTINODEID;
-            task.done->Run();
-        }))
-        .WillOnce(Invoke([partition, fsId](const braft::Task& task) {
             ASSERT_EQ(partition->DeleteInode(fsId, ROOTINODEID + 1),
                       MetaStatusCode::OK);
             LOG(INFO) << "Partition DeleteInode, fsId = " << fsId
                       << ", inodeId = " << ROOTINODEID + 1;
+            task.done->Run();
+        }))
+        .WillOnce(Invoke([partition, fsId](const braft::Task& task) {
+            ASSERT_EQ(partition->DeleteInode(fsId, ROOTINODEID),
+                      MetaStatusCode::OK);
+            LOG(INFO) << "Partition DeleteInode, fsId = " << fsId
+                      << ", inodeId = " << ROOTINODEID;
             task.done->Run();
         }))
         .WillOnce(Invoke([partition](const braft::Task& task) {


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #883 

Problem Summary: fix some bug when delete fs

### What is changed and how it works?

What's Changed:
1. Mds mark partition to DELETING after call metaserver DeletePartition.
2. When GetInode, delete check Partition status.
3. Only leader copyset can should delete inode and partition from raft.
4. s3 param conf in metaserver.conf and client.conf is mismatch. Change theas param same.

How it Works:

Side effects(Breaking backward compatibility? Performance regression?): 

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
