### PR TITLE
curvefs metaserver supports external services

### DIFF
--- a/curvefs/conf/metaserver.conf
+++ b/curvefs/conf/metaserver.conf
@@ -49,6 +49,8 @@ s3compactwq.s3infocache_size=100
 global.ip=127.0.0.1  # __CURVEADM_TEMPLATE__ ${service_addr} __CURVEADM_TEMPLATE__  __ANSIBLE_TEMPLATE__ {{ curvefs_metaserver_listen_host }} __ANSIBLE_TEMPLATE__
 global.port=16701  # __CURVEADM_TEMPLATE__ ${service_port} __CURVEADM_TEMPLATE__  __ANSIBLE_TEMPLATE__ {{ curvefs_metaserver_listen_port }} __ANSIBLE_TEMPLATE__
 global.external_ip=127.0.0.1  # __CURVEADM_TEMPLATE__ ${service_external_addr} __CURVEADM_TEMPLATE__  __ANSIBLE_TEMPLATE__ {{ curvefs_metaserver_listen_host }} __ANSIBLE_TEMPLATE__
+global.external_port=16701 # __CURVEADM_TEMPLATE__ ${service_external_port} __CURVEADM_TEMPLATE__
+global.enable_external_server=false
 
 # metaserver log directory
 # this config item can be replaced by start up option `-log_dir`

--- a/curvefs/conf/tools.conf
+++ b/curvefs/conf/tools.conf
@@ -6,7 +6,7 @@ rpcTimeoutMs=10000
 rpcRetryTimes=5
 # topo file path
 topoFilePath=curvefs/test/tools/topo_example.json  # __CURVEADM_TEMPLATE__ /curvefs/tools/conf/topology.json __CURVEADM_TEMPLATE__  __ANSIBLE_TEMPLATE__ {{ project_root_dest }}/conf/topology.json __ANSIBLE_TEMPLATE__
-# metaserver
+# metaserver external address
 metaserverAddr=127.0.0.1:6701  # __CURVEADM_TEMPLATE__ ${cluster_metaserver_addr} __CURVEADM_TEMPLATE__  __ANSIBLE_TEMPLATE__ {{ groups.metaserver | join_peer(hostvars, "metaserver_listen_port") }} __ANSIBLE_TEMPLATE__
 # etcd
 etcdAddr=127.0.0.1:12379  # __CURVEADM_TEMPLATE__ ${cluster_etcd_addr} __CURVEADM_TEMPLATE__  __ANSIBLE_TEMPLATE__ {{ groups.etcd | join_peer(hostvars, "etcd_listen_client_port") }} __ANSIBLE_TEMPLATE__

--- a/curvefs/proto/topology.proto
+++ b/curvefs/proto/topology.proto
@@ -73,9 +73,9 @@ message ZoneData {
 message ServerData {
     required uint32 serverId = 1;
     required string hostName = 2;
-    required string internalHostIP = 3;
+    required string internalIP = 3;
     required uint32 internalPort = 4;
-    required string externalHostIP = 5;
+    required string externalIP = 5;
     required uint32 externalPort = 6;
     required uint32 zoneId = 7;
     required uint32 PoolId = 8;
@@ -85,9 +85,9 @@ message MetaServerData {
     required uint32 MetaServerId = 1;
     required string hostName = 2;
     required string token = 3;
-    required string internalHostIP = 4;
+    required string internalIP = 4;
     required uint32 internalPort = 5;
-    required string externalHostIP = 6;
+    required string externalIP = 6;
     required uint32 externalPort = 7;
     required uint32 serverId = 8;
     required uint64 diskCapacity = 9;
@@ -115,8 +115,8 @@ message Copyset {
 message MetaServerInfo {
     required uint32 metaServerID = 1;
     required string hostname = 2;
-    required string hostIp = 3;
-    required uint32 port = 4;
+    required string internalIp = 3;
+    required uint32 internalPort = 4;
     required string externalIp = 5;
     required uint32 externalPort = 6;
     required OnlineState onlineState = 7;
@@ -126,8 +126,8 @@ message MetaServerInfo {
 // MetaServer message
 message MetaServerRegistRequest {
     required string hostName = 1;
-    required string hostIp = 2;
-    required uint32 port = 3;
+    required string internalIp = 2;
+    required uint32 internalPort = 3;
     required string externalIp = 4;
     required uint32 externalPort = 5;
 };
@@ -325,9 +325,10 @@ message GetMetaServerListInCopySetsRequest {
 
 message MetaServerLocation {
     required uint32 metaServerID = 1;
-    required string hostIp = 2;
-    required uint32 port = 3;
+    required string internalIp = 2;
+    required uint32 internalport = 3;
     optional string externalIp = 4;
+    optional uint32 externalPort = 5;
 }
 
 message CopySetServerInfo {

--- a/curvefs/src/mds/heartbeat/copyset_conf_generator.cpp
+++ b/curvefs/src/mds/heartbeat/copyset_conf_generator.cpp
@@ -170,7 +170,7 @@ std::string CopysetConfGenerator::BuildPeerByMetaserverId(
     }
 
     return ::curvefs::mds::topology::BuildPeerIdWithIpPort(
-        metaServer.GetInternalHostIp(), metaServer.GetInternalPort(), 0);
+        metaServer.GetInternalIp(), metaServer.GetInternalPort(), 0);
 }
 }  // namespace heartbeat
 }  // namespace mds

--- a/curvefs/src/mds/heartbeat/heartbeat_manager.cpp
+++ b/curvefs/src/mds/heartbeat/heartbeat_manager.cpp
@@ -181,14 +181,14 @@ HeartbeatStatusCode HeartbeatManager::CheckRequest(
     }
 
     // mismatch ip address reported by metaserver and mds record
-    if (request.ip() != metaServer.GetInternalHostIp() ||
+    if (request.ip() != metaServer.GetInternalIp() ||
         request.port() != metaServer.GetInternalPort()) {
         LOG(ERROR) << "heartbeatManager receive heartbeat from metaServer: "
                    << request.metaserverid()
                    << ", but find report ip:" << request.ip()
                    << ", report port:" << request.port()
                    << " do not consistent with topo record ip:"
-                   << metaServer.GetInternalHostIp()
+                   << metaServer.GetInternalIp()
                    << ", record port:" << metaServer.GetInternalPort();
         return HeartbeatStatusCode::hbMetaServerIpPortNotMatch;
     }

--- a/curvefs/src/mds/schedule/topoAdapter.cpp
+++ b/curvefs/src/mds/schedule/topoAdapter.cpp
@@ -227,7 +227,7 @@ bool TopoAdapterImpl::GetPeerInfo(MetaServerIdType id, PeerInfo *peerInfo) {
     if ((canGetMetaServer = topo_->GetMetaServer(id, &ms)) &&
         (canGetServer = topo_->GetServer(ms.GetServerId(), &server))) {
         *peerInfo = PeerInfo(ms.GetId(), server.GetZoneId(), server.GetId(),
-                             ms.GetInternalHostIp(), ms.GetInternalPort());
+                             ms.GetInternalIp(), ms.GetInternalPort());
     } else {
         LOG(ERROR) << "topoAdapter can not find metaServer(" << id
                    << ", res:" << canGetMetaServer
@@ -276,10 +276,10 @@ bool TopoAdapterImpl::MetaServerFromTopoToSchedule(
     if (topo_->GetServer(origin.GetServerId(), &server)) {
         out->info =
             PeerInfo{origin.GetId(), server.GetZoneId(), server.GetId(),
-                     origin.GetInternalHostIp(), origin.GetInternalPort()};
+                     origin.GetInternalIp(), origin.GetInternalPort()};
     } else {
         LOG(ERROR) << "can not get server:" << origin.GetId()
-                   << ", ip:" << origin.GetInternalHostIp()
+                   << ", ip:" << origin.GetInternalIp()
                    << ", port:" << origin.GetInternalPort() << " from topology";
 
         return false;

--- a/curvefs/src/mds/topology/topology.cpp
+++ b/curvefs/src/mds/topology/topology.cpp
@@ -445,13 +445,13 @@ ServerIdType TopologyImpl::FindServerByHostIpPort(const std::string &hostIp,
                                                   uint32_t port) const {
     ReadLockGuard rlockServer(serverMutex_);
     for (auto it = serverMap_.begin(); it != serverMap_.end(); it++) {
-        if (it->second.GetInternalHostIp() == hostIp) {
+        if (it->second.GetInternalIp() == hostIp) {
             if (0 == it->second.GetInternalPort()) {
                 return it->first;
             } else if (port == it->second.GetInternalPort()) {
                 return it->first;
             }
-        } else if (it->second.GetExternalHostIp() == hostIp) {
+        } else if (it->second.GetExternalIp() == hostIp) {
             if (0 == it->second.GetExternalPort()) {
                 return it->first;
             } else if (port == it->second.GetExternalPort()) {
@@ -509,7 +509,7 @@ bool TopologyImpl::GetMetaServer(const std::string &hostIp, uint32_t port,
     ReadLockGuard rlockMetaServerMap(metaServerMutex_);
     for (auto it = metaServerMap_.begin(); it != metaServerMap_.end(); it++) {
         ReadLockGuard rlockMetaServer(it->second.GetRWLockRef());
-        if (it->second.GetInternalHostIp() == hostIp &&
+        if (it->second.GetInternalIp() == hostIp &&
             it->second.GetInternalPort() == port) {
             *out = it->second;
             return true;
@@ -1343,7 +1343,7 @@ void TopologyImpl::GetMetaServersSpace(
         ReadLockGuard rlockMetaServer(i.second.GetRWLockRef());
         auto metaServerUsage = new curvefs::mds::topology::MetadataUsage();
         metaServerUsage->set_metaserveraddr(
-            i.second.GetInternalHostIp() + ":" +
+            i.second.GetInternalIp() + ":" +
             std::to_string(i.second.GetInternalPort()));
         auto const& space = i.second.GetMetaServerSpace();
         metaServerUsage->set_total(space.GetDiskCapacity());

--- a/curvefs/src/mds/topology/topology_item.cpp
+++ b/curvefs/src/mds/topology/topology_item.cpp
@@ -130,9 +130,9 @@ bool Server::SerializeToString(std::string *value) const {
     ServerData data;
     data.set_serverid(id_);
     data.set_hostname(hostName_);
-    data.set_internalhostip(internalHostIp_);
+    data.set_internalip(internalIp_);
     data.set_internalport(internalPort_);
-    data.set_externalhostip(externalHostIp_);
+    data.set_externalip(externalIp_);
     data.set_externalport(externalPort_);
     data.set_zoneid(zoneId_);
     data.set_poolid(poolId_);
@@ -144,9 +144,9 @@ bool Server::ParseFromString(const std::string &value) {
     bool ret = data.ParseFromString(value);
     id_ = data.serverid();
     hostName_ = data.hostname();
-    internalHostIp_ = data.internalhostip();
+    internalIp_ = data.internalip();
     internalPort_ = data.internalport();
-    externalHostIp_ = data.externalhostip();
+    externalIp_ = data.externalip();
     externalPort_ = data.externalport();
     zoneId_ = data.zoneid();
     poolId_ = data.poolid();
@@ -158,9 +158,9 @@ bool MetaServer::SerializeToString(std::string *value) const {
     data.set_metaserverid(id_);
     data.set_hostname(hostName_);
     data.set_token(token_);
-    data.set_internalhostip(internalHostIp_);
+    data.set_internalip(internalIp_);
     data.set_internalport(internalPort_);
-    data.set_externalhostip(externalHostIp_);
+    data.set_externalip(externalIp_);
     data.set_externalport(externalPort_);
     data.set_serverid(serverId_);
     data.set_diskcapacity(space_.GetDiskCapacity());
@@ -176,9 +176,9 @@ bool MetaServer::ParseFromString(const std::string &value) {
     hostName_ = data.hostname();
     token_ = data.token();
     serverId_ = data.serverid();
-    internalHostIp_ = data.internalhostip();
+    internalIp_ = data.internalip();
     internalPort_ = data.internalport();
-    externalHostIp_ = data.externalhostip();
+    externalIp_ = data.externalip();
     externalPort_ = data.externalport();
     onlineState_ = OnlineState::UNSTABLE;
     space_.SetDiskCapacity(data.diskcapacity());

--- a/curvefs/src/mds/topology/topology_item.h
+++ b/curvefs/src/mds/topology/topology_item.h
@@ -171,21 +171,21 @@ class Server {
     Server()
         : id_(UNINITIALIZE_ID),
           hostName_(""),
-          internalHostIp_(""),
+          internalIp_(""),
           internalPort_(0),
-          externalHostIp_(""),
+          externalIp_(""),
           externalPort_(0),
           zoneId_(UNINITIALIZE_ID),
           poolId_(UNINITIALIZE_ID) {}
     Server(ServerIdType id, const std::string &hostName,
-           const std::string &internalHostIp, uint32_t internalPort,
-           const std::string &externalHostIp, uint32_t externalPort,
+           const std::string &internalIp, uint32_t internalPort,
+           const std::string &externalIp, uint32_t externalPort,
            ZoneIdType zoneId, PoolIdType poolId)
         : id_(id),
           hostName_(hostName),
-          internalHostIp_(internalHostIp),
+          internalIp_(internalIp),
           internalPort_(internalPort),
-          externalHostIp_(externalHostIp),
+          externalIp_(externalIp),
           externalPort_(externalPort),
           zoneId_(zoneId),
           poolId_(poolId) {}
@@ -194,11 +194,11 @@ class Server {
 
     std::string GetHostName() const { return hostName_; }
 
-    std::string GetInternalHostIp() const { return internalHostIp_; }
+    std::string GetInternalIp() const { return internalIp_; }
 
     uint32_t GetInternalPort() const { return internalPort_; }
 
-    std::string GetExternalHostIp() const { return externalHostIp_; }
+    std::string GetExternalIp() const { return externalIp_; }
 
     uint32_t GetExternalPort() const { return externalPort_; }
 
@@ -221,9 +221,9 @@ class Server {
  private:
     ServerIdType id_;
     std::string hostName_;
-    std::string internalHostIp_;
+    std::string internalIp_;
     uint32_t internalPort_;
-    std::string externalHostIp_;
+    std::string externalIp_;
     uint32_t externalPort_;
     ZoneIdType zoneId_;
     PoolIdType poolId_;
@@ -259,9 +259,9 @@ class MetaServer {
           hostName_(""),
           token_(""),
           serverId_(UNINITIALIZE_ID),
-          internalHostIp_(""),
+          internalIp_(""),
           internalPort_(0),
-          externalHostIp_(""),
+          externalIp_(""),
           externalPort_(0),
           startUpTime_(0),
           onlineState_(OFFLINE),
@@ -269,16 +269,16 @@ class MetaServer {
 
     MetaServer(MetaServerIdType id, const std::string &hostName,
                const std::string &token, ServerIdType serverId,
-               const std::string &hostIp, uint32_t port,
-               const std::string &externalHostIp, uint32_t externalPort,
+               const std::string &internalIp, uint32_t internalPort,
+               const std::string &externalIp, uint32_t externalPort,
                OnlineState onlineState = OnlineState::OFFLINE)
         : id_(id),
           hostName_(hostName),
           token_(token),
           serverId_(serverId),
-          internalHostIp_(hostIp),
-          internalPort_(port),
-          externalHostIp_(externalHostIp),
+          internalIp_(internalIp),
+          internalPort_(internalPort),
+          externalIp_(externalIp),
           externalPort_(externalPort),
           startUpTime_(0),
           onlineState_(onlineState),
@@ -289,9 +289,9 @@ class MetaServer {
           hostName_(v.hostName_),
           token_(v.token_),
           serverId_(v.serverId_),
-          internalHostIp_(v.internalHostIp_),
+          internalIp_(v.internalIp_),
           internalPort_(v.internalPort_),
-          externalHostIp_(v.externalHostIp_),
+          externalIp_(v.externalIp_),
           externalPort_(v.externalPort_),
           startUpTime_(v.startUpTime_),
           onlineState_(v.onlineState_),
@@ -306,9 +306,9 @@ class MetaServer {
         hostName_ = v.hostName_;
         token_ = v.token_;
         serverId_ = v.serverId_;
-        internalHostIp_ = v.internalHostIp_;
+        internalIp_ = v.internalIp_;
         internalPort_ = v.internalPort_;
-        externalHostIp_ = v.externalHostIp_;
+        externalIp_ = v.externalIp_;
         externalPort_ = v.externalPort_;
         startUpTime_ = v.startUpTime_;
         onlineState_ = v.onlineState_;
@@ -329,19 +329,19 @@ class MetaServer {
 
     ServerIdType GetServerId() const { return serverId_; }
 
-    std::string GetInternalHostIp() const { return internalHostIp_; }
+    std::string GetInternalIp() const { return internalIp_; }
 
     uint32_t GetInternalPort() const { return internalPort_; }
 
-    void SetInternalHostIp(std::string internalHostIp) {
-        internalHostIp_ = internalHostIp;
+    void SetInternalIp(std::string internalIp) {
+        internalIp_ = internalIp;
     }
 
     void SetInternalPort(uint32_t internalPort) {
         internalPort_ = internalPort;
     }
 
-    std::string GetExternalHostIp() const { return externalHostIp_; }
+    std::string GetExternalIp() const { return externalIp_; }
 
     uint32_t GetExternalPort() const { return externalPort_; }
 
@@ -372,9 +372,9 @@ class MetaServer {
     std::string hostName_;
     std::string token_;
     ServerIdType serverId_;
-    std::string internalHostIp_;
+    std::string internalIp_;
     uint32_t internalPort_;
-    std::string externalHostIp_;
+    std::string externalIp_;
     uint32_t externalPort_;
     uint64_t startUpTime_;
     OnlineState onlineState_;  // 0:online、1: offline

--- a/curvefs/src/metaserver/metaserver.h
+++ b/curvefs/src/metaserver/metaserver.h
@@ -31,6 +31,7 @@
 #include "curvefs/src/metaserver/copyset/apply_queue.h"
 #include "curvefs/src/metaserver/copyset/config.h"
 #include "curvefs/src/metaserver/copyset/copyset_node_manager.h"
+#include "curvefs/src/metaserver/copyset/raft_cli_service2.h"
 #include "curvefs/src/metaserver/copyset/copyset_service.h"
 #include "curvefs/src/metaserver/register.h"
 #include "curvefs/src/metaserver/heartbeat.h"
@@ -48,11 +49,13 @@ using ::curvefs::metaserver::copyset::ApplyQueue;
 using ::curvefs::metaserver::copyset::CopysetNodeManager;
 using ::curvefs::metaserver::copyset::CopysetNodeOptions;
 using ::curvefs::metaserver::copyset::CopysetServiceImpl;
+using ::curvefs::metaserver::copyset::RaftCliService2;
 
 struct MetaserverOptions {
     std::string ip;
     int port;
     int bthreadWorkerCount = -1;
+    bool enableExternalServer;
 };
 
 class Metaserver {
@@ -87,8 +90,11 @@ class Metaserver {
     MetaServerMetadata metadate_;
 
     std::unique_ptr<brpc::Server> server_;
+    std::unique_ptr<brpc::Server> externalServer_;
+
     std::unique_ptr<MetaServerServiceImpl> metaService_;
     std::unique_ptr<CopysetServiceImpl> copysetService_;
+    std::unique_ptr<RaftCliService2> raftCliService2_;
 
     HeartbeatOptions heartbeatOptions_;
     Heartbeat heartbeat_;

--- a/curvefs/src/metaserver/register.cpp
+++ b/curvefs/src/metaserver/register.cpp
@@ -67,16 +67,17 @@ int Register::RegisterToMDS(MetaServerMetadata *metadata) {
     }
 
     req.set_hostname(hostname);
-    req.set_hostip(ops_.metaserverInternalIp);
-    req.set_port(ops_.metaserverPort);
+    req.set_internalip(ops_.metaserverInternalIp);
+    req.set_internalport(ops_.metaserverInternalPort);
     req.set_externalip(ops_.metaserverExternalIp);
-    req.set_externalport(ops_.metaserverPort);
+    req.set_externalport(ops_.metaserverExternalPort);
 
     LOG(INFO) << " Registering to MDS " << mdsEps_[inServiceIndex_]
               << ". hostname: " << hostname
               << ", internal ip: " << ops_.metaserverInternalIp
-              << ", port: " << ops_.metaserverPort
-              << ", external ip: " << ops_.metaserverExternalIp;
+              << ", internal port: " << ops_.metaserverInternalPort
+              << ", external ip: " << ops_.metaserverExternalIp
+              << ", external port: " << ops_.metaserverExternalPort;
 
     int retries = ops_.registerRetries;
     while (retries >= 0) {
@@ -87,7 +88,7 @@ int Register::RegisterToMDS(MetaServerMetadata *metadata) {
 
         if (channel.Init(mdsEps_[inServiceIndex_].c_str(), NULL) != 0) {
             LOG(ERROR) << ops_.metaserverInternalIp << ":"
-                       << ops_.metaserverPort
+                       << ops_.metaserverInternalPort
                        << " Fail to init channel to MDS "
                        << mdsEps_[inServiceIndex_];
             return -1;
@@ -99,12 +100,13 @@ int Register::RegisterToMDS(MetaServerMetadata *metadata) {
             break;
         } else {
             LOG(INFO) << ops_.metaserverInternalIp << ":"
-                       << ops_.metaserverPort << " Fail to register to MDS "
-                       << mdsEps_[inServiceIndex_]
-                       << ", cntl errorCode: " << cntl.ErrorCode() << ","
-                       << " cntl error: " << cntl.ErrorText() << ","
-                       << " statusCode: " << resp.statuscode() << ","
-                       << " going to sleep and try again.";
+                      << ops_.metaserverInternalPort
+                      << " Fail to register to MDS "
+                      << mdsEps_[inServiceIndex_]
+                      << ", cntl errorCode: " << cntl.ErrorCode() << ","
+                      << " cntl error: " << cntl.ErrorText() << ","
+                      << " statusCode: " << resp.statuscode() << ","
+                      << " going to sleep and try again.";
             if (cntl.ErrorCode() == EHOSTDOWN ||
                 cntl.ErrorCode() == brpc::ELOGOFF) {
                 inServiceIndex_ = (inServiceIndex_ + 1) % mdsEps_.size();
@@ -115,7 +117,8 @@ int Register::RegisterToMDS(MetaServerMetadata *metadata) {
     }
 
     if (retries <= 0) {
-        LOG(ERROR) << ops_.metaserverInternalIp << ":" << ops_.metaserverPort
+        LOG(ERROR) << ops_.metaserverInternalIp << ":"
+                   << ops_.metaserverInternalPort
                    << " Fail to register to MDS for " << ops_.registerRetries
                    << " times.";
         return -1;
@@ -125,7 +128,7 @@ int Register::RegisterToMDS(MetaServerMetadata *metadata) {
     metadata->set_id(resp.metaserverid());
     metadata->set_token(resp.token());
 
-    LOG(INFO) << ops_.metaserverInternalIp << ":" << ops_.metaserverPort
+    LOG(INFO) << ops_.metaserverInternalIp << ":" << ops_.metaserverInternalPort
               << " Successfully registered to MDS: " << mdsEps_[inServiceIndex_]
               << ", metaserver id: " << metadata->id() << ","
               << " token: " << metadata->token();

--- a/curvefs/src/metaserver/register.h
+++ b/curvefs/src/metaserver/register.h
@@ -36,7 +36,8 @@ struct RegisterOptions {
     std::string mdsListenAddr;
     std::string metaserverInternalIp;
     std::string metaserverExternalIp;
-    int metaserverPort;
+    uint32_t metaserverInternalPort;
+    uint32_t metaserverExternalPort;
     int registerRetries;
     int registerTimeout;
 };

--- a/curvefs/src/tools/curvefs_tool_define.cpp
+++ b/curvefs/src/tools/curvefs_tool_define.cpp
@@ -347,7 +347,8 @@ std::string MetaserverInfo2Str(
     std::stringstream ret;
     ret << "metaserverId:" << metaserver.metaserverid()
         << ", hostname:" << metaserver.hostname()
-        << ", hostIp:" << metaserver.hostip() << ", port:" << metaserver.port()
+        << ", InternalIp:" << metaserver.internalip()
+        << ", internalPort:" << metaserver.internalport()
         << ", externalIp:" << metaserver.externalip()
         << ", externalPort:" << metaserver.externalport() << ", onlineState:"
         << mds::topology::OnlineState_Name(metaserver.onlinestate())

--- a/curvefs/src/tools/list/curvefs_topology_tree_json.cpp
+++ b/curvefs/src/tools/list/curvefs_topology_tree_json.cpp
@@ -193,8 +193,8 @@ bool TopologyTreeJson::GetMetaserverTree(Json::Value* metaserver,
     auto metaserverinfo = metaserverId2MetaserverInfo_[metaserverId];
     (*metaserver)[mds::topology::kMetaserverId] = metaserverinfo.metaserverid();
     (*metaserver)[mds::topology::kHostName] = metaserverinfo.hostname();
-    (*metaserver)[mds::topology::kHostIp] = metaserverinfo.hostip();
-    (*metaserver)[mds::topology::kPort] = metaserverinfo.port();
+    (*metaserver)[mds::topology::kHostIp] = metaserverinfo.internalip();
+    (*metaserver)[mds::topology::kPort] = metaserverinfo.internalport();
     (*metaserver)[mds::topology::kExternalIp] = metaserverinfo.externalip();
     (*metaserver)[mds::topology::kExternalPort] = metaserverinfo.externalport();
     (*metaserver)[mds::topology::kOnlineState] = metaserverinfo.onlinestate();

--- a/curvefs/test/client/rpcclient/mds_client_test.cpp
+++ b/curvefs/test/client/rpcclient/mds_client_test.cpp
@@ -515,8 +515,8 @@ TEST_F(MdsClientImplTest, test_GetMetaServerInfo) {
     auto metaserverInfo = new curvefs::mds::topology::MetaServerInfo();
     metaserverInfo->set_metaserverid(1);
     metaserverInfo->set_hostname("hangzhou");
-    metaserverInfo->set_hostip("127.0.0.1");
-    metaserverInfo->set_port(5000);
+    metaserverInfo->set_internalip("127.0.0.1");
+    metaserverInfo->set_internalport(5000);
     metaserverInfo->set_externalip("127.0.0.1");
     metaserverInfo->set_externalport(5000);
     metaserverInfo->set_onlinestate(::curvefs::mds::topology::ONLINE);
@@ -559,8 +559,8 @@ TEST_F(MdsClientImplTest, GetMetaServerListInCopysets) {
     auto l2 = copysetInfo->add_cslocs();
     auto l3 = copysetInfo->add_cslocs();
     l1->set_metaserverid(1);
-    l1->set_hostip("127.0.0.1");
-    l1->set_port(9000);
+    l1->set_internalip("127.0.0.1");
+    l1->set_internalport(9000);
     l1->set_externalip("127.0.0.1");
     l2->CopyFrom(*l1);
     l2->set_metaserverid(2);

--- a/curvefs/test/mds/heartbeat/heartbeat_manager_test.cpp
+++ b/curvefs/test/mds/heartbeat/heartbeat_manager_test.cpp
@@ -150,7 +150,7 @@ TEST_F(TestHeartbeatManager, test_checkReuqest_abnormal) {
               response.statuscode());
 
     // 4. port not same
-    metaServer.SetInternalHostIp("192.168.10.1");
+    metaServer.SetInternalIp("192.168.10.1");
     metaServer.SetInternalPort(11000);
     EXPECT_CALL(*topology_, GetMetaServer(_, _))
         .WillOnce(DoAll(SetArgPointee<1>(metaServer), Return(true)));

--- a/curvefs/test/mds/topology/test_topology_helper.cpp
+++ b/curvefs/test/mds/topology/test_topology_helper.cpp
@@ -44,9 +44,9 @@ bool CompareZone(const Zone &lh, const Zone &rh) {
 bool CompareServer(const Server &lh, const Server &rh) {
     return lh.GetId() == rh.GetId() &&
            lh.GetHostName() == rh.GetHostName() &&
-           lh.GetInternalHostIp() == rh.GetInternalHostIp() &&
+           lh.GetInternalIp() == rh.GetInternalIp() &&
            lh.GetInternalPort() == rh.GetInternalPort() &&
-           lh.GetExternalHostIp() == rh.GetExternalHostIp() &&
+           lh.GetExternalIp() == rh.GetExternalIp() &&
            lh.GetExternalPort() == rh.GetExternalPort() &&
            lh.GetZoneId() == rh.GetZoneId() &&
            lh.GetPoolId() == rh.GetPoolId();
@@ -57,9 +57,9 @@ bool CompareMetaServer(const MetaServer &lh, const MetaServer &rh) {
            lh.GetHostName() == rh.GetHostName() &&
            lh.GetToken() == rh.GetToken() &&
            lh.GetServerId() == rh.GetServerId() &&
-           lh.GetInternalHostIp() == rh.GetInternalHostIp() &&
+           lh.GetInternalIp() == rh.GetInternalIp() &&
            lh.GetInternalPort() == rh.GetInternalPort() &&
-           lh.GetExternalHostIp() == rh.GetExternalHostIp() &&
+           lh.GetExternalIp() == rh.GetExternalIp() &&
            lh.GetExternalPort() == rh.GetExternalPort() &&
            lh.GetStartUpTime() == rh.GetStartUpTime() &&
            lh.GetMetaServerSpace().GetDiskCapacity() ==

--- a/curvefs/test/mds/topology/test_topology_manager.cpp
+++ b/curvefs/test/mds/topology/test_topology_manager.cpp
@@ -199,8 +199,8 @@ TEST_F(TestTopologyManager, test_RegistMetaServer_SuccessWithExIp) {
 
     MetaServerRegistRequest request;
     request.set_hostname("metaserver");
-    request.set_hostip("testInternalIp");
-    request.set_port(0);
+    request.set_internalip("testInternalIp");
+    request.set_internalport(0);
     request.set_externalip("externalIp1");
     request.set_externalport(0);
 
@@ -219,7 +219,7 @@ TEST_F(TestTopologyManager, test_RegistMetaServer_SuccessWithExIp) {
     ASSERT_EQ(token, response.token());
     MetaServer metaserver;
     ASSERT_TRUE(topology_->GetMetaServer(csId, &metaserver));
-    ASSERT_EQ("externalIp1", metaserver.GetExternalHostIp());
+    ASSERT_EQ("externalIp1", metaserver.GetExternalIp());
 }
 
 TEST_F(TestTopologyManager, test_RegistMetaServer_ExIpNotMatch) {
@@ -234,8 +234,8 @@ TEST_F(TestTopologyManager, test_RegistMetaServer_ExIpNotMatch) {
 
     MetaServerRegistRequest request;
     request.set_hostname("metaserver");
-    request.set_hostip("testInternalIp");
-    request.set_port(0);
+    request.set_internalip("testInternalIp");
+    request.set_internalport(0);
     request.set_externalip("externalIp2");
     request.set_externalport(0);
 
@@ -260,8 +260,8 @@ TEST_F(TestTopologyManager, test_RegistMetaServer_ServerNotFound) {
 
     MetaServerRegistRequest request;
     request.set_hostname("metaserver");
-    request.set_hostip("unExistIp");
-    request.set_port(100);
+    request.set_internalip("unExistIp");
+    request.set_internalport(100);
     request.set_externalip("externalIp1");
     request.set_externalport(0);
 
@@ -283,8 +283,8 @@ TEST_F(TestTopologyManager, test_RegistMetaServer_AllocateIdFail) {
 
     MetaServerRegistRequest request;
     request.set_hostname("metaserver");
-    request.set_hostip("testInternalIp");
-    request.set_port(100);
+    request.set_internalip("testInternalIp");
+    request.set_internalport(100);
     request.set_externalip("externalIp1");
     request.set_externalport(0);
 
@@ -310,8 +310,8 @@ TEST_F(TestTopologyManager, test_RegistMetaServer_AddMetaServerFail) {
 
     MetaServerRegistRequest request;
     request.set_hostname("metaserver");
-    request.set_hostip("testInternalIp");
-    request.set_port(100);
+    request.set_internalip("testInternalIp");
+    request.set_internalport(100);
     request.set_externalip("externalIp1");
     request.set_externalport(0);
 
@@ -354,15 +354,15 @@ TEST_F(TestTopologyManager, test_ListMetaServer_ByIdSuccess) {
 
     ASSERT_THAT(response.metaserverinfos(0).metaserverid(),
                 AnyOf(csId1, csId2));
-    ASSERT_EQ("ip1", response.metaserverinfos(0).hostip());
+    ASSERT_EQ("ip1", response.metaserverinfos(0).internalip());
     ASSERT_EQ("ip2", response.metaserverinfos(0).externalip());
-    ASSERT_THAT(response.metaserverinfos(0).port(), AnyOf(100, 200));
+    ASSERT_THAT(response.metaserverinfos(0).internalport(), AnyOf(100, 200));
 
     ASSERT_THAT(response.metaserverinfos(1).metaserverid(),
                 AnyOf(csId1, csId2));
-    ASSERT_EQ("ip1", response.metaserverinfos(1).hostip());
+    ASSERT_EQ("ip1", response.metaserverinfos(1).internalip());
     ASSERT_EQ("ip2", response.metaserverinfos(1).externalip());
-    ASSERT_THAT(response.metaserverinfos(1).port(), AnyOf(100, 200));
+    ASSERT_THAT(response.metaserverinfos(1).internalport(), AnyOf(100, 200));
 }
 
 TEST_F(TestTopologyManager, test_ListMetaServer_ServerNotFound) {
@@ -410,8 +410,8 @@ TEST_F(TestTopologyManager, test_GetMetaServer_ByIdSuccess) {
     ASSERT_TRUE(response.has_metaserverinfo());
 
     ASSERT_EQ(csId1, response.metaserverinfo().metaserverid());
-    ASSERT_EQ("ip1", response.metaserverinfo().hostip());
-    ASSERT_EQ(100, response.metaserverinfo().port());
+    ASSERT_EQ("ip1", response.metaserverinfo().internalip());
+    ASSERT_EQ(100, response.metaserverinfo().internalport());
     ASSERT_EQ("ip2", response.metaserverinfo().externalip());
     ASSERT_EQ(100, response.metaserverinfo().externalport());
 }
@@ -1324,9 +1324,9 @@ TEST_F(TestTopologyManager, test_GetMetaServerListInCopySets_success) {
 
     ASSERT_THAT(response.csinfo(0).cslocs(0).metaserverid(),
                 AnyOf(0x41, 0x42, 0x43));
-    ASSERT_EQ("ip1", response.csinfo(0).cslocs(0).hostip());
+    ASSERT_EQ("ip1", response.csinfo(0).cslocs(0).internalip());
     ASSERT_EQ("ip2", response.csinfo(0).cslocs(0).externalip());
-    ASSERT_EQ(0, response.csinfo(0).cslocs(0).port());
+    ASSERT_EQ(0, response.csinfo(0).cslocs(0).internalport());
 }
 
 TEST_F(TestTopologyManager, test_GetMetaServerListInCopySets_CopysetNotFound) {
@@ -2261,8 +2261,9 @@ TEST_F(TestTopologyManager, test_GetMetaServerListInCopysets_Success) {
 
     ASSERT_THAT(response.csinfo(0).cslocs(0).metaserverid(),
                 AnyOf(0x41, 0x42, 0x43));
-    ASSERT_EQ(response.csinfo(0).cslocs(0).hostip(), "127.0.0.1");
-    ASSERT_THAT(response.csinfo(0).cslocs(0).port(), AnyOf(7777, 7778, 7779));
+    ASSERT_EQ(response.csinfo(0).cslocs(0).internalip(), "127.0.0.1");
+    ASSERT_THAT(response.csinfo(0).cslocs(0).internalport(),
+        AnyOf(7777, 7778, 7779));
 }
 
 TEST_F(TestTopologyManager, test_GetMetaServerListInCopysets_Fail) {

--- a/curvefs/test/mds/topology/test_topology_service.cpp
+++ b/curvefs/test/mds/topology/test_topology_service.cpp
@@ -107,8 +107,8 @@ TEST_F(TestTopologyService, test_RegistMetaServer_success) {
     brpc::Controller cntl;
     MetaServerRegistRequest request;
     request.set_hostname("metaserver");
-    request.set_hostip("127.0.0.1");
-    request.set_port(8888);
+    request.set_internalip("127.0.0.1");
+    request.set_internalport(8888);
     request.set_externalip("127.0.0.1");
     request.set_externalport(9999);
 
@@ -134,8 +134,8 @@ TEST_F(TestTopologyService, test_RegistMetaServer_fail) {
     brpc::Controller cntl;
     MetaServerRegistRequest request;
     request.set_hostname("metaserver");
-    request.set_hostip("127.0.0.1");
-    request.set_port(8888);
+    request.set_internalip("127.0.0.1");
+    request.set_internalport(8888);
     request.set_externalip("127.0.0.1");
     request.set_externalport(9999);
 


### PR DESCRIPTION
…cluster communicate itself and some external services support for client and management tools.

If all the services start on the same ip+port will affect the communication within the cluster when the heavy stress from client.
Start the services needed by outsied on another ip+port as a external server.

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?
#973 
Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?): 

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
