### PR TITLE
curvefs/tool: fix error

### DIFF
--- a/curvefs/conf/tools.conf
+++ b/curvefs/conf/tools.conf
@@ -2,7 +2,7 @@
 mdsAddr=127.0.0.1:6700  # __CURVEADM_TEMPLATE__ ${cluster_mds_addr} __CURVEADM_TEMPLATE__  __ANSIBLE_TEMPLATE__ {{ groups.mds | join_peer(hostvars, "mds_listen_port") }} __ANSIBLE_TEMPLATE__
 mdsDummyAddr=127.0.0.1:7700  # __CURVEADM_TEMPLATE__ ${cluster_mds_dummy_addr} __CURVEADM_TEMPLATE__  __ANSIBLE_TEMPLATE__ {{ groups.mds | join_peer(hostvars, "mds_listen_dummy_port") }} __ANSIBLE_TEMPLATE__
 # rpc timeout
-rpcTimeoutMs=500
+rpcTimeoutMs=10000
 rpcRetryTimes=5
 # topo file path
 topoFilePath=curvefs/test/tools/topo_example.json  # __CURVEADM_TEMPLATE__ /curvefs/tools/conf/topology.json __CURVEADM_TEMPLATE__  __ANSIBLE_TEMPLATE__ {{ project_root_dest }}/conf/topology.json __ANSIBLE_TEMPLATE__
@@ -23,6 +23,6 @@ volumePassword=password
 s3.ak=ak
 s3.sk=sk
 s3.endpoint=endpoint
-s3.bucket_Name=bucket
+s3.bucket_name=bucket
 s3.blocksize=1048576
 s3.chunksize=4194304

--- a/curvefs/src/mds/mds.cpp
+++ b/curvefs/src/mds/mds.cpp
@@ -262,6 +262,9 @@ void MDS::StartDummyServer() {
     status_.expose("curvefs_mds_status");
     status_.set_value("follower");
 
+    // set mds version in metric
+    curve::common::ExposeCurveVersion();
+
     LOG_IF(FATAL, 0 != brpc::StartDummyServerAt(options_.dummyPort))
         << "Start dummy server failed";
 }

--- a/curvefs/src/tools/check/curvefs_copyset_check.h
+++ b/curvefs/src/tools/check/curvefs_copyset_check.h
@@ -25,47 +25,32 @@
 
 #include <brpc/channel.h>
 
-#include <map>
 #include <memory>
 #include <string>
 #include <vector>
 
-#include "curvefs/proto/copyset.pb.h"
 #include "curvefs/src/tools/curvefs_tool.h"
 #include "curvefs/src/tools/curvefs_tool_define.h"
+#include "curvefs/src/tools/query/curvefs_copyset_query.h"
 #include "src/common/string_util.h"
 
 namespace curvefs {
 namespace tools {
 namespace check {
 
-using CopysetStatusType = curvefs::metaserver::copyset::CopysetStatus;
-
-class CopysetCheckTool
-    : public CurvefsToolRpc<
-          curvefs::metaserver::copyset::CopysetsStatusRequest,
-          curvefs::metaserver::copyset::CopysetsStatusResponse,
-          curvefs::metaserver::copyset::CopysetService_Stub> {
+class CopysetCheckTool : public CurvefsTool {
  public:
     explicit CopysetCheckTool(const std::string& cmd = kCopysetCheckCmd,
                               bool show = true)
-        : CurvefsToolRpc(cmd) {
+        : CurvefsTool(cmd) {
         show_ = show;
     }
     void PrintHelp() override;
-    int RunCommand();
+    int RunCommand() override;
     int Init() override;
-    std::map<uint64_t, std::vector<CopysetStatusType>> GetKey2CopysetStatus() {
-        return key2CopysetStatus_;
-    }
 
  protected:
-    void AddUpdateFlags() override;
-    bool AfterSendRequestToHost(const std::string& host) override;
-
- protected:
-    std::vector<uint64_t> key_;
-    std::map<uint64_t, std::vector<CopysetStatusType>> key2CopysetStatus_;
+    std::shared_ptr<query::CopysetQueryTool> queryCopysetTool_;
 };
 
 }  // namespace check

--- a/curvefs/src/tools/copyset/curvefs_copyset_base_tool.cpp
+++ b/curvefs/src/tools/copyset/curvefs_copyset_base_tool.cpp
@@ -72,15 +72,16 @@ bool CopysetInfo2CopysetStatus(
     for (auto const& i : addr2Request) {
         // set host
         FLAGS_metaserverAddr = i.first;
-        check::CopysetCheckTool copysetCheckTool("", false);
-        copysetCheckTool.Init();
-        copysetCheckTool.SetRequestQueue(i.second);
-        auto checkRet = copysetCheckTool.RunCommand();
+        copyset::GetCopysetStatusTool getCopysetStatusTool("", false);
+        getCopysetStatusTool.Init();
+        getCopysetStatusTool.SetRequestQueue(i.second);
+        auto checkRet = getCopysetStatusTool.RunCommand();
         if (checkRet < 0) {
             std::cerr << "send request to mds get error." << std::endl;
             ret = false;
         }
-        const auto& copysetsStatus = copysetCheckTool.GetResponse()->status();
+        const auto& copysetsStatus =
+            getCopysetStatusTool.GetResponse()->status();
         auto copysets = i.second.front().copysets();
         for (int m = 0, n = 0; m < copysets.size() && n < copysetsStatus.size();
              ++m, ++n) {
@@ -129,15 +130,16 @@ bool CopysetInfo2CopysetStatus(
     for (auto const& i : addr2Request) {
         // set host
         FLAGS_metaserverAddr = i.first;
-        check::CopysetCheckTool copysetCheckTool("", false);
-        copysetCheckTool.Init();
-        copysetCheckTool.SetRequestQueue(i.second);
-        auto checkRet = copysetCheckTool.RunCommand();
+        copyset::GetCopysetStatusTool getCopysetStatusTool("", false);
+        getCopysetStatusTool.Init();
+        getCopysetStatusTool.SetRequestQueue(i.second);
+        auto checkRet = getCopysetStatusTool.RunCommand();
         if (checkRet < 0) {
             std::cerr << "send request to mds get error." << std::endl;
             ret = false;
         }
-        const auto& copysetsStatus = copysetCheckTool.GetResponse()->status();
+        const auto& copysetsStatus =
+            getCopysetStatusTool.GetResponse()->status();
         auto copysets = i.second.front().copysets();
         for (int m = 0, n = 0; m < copysets.size() && n < copysetsStatus.size();
              ++m, ++n) {

--- a/curvefs/src/tools/copyset/curvefs_copyset_base_tool.h
+++ b/curvefs/src/tools/copyset/curvefs_copyset_base_tool.h
@@ -31,7 +31,7 @@
 #include "curvefs/proto/mds.pb.h"
 #include "curvefs/proto/topology.pb.h"
 #include "curvefs/src/mds/topology/deal_peerid.h"
-#include "curvefs/src/tools/check/curvefs_copyset_check.h"
+#include "curvefs/src/tools/copyset/curvefs_copyset_status.h"
 
 namespace curvefs {
 namespace tools {

--- a/curvefs/src/tools/copyset/curvefs_copyset_status.cpp
+++ b/curvefs/src/tools/copyset/curvefs_copyset_status.cpp
@@ -1,0 +1,119 @@
+/*
+ *  Copyright (c) 2021 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * Project: curve
+ * Created Date: 2021-10-31
+ * Author: chengyi01
+ */
+
+#include "curvefs/src/tools/copyset/curvefs_copyset_status.h"
+
+DECLARE_string(metaserverAddr);
+DECLARE_string(poolId);
+DECLARE_string(copysetId);
+
+namespace curvefs {
+namespace tools {
+namespace copyset {
+
+void GetCopysetStatusTool::PrintHelp() {
+    CurvefsToolRpc::PrintHelp();
+    std::cout << " -copysetId=" << FLAGS_copysetId
+              << " -poolId=" << FLAGS_poolId
+              << " [-metaserverAddr=" << FLAGS_metaserverAddr << "]";
+    std::cout << std::endl;
+}
+
+int GetCopysetStatusTool::Init() {
+    if (CurvefsToolRpc::Init() != 0) {
+        return -1;
+    }
+
+    curve::common::SplitString(FLAGS_metaserverAddr, ",", &hostsAddr_);
+
+    std::vector<std::string> copysetsId;
+    curve::common::SplitString(FLAGS_copysetId, ",", &copysetsId);
+    std::vector<std::string> poolsId;
+    curve::common::SplitString(FLAGS_poolId, ",", &poolsId);
+    if (copysetsId.size() != poolsId.size()) {
+        std::cerr << "copysets not match pools." << std::endl;
+        return -1;
+    }
+    curvefs::metaserver::copyset::CopysetsStatusRequest request;
+    for (size_t i = 0; i < poolsId.size(); ++i) {
+        auto copysetKey = request.add_copysets();
+        auto poolId = std::stoul(poolsId[i]);
+        auto copysetId = std::stoul(copysetsId[i]);
+        copysetKey->set_poolid(poolId);
+        copysetKey->set_copysetid(copysetId);
+        key_.push_back((poolId << 32) | copysetId);
+    }
+    AddRequest(request);
+
+    service_stub_func_ = std::bind(
+        &curvefs::metaserver::copyset::CopysetService_Stub::GetCopysetsStatus,
+        service_stub_.get(), std::placeholders::_1, std::placeholders::_2,
+        std::placeholders::_3, nullptr);
+    return 0;
+}
+
+int GetCopysetStatusTool::RunCommand() {
+    return CurvefsToolRpc::RunCommand();
+}
+
+bool GetCopysetStatusTool::AfterSendRequestToHost(const std::string& host) {
+    bool ret = true;
+    if (controller_->Failed()) {
+        errorOutput_ << "get copyset status from metaserver: " << host
+                     << " failed, errorcode= " << controller_->ErrorCode()
+                     << ", error text " << controller_->ErrorText() << "\n";
+        ret = false;
+    } else {
+        auto copysetsStatus = response_->status();
+        for (size_t i = 0; i < key_.size(); i++) {
+            key2CopysetStatus_[key_[i]].push_back(
+                copysetsStatus[i].copysetstatus());
+        }
+    }
+    if (show_) {
+        for (auto const& i : key2CopysetStatus_) {
+            std::cout << "copyset[" << i.first << "]:" << std::endl;
+            for (auto const& j : i.second) {
+                std::cout << j.DebugString() << std::endl;
+            }
+        }
+    }
+    return ret;
+}
+
+void GetCopysetStatusTool::AddUpdateFlags() {
+    AddUpdateFlagsFunc(curvefs::tools::SetMetaserverAddr);
+}
+
+bool GetCopysetStatusTool::CheckRequiredFlagDefault() {
+    google::CommandLineFlagInfo info;
+    if (CheckPoolIdDefault(&info) && CheckCopysetIdDefault(&info)) {
+        std::cerr << "no -poolId=*,* -copysetId=*,* , please use -example!"
+                  << std::endl;
+        return true;
+    }
+    return false;
+}
+
+}  // namespace copyset
+}  // namespace tools
+}  // namespace curvefs

--- a/curvefs/src/tools/copyset/curvefs_copyset_status.h
+++ b/curvefs/src/tools/copyset/curvefs_copyset_status.h
@@ -16,56 +16,61 @@
 
 /*
  * Project: curve
- * Created Date: 2021-09-27
+ * Created Date: 2021-10-31
  * Author: chengyi01
  */
-#ifndef CURVEFS_SRC_TOOLS_UMOUNT_CURVEFS_UMOUNT_FS_TOOL_H_
-#define CURVEFS_SRC_TOOLS_UMOUNT_CURVEFS_UMOUNT_FS_TOOL_H_
+
+#ifndef CURVEFS_SRC_TOOLS_COPYSET_CURVEFS_COPYSET_STATUS_H_
+#define CURVEFS_SRC_TOOLS_COPYSET_CURVEFS_COPYSET_STATUS_H_
 
 #include <brpc/channel.h>
-#include <brpc/server.h>
-#include <gflags/gflags.h>
 
-#include <cstdlib>  // std::system
-#include <functional>
-#include <iostream>
+#include <map>
 #include <memory>
-#include <sstream>
 #include <string>
-#include <thread>  //NOLINT
-#include <utility>
 #include <vector>
 
-#include "curvefs/proto/mds.pb.h"
+#include "curvefs/proto/copyset.pb.h"
 #include "curvefs/src/tools/curvefs_tool.h"
 #include "curvefs/src/tools/curvefs_tool_define.h"
 #include "src/common/string_util.h"
 
 namespace curvefs {
 namespace tools {
-namespace umount {
+namespace copyset {
 
-class UmountFsTool : public CurvefsToolRpc<curvefs::mds::UmountFsRequest,
-                                           curvefs::mds::UmountFsResponse,
-                                           curvefs::mds::MdsService_Stub> {
+using CopysetStatusType = curvefs::metaserver::copyset::CopysetStatus;
+
+class GetCopysetStatusTool
+    : public CurvefsToolRpc<
+          curvefs::metaserver::copyset::CopysetsStatusRequest,
+          curvefs::metaserver::copyset::CopysetsStatusResponse,
+          curvefs::metaserver::copyset::CopysetService_Stub> {
  public:
-    explicit UmountFsTool(const std::string& cmd = kUmountFsCmd)
-        : CurvefsToolRpc(cmd) {}
+    explicit GetCopysetStatusTool(const std::string& cmd = kNoInvokeCmd,
+                                  bool show = true)
+        : CurvefsToolRpc(cmd) {
+        show_ = show;
+    }
     void PrintHelp() override;
-
     int RunCommand() override;
     int Init() override;
-
-    void InitHostsAddr() override;
+    std::map<uint64_t, std::vector<CopysetStatusType>> GetKey2CopysetStatus() {
+        return key2CopysetStatus_;
+    }
 
  protected:
     void AddUpdateFlags() override;
     bool AfterSendRequestToHost(const std::string& host) override;
     bool CheckRequiredFlagDefault() override;
+
+ protected:
+    std::vector<uint64_t> key_;
+    std::map<uint64_t, std::vector<CopysetStatusType>> key2CopysetStatus_;
 };
 
-}  // namespace umount
+}  // namespace copyset
 }  // namespace tools
 }  // namespace curvefs
 
-#endif  // CURVEFS_SRC_TOOLS_UMOUNT_CURVEFS_UMOUNT_FS_TOOL_H_
+#endif  // CURVEFS_SRC_TOOLS_COPYSET_CURVEFS_COPYSET_STATUS_H_

--- a/curvefs/src/tools/create/curvefs_create_fs.h
+++ b/curvefs/src/tools/create/curvefs_create_fs.h
@@ -45,6 +45,8 @@ class CreateFsTool : public CurvefsToolRpc<curvefs::mds::CreateFsRequest,
 
     int Init() override;
 
+    bool CheckRequiredFlagDefault() override;
+
  protected:
     void AddUpdateFlags() override;
     bool AfterSendRequestToHost(const std::string& host) override;

--- a/curvefs/src/tools/curvefs_tool.cpp
+++ b/curvefs/src/tools/curvefs_tool.cpp
@@ -42,8 +42,11 @@ int CurvefsTool::Run() {
 }
 
 void CurvefsTool::PrintError() {
-    std::cerr << "[error]" << std::endl;
-    std::cerr << errorOutput_.str();
+    if (errorOutput_.tellg() > 0) {
+        // only show if errorOutput is not empty
+        std::cerr << "[error]" << std::endl;
+        std::cerr << errorOutput_.str();
+    }
 }
 
 int CurvefsToolMetric::Init(const std::shared_ptr<MetricClient>& metricClient) {

--- a/curvefs/src/tools/curvefs_tool_define.cpp
+++ b/curvefs/src/tools/curvefs_tool_define.cpp
@@ -35,8 +35,8 @@ DEFINE_string(fsName, "curvefs", "fs name");
 DEFINE_string(fsId, "1,2,3", "fs id");
 DEFINE_string(mountpoint, "127.0.0.1:/mnt/curvefs-umount-test",
               "curvefs mount in local path");
-DEFINE_uint64(rpcRetryTimes, 5, "rpc retry times");
-DEFINE_uint32(rpcTimeoutMs, 5000u, "rpc time out");
+DEFINE_uint32(rpcRetryTimes, 0, "rpc retry times");
+DEFINE_uint32(rpcTimeoutMs, 10000u, "rpc time out");
 DEFINE_string(copysetId, "1,2,3", "copysets id");
 DEFINE_string(poolId, "1,2,3", "pools id");
 DEFINE_bool(detail, false, "show more infomation");
@@ -75,9 +75,20 @@ void SetFlagInfo(curve::common::Configuration* conf,
     }
 }
 
+// Used for flagname and the name in the configuration file is inconsistent
+template <class FlagInfoT>
+void SetDiffFlagInfo(curve::common::Configuration* conf,
+                     google::CommandLineFlagInfo* info,
+                     const std::string& flagName, const std::string& key,
+                     FlagInfoT* flag) {
+    if (GetCommandLineFlagInfo(flagName.c_str(), info) && info->is_default) {
+        conf->GetValueFatalIfFail(key, flag);
+    }
+}
+
 template <class FlagInfoT>
 bool CheckFlagInfoDefault(google::CommandLineFlagInfo* info,
-                          const std::string& key, FlagInfoT* flag) {
+                          const std::string& key) {
     return (GetCommandLineFlagInfo(key.c_str(), info) && info->is_default);
 }
 
@@ -93,7 +104,7 @@ std::function<void(curve::common::Configuration*, google::CommandLineFlagInfo*)>
 
 std::function<void(curve::common::Configuration*, google::CommandLineFlagInfo*)>
     SetRpcRetryTimes =
-        std::bind(&SetFlagInfo<uint64_t>, std::placeholders::_1,
+        std::bind(&SetFlagInfo<uint32_t>, std::placeholders::_1,
                   std::placeholders::_2, "rpcRetryTimes", &FLAGS_rpcRetryTimes);
 
 std::function<void(curve::common::Configuration*, google::CommandLineFlagInfo*)>
@@ -145,49 +156,64 @@ std::function<void(curve::common::Configuration*, google::CommandLineFlagInfo*)>
                                   "volumePassword", &FLAGS_volumePassword);
 
 std::function<void(curve::common::Configuration*, google::CommandLineFlagInfo*)>
-    SetS3_ak = std::bind(&SetFlagInfo<fLS::clstring>, std::placeholders::_1,
-                         std::placeholders::_2, "s3.ak", &FLAGS_s3_ak);
+    SetS3_ak = std::bind(&SetDiffFlagInfo<fLS::clstring>, std::placeholders::_1,
+                         std::placeholders::_2, "s3_ak", "s3.ak", &FLAGS_s3_ak);
 
 std::function<void(curve::common::Configuration*, google::CommandLineFlagInfo*)>
-    SetS3_sk = std::bind(&SetFlagInfo<fLS::clstring>, std::placeholders::_1,
-                         std::placeholders::_2, "s3.sk", &FLAGS_s3_sk);
+    SetS3_sk = std::bind(&SetDiffFlagInfo<fLS::clstring>, std::placeholders::_1,
+                         std::placeholders::_2, "s3_sk", "s3.sk", &FLAGS_s3_sk);
 
 std::function<void(curve::common::Configuration*, google::CommandLineFlagInfo*)>
     SetS3_endpoint =
-        std::bind(&SetFlagInfo<fLS::clstring>, std::placeholders::_1,
-                  std::placeholders::_2, "s3.endpoint", &FLAGS_s3_endpoint);
+        std::bind(&SetDiffFlagInfo<fLS::clstring>, std::placeholders::_1,
+                  std::placeholders::_2, "s3_endpoint", "s3.endpoint",
+                  &FLAGS_s3_endpoint);
 
 std::function<void(curve::common::Configuration*, google::CommandLineFlagInfo*)>
-    SetS3_bucket_name = std::bind(&SetFlagInfo<fLS::clstring>,
-                                  std::placeholders::_1, std::placeholders::_2,
-                                  "s3.bucket_name", &FLAGS_s3_bucket_name);
+    SetS3_bucket_name =
+        std::bind(&SetDiffFlagInfo<fLS::clstring>, std::placeholders::_1,
+                  std::placeholders::_2, "s3_bucket_name", "s3.bucket_name",
+                  &FLAGS_s3_bucket_name);
 
 std::function<void(curve::common::Configuration*, google::CommandLineFlagInfo*)>
     SetS3_blocksize =
-        std::bind(&SetFlagInfo<uint64_t>, std::placeholders::_1,
-                  std::placeholders::_2, "s3.blocksize", &FLAGS_s3_blocksize);
+        std::bind(&SetDiffFlagInfo<uint64_t>, std::placeholders::_1,
+                  std::placeholders::_2, "s3_blocksize", "s3.blocksize",
+                  &FLAGS_s3_blocksize);
 
 std::function<void(curve::common::Configuration*, google::CommandLineFlagInfo*)>
     SetS3_chunksize =
-        std::bind(&SetFlagInfo<uint64_t>, std::placeholders::_1,
-                  std::placeholders::_2, "s3.chunksize", &FLAGS_s3_chunksize);
+        std::bind(&SetDiffFlagInfo<uint64_t>, std::placeholders::_1,
+                  std::placeholders::_2, "s3_chunksize", "s3.chunksize",
+                  &FLAGS_s3_chunksize);
 
 /* check flag */
 std::function<bool(google::CommandLineFlagInfo*)> CheckMetaserverIdDefault =
     std::bind(&CheckFlagInfoDefault<fLS::clstring>, std::placeholders::_1,
-              "metaserverId", &FLAGS_metaserverId);
+              "metaserverId");
 
 std::function<bool(google::CommandLineFlagInfo*)> CheckMetaserverAddrDefault =
     std::bind(&CheckFlagInfoDefault<fLS::clstring>, std::placeholders::_1,
-              "metaserverAddr", &FLAGS_metaserverAddr);
+              "metaserverAddr");
 
 std::function<bool(google::CommandLineFlagInfo*)> CheckFsNameDefault =
     std::bind(&CheckFlagInfoDefault<fLS::clstring>, std::placeholders::_1,
-              "fsName", &FLAGS_fsName);
+              "fsName");
 
-std::function<bool(google::CommandLineFlagInfo*)> CheckFsIdDefault =
+std::function<bool(google::CommandLineFlagInfo*)> CheckFsIdDefault = std::bind(
+    &CheckFlagInfoDefault<fLS::clstring>, std::placeholders::_1, "fsId");
+
+std::function<bool(google::CommandLineFlagInfo*)> CheckPoolIdDefault =
     std::bind(&CheckFlagInfoDefault<fLS::clstring>, std::placeholders::_1,
-              "fsId", &FLAGS_fsId);
+              "poolId");
+
+std::function<bool(google::CommandLineFlagInfo*)> CheckCopysetIdDefault =
+    std::bind(&CheckFlagInfoDefault<fLS::clstring>, std::placeholders::_1,
+              "copysetId");
+
+std::function<bool(google::CommandLineFlagInfo*)> CheckPartitionIdDefault =
+    std::bind(&CheckFlagInfoDefault<fLS::clstring>, std::placeholders::_1,
+              "partitionId");
 
 /* translate to string */
 

--- a/curvefs/src/tools/curvefs_tool_define.h
+++ b/curvefs/src/tools/curvefs_tool_define.h
@@ -125,7 +125,7 @@ const char kMetaserverStatusUri[] = "/vars/pid";
 const char kEtcdVersionUri[] = "/version";
 const char kEtcdStatusUri[] = "/v2/stats/self";
 const char kEtcdClusterVersionKey[] = "etcdcluster";
-const char kVersionKey[] = "curvefs_version";
+const char kVersionKey[] = "curve_version";
 const char kMdsStatusKey[] = "curvefs_mds_status";
 const char kEtcdStateKey[] = "state";
 const char kHostLeaderValue[] = "leader";
@@ -237,6 +237,13 @@ extern std::function<bool(google::CommandLineFlagInfo*)>
 extern std::function<bool(google::CommandLineFlagInfo*)> CheckFsNameDefault;
 
 extern std::function<bool(google::CommandLineFlagInfo*)> CheckFsIdDefault;
+
+extern std::function<bool(google::CommandLineFlagInfo*)> CheckPoolIdDefault;
+
+extern std::function<bool(google::CommandLineFlagInfo*)> CheckCopysetIdDefault;
+
+extern std::function<bool(google::CommandLineFlagInfo*)>
+    CheckPartitionIdDefault;
 
 /* translate to string */
 std::string StrVec2Str(const std::vector<std::string>&);

--- a/curvefs/src/tools/curvefs_tool_factory.cpp
+++ b/curvefs/src/tools/curvefs_tool_factory.cpp
@@ -23,6 +23,7 @@
 #include "curvefs/src/tools/curvefs_tool_factory.h"
 
 #include "curvefs/src/tools/check/curvefs_copyset_check.h"
+#include "curvefs/src/tools/copyset/curvefs_copyset_status.h"
 #include "curvefs/src/tools/create/curvefs_create_fs.h"
 #include "curvefs/src/tools/create/curvefs_create_topology_tool.h"
 #include "curvefs/src/tools/curvefs_tool_define.h"

--- a/curvefs/src/tools/curvefs_tool_metric.cpp
+++ b/curvefs/src/tools/curvefs_tool_metric.cpp
@@ -23,7 +23,7 @@
 #include "curvefs/src/tools/curvefs_tool_metric.h"
 
 DECLARE_uint32(rpcTimeoutMs);
-DECLARE_uint64(rpcRetryTimes);
+DECLARE_uint32(rpcRetryTimes);
 
 namespace curvefs {
 namespace tools {
@@ -107,7 +107,8 @@ int MetricClient::GetKeyValueFromString(const std::string& str,
                                         std::string* value) {
     auto pos = str.find(":");
     if (pos == std::string::npos) {
-        std::cout << "parse response attachment fail!" << std::endl;
+        std::cerr << "parse " << key << " fail! it should be like: ***:***."
+                  << std::endl;
         return -1;
     }
     *value = str.substr(pos + 1);

--- a/curvefs/src/tools/delete/curvefs_delete_fs_tool.cpp
+++ b/curvefs/src/tools/delete/curvefs_delete_fs_tool.cpp
@@ -89,15 +89,29 @@ bool DeleteFsTool::AfterSendRequestToHost(const std::string& host) {
         errorOutput_ << "send delete fs request to mds: " << host
                      << " failed. errorcode= " << controller_->ErrorCode()
                      << ", error text " << controller_->ErrorText() << "\n";
-    } else if (response_->statuscode() != curvefs::mds::FSStatusCode::OK) {
-        std::cerr << "delete fs from mds: " << host
-                  << " failed. errorcode= " << response_->statuscode()
-                  << std::endl;
-    } else {
+    } else if (response_->statuscode() ==
+               curvefs::mds::FSStatusCode::NOT_FOUND) {
+        std::cerr << "delete fs failed, fs not found!" << std::endl;
+    } else if (response_->statuscode() == curvefs::mds::FSStatusCode::OK) {
         std::cout << "delete fs " << FLAGS_fsName << " success." << std::endl;
         ret = true;
+    } else {
+        std::cerr << "delete fs from mds: " << host
+                  << " failed. errorcode= " << response_->statuscode()
+                  << ", errorname: "
+                  << mds::FSStatusCode_Name(response_->statuscode())
+                  << std::endl;
     }
     return ret;
+}
+
+bool DeleteFsTool::CheckRequiredFlagDefault() {
+    google::CommandLineFlagInfo info;
+    if (CheckFsNameDefault(&info)) {
+        std::cerr << "no -fsName=***, please use -example!" << std::endl;
+        return true;
+    }
+    return false;
 }
 
 }  // namespace delete_

--- a/curvefs/src/tools/delete/curvefs_delete_fs_tool.h
+++ b/curvefs/src/tools/delete/curvefs_delete_fs_tool.h
@@ -53,6 +53,7 @@ class DeleteFsTool : public CurvefsToolRpc<curvefs::mds::DeleteFsRequest,
  protected:
     void AddUpdateFlags() override;
     bool AfterSendRequestToHost(const std::string& host) override;
+    bool CheckRequiredFlagDefault() override;
 
  protected:
     uint32_t checkTimes_ = 3;

--- a/curvefs/src/tools/list/curvefs_copysetinfo_list.cpp
+++ b/curvefs/src/tools/list/curvefs_copysetinfo_list.cpp
@@ -30,7 +30,7 @@ namespace list {
 
 void CopysetInfoListTool::PrintHelp() {
     CurvefsToolRpc::PrintHelp();
-    std::cout << " [-mds=" << FLAGS_mdsAddr;
+    std::cout << " [-mds=" << FLAGS_mdsAddr << "]";
     std::cout << std::endl;
 }
 

--- a/curvefs/src/tools/list/curvefs_fsinfo_list.cpp
+++ b/curvefs/src/tools/list/curvefs_fsinfo_list.cpp
@@ -68,6 +68,10 @@ bool FsInfoListTool::AfterSendRequestToHost(const std::string& host) {
                      << " failed, errorcode= " << controller_->ErrorCode()
                      << ", error text " << controller_->ErrorText() << "\n";
     } else if (show_) {
+        if (response_->fsinfo().empty()) {
+            std::cout << "no fs in cluster." << std::endl;
+        }
+
         for (auto const& i : response_->fsinfo()) {
             std::cout << i.DebugString() << std::endl;
         }

--- a/curvefs/src/tools/query/curvefs_copyset_query.h
+++ b/curvefs/src/tools/query/curvefs_copyset_query.h
@@ -37,7 +37,7 @@
 #include "curvefs/proto/mds.pb.h"
 #include "curvefs/proto/topology.pb.h"
 #include "curvefs/src/mds/topology/deal_peerid.h"
-#include "curvefs/src/tools/check/curvefs_copyset_check.h"
+#include "curvefs/src/tools/copyset/curvefs_copyset_status.h"
 #include "curvefs/src/tools/curvefs_tool.h"
 #include "curvefs/src/tools/curvefs_tool_define.h"
 #include "src/common/string_util.h"
@@ -63,14 +63,25 @@ class CopysetQueryTool
     void PrintHelp() override;
     int Init() override;
 
+    std::map<uint64_t, std::vector<InfoType>> GetKey2Info() {
+        return key2Info_;
+    }
+    std::map<uint64_t, std::vector<StatusType>> GetKey2Status() {
+        return key2Status_;
+    }
+    std::vector<uint64_t> GetKey_() {
+        return copysetKeys_;
+    }
+
  protected:
     void AddUpdateFlags() override;
     bool AfterSendRequestToHost(const std::string& host) override;
     bool GetCopysetStatus();
+    bool CheckRequiredFlagDefault() override;
 
  protected:
     // key = (poolId << 32) | copysetId
-    std::map<uint64_t, std::vector<InfoType>> key2Infos_;
+    std::map<uint64_t, std::vector<InfoType>> key2Info_;
     std::map<std::string, std::queue<StatusRequestType>>
         addr2Request_;                                        // detail
     std::map<uint64_t, std::vector<StatusType>> key2Status_;  // detail

--- a/curvefs/src/tools/query/curvefs_fs_query.cpp
+++ b/curvefs/src/tools/query/curvefs_fs_query.cpp
@@ -32,7 +32,7 @@ namespace query {
 
 void FsQueryTool::PrintHelp() {
     CurvefsToolRpc::PrintHelp();
-    std::cout << " -fsName=" << FLAGS_fsName << "|-fsId(matter)=" << FLAGS_fsId
+    std::cout << " -fsName=" << FLAGS_fsName << "|-fsId=" << FLAGS_fsId
               << " [-mdsAddr=" << FLAGS_mdsAddr << "]";
     std::cout << std::endl;
 }
@@ -94,10 +94,32 @@ bool FsQueryTool::AfterSendRequestToHost(const std::string& host) {
                      << ", error text " << controller_->ErrorText() << "\n";
         return false;
     } else if (show_) {
-        std::cout << response_->DebugString() << std::endl;
+        if (response_->statuscode() == mds::FSStatusCode::OK) {
+            std::cout << response_->DebugString() << std::endl;
+        } else if (response_->statuscode() == mds::FSStatusCode::NOT_FOUND) {
+            std::cerr << "fs not found!" << std::endl;
+            return false;
+        } else {
+            std::cerr << response_->DebugString() << std::endl;
+            return false;
+        }
     }
     return true;
 }
+
+bool FsQueryTool::CheckRequiredFlagDefault() {
+    google::CommandLineFlagInfo info;
+    if (CheckFsNameDefault(&info) && CheckFsIdDefault(&info)) {
+        std::cerr << "no -fsName=***|-fsId=***, please use --example check!"
+                  << std::endl;
+        return true;
+    } else if (!CheckFsNameDefault(&info) && !CheckFsIdDefault(&info)) {
+        std::cerr << "please use one of -fsName=***|-fsId=*** !" << std::endl;
+        return true;
+    }
+    return false;
+}
+
 }  // namespace query
 }  // namespace tools
 }  // namespace curvefs

--- a/curvefs/src/tools/query/curvefs_fs_query.h
+++ b/curvefs/src/tools/query/curvefs_fs_query.h
@@ -51,6 +51,9 @@ class FsQueryTool : public CurvefsToolRpc<curvefs::mds::GetFsInfoRequest,
  protected:
     void AddUpdateFlags() override;
     bool AfterSendRequestToHost(const std::string& host) override;
+    bool CheckRequiredFlagDefault() override;
+
+ protected:
     std::vector<std::string> requestValueVec_;
 };
 

--- a/curvefs/src/tools/query/curvefs_metaserver_query.cpp
+++ b/curvefs/src/tools/query/curvefs_metaserver_query.cpp
@@ -101,6 +101,17 @@ bool MetaserverQueryTool::AfterSendRequestToHost(const std::string& host) {
     return true;
 }
 
+bool MetaserverQueryTool::CheckRequiredFlagDefault() {
+    google::CommandLineFlagInfo info;
+    if (CheckMetaserverIdDefault(&info) && CheckMetaserverAddrDefault(&info)) {
+        std::cerr << "no -metaserverId=*,*|-metaserverAddr=*:*,*:*, please use "
+                     "-example!"
+                  << std::endl;
+        return true;
+    }
+    return false;
+}
+
 }  // namespace query
 }  // namespace tools
 }  // namespace curvefs

--- a/curvefs/src/tools/query/curvefs_metaserver_query.h
+++ b/curvefs/src/tools/query/curvefs_metaserver_query.h
@@ -56,6 +56,7 @@ class MetaserverQueryTool
  protected:
     void AddUpdateFlags() override;
     bool AfterSendRequestToHost(const std::string& host) override;
+    bool CheckRequiredFlagDefault() override;
 };
 }  // namespace query
 }  // namespace tools

--- a/curvefs/src/tools/query/curvefs_partition_query.cpp
+++ b/curvefs/src/tools/query/curvefs_partition_query.cpp
@@ -69,18 +69,29 @@ bool PartitionQueryTool::AfterSendRequestToHost(const std::string& host) {
                      << requestQueue_.front().DebugString()
                      << "\nto mds: " << host
                      << " failed, errorcode= " << controller_->ErrorCode()
-                     << ", error text " << controller_->ErrorText() << "\n";
+                     << ", error text " << controller_->ErrorText()
+                     << std::endl;
         return false;
     } else if (response_->statuscode() != curvefs::mds::topology::TOPO_OK) {
         std::cerr << "query partition [" << FLAGS_partitionId
-                  << "], error code=" << response_->statuscode()
+                  << "] error, error code=" << response_->statuscode()
                   << " error name is "
                   << curvefs::mds::topology::TopoStatusCode_Name(
-                         response_->statuscode());
+                         response_->statuscode())
+                  << std::endl;
     } else if (show_) {
         std::cout << response_->DebugString() << std::endl;
     }
     return true;
+}
+
+bool PartitionQueryTool::CheckRequiredFlagDefault() {
+    google::CommandLineFlagInfo info;
+    if (CheckPartitionIdDefault(&info)) {
+        std::cerr << "no -partitionId=***, please use -example!" << std::endl;
+        return true;
+    }
+    return false;
 }
 
 }  // namespace query

--- a/curvefs/src/tools/query/curvefs_partition_query.h
+++ b/curvefs/src/tools/query/curvefs_partition_query.h
@@ -56,6 +56,7 @@ class PartitionQueryTool
  protected:
     void AddUpdateFlags() override;
     bool AfterSendRequestToHost(const std::string& host) override;
+    bool CheckRequiredFlagDefault() override;
 };
 
 }  // namespace query

--- a/curvefs/test/tools/curvefs_umount_fs_tool_test.cpp
+++ b/curvefs/test/tools/curvefs_umount_fs_tool_test.cpp
@@ -36,6 +36,7 @@
 
 DECLARE_string(mdsAddr);
 DECLARE_string(mountpoint);
+DECLARE_string(fsName);
 
 namespace curvefs {
 namespace tools {
@@ -76,6 +77,7 @@ void UF(::google::protobuf::RpcController* controller,
 
 TEST_F(UmountfsToolTest, test_umount_success) {
     FLAGS_mdsAddr = addr_;
+    FLAGS_fsName = "test";
     ::curvefs::mds::UmountFsResponse response;
     response.set_statuscode(curvefs::mds::FSStatusCode::OK);
     EXPECT_CALL(mockMdsService_, UmountFs(_, _, _, _))
@@ -87,6 +89,7 @@ TEST_F(UmountfsToolTest, test_umount_success) {
 // mountpoint not exist
 TEST_F(UmountfsToolTest, test_umount_failed) {
     FLAGS_mdsAddr = addr_;
+    FLAGS_fsName = "test";
     ::curvefs::mds::UmountFsResponse response;
     response.set_statuscode(curvefs::mds::FSStatusCode::MOUNT_POINT_NOT_EXIST);
     EXPECT_CALL(mockMdsService_, UmountFs(_, _, _, _))
@@ -98,6 +101,7 @@ TEST_F(UmountfsToolTest, test_umount_failed) {
 // connect to mds failed
 TEST_F(UmountfsToolTest, test_umount_connect_failed) {
     FLAGS_mdsAddr = "127.0.0.1:6700";
+    FLAGS_fsName = "test";
     int ret = ut_.Run();
     ASSERT_EQ(ret, -1);
 }
@@ -105,6 +109,7 @@ TEST_F(UmountfsToolTest, test_umount_connect_failed) {
 // init failed
 TEST_F(UmountfsToolTest, test_umount_init_name) {
     FLAGS_mdsAddr = "abcd";
+    FLAGS_fsName = "test";
     int ret = ut_.Run();
     ASSERT_EQ(ret, -1);
 }
@@ -113,6 +118,7 @@ TEST_F(UmountfsToolTest, test_umount_init_name) {
 TEST_F(UmountfsToolTest, test_umount_invalid_mountpoint) {
     FLAGS_mdsAddr = addr_;
     FLAGS_mountpoint = "/1234/";
+    FLAGS_fsName = "test";
     int ret = ut_.Run();
     ASSERT_EQ(ret, -1);
     FLAGS_mountpoint = "127.0.0.1:/mnt/curvefs-umount-test";
@@ -121,6 +127,7 @@ TEST_F(UmountfsToolTest, test_umount_invalid_mountpoint) {
 // init
 TEST_F(UmountfsToolTest, test_umount_tool_init) {
     FLAGS_mdsAddr = addr_;
+    FLAGS_fsName = "test";
 
     std::shared_ptr<brpc::Channel> channel = std::make_shared<brpc::Channel>();
     std::shared_ptr<brpc::Controller> controller =


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: close #932 #922 #945 <!-- REMOVE this line if no issue to close -->

Problem Summary:

1. fix some error in  create-fs
2. fix some error output in curvefs_tool
3. adjust output of umount-fs
4. adjust output of create-fs: add fs exist (create same fs name but the
parameters are inconsistent)
5. adjust output of query-copyset: indicate that the number of statuses
is inconsistent with the peers in the info
6. adjust output of query-fs: add fs not found
7. adjust output of delete-fs: add fs not found
8. fix check-copyset
9. fix query-copyset fail when query same copyset: add requset
copysetkey when sure

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?): 

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
