### PR TITLE
curvefs: fix create copyset when exist already.

### DIFF
--- a/curvefs/conf/mds.conf
+++ b/curvefs/conf/mds.conf
@@ -15,7 +15,7 @@ space.rpcTimeoutMs=500
 # metaserver options
 #
 metaserver.addr=127.0.0.1:6701  # __CURVEADM_TEMPLATE__ ${cluster_mds_addr} __CURVEADM_TEMPLATE__  __ANSIBLE_TEMPLATE__ {{ groups.metaserver | join_peer(hostvars, "metaserver_listen_port") }} __ANSIBLE_TEMPLATE__
-metaserver.rpcTimeoutMs=500
+metaserver.rpcTimeoutMs=5000
 metaserver.rpcRertyTimes=3
 metaserver.rpcRetryIntervalUs=1000000
 

--- a/curvefs/src/mds/metaserverclient/metaserver_client.cpp
+++ b/curvefs/src/mds/metaserverclient/metaserver_client.cpp
@@ -349,6 +349,12 @@ FSStatusCode MetaserverClient::CreateCopySet(
 
         uint32_t maxRetry = options_.rpcRetryTimes;
         while (cntl.Failed() && maxRetry > 0) {
+            LOG(WARNING) << "Create copyset failed"
+                         << " from " << cntl.remote_side() << " to "
+                         << cntl.local_side()
+                         << " errCode = " << cntl.ErrorCode()
+                         << " errorText = " << cntl.ErrorText()
+                         << ", then will retry " << maxRetry << " times.";
             maxRetry--;
             bthread_usleep(options_.rpcRetryIntervalUs);
             cntl.Reset();

--- a/curvefs/src/mds/topology/topology_manager.cpp
+++ b/curvefs/src/mds/topology/topology_manager.cpp
@@ -762,7 +762,6 @@ TopoStatusCode TopologyManager::CreateCopyset() {
             CopySetInfo copyset(poolId, id);
             copyset.SetCopySetMembers(metaServerIds);
             TopoStatusCode ret = topology_->AddCopySet(copyset);
-            // TODO(wanghai): delete copyset on metaserver
             if (TopoStatusCode::TOPO_OK != ret) {
                 LOG(ERROR) << "Add copyset failed after create copyset."
                            << " poolId = " << poolId << ", copysetId = " << id

--- a/curvefs/src/metaserver/copyset/copyset_node_manager.h
+++ b/curvefs/src/metaserver/copyset/copyset_node_manager.h
@@ -57,7 +57,11 @@ class CopysetNodeManager {
 
     virtual CopysetNode* GetCopysetNode(PoolId poolId, CopysetId copysetId);
 
-    bool IsCopysetNodeExist(PoolId poolId, CopysetId copysetId);
+    /**
+     * @return 0: not exist; 1: key exist and peers are exactly same;
+     * -1: key exist but peers are not exactly same
+     */
+    int IsCopysetNodeExist(const CreateCopysetRequest::Copyset& copyset);
 
     bool CreateCopysetNode(PoolId poolId, CopysetId copysetId,
                            const braft::Configuration& conf,

--- a/curvefs/src/metaserver/copyset/copyset_service.cpp
+++ b/curvefs/src/metaserver/copyset/copyset_service.cpp
@@ -79,13 +79,17 @@ void CopysetServiceImpl::GetCopysetsStatus(
 
 COPYSET_OP_STATUS CopysetServiceImpl::CreateOneCopyset(
     const CreateCopysetRequest::Copyset& copyset) {
-    bool exists =
-        manager_->IsCopysetNodeExist(copyset.poolid(), copyset.copysetid());
-    if (exists) {
+    int exists = manager_->IsCopysetNodeExist(copyset);
+    if (-1 == exists) {
+        LOG(ERROR) << "Copyset "
+                   << ToGroupIdString(copyset.poolid(), copyset.copysetid())
+                   << " already exists, but peers not exactly the same.";
+        return COPYSET_OP_STATUS_EXIST;
+    } else if (1 == exists) {
         LOG(WARNING) << "Copyset "
                      << ToGroupIdString(copyset.poolid(), copyset.copysetid())
-                     << " already exists";
-        return COPYSET_OP_STATUS_EXIST;
+                     << " already exists.";
+        return COPYSET_OP_STATUS_SUCCESS;
     }
 
     braft::Configuration conf;

--- a/curvefs/test/metaserver/copyset/copyset_node_manager_test.cpp
+++ b/curvefs/test/metaserver/copyset/copyset_node_manager_test.cpp
@@ -149,7 +149,17 @@ TEST_F(CopysetNodeManagerTest, CreateCopysetTest_Common) {
         nodeManager_->AddService(&server, butil::EndPoint(ip, kPort)));
 
     EXPECT_TRUE(nodeManager_->CreateCopysetNode(kPoolId, kCopysetId, conf));
-    EXPECT_TRUE(nodeManager_->IsCopysetNodeExist(kPoolId, kCopysetId));
+
+    CreateCopysetRequest::Copyset copyset;
+    copyset.set_poolid(kPoolId);
+    copyset.set_copysetid(kCopysetId);
+    copyset.add_peers()->set_address("127.0.0.1:29920:0");
+    copyset.add_peers()->set_address("127.0.0.1:29921:0");
+    copyset.add_peers()->set_address("127.0.0.1:29922:0");
+    EXPECT_EQ(1, nodeManager_->IsCopysetNodeExist(copyset));
+
+    copyset.mutable_peers(0)->set_address("127.0.0.1:29923:0");
+    EXPECT_EQ(-1, nodeManager_->IsCopysetNodeExist(copyset));
 
     // create same copyset will failed
     EXPECT_FALSE(nodeManager_->CreateCopysetNode(kPoolId, kCopysetId, conf));
@@ -180,7 +190,6 @@ TEST_F(CopysetNodeManagerTest, DeleteCopysetNodeTest_Success) {
         nodeManager_->AddService(&server, butil::EndPoint(ip, kPort)));
 
     EXPECT_TRUE(nodeManager_->CreateCopysetNode(kPoolId, kCopysetId, conf));
-    EXPECT_TRUE(nodeManager_->IsCopysetNodeExist(kPoolId, kCopysetId));
 
     // create same copyset will failed
     EXPECT_FALSE(nodeManager_->CreateCopysetNode(kPoolId, kCopysetId, conf));
@@ -218,7 +227,6 @@ TEST_F(CopysetNodeManagerTest,
         nodeManager_->AddService(&server, butil::EndPoint(ip, kPort)));
 
     EXPECT_TRUE(nodeManager_->CreateCopysetNode(kPoolId, kCopysetId, conf));
-    EXPECT_TRUE(nodeManager_->IsCopysetNodeExist(kPoolId, kCopysetId));
 
     // create same copyset will failed
     EXPECT_FALSE(nodeManager_->CreateCopysetNode(kPoolId, kCopysetId, conf));

--- a/curvefs/test/metaserver/copyset/copyset_service_test.cpp
+++ b/curvefs/test/metaserver/copyset/copyset_service_test.cpp
@@ -142,6 +142,28 @@ TEST_F(CopysetServiceTest, CreateCopysetTest) {
         stub.CreateCopysetNode(&cntl, &request, &response, nullptr);
 
         ASSERT_FALSE(cntl.Failed()) << cntl.ErrorText();
+        ASSERT_EQ(COPYSET_OP_STATUS::COPYSET_OP_STATUS_SUCCESS,
+                  response.status());
+    }
+
+    // create copyset exist
+    {
+        CopysetService_Stub stub(&channel_);
+        brpc::Controller cntl;
+
+        CreateCopysetRequest request;
+        CreateCopysetResponse response;
+
+        auto* copyset = request.add_copysets();
+        copyset->set_poolid(poolId_);
+        copyset->set_copysetid(copysetId_);
+        copyset->add_peers()->set_address("127.0.0.1:29960:0");
+        copyset->add_peers()->set_address("127.0.0.1:29961:0");
+        copyset->add_peers()->set_address("127.0.0.1:29963:0");
+
+        stub.CreateCopysetNode(&cntl, &request, &response, nullptr);
+
+        ASSERT_FALSE(cntl.Failed()) << cntl.ErrorText();
         ASSERT_EQ(COPYSET_OP_STATUS::COPYSET_OP_STATUS_EXIST,
                   response.status());
     }


### PR DESCRIPTION
curvefs: fix create copyset when exist already. If peers are all the same will success, otherwise return exist.

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->
#998 

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?): 

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
