### PR TITLE
persist metaserver meta info

### DIFF
--- a/curvefs/conf/metaserver.conf
+++ b/curvefs/conf/metaserver.conf
@@ -55,6 +55,8 @@ metaserver.common.logDir=/tmp/curvefs/metaserver  # __CURVEADM_TEMPLATE__ ${pref
 # we have loglevel: {3,6,9}
 # as the number increases, it becomes more and more detailed
 metaserver.loglevel=0
+# metaserver meta file path, every metaserver need persist MetaServerMetadata on its own disk
+metaserver.meta_file_path=./0/metaserver.dat  # __CURVEADM_TEMPLATE__ ${prefix}/data/metaserver.dat __CURVEADM_TEMPLATE__
 
 # copyset data uri
 # all uri (data_uri/raft_log_uri/raft_meta_uri/raft_snapshot_uri/trash.uri) are ${protocol}://${path}

--- a/curvefs/proto/metaserver.proto
+++ b/curvefs/proto/metaserver.proto
@@ -312,7 +312,7 @@ message MetaServerMetadata {
     required uint32 version = 1;
     required uint32 id = 2;
     required string token = 3;
-    // required uint32 checksum = 4;
+    required uint32 checksum = 4;
 }
 
 message GetOrModifyS3ChunkInfoRequest {

--- a/curvefs/proto/topology.proto
+++ b/curvefs/proto/topology.proto
@@ -43,6 +43,7 @@ enum TopoStatusCode {
     TOPO_LEADER_NOT_FOUND = 19;
     TOPO_PARTITION_NOT_FOUND = 20;
     TOPO_CREATE_PARTITION_FAIL = 21;
+    TOPO_METASERVER_EXIST = 22;
 }
 
 enum OnlineState {

--- a/curvefs/test/metaserver/metastore_test.cpp
+++ b/curvefs/test/metaserver/metastore_test.cpp
@@ -40,9 +40,14 @@ namespace curvefs {
 namespace metaserver {
 class MetastoreTest : public ::testing::Test {
  protected:
-    void SetUp() override {}
+    void SetUp() override {
+        test_path_ = "./metastore_test.dat";
+    }
 
-    void TearDown() override {}
+    void TearDown() override {
+        std::string cmd = "rm -rf " + test_path_;
+        system(cmd.c_str());
+    }
 
     bool CompareInode(const Inode &first, const Inode &second) {
         uint64_t firstMtime = first.mtime() * 1000000000u
@@ -133,6 +138,8 @@ class MetastoreTest : public ::testing::Test {
         std::mutex mtx_;
         std::condition_variable condition_;
     };
+
+    std::string test_path_;
 };
 
 TEST_F(MetastoreTest, partition) {
@@ -797,7 +804,7 @@ TEST_F(MetastoreTest, persist_success) {
     // dump MetaStoreImpl to file
     OnSnapshotSaveDoneImpl done;
     LOG(INFO) << "MetastoreTest test Save";
-    ASSERT_TRUE(metastore.Save("./metastore_test", &done));
+    ASSERT_TRUE(metastore.Save(test_path_, &done));
 
     // wait meta save to file
     done.Wait();
@@ -806,7 +813,7 @@ TEST_F(MetastoreTest, persist_success) {
     // load MetaStoreImpl to new meta
     MetaStoreImpl metastoreNew(nullptr);
     LOG(INFO) << "MetastoreTest test Load";
-    ASSERT_TRUE(metastoreNew.Load("./metastore_test"));
+    ASSERT_TRUE(metastoreNew.Load(test_path_));
 
     // compare two meta
     ASSERT_TRUE(ComparePartition(
@@ -949,7 +956,7 @@ TEST_F(MetastoreTest, persist_deleting_partition_success) {
     // dump MetaStoreImpl to file
     OnSnapshotSaveDoneImpl done;
     LOG(INFO) << "MetastoreTest test Save";
-    ASSERT_TRUE(metastore.Save("./metastore_test", &done));
+    ASSERT_TRUE(metastore.Save(test_path_, &done));
 
     // wait meta save to file
     done.Wait();
@@ -958,7 +965,7 @@ TEST_F(MetastoreTest, persist_deleting_partition_success) {
     // load MetaStoreImpl to new meta
     MetaStoreImpl metastoreNew(nullptr);
     LOG(INFO) << "MetastoreTest test Load";
-    ASSERT_TRUE(metastoreNew.Load("./metastore_test"));
+    ASSERT_TRUE(metastoreNew.Load(test_path_));
 
     // compare two meta
     ASSERT_TRUE(ComparePartition(
@@ -996,7 +1003,7 @@ TEST_F(MetastoreTest, persist_partition_fail) {
     // dump MetaStoreImpl to file
     OnSnapshotSaveDoneImpl done;
     LOG(INFO) << "MetastoreTest test Save";
-    ASSERT_TRUE(metastore.Save("./metastore_test", &done));
+    ASSERT_TRUE(metastore.Save(test_path_, &done));
 
     // wait meta save to file
     done.Wait();
@@ -1074,7 +1081,7 @@ TEST_F(MetastoreTest, persist_dentry_fail) {
     // dump MetaStoreImpl to file
     OnSnapshotSaveDoneImpl done;
     LOG(INFO) << "MetastoreTest test Save";
-    ASSERT_TRUE(metastore.Save("./metastore_test", &done));
+    ASSERT_TRUE(metastore.Save(test_path_, &done));
 
     // wait meta save to file
     done.Wait();


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #938 

Problem Summary:  

### What is changed and how it works?

What's Changed:

1. persist metaserver meta info in local filesystem, persist this struct

```
message MetaServerMetadata {
    required uint32 version = 1;
    required uint32 id = 2;
    required string token = 3;
    required uint32 checksum = 4;
}
```

2. When metasever regist to mds, if mds already has metaserver with same ip and port, and metaserver in mds already has copyset, reject this request.

How it Works:

Side effects(Breaking backward compatibility? Performance regression?): 

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
