### PR TITLE
metaserver: fix deadlock and remove related tasks when copyset stop

### DIFF
--- a/curvefs/src/metaserver/copyset/copyset_node.cpp
+++ b/curvefs/src/metaserver/copyset/copyset_node.cpp
@@ -108,7 +108,7 @@ bool CopysetNode::Init(const CopysetNodeOptions& options) {
     }
 
     // create metastore
-    metaStore_ = absl::make_unique<MetaStoreImpl>();
+    metaStore_ = absl::make_unique<MetaStoreImpl>(this);
 
     InitRaftNodeOptions();
 
@@ -148,6 +148,11 @@ void CopysetNode::Stop() {
         applyQueue_->Flush();
         applyQueue_->Stop();
         applyQueue_.reset();
+    }
+
+    if (metaStore_) {
+        metaStore_->Clear();
+        metaStore_.reset();
     }
 }
 

--- a/curvefs/src/metaserver/copyset/copyset_node_manager.h
+++ b/curvefs/src/metaserver/copyset/copyset_node_manager.h
@@ -63,8 +63,6 @@ class CopysetNodeManager {
      */
     int IsCopysetNodeExist(const CreateCopysetRequest::Copyset& copyset);
 
-    bool IsCopysetNodeExist(PoolId poolId, CopysetId copysetId) const;
-
     bool CreateCopysetNode(PoolId poolId, CopysetId copysetId,
                            const braft::Configuration& conf,
                            bool checkLoadFinish = true);

--- a/curvefs/src/metaserver/metastore.h
+++ b/curvefs/src/metaserver/metastore.h
@@ -33,6 +33,11 @@
 
 namespace curvefs {
 namespace metaserver {
+
+namespace copyset {
+class CopysetNode;
+}  // namespace copyset
+
 // dentry
 using curvefs::metaserver::GetDentryRequest;
 using curvefs::metaserver::GetDentryResponse;
@@ -122,7 +127,7 @@ class MetaStore {
 
 class MetaStoreImpl : public MetaStore {
  public:
-    MetaStoreImpl();
+    explicit MetaStoreImpl(copyset::CopysetNode* node);
 
     bool Load(const std::string& pathname) override;
     bool Save(const std::string& path,
@@ -202,6 +207,8 @@ class MetaStoreImpl : public MetaStore {
     RWLock rwLock_;  // protect partitionMap_
     std::map<uint32_t, std::shared_ptr<Partition>> partitionMap_;
     std::list<uint32_t> partitionIds_;
+
+    copyset::CopysetNode* copysetNode_;
 };
 }  // namespace metaserver
 }  // namespace curvefs

--- a/curvefs/test/metaserver/copyset/copyset_node_snapshot_test.cpp
+++ b/curvefs/test/metaserver/copyset/copyset_node_snapshot_test.cpp
@@ -345,6 +345,7 @@ TEST_F(CopysetNodeRaftSnapshotTest,
     node->ListPeers(&peers);
     EXPECT_EQ(3, peers.size());
     EXPECT_EQ(epochBefore, node->GetConfEpoch());
+    node->SetMetaStore(nullptr);
 }
 
 TEST_F(CopysetNodeRaftSnapshotTest, SnapshotLoadTest_MetaStoreLoadFailed) {
@@ -372,6 +373,7 @@ TEST_F(CopysetNodeRaftSnapshotTest, SnapshotLoadTest_MetaStoreLoadFailed) {
         .Times(0);
 
     EXPECT_NE(0, node->on_snapshot_load(&reader));
+    node->SetMetaStore(nullptr);
 }
 
 }  // namespace copyset

--- a/curvefs/test/metaserver/copyset/meta_operator_test.cpp
+++ b/curvefs/test/metaserver/copyset/meta_operator_test.cpp
@@ -154,6 +154,9 @@ TEST_F(MetaOperatorTest, OnApplyErrorTest) {
     mock::MockMetaStore* mockMetaStore = new mock::MockMetaStore();
     node.SetMetaStore(mockMetaStore);
 
+    ON_CALL(*mockMetaStore, Clear())
+        .WillByDefault(Return(true));
+
     brpc::Controller cntl;
 
 #define OPERATOR_ON_APPLY_TEST(TYPE)                                           \
@@ -256,6 +259,9 @@ TEST_F(MetaOperatorTest, OnApplyFromLogErrorTest) {
     CopysetNode node(poolId, copysetId, conf, &mockNodeManager_);
     mock::MockMetaStore* mockMetaStore = new mock::MockMetaStore();
     node.SetMetaStore(mockMetaStore);
+
+    ON_CALL(*mockMetaStore, Clear())
+        .WillByDefault(Return(true));
 
     brpc::Controller cntl;
 
@@ -378,6 +384,8 @@ TEST_F(MetaOperatorTest, PropostTest_RequestCanBypassProcess) {
     auto* mockRaftNode = new MockRaftNode();
     node.SetRaftNode(mockRaftNode);
 
+    ON_CALL(*mockMetaStore, Clear())
+        .WillByDefault(Return(true));
     EXPECT_CALL(*mockRaftNode, apply(_))
         .Times(0);
     EXPECT_CALL(*mockRaftNode, shutdown(_))

--- a/curvefs/test/metaserver/metastore_test.cpp
+++ b/curvefs/test/metaserver/metastore_test.cpp
@@ -135,7 +135,7 @@ class MetastoreTest : public ::testing::Test {
 };
 
 TEST_F(MetastoreTest, partition) {
-    MetaStoreImpl metastore;
+    MetaStoreImpl metastore(nullptr);
     CreatePartitionRequest createPartitionRequest;
     CreatePartitionResponse createPartitionResponse;
     PartitionInfo partitionInfo;
@@ -230,7 +230,7 @@ TEST_F(MetastoreTest, partition) {
 }
 
 TEST_F(MetastoreTest, test_inode) {
-    MetaStoreImpl metastore;
+    MetaStoreImpl metastore(nullptr);
 
     // create partition1 partition2
     CreatePartitionRequest createPartitionRequest;
@@ -464,7 +464,7 @@ TEST_F(MetastoreTest, test_inode) {
 }
 
 TEST_F(MetastoreTest, test_dentry) {
-    MetaStoreImpl metastore;
+    MetaStoreImpl metastore(nullptr);
 
     // create partition1 partition2
     CreatePartitionRequest createPartitionRequest;
@@ -689,7 +689,7 @@ TEST_F(MetastoreTest, test_dentry) {
 }
 
 TEST_F(MetastoreTest, persist_success) {
-    MetaStoreImpl metastore;
+    MetaStoreImpl metastore(nullptr);
     uint32_t partitionId = 4;
     uint32_t partitionId2 = 2;
     // create partition1
@@ -803,7 +803,7 @@ TEST_F(MetastoreTest, persist_success) {
     ASSERT_TRUE(done.IsSuccess());
 
     // load MetaStoreImpl to new meta
-    MetaStoreImpl metastoreNew;
+    MetaStoreImpl metastoreNew(nullptr);
     LOG(INFO) << "MetastoreTest test Load";
     ASSERT_TRUE(metastoreNew.Load("./metastore_test"));
 
@@ -827,7 +827,7 @@ TEST_F(MetastoreTest, persist_success) {
 }
 
 TEST_F(MetastoreTest, persist_deleting_partition_success) {
-    MetaStoreImpl metastore;
+    MetaStoreImpl metastore(nullptr);
     uint32_t partitionId = 4;
     uint32_t partitionId2 = 2;
     // create partition1
@@ -955,7 +955,7 @@ TEST_F(MetastoreTest, persist_deleting_partition_success) {
     ASSERT_TRUE(done.IsSuccess());
 
     // load MetaStoreImpl to new meta
-    MetaStoreImpl metastoreNew;
+    MetaStoreImpl metastoreNew(nullptr);
     LOG(INFO) << "MetastoreTest test Load";
     ASSERT_TRUE(metastoreNew.Load("./metastore_test"));
 
@@ -979,7 +979,7 @@ TEST_F(MetastoreTest, persist_deleting_partition_success) {
 }
 
 TEST_F(MetastoreTest, persist_partition_fail) {
-    MetaStoreImpl metastore;
+    MetaStoreImpl metastore(nullptr);
     uint32_t partitionId = 4;
     // create partition1
     CreatePartitionRequest createPartitionRequest;
@@ -1003,7 +1003,7 @@ TEST_F(MetastoreTest, persist_partition_fail) {
 }
 
 TEST_F(MetastoreTest, persist_dentry_fail) {
-    MetaStoreImpl metastore;
+    MetaStoreImpl metastore(nullptr);
     uint32_t partitionId = 4;
 
     // create partition1

--- a/curvefs/test/tools/curvefs_umount_fs_tool_test.cpp
+++ b/curvefs/test/tools/curvefs_umount_fs_tool_test.cpp
@@ -62,7 +62,7 @@ class UmountfsToolTest : public testing::Test {
     }
 
  protected:
-    std::string addr_ = "127.0.0.1:6791";
+    std::string addr_ = "127.0.0.1:6701";
     brpc::Server server_;
     MockMdsService mockMdsService_;
     UmountFsTool ut_;


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: close #1025 #1056

Problem Summary:

after restarting metaserver, all previous copysets will be created and recover from raft snapshot, during recovery, it will also restart partition clean tasks, and each task needs corresponding copyset node.
    
deadlock happens because creating and recovering a copyset is protected by CopysetNodeManager's lock, but partition clean tasks also acquire this lock to get corresponding copyset node.
    
another problem is when copyset needs purge, we forget to stop related tasks like partition cleaning task, s3 compact tasks. so, when these tasks start to execution, metaserver will end up with segment fault.

### What is changed and how it works?

What's Changed:

this patch passes CopysetNode when creating MetaStore, so partition clean task no need to acquire the lock, and, also call `MetaStore::Clear` when copyset stop.

How it Works:

Side effects(Breaking backward compatibility? Performance regression?): 

### Check List

- [x] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license
