### PR TITLE
curvefs/client: fix truncate file is too slow to reach a large length

### DIFF
--- a/curvefs/src/client/fuse_s3_client.cpp
+++ b/curvefs/src/client/fuse_s3_client.cpp
@@ -238,7 +238,7 @@ CURVEFS_ERROR FuseS3Client::FuseOpFsync(fuse_req_t req, fuse_ino_t ino,
 }
 
 CURVEFS_ERROR FuseS3Client::Truncate(Inode *inode, uint64_t length) {
-    return s3Adaptor_->Truncate(inode, 0);
+    return s3Adaptor_->Truncate(inode, length);
 }
 
 void FuseS3Client::FlushData() {

--- a/curvefs/src/client/s3/client_s3_adaptor.cpp
+++ b/curvefs/src/client/s3/client_s3_adaptor.cpp
@@ -187,16 +187,16 @@ CURVEFS_ERROR S3ClientAdaptorImpl::Truncate(Inode* inode, uint64_t size) {
         uint64_t chunkId;
         FSStatusCode ret;
         uint64_t fsId = inode->fsid();
+        ret = AllocS3ChunkId(fsId, &chunkId);
+        if (ret != FSStatusCode::OK) {
+            LOG(ERROR) << "Truncate alloc s3 chunkid fail. ret:" << ret;
+            return CURVEFS_ERROR::INTERNAL;
+        }
         while (len > 0) {
             if (chunkPos + len > chunkSize_) {
                 n = chunkSize_ - chunkPos;
             } else {
                 n = len;
-            }
-            ret = AllocS3ChunkId(fsId, &chunkId);
-            if (ret != FSStatusCode::OK) {
-                LOG(ERROR) << "Truncate alloc s3 chunkid fail. ret:" << ret;
-                return CURVEFS_ERROR::INTERNAL;
             }
             S3ChunkInfo *tmp;
             auto s3ChunkInfoMap = inode->mutable_s3chunkinfomap();

--- a/curvefs/test/client/client_s3_adaptor_test.cpp
+++ b/curvefs/test/client/client_s3_adaptor_test.cpp
@@ -1631,6 +1631,7 @@ TEST_F(ClientS3AdaptorTest, test_flush_write_more_chunk) {
     S3ChunkInfo tmp;
     S3ChunkInfoList tmpList;
     ASSERT_NE(s3InfoListIter, inode.s3chunkinfomap().end());
+    VLOG(9) << "index: " << s3InfoListIter->first;
     tmpList = s3InfoListIter->second;
     ASSERT_EQ(1, tmpList.s3chunks_size());
     tmp = tmpList.s3chunks(0);


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?
fix truncate file is too slow to reach a large length
Issue Number: close #914  <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?): 

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
