### PR TITLE
curvefs/tool: fix copyset health check error

### DIFF
--- a/curvefs/src/tools/copyset/curvefs_copyset_base_tool.cpp
+++ b/curvefs/src/tools/copyset/curvefs_copyset_base_tool.cpp
@@ -88,7 +88,6 @@ bool CopysetInfo2CopysetStatus(
             uint64_t key = (static_cast<uint64_t>(copysets[m].poolid()) << 32) |
                            copysets[m].copysetid();
             (*key2Status)[key].push_back(copysetsStatus[n]);
-            // TODO(chengyi01): check copysetsStatus[n].status()
         }
     }
     return ret;
@@ -135,7 +134,8 @@ bool CopysetInfo2CopysetStatus(
         getCopysetStatusTool.SetRequestQueue(i.second);
         auto checkRet = getCopysetStatusTool.RunCommand();
         if (checkRet < 0) {
-            std::cerr << "send request to mds get error." << std::endl;
+            std::cerr << "send request to metaserver (" << FLAGS_metaserverAddr
+                      << ") get error." << std::endl;
             ret = false;
         }
         const auto& copysetsStatus =
@@ -146,7 +146,6 @@ bool CopysetInfo2CopysetStatus(
             uint64_t key = (static_cast<uint64_t>(copysets[m].poolid()) << 32) |
                            copysets[m].copysetid();
             (*key2Status)[key].push_back(copysetsStatus[n]);
-            // TODO(chengyi01): check copysetsStatus[n].status()
         }
     }
     return ret;


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: close #1022 #1026  <!-- REMOVE this line if no issue to close -->

Problem Summary:

when get all coysetinfo (in curvefs_copyset_status) has error,
tools would not to check copyset status,
so get health instaed of unhealthy

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?): 

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
