### PR TITLE
curvefs/metaserver: fix s3adapter get/release bug

### DIFF
--- a/curvefs/src/metaserver/s3compact_manager.cpp
+++ b/curvefs/src/metaserver/s3compact_manager.cpp
@@ -82,6 +82,7 @@ std::pair<uint64_t, S3Adapter*> S3AdapterManager::GetS3Adapter() {
 
 void S3AdapterManager::ReleaseS3Adapter(uint64_t index) {
     std::lock_guard<std::mutex> lock(mtx_);
+    if (!inited_) return;
     assert(index < used_.size());
     assert(used_[index] == true);
     used_[index] = false;


### PR DESCRIPTION
we need release s3adapter after get one(SetupS3Adapter) in a compactchunks

we will only get/release in compactchunks function