### PR TITLE
refactor s3compact code & workaround read failure when diskcachetype=2

### DIFF
--- a/curvefs/conf/metaserver.conf
+++ b/curvefs/conf/metaserver.conf
@@ -33,7 +33,7 @@ s3.throttle.bpsTotalMB=0
 s3.throttle.bpsReadMB=0
 s3.throttle.bpsWriteMB=0
 # s3 workqueue
-s3compactwq.enable=False
+s3compactwq.enable=True
 s3compactwq.thread_num=2
 s3compactwq.queue_size=5
 # fragments threshold in a s3chuninfolist
@@ -43,6 +43,9 @@ s3compactwq.max_chunks_per_compact=10
 # roughly control the compact freq
 s3compactwq.enqueue_sleep_ms=1000
 s3compactwq.s3infocache_size=100
+# workaround read failure when diskcache is enabled
+s3compactwq.s3_read_max_retry=5
+s3compactwq.s3_read_retry_interval=5 # in seconds
 
 # metaserver listen ip and port
 # these two config items ip and port can be replaced by start up options `-ip` and `-port`

--- a/curvefs/proto/metaserver.proto
+++ b/curvefs/proto/metaserver.proto
@@ -314,6 +314,8 @@ message GetOrModifyS3ChunkInfoRequest {
     map<uint64, S3ChunkInfoList> s3ChunkInfoAdd = 6;
     map<uint64, S3ChunkInfoList> s3ChunkInfoRemove = 7;
     required bool returnS3ChunkInfoMap = 8;
+    optional bool fromS3Compaction = 9;
+    // todo: we only need a bit flag to indicate a lot of bool
 }
 
 message GetOrModifyS3ChunkInfoResponse {

--- a/curvefs/src/metaserver/inode_manager.h
+++ b/curvefs/src/metaserver/inode_manager.h
@@ -55,13 +55,14 @@ class InodeManager {
 
     MetaStatusCode UpdateInode(const UpdateInodeRequest &request);
 
-    MetaStatusCode GetOrModifyS3ChunkInfo(uint32_t fsId, uint64_t inodeId,
-        const google::protobuf::Map<uint64_t, S3ChunkInfoList> &s3ChunkInfoAdd,
-        const google::protobuf::Map<uint64_t, S3ChunkInfoList>
-            &s3ChunkInfoRemove,
+    MetaStatusCode GetOrModifyS3ChunkInfo(
+        uint32_t fsId, uint64_t inodeId,
+        const google::protobuf::Map<uint64_t, S3ChunkInfoList>& s3ChunkInfoAdd,
+        const google::protobuf::Map<uint64_t, S3ChunkInfoList>&
+            s3ChunkInfoRemove,
         bool returnS3ChunkInfoMap,
-        google::protobuf::Map<
-            uint64_t, S3ChunkInfoList> *out);
+        google::protobuf::Map<uint64_t, S3ChunkInfoList>* out,
+        bool fromS3Compaction);
 
     MetaStatusCode UpdateInodeWhenCreateOrRemoveSubNode(uint32_t fsId,
         uint64_t inodeId, bool isCreate);

--- a/curvefs/src/metaserver/inode_storage.cpp
+++ b/curvefs/src/metaserver/inode_storage.cpp
@@ -75,11 +75,6 @@ InodeStorage::ContainerType* MemoryInodeStorage::GetContainer() {
     return &inodeMap_;
 }
 
-InodeStorage::ContainerType MemoryInodeStorage::GetContainerData() {
-    ReadLockGuard readLockGuard(rwLock_);
-    return inodeMap_;
-}
-
 void MemoryInodeStorage::GetInodeIdList(std::list<uint64_t>* inodeIdList) {
     ReadLockGuard readLockGuard(rwLock_);
     for (auto it = inodeMap_.begin(); it != inodeMap_.end(); ++it) {

--- a/curvefs/src/metaserver/inode_storage.h
+++ b/curvefs/src/metaserver/inode_storage.h
@@ -69,7 +69,6 @@ class InodeStorage {
     virtual MetaStatusCode Update(const Inode &inode) = 0;
     virtual int Count() = 0;
     virtual ContainerType* GetContainer() = 0;
-    virtual ContainerType GetContainerData() = 0;
     virtual void GetInodeIdList(std::list<uint64_t>* InodeIdList) = 0;
     virtual ~InodeStorage() = default;
 };
@@ -121,8 +120,6 @@ class MemoryInodeStorage : public InodeStorage {
      * @return Inode container, here returns inodeMap_ pointer
      */
     ContainerType* GetContainer() override;
-    ContainerType GetContainerData() override;
-
 
     void GetInodeIdList(std::list<uint64_t>* inodeIdList) override;
 

--- a/curvefs/src/metaserver/metastore.cpp
+++ b/curvefs/src/metaserver/metastore.cpp
@@ -589,7 +589,8 @@ MetaStatusCode MetaStoreImpl::GetOrModifyS3ChunkInfo(
     }
     MetaStatusCode status = partition->GetOrModifyS3ChunkInfo(
         fsId, inodeId, request->s3chunkinfoadd(), request->s3chunkinforemove(),
-        request->returns3chunkinfomap(), response->mutable_s3chunkinfomap());
+        request->returns3chunkinfomap(), response->mutable_s3chunkinfomap(),
+        request->has_froms3compaction() && request->froms3compaction());
     response->set_statuscode(status);
     return status;
 }

--- a/curvefs/src/metaserver/partition.cpp
+++ b/curvefs/src/metaserver/partition.cpp
@@ -50,7 +50,7 @@ Partition::Partition(const PartitionInfo& paritionInfo) {
 
     if (paritionInfo.status() != PartitionStatus::DELETING) {
         TrashManager::GetInstance().Add(paritionInfo.partitionid(), trash_);
-        s3compact_ = std::make_shared<S3Compact>(inodeStorage_, partitionInfo_);
+        s3compact_ = std::make_shared<S3Compact>(inodeManager_, partitionInfo_);
         S3CompactManager::GetInstance().RegisterS3Compact(s3compact_);
     }
 }
@@ -245,12 +245,11 @@ MetaStatusCode Partition::UpdateInode(const UpdateInodeRequest& request) {
 
 MetaStatusCode Partition::GetOrModifyS3ChunkInfo(
     uint32_t fsId, uint64_t inodeId,
-    const google::protobuf::Map<uint64_t, S3ChunkInfoList> &s3ChunkInfoAdd,
-    const google::protobuf::Map<uint64_t, S3ChunkInfoList>
-        &s3ChunkInfoRemove,
+    const google::protobuf::Map<uint64_t, S3ChunkInfoList>& s3ChunkInfoAdd,
+    const google::protobuf::Map<uint64_t, S3ChunkInfoList>& s3ChunkInfoRemove,
     bool returnS3ChunkInfoMap,
-    google::protobuf::Map<
-            uint64_t, S3ChunkInfoList> *out) {
+    google::protobuf::Map<uint64_t, S3ChunkInfoList>* out,
+    bool fromS3Compaction) {
     if (!IsInodeBelongs(fsId, inodeId)) {
         return MetaStatusCode::PARTITION_ID_MISSMATCH;
     }
@@ -260,8 +259,8 @@ MetaStatusCode Partition::GetOrModifyS3ChunkInfo(
     }
 
     return inodeManager_->GetOrModifyS3ChunkInfo(
-        fsId, inodeId, s3ChunkInfoAdd, s3ChunkInfoRemove,
-        returnS3ChunkInfoMap, out);
+        fsId, inodeId, s3ChunkInfoAdd, s3ChunkInfoRemove, returnS3ChunkInfoMap,
+        out, fromS3Compaction);
 }
 
 MetaStatusCode Partition::InsertInode(const Inode& inode) {

--- a/curvefs/src/metaserver/partition.h
+++ b/curvefs/src/metaserver/partition.h
@@ -79,13 +79,14 @@ class Partition {
 
     MetaStatusCode UpdateInode(const UpdateInodeRequest& request);
 
-    MetaStatusCode GetOrModifyS3ChunkInfo(uint32_t fsId, uint64_t inodeId,
-        const google::protobuf::Map<uint64_t, S3ChunkInfoList> &s3ChunkInfoAdd,
-        const google::protobuf::Map<uint64_t, S3ChunkInfoList>
-            &s3ChunkInfoRemove,
+    MetaStatusCode GetOrModifyS3ChunkInfo(
+        uint32_t fsId, uint64_t inodeId,
+        const google::protobuf::Map<uint64_t, S3ChunkInfoList>& s3ChunkInfoAdd,
+        const google::protobuf::Map<uint64_t, S3ChunkInfoList>&
+            s3ChunkInfoRemove,
         bool returnS3ChunkInfoMap,
-        google::protobuf::Map<
-            uint64_t, S3ChunkInfoList> *out);
+        google::protobuf::Map<uint64_t, S3ChunkInfoList>* out,
+        bool fromS3Compaction);
 
     MetaStatusCode InsertInode(const Inode& inode);
 

--- a/curvefs/src/metaserver/s3compact.h
+++ b/curvefs/src/metaserver/s3compact.h
@@ -26,7 +26,7 @@
 #include <memory>
 
 #include "curvefs/proto/common.pb.h"
-#include "curvefs/src/metaserver/inode_storage.h"
+#include "curvefs/src/metaserver/inode_manager.h"
 
 namespace curvefs {
 namespace metaserver {
@@ -35,12 +35,12 @@ using curvefs::common::PartitionInfo;
 // one S3Compact per partition
 class S3Compact {
  public:
-    explicit S3Compact(std::shared_ptr<InodeStorage> inodeStorage,
-                       const PartitionInfo& partitionInfo)
-        : inodeStorage_(inodeStorage), partitionInfo_(partitionInfo) {}
+    S3Compact(const std::shared_ptr<InodeManager>& inodeManager,
+              const PartitionInfo& partitionInfo)
+        : inodeManager_(inodeManager), partitionInfo_(partitionInfo) {}
 
-    std::shared_ptr<InodeStorage> GetMutableInodeStorage() {
-        return inodeStorage_;
+    std::shared_ptr<InodeManager> GetInodeManager() {
+        return inodeManager_;
     }
 
     PartitionInfo GetPartition() const {
@@ -48,7 +48,7 @@ class S3Compact {
     }
 
  private:
-    std::shared_ptr<InodeStorage> inodeStorage_;
+    std::shared_ptr<InodeManager> inodeManager_;
     // we only need data that will not be changed after being created.
     const PartitionInfo partitionInfo_;
 };

--- a/curvefs/src/metaserver/s3compact_manager.h
+++ b/curvefs/src/metaserver/s3compact_manager.h
@@ -78,6 +78,8 @@ struct S3CompactWorkQueueOption {
     std::string metaserverIpStr;
     uint64_t metaserverPort;
     uint64_t s3infocacheSize;
+    uint64_t s3ReadMaxRetry;
+    uint64_t s3ReadRetryInterval;
 
     void Init(std::shared_ptr<Configuration> conf);
 };

--- a/curvefs/src/metaserver/s3compact_wq_impl.cpp
+++ b/curvefs/src/metaserver/s3compact_wq_impl.cpp
@@ -44,7 +44,7 @@ using curvefs::metaserver::copyset::GetOrModifyS3ChunkInfoOperator;
 namespace curvefs {
 namespace metaserver {
 
-void S3CompactWorkQueueImpl::Enqueue(std::shared_ptr<InodeStorage> inodeStorage,
+void S3CompactWorkQueueImpl::Enqueue(std::shared_ptr<InodeManager> inodeManager,
                                      InodeKey inodeKey, PartitionInfo pinfo,
                                      CopysetNode* copysetNode) {
     std::unique_lock<std::mutex> guard(mutex_);
@@ -59,10 +59,11 @@ void S3CompactWorkQueueImpl::Enqueue(std::shared_ptr<InodeStorage> inodeStorage,
         notFull_.wait(guard);
     }
     compactingInodes_.push_back(inodeKey);
-    auto copysetNodeWrapper = std::make_shared<CopysetNodeWrapper>(copysetNode);
-    auto task = std::bind(&S3CompactWorkQueueImpl::CompactChunks, this,
-                          inodeStorage, inodeKey, pinfo, copysetNodeWrapper,
-                          s3adapterManager_, s3infoCache_);
+    struct S3CompactTask t {
+        inodeManager, inodeKey, pinfo,
+            std::make_shared<CopysetNodeWrapper>(copysetNode)
+    };
+    auto task = std::bind(&S3CompactWorkQueueImpl::CompactChunks, this, t);
     // am i copysetnode leader?_
     queue_.push_back(std::move(task));
     notEmpty_.notify_one();
@@ -110,6 +111,7 @@ std::vector<uint64_t> S3CompactWorkQueueImpl::GetNeedCompact(
 void S3CompactWorkQueueImpl::DeleteObjs(const std::vector<std::string>& objs,
                                         S3Adapter* s3adapter) {
     for (const auto& obj : objs) {
+        VLOG(9) << "s3compact: delete " << obj;
         const Aws::String aws_key(obj.c_str(), obj.size());
         int ret =
             s3adapter->DeleteObject(aws_key);  // don't care success or not
@@ -135,7 +137,6 @@ S3CompactWorkQueueImpl::BuildValidList(const S3ChunkInfoList& s3chunkinfolist,
             // data from B is newer than A
             uint64_t nodeBegin = it->begin;
             uint64_t nodeEnd = it->end;
-            bool nodeZero = it->zero;
             if (newNode.end < nodeBegin) {
                 // A,B no overlap, B is left A, just add to list
                 validList.emplace(it, newNode);
@@ -198,13 +199,20 @@ S3CompactWorkQueueImpl::BuildValidList(const S3ChunkInfoList& s3chunkinfolist,
         validList.emplace_back(newNode);
     };
 
+    VLOG(9) << "s3compact: list s3chunkinfo list";
     for (auto i = 0; i < s3chunkinfolist.s3chunks_size(); i++) {
         auto chunkinfo = s3chunkinfolist.s3chunks(i);
+        // print s3chunkinfolist
         struct Node n {
             chunkinfo.offset(), chunkinfo.offset() + chunkinfo.len() - 1,
                 chunkinfo.chunkid(), chunkinfo.compaction(), chunkinfo.offset(),
                 chunkinfo.len(), chunkinfo.zero()
         };
+        VLOG(9) << "chunkid: " << chunkinfo.chunkid()
+                << ", offset:" << chunkinfo.offset()
+                << ", len:" << chunkinfo.len()
+                << ", compaction:" << chunkinfo.compaction()
+                << ", zero: " << chunkinfo.zero();
         addToValidList(std::move(n));
     }
 
@@ -213,7 +221,8 @@ S3CompactWorkQueueImpl::BuildValidList(const S3ChunkInfoList& s3chunkinfolist,
         auto next = std::next(curr);
         if (next == validList.end()) break;
         if (curr->end == next->begin - 1) {
-            if (curr->chunkid == next->chunkid) {
+            if (curr->chunkid == next->chunkid &&
+                curr->compaction == next->compaction) {
                 next->begin = curr->begin;
                 validList.erase(curr);
             }
@@ -223,75 +232,143 @@ S3CompactWorkQueueImpl::BuildValidList(const S3ChunkInfoList& s3chunkinfolist,
     return validList;
 }
 
-int S3CompactWorkQueueImpl::ReadFullChunk(
-    const std::list<struct S3CompactWorkQueueImpl::Node>& validList,
-    uint64_t fsId, uint64_t inodeId, uint64_t blockSize, uint64_t chunkSize,
-    std::string* fullChunk, uint64_t* newChunkid, uint64_t* newCompaction,
-    S3Adapter* s3adapter) {
+void S3CompactWorkQueueImpl::GenS3ReadRequests(
+    const struct S3CompactCtx& ctx, const std::list<struct Node>& validList,
+    std::vector<struct S3Request>* reqs, struct S3NewChunkInfo* newChunkInfo) {
+    int reqIndex = 0;
+    uint64_t newChunkId = 0;
+    uint64_t newCompaction = 0;
     for (auto curr = validList.begin(); curr != validList.end();) {
         auto next = std::next(curr);
         if (curr->zero) {
-            fullChunk->append(curr->end - curr->begin + 1, '\0');
+            reqs->emplace_back(reqIndex++, true, "", 0,
+                               curr->end - curr->begin + 1);
             curr = next;
             continue;
         }
 
-        VLOG(9) << "s3compact: read [" << curr->begin << "-" << curr->end
-                << "]";
+        const auto& blockSize = ctx.blockSize;
+        const auto& chunkSize = ctx.chunkSize;
         uint64_t beginRoundDown = curr->begin / chunkSize * chunkSize;
         uint64_t startIndex = (curr->begin - beginRoundDown) / blockSize;
         for (uint64_t index = startIndex;
              beginRoundDown + index * blockSize <= curr->end; index++) {
             // read the block obj
             std::string objName = curvefs::common::s3util::GenObjName(
-                curr->chunkid, index, curr->compaction, fsId, inodeId);
-            VLOG(9) << "s3compact: get " << objName;
-            std::string buf;
-            const Aws::String aws_key(objName.c_str(), objName.size());
-            int ret = s3adapter->GetObject(aws_key, &buf);
-            if (ret != 0) {
-                LOG(WARNING) << "Get S3 obj " << objName << " failed.";
-                return ret;
-            } else {
-                uint64_t s3objBegin = std::max(
-                    curr->chunkoff, beginRoundDown + index * blockSize);
-                uint64_t s3objEnd =
-                    std::min(curr->chunkoff + curr->chunklen - 1,
-                             beginRoundDown + (index + 1) * blockSize - 1);
-                VLOG(9) << "s3compact: get success " << s3objBegin << "-"
-                        << s3objEnd;
-                if (curr->begin >= s3objBegin && curr->end <= s3objEnd) {
-                    // all what we need is only part of block
-                    (*fullChunk) += buf.substr(curr->begin - s3objBegin,
-                                               curr->end - curr->begin + 1);
-                } else if (curr->begin >= s3objBegin && curr->end > s3objEnd) {
-                    // not last block, what we need is part of block
-                    (*fullChunk) += buf.substr(curr->begin - s3objBegin,
-                                               s3objEnd - curr->begin + 1);
-                } else if (curr->begin < s3objBegin && curr->end > s3objEnd) {
-                    // what we need is full block
-                    (*fullChunk) += buf.substr(0, blockSize);
-                } else if (curr->begin < s3objBegin && curr->end <= s3objEnd) {
-                    // last block, what we need is part of block
-                    (*fullChunk) += buf.substr(0, curr->end - s3objBegin + 1);
-                    break;
-                }
-                VLOG(9) << "s3compact: append to output success " << objName;
+                curr->chunkid, index, curr->compaction, ctx.fsId, ctx.inodeId);
+            uint64_t s3objBegin =
+                std::max(curr->chunkoff, beginRoundDown + index * blockSize);
+            uint64_t s3objEnd =
+                std::min(curr->chunkoff + curr->chunklen - 1,
+                         beginRoundDown + (index + 1) * blockSize - 1);
+            if (curr->begin >= s3objBegin && curr->end <= s3objEnd) {
+                // all what we need is only part of block
+                reqs->emplace_back(reqIndex++, false, std::move(objName),
+                                   curr->begin - s3objBegin,
+                                   curr->end - curr->begin + 1);
+            } else if (curr->begin >= s3objBegin && curr->end > s3objEnd) {
+                // not last block, what we need is part of block
+                reqs->emplace_back(reqIndex++, false, std::move(objName),
+                                   curr->begin - s3objBegin,
+                                   s3objEnd - curr->begin + 1);
+            } else if (curr->begin < s3objBegin && curr->end > s3objEnd) {
+                // what we need is full block
+                reqs->emplace_back(reqIndex++, false, std::move(objName), 0,
+                                   blockSize);
+            } else if (curr->begin < s3objBegin && curr->end <= s3objEnd) {
+                // last block, what we need is part of block
+                reqs->emplace_back(reqIndex++, false, std::move(objName), 0,
+                                   curr->end - s3objBegin + 1);
+                break;
             }
         }
 
-        if (curr->chunkid >= *newChunkid) {
-            (*newChunkid) = curr->chunkid;
-            (*newCompaction) = curr->compaction;
+        if (curr->chunkid >= newChunkId) {
+            newChunkId = curr->chunkid;
+            newCompaction = curr->compaction;
         }
         if (next != validList.end() && curr->end + 1 < next->begin) {
             // hole, append 0
-            fullChunk->append(next->begin - curr->end - 1, '\0');
+            reqs->emplace_back(reqIndex++, true, "", 0,
+                               next->begin - curr->end - 1);
         }
         curr = next;
     }
     // inc compaction
-    (*newCompaction) += 1;
+    newCompaction += 1;
+    newChunkInfo->newChunkId = newChunkId;
+    newChunkInfo->newOff = validList.front().chunkoff;
+    newChunkInfo->newCompaction = newCompaction;
+}
+
+int S3CompactWorkQueueImpl::ReadFullChunk(
+    const struct S3CompactCtx& ctx, const std::list<struct Node>& validList,
+    std::string* fullChunk, struct S3NewChunkInfo* newChunkInfo) {
+    std::vector<struct S3Request> s3reqs;
+    std::vector<std::string> readContent;
+    // generate s3request first
+    GenS3ReadRequests(ctx, validList, &s3reqs, newChunkInfo);
+    VLOG(9) << "s3compact: s3 request generated";
+    for (const auto& s3req : s3reqs) {
+        VLOG(9) << "index:" << s3req.reqIndex << ", zero:" << s3req.zero
+                << ", s3objname:" << s3req.objName << ", off:" << s3req.off
+                << ", len:" << s3req.len;
+    }
+    readContent.resize(s3reqs.size());
+    std::unordered_map<std::string, std::vector<struct S3Request*>> objReqs;
+    for (auto& req : s3reqs) {
+        if (req.zero) {
+            objReqs["zero"].emplace_back(&req);
+        } else {
+            objReqs[req.objName].emplace_back(&req);
+        }
+    }
+    // process zero first and will not fail
+    if (objReqs.find("zero") != objReqs.end()) {
+        for (const auto& req : objReqs["zero"]) {
+            readContent[req->reqIndex] = std::string(req->len, '\0');
+        }
+        objReqs.erase("zero");
+    }
+    // read and process objs one by one
+    uint64_t retry = 0;
+    for (auto it = objReqs.begin(); it != objReqs.end(); it++) {
+        std::string buf;
+        const std::string& objName = it->first;
+        const auto& reqs = it->second;
+        const Aws::String aws_key(objName.c_str(), objName.size());
+        const auto maxRetry = opts_.s3ReadMaxRetry;
+        const auto retryInterval = opts_.s3ReadRetryInterval;
+        while (retry <= maxRetry) {
+            // why we need retry
+            // if you enable client's diskcache,
+            // metadata may be newer than data in s3
+            // which means you cannot read data from s3
+            // we have to wait data to be flushed to s3
+            int ret = ctx.s3adapter->GetObject(aws_key, &buf);
+            if (ret != 0) {
+                LOG(WARNING)
+                    << "s3compact: get s3 obj " << objName << " failed";
+                if (retry == maxRetry) return -1;  // no chance
+                retry++;
+                LOG(WARNING) << "s3compact: will retry after " << retryInterval
+                             << " seconds, current retry time:" << retry;
+                std::this_thread::sleep_for(
+                    std::chrono::seconds(retryInterval));
+                continue;
+            }
+            for (const auto& req : reqs) {
+                readContent[req->reqIndex] = buf.substr(req->off, req->len);
+            }
+            break;
+        }
+    }
+
+    // merge all read content
+    for (auto content : readContent) {
+        (*fullChunk) += std::move(content);
+    }
+
     return 0;
 }
 
@@ -308,6 +385,7 @@ MetaStatusCode S3CompactWorkQueueImpl::UpdateInode(
     *request.mutable_s3chunkinfoadd() = std::move(s3ChunkInfoAdd);
     *request.mutable_s3chunkinforemove() = std::move(s3ChunkInfoRemove);
     request.set_returns3chunkinfomap(false);
+    request.set_froms3compaction(true);
     GetOrModifyS3ChunkInfoResponse response;
     S3CompactWorkQueueImpl::GetOrModifyS3ChunkInfoClosure done;
     // if copysetnode change to nullptr, maybe crash
@@ -319,30 +397,32 @@ MetaStatusCode S3CompactWorkQueueImpl::UpdateInode(
 }
 
 int S3CompactWorkQueueImpl::WriteFullChunk(
-    const std::string& fullChunk, uint64_t fsId, uint64_t inodeId,
-    uint64_t blockSize, uint64_t chunkSize, uint64_t newChunkid,
-    uint64_t newCompaction, uint64_t newOff,
-    std::vector<std::string>* objsAdded, S3Adapter* s3adapter) {
+    const struct S3CompactCtx& ctx, const struct S3NewChunkInfo& newChunkInfo,
+    const std::string& fullChunk, std::vector<std::string>* objsAdded) {
     uint64_t chunkLen = fullChunk.length();
+    const auto& blockSize = ctx.blockSize;
+    const auto& chunkSize = ctx.chunkSize;
+    const auto& newOff = newChunkInfo.newOff;
     uint64_t offRoundDown = newOff / chunkSize * chunkSize;
     uint64_t startIndex = (newOff - newOff / chunkSize * chunkSize) / blockSize;
     for (uint64_t index = startIndex;
          index * blockSize + offRoundDown < newOff + chunkLen; index += 1) {
         std::string objName = curvefs::common::s3util::GenObjName(
-            newChunkid, index, newCompaction, fsId, inodeId);
-        VLOG(9) << "s3compact: put " << objName;
+            newChunkInfo.newChunkId, index, newChunkInfo.newCompaction,
+            ctx.fsId, ctx.inodeId);
         const Aws::String aws_key(objName.c_str(), objName.size());
         int ret;
         uint64_t s3objBegin =
             std::max(newOff, offRoundDown + index * blockSize);
         uint64_t s3objEnd = std::min(
             newOff + chunkLen - 1, offRoundDown + (index + 1) * blockSize - 1);
-        VLOG(9) << "s3compact: [" << s3objBegin << "-" << s3objEnd << "]";
-        ret = s3adapter->PutObject(
+        VLOG(9) << "s3compact: put " << objName << ", [" << s3objBegin << "-"
+                << s3objEnd << "]";
+        ret = ctx.s3adapter->PutObject(
             aws_key,
             fullChunk.substr(s3objBegin - newOff, s3objEnd - s3objBegin + 1));
         if (ret != 0) {
-            LOG(WARNING) << "Put S3 object " << objName << " failed";
+            LOG(WARNING) << "s3compact: put s3 object " << objName << " failed";
             return ret;
         } else {
             objsAdded->emplace_back(std::move(objName));
@@ -351,78 +431,64 @@ int S3CompactWorkQueueImpl::WriteFullChunk(
     return 0;
 }
 
-void S3CompactWorkQueueImpl::CompactChunks(
-    std::shared_ptr<InodeStorage> inodeStorage, InodeKey inodeKey,
-    PartitionInfo pinfo, std::shared_ptr<CopysetNodeWrapper> copysetNodeWrapper,
-    std::shared_ptr<S3AdapterManager> s3adapterManager,
-    std::shared_ptr<S3InfoCache> s3infoCache) {
-    auto cleanup = absl::MakeCleanup([this, inodeKey]() {
-        std::lock_guard<std::mutex> guard(mutex_);
-        auto it = std::find(compactingInodes_.begin(), compactingInodes_.end(),
-                            inodeKey);
-        if (it != compactingInodes_.end()) {
-            compactingInodes_.erase(it);
-        }
-    });
-
-    VLOG(6) << "s3compact: try to compact, fsId: " << inodeKey.fsId
-            << " , inodeId: " << inodeKey.inodeId;
+bool S3CompactWorkQueueImpl::CompactPrecheck(
+    const struct S3CompactTask& task, Inode* inode,
+    std::vector<uint64_t>* needCompact) {
     // am i copysetnode leader?
-    if (!copysetNodeWrapper->IsLeaderTerm()) {
+    if (!task.copysetNodeWrapper->IsLeaderTerm()) {
         VLOG(6) << "s3compact: i am not the leader, finish";
-        return;
+        return false;
     }
 
     // inode exist?
-    Inode inode;
-    MetaStatusCode ret = inodeStorage->Get(inodeKey, &inode);
+    MetaStatusCode ret = task.inodeManager->GetInode(
+        task.inodeKey.fsId, task.inodeKey.inodeId, inode);
     if (ret != MetaStatusCode::OK) {
-        LOG(WARNING) << "GetInode fail, inodeKey = " << inodeKey.fsId << ","
-                     << inodeKey.inodeId
+        LOG(WARNING) << "s3compact: GetInode fail, inodeKey = "
+                     << task.inodeKey.fsId << "," << task.inodeKey.inodeId
                      << ", ret = " << MetaStatusCode_Name(ret);
-        return;
+        return false;
     }
 
     // deleted?
-    if (inode.nlink() == 0) {
-        VLOG(6) << "s3compact: inode already deleted";
-        return;
+    if (inode->nlink() == 0) {
+        VLOG(6) << "s3compact: inode is already deleted";
+        return false;
     }
 
     // s3chunkinfomap size 0?
-    if (inode.s3chunkinfomap().size() == 0) {
+    if (inode->s3chunkinfomap().size() == 0) {
         VLOG(6) << "s3compact: empty s3chunkinfomap";
-        return;
+        return false;
     }
-    uint64_t fsId = inode.fsid();
-    uint64_t inodeId = inode.inodeid();
-    uint64_t inodeLen = inode.length();
-
     // need compact?
-    const auto& origMap = inode.s3chunkinfomap();
-    std::vector<uint64_t> needCompact(GetNeedCompact(origMap));
-    if (needCompact.empty()) {
-        VLOG(6) << "s3compact: no need to compact " << inode.inodeid();
-        return;
+    *needCompact = GetNeedCompact(inode->s3chunkinfomap());
+    if (needCompact->empty()) {
+        VLOG(6) << "s3compact: no need to compact " << inode->inodeid();
+        return false;
     }
 
-    // let's compact
-    // 0. get s3adapter&s3info, set s3adapter
-    // include ak, sk, addr, bucket, blocksize, chunksize
-    uint64_t blockSize, chunkSize;
-    auto pairResult = s3adapterManager->GetS3Adapter();
-    uint64_t s3adapterIndex = pairResult.first;
-    S3Adapter* s3adapter = pairResult.second;
+    // pass
+    return true;
+}
+
+S3Adapter* S3CompactWorkQueueImpl::SetupS3Adapter(uint64_t fsId,
+                                                  uint64_t* s3adapterIndex,
+                                                  uint64_t* blockSize,
+                                                  uint64_t* chunkSize) {
+    auto pairResult = s3adapterManager_->GetS3Adapter();
+    *s3adapterIndex = pairResult.first;
+    auto s3adapter = pairResult.second;
     if (s3adapter == nullptr) {
-        VLOG(3) << "s3compact: fail to get s3adapter";
-        return;
+        LOG(WARNING) << "s3compact: fail to get s3adapter";
+        return nullptr;
     }
 
     S3Info s3info;
-    int status = s3infoCache->GetS3Info(fsId, &s3info);
+    int status = s3infoCache_->GetS3Info(fsId, &s3info);
     if (status == 0) {
-        blockSize = s3info.blocksize();
-        chunkSize = s3info.chunksize();
+        *blockSize = s3info.blocksize();
+        *chunkSize = s3info.chunksize();
         if (s3adapter->GetS3Ak() != s3info.ak() ||
             s3adapter->GetS3Sk() != s3info.sk() ||
             s3adapter->GetS3Endpoint() != s3info.endpoint()) {
@@ -439,119 +505,184 @@ void S3CompactWorkQueueImpl::CompactChunks(
                 << ", endpoint: " << s3info.endpoint()
                 << ", bucket: " << s3info.bucketname();
     } else {
-        VLOG(6) << "s3compact: fail to get s3info " << fsId;
-        return;
+        LOG(WARNING) << "s3compact: fail to get s3info of " << fsId;
+        return nullptr;
     }
     VLOG(6) << "s3compact: set s3adapter " << s3info.ak() << ", " << s3info.sk()
             << ", " << s3info.endpoint() << ", " << s3info.bucketname();
-    // 1. write new objs, each chunk one by one
+    return s3adapter;
+}
+
+void S3CompactWorkQueueImpl::CompactChunk(
+    const struct S3CompactCtx& compactCtx, uint64_t index, const Inode& inode,
+    std::unordered_map<uint64_t, std::vector<std::string>>* objsAddedMap,
+    ::google::protobuf::Map<uint64_t, S3ChunkInfoList>* s3ChunkInfoAdd,
+    ::google::protobuf::Map<uint64_t, S3ChunkInfoList>* s3ChunkInfoRemove) {
+    auto cleanup = absl::MakeCleanup(
+        [&]() { VLOG(6) << "s3compact: exit index " << index; });
+    VLOG(6) << "s3compact: begin to compact index " << index;
+    const auto& s3chunkinfolist = inode.s3chunkinfomap().at(index);
+    // 1.1 build valid list
+    std::list<struct S3CompactWorkQueueImpl::Node> validList(
+        BuildValidList(s3chunkinfolist, inode.length()));
+    VLOG(6) << "s3compact: finish build valid list";
+    VLOG(9) << "s3compact: show valid list";
+    for (const auto& node : validList) {
+        VLOG(9) << "[" << node.begin << "-" << node.end
+                << "], chunkid:" << node.chunkid
+                << ", chunkoff:" << node.chunkoff
+                << ", chunklen:" << node.chunklen << ", zero:" << node.zero;
+    }
+    // 1.2  first read full chunk
+    struct S3NewChunkInfo newChunkInfo;
+    std::string fullChunk;
+    int ret = ReadFullChunk(compactCtx, validList, &fullChunk, &newChunkInfo);
+    if (ret != 0) {
+        LOG(WARNING) << "s3compact: ReadFullChunk failed, index " << index;
+        s3infoCache_->InvalidateS3Info(
+            compactCtx.fsId);  // maybe s3info changed?
+        s3adapterManager_->ReleaseS3Adapter(compactCtx.s3adapterIndex);
+        return;
+    }
+    VLOG(6) << "s3compact: finish read full chunk, size: " << fullChunk.size();
+    VLOG(6) << "s3compact: new s3chunk info will be id:"
+            << newChunkInfo.newChunkId << ", off:" << newChunkInfo.newOff
+            << ", compaction:" << newChunkInfo.newCompaction;
+    // 1.3 then write objs with newChunkid and newCompaction
     std::vector<std::string> objsAdded;
+    ret = WriteFullChunk(compactCtx, newChunkInfo, fullChunk, &objsAdded);
+    if (ret != 0) {
+        LOG(WARNING) << "s3compact: WriteFullChunk failed, index " << index;
+        s3infoCache_->InvalidateS3Info(
+            compactCtx.fsId);  // maybe s3info changed?
+        DeleteObjs(objsAdded, compactCtx.s3adapter);
+        s3adapterManager_->ReleaseS3Adapter(compactCtx.s3adapterIndex);
+        return;
+    }
+    VLOG(6) << "s3compact: finish write full chunk";
+    // 1.4 record add/delete
+    objsAddedMap->emplace(index, std::move(objsAdded));
+    // to add
+    S3ChunkInfoList toAddList;
+    S3ChunkInfo toAdd;
+    toAdd.set_chunkid(newChunkInfo.newChunkId);
+    toAdd.set_compaction(newChunkInfo.newCompaction);
+    toAdd.set_offset(newChunkInfo.newOff);
+    toAdd.set_len(fullChunk.length());
+    toAdd.set_size(fullChunk.length());
+    toAdd.set_zero(false);
+    *toAddList.add_s3chunks() = std::move(toAdd);
+    s3ChunkInfoAdd->insert({index, std::move(toAddList)});
+    // to remove
+    s3ChunkInfoRemove->insert({index, s3chunkinfolist});
+}
+
+void S3CompactWorkQueueImpl::DeleteObjsOfS3ChunkInfoList(
+    const struct S3CompactCtx& ctx, const S3ChunkInfoList& s3chunkinfolist) {
+    for (auto i = 0; i < s3chunkinfolist.s3chunks_size(); i++) {
+        const auto& chunkinfo = s3chunkinfolist.s3chunks(i);
+        uint64_t off = chunkinfo.offset();
+        uint64_t len = chunkinfo.len();
+        uint64_t offRoundDown = off / ctx.chunkSize * ctx.chunkSize;
+        uint64_t startIndex = (off - offRoundDown) / ctx.blockSize;
+        for (uint64_t index = startIndex;
+             offRoundDown + index * ctx.blockSize < off + len; index++) {
+            std::string objName = curvefs::common::s3util::GenObjName(
+                chunkinfo.chunkid(), index, chunkinfo.compaction(), ctx.fsId,
+                ctx.inodeId);
+            VLOG(6) << "s3compact: delete " << objName;
+            const Aws::String aws_key(objName.c_str(), objName.size());
+            int r = ctx.s3adapter->DeleteObject(
+                aws_key);  // don't care success or not
+            if (r != 0)
+                VLOG(6) << "s3compact: delete obj " << objName << "failed.";
+        }
+    }
+}
+
+void S3CompactWorkQueueImpl::CompactChunks(const struct S3CompactTask& task) {
+    auto cleanup = absl::MakeCleanup([this, task]() {
+        std::lock_guard<std::mutex> guard(mutex_);
+        auto it = std::find(compactingInodes_.begin(), compactingInodes_.end(),
+                            task.inodeKey);
+        if (it != compactingInodes_.end()) {
+            compactingInodes_.erase(it);
+        }
+        VLOG(6) << "s3compact: exit compaction";
+    });
+
+    VLOG(6) << "s3compact: try to compact, fsId: " << task.inodeKey.fsId
+            << " , inodeId: " << task.inodeKey.inodeId;
+
+    Inode inode;
+    std::vector<uint64_t> needCompact;
+    if (!CompactPrecheck(task, &inode, &needCompact)) return;
+    uint64_t fsId = inode.fsid();
+    uint64_t inodeId = inode.inodeid();
+
+    // let's compact
+    // 0. get s3adapter&s3info, set s3adapter
+    // include ak, sk, addr, bucket, blocksize, chunksize
+    uint64_t blockSize, chunkSize;
+    uint64_t s3adapterIndex;
+    S3Adapter* s3adapter = SetupS3Adapter(task.inodeKey.fsId, &s3adapterIndex,
+                                          &blockSize, &chunkSize);
+    if (s3adapter == nullptr) return;
+
+    // 1. read full chunk & write new objs, each chunk one by one
+    struct S3CompactCtx compactCtx {
+        task.inodeKey.inodeId, task.inodeKey.fsId, task.pinfo, blockSize,
+            chunkSize, s3adapterIndex, s3adapter
+    };
+    std::unordered_map<uint64_t, std::vector<std::string>> objsAddedMap;
     ::google::protobuf::Map<uint64_t, S3ChunkInfoList> s3ChunkInfoAdd;
     ::google::protobuf::Map<uint64_t, S3ChunkInfoList> s3ChunkInfoRemove;
     std::vector<uint64_t> indexToDelete;
+    VLOG(6) << "s3compact: begin to compact fsId:" << fsId
+            << ", inodeId:" << inodeId;
     for (const auto& index : needCompact) {
-        VLOG(6) << "s3compact: currindex " << index;
-        // 1.1 build valid list
-        auto s3chunkVec =
-            inode.mutable_s3chunkinfomap()->at(index).mutable_s3chunks();
         // sort s3chunks to make small chunkid -> big chunkid
         // bigger chunkid means newer data
+        auto s3chunkVec =
+            inode.mutable_s3chunkinfomap()->at(index).mutable_s3chunks();
         std::sort(s3chunkVec->begin(), s3chunkVec->end(),
                   [](const S3ChunkInfo& a, const S3ChunkInfo& b) {
                       return a.chunkid() < b.chunkid();
                   });
-        const auto& s3chunkinfolist = origMap.at(index);
-
-        std::list<struct S3CompactWorkQueueImpl::Node> validList(
-            BuildValidList(s3chunkinfolist, inodeLen));
-        VLOG(6) << "s3compact: finish build valid list";
-        // 1.2 gen obj names and read s3
-        std::string fullChunk;
-        uint64_t newChunkid = 0;
-        uint64_t newCompaction = 0;
-        int ret =
-            ReadFullChunk(validList, fsId, inodeId, blockSize, chunkSize,
-                          &fullChunk, &newChunkid, &newCompaction, s3adapter);
-        if (ret != 0) {
-            LOG(WARNING) << "S3Compact ReadFullChunk failed, index " << index;
-            s3infoCache_->InvalidateS3Info(fsId);
-            DeleteObjs(objsAdded, s3adapter);
-            s3adapterManager->ReleaseS3Adapter(s3adapterIndex);
-            return;
-        }
-        VLOG(6) << "s3compact: finish read full chunk, size: "
-                << fullChunk.size();
-        // 1.3 then write objs with newChunkid and newCompaction
-        uint64_t newOff = validList.front().chunkoff;
-        ret = WriteFullChunk(fullChunk, fsId, inodeId, blockSize, chunkSize,
-                             newChunkid, newCompaction, newOff, &objsAdded,
-                             s3adapter);
-        if (ret != 0) {
-            LOG(WARNING) << "S3Compact WriteFullChunk failed, index " << index;
-            s3infoCache_->InvalidateS3Info(fsId);
-            DeleteObjs(objsAdded, s3adapter);
-            s3adapterManager->ReleaseS3Adapter(s3adapterIndex);
-            return;
-        }
-        VLOG(6) << "s3compact: finish write full chunk";
-        // 1.4 record add/delete
-        // to add
-        S3ChunkInfoList toAddList;
-        S3ChunkInfo toAdd;
-        toAdd.set_chunkid(newChunkid);
-        toAdd.set_compaction(newCompaction);
-        toAdd.set_offset(validList.begin()->begin);
-        toAdd.set_len(fullChunk.length());
-        toAdd.set_size(fullChunk.length());
-        toAdd.set_zero(false);
-        *toAddList.add_s3chunks() = std::move(toAdd);
-        s3ChunkInfoAdd.insert({index, std::move(toAddList)});
-        // to remove
-        indexToDelete.emplace_back(index);
-        s3ChunkInfoRemove.insert({index, origMap.at(index)});
+        CompactChunk(compactCtx, index, inode, &objsAddedMap, &s3ChunkInfoAdd,
+                     &s3ChunkInfoRemove);
+    }
+    if (s3ChunkInfoAdd.empty()) {
+        VLOG(6) << "s3compact: do nothing to metadata";
+        return;
     }
 
     // 2. update inode
     VLOG(6) << "s3compact: start update inode";
-    if (!copysetNodeWrapper->IsValid()) return;
-    ret = UpdateInode(copysetNodeWrapper->Get(), pinfo, inodeId,
-                      std::move(s3ChunkInfoAdd), std::move(s3ChunkInfoRemove));
+    if (!task.copysetNodeWrapper->IsValid()) return;
+    auto ret =
+        UpdateInode(task.copysetNodeWrapper->Get(), compactCtx.pinfo, inodeId,
+                    std::move(s3ChunkInfoAdd), std::move(s3ChunkInfoRemove));
     if (ret != MetaStatusCode::OK) {
-        LOG(WARNING) << "S3Compact UpdateInode failed, inodeKey = "
-                     << inodeKey.fsId << "," << inodeKey.inodeId
+        LOG(WARNING) << "s3compact: UpdateInode failed, inodeKey = "
+                     << compactCtx.fsId << "," << compactCtx.inodeId
                      << ", ret = " << MetaStatusCode_Name(ret);
-        DeleteObjs(objsAdded, s3adapter);
-        s3adapterManager->ReleaseS3Adapter(s3adapterIndex);
+        for (const auto& item : objsAddedMap) {
+            DeleteObjs(item.second, s3adapter);
+        }
+        s3adapterManager_->ReleaseS3Adapter(s3adapterIndex);
         return;
     }
     VLOG(6) << "s3compact: finish update inode";
 
     // 3. delete old objs
     VLOG(6) << "s3compact: start delete old objs";
-    for (const auto& index : indexToDelete) {
-        const auto& s3chunkinfolist = origMap.at(index);
-        for (auto i = 0; i < s3chunkinfolist.s3chunks_size(); i++) {
-            const auto& chunkinfo = s3chunkinfolist.s3chunks(i);
-            uint64_t off = chunkinfo.offset();
-            uint64_t len = chunkinfo.len();
-            uint64_t offRoundDown = off / chunkSize * chunkSize;
-            uint64_t startIndex = (off - offRoundDown) / blockSize;
-            for (uint64_t index = startIndex;
-                 offRoundDown + index * blockSize < off + len; index++) {
-                std::string objName = curvefs::common::s3util::GenObjName(
-                    chunkinfo.chunkid(), index, chunkinfo.compaction(), fsId,
-                    inodeId);
-                VLOG(6) << "s3compact: delete " << objName;
-                const Aws::String aws_key(objName.c_str(), objName.size());
-                int r = s3adapter->DeleteObject(
-                    aws_key);  // don't care success or not
-                if (r != 0)
-                    VLOG(6) << "s3compact: delete obj " << objName << "failed.";
-            }
-        }
+    for (const auto& item : objsAddedMap) {
+        const auto& l = inode.s3chunkinfomap().at(item.first);
+        DeleteObjsOfS3ChunkInfoList(compactCtx, l);
     }
     VLOG(6) << "s3compact: finish delete objs";
-    s3adapterManager->ReleaseS3Adapter(s3adapterIndex);
+    s3adapterManager_->ReleaseS3Adapter(s3adapterIndex);
     VLOG(6) << "s3compact: compact successfully";
 }
 

--- a/curvefs/test/metaserver/inode_storage_test.cpp
+++ b/curvefs/test/metaserver/inode_storage_test.cpp
@@ -103,11 +103,6 @@ TEST_F(InodeStorageTest, test1) {
     ASSERT_TRUE(CompareInode((*mapPtr)[InodeKey(inode2)], inode2));
     ASSERT_TRUE(CompareInode((*mapPtr)[InodeKey(inode3)], inode3));
 
-    // GetInodeContainerData
-    auto mapData = storage.GetContainerData();
-    ASSERT_TRUE(CompareInode(mapData[InodeKey(inode2)], inode2));
-    ASSERT_TRUE(CompareInode(mapData[InodeKey(inode3)], inode3));
-
     // GetInodeIdList
     std::list<uint64_t> inodeIdList;
     storage.GetInodeIdList(&inodeIdList);


### PR DESCRIPTION
1. refactor s3compact code
2. with diskcache write cache enable, metadata may be
newer than data in s3. so we will meet s3 read failure,
add retry to workaround this situation.
3. change GetOrModifyS3ChunkInfo request process, to keep order in s3chunkinfolist