### PR TITLE
curvefs update copyset condidate

### DIFF
--- a/curvefs/src/mds/heartbeat/copyset_conf_generator.cpp
+++ b/curvefs/src/mds/heartbeat/copyset_conf_generator.cpp
@@ -163,9 +163,9 @@ bool CopysetConfGenerator::FollowerGenCopysetConf(
 }
 
 std::string CopysetConfGenerator::BuildPeerByMetaserverId(
-    MetaServerIdType csId) {
+    MetaServerIdType msId) {
     MetaServer metaServer;
-    if (!topo_->GetMetaServer(csId, &metaServer)) {
+    if (!topo_->GetMetaServer(msId, &metaServer)) {
         return "";
     }
 

--- a/curvefs/src/mds/heartbeat/heartbeat_manager.cpp
+++ b/curvefs/src/mds/heartbeat/heartbeat_manager.cpp
@@ -240,6 +240,19 @@ bool HeartbeatManager::TransformHeartbeatCopySetInfoToTopologyOne(
     // set leader
     topoCopysetInfo.SetLeader(leader);
 
+    // set info of configuration changes
+    if (info.configchangeinfo().IsInitialized()) {
+        MetaServerIdType res =
+            GetMetaserverIdByPeerStr(info.configchangeinfo().peer().address());
+        if (res == UNINITIALIZE_ID) {
+            LOG(ERROR) << "heartbeat manager can not get metaInfo"
+                       "according to report candidate ipPort: "
+                       << info.configchangeinfo().peer().address();
+            return false;
+        }
+        topoCopysetInfo.SetCandidate(res);
+    }
+
     *out = topoCopysetInfo;
     return true;
 }

--- a/curvefs/src/mds/topology/topology.cpp
+++ b/curvefs/src/mds/topology/topology.cpp
@@ -1028,6 +1028,11 @@ TopoStatusCode TopologyImpl::UpdateCopySetTopo(const CopySetInfo &data) {
         it->second.SetPartitionNum(data.GetPartitionNum());
         it->second.SetCopySetMembers(data.GetCopySetMembers());
         it->second.SetDirtyFlag(true);
+        if (data.HasCandidate()) {
+            it->second.SetCandidate(data.GetCandidate());
+        } else {
+            it->second.ClearCandidate();
+        }
         return TopoStatusCode::TOPO_OK;
     } else {
         LOG(WARNING) << "UpdateCopySetTopo can not find copyset, "

--- a/curvefs/test/mds/heartbeat/heartbeat_manager_test.cpp
+++ b/curvefs/test/mds/heartbeat/heartbeat_manager_test.cpp
@@ -36,6 +36,7 @@ using ::curvefs::mds::topology::MockStorage;
 using ::curvefs::mds::topology::MockTokenGenerator;
 using ::curvefs::mds::topology::MockTopology;
 using ::curvefs::mds::topology::TopoStatusCode;
+using ::curve::mds::heartbeat::ConfigChangeType;
 using ::testing::_;
 using ::testing::DoAll;
 using ::testing::Return;
@@ -325,6 +326,7 @@ TEST_F(TestHeartbeatManager, test_heartbeatCopySetInfo_to_topologyOne) {
     info.set_poolid(1);
     info.set_copysetid(1);
     info.set_epoch(10);
+    auto candidate = new ConfigChangeInfo;
     for (int i = 1; i <= 4; i++) {
         std::string ip = "192.168.10." + std::to_string(i) + ":9000:0";
         if (i == 1) {
@@ -336,12 +338,16 @@ TEST_F(TestHeartbeatManager, test_heartbeatCopySetInfo_to_topologyOne) {
         if (i == 4) {
             auto replica = new ::curvefs::common::Peer();
             replica->set_address(ip);
+            candidate->set_allocated_peer(replica);
+            candidate->set_finished(true);
+            candidate->set_type(ConfigChangeType::ADD_PEER);
             continue;
         }
         auto replica = info.add_peers();
         replica->set_address(ip);
     }
     auto addInfo = request.add_copysetinfos();
+    info.set_allocated_configchangeinfo(candidate);
     *addInfo = info;
     EXPECT_CALL(*topology_, GetMetaServer(1, _))
         .WillOnce(DoAll(SetArgPointee<1>(metaServer1), Return(true)))
@@ -349,7 +355,9 @@ TEST_F(TestHeartbeatManager, test_heartbeatCopySetInfo_to_topologyOne) {
     EXPECT_CALL(*topology_, GetMetaServer(_, _, _))
         .WillOnce(DoAll(SetArgPointee<2>(metaServer1), Return(true)))
         .WillOnce(DoAll(SetArgPointee<2>(metaServer2), Return(true)))
+        .WillOnce(DoAll(SetArgPointee<2>(metaServer3), Return(true)))
         .WillOnce(DoAll(SetArgPointee<2>(metaServer3), Return(true)));
+
     EXPECT_CALL(*topology_, GetCopySet(_, _)).WillOnce(Return(false))
         .WillOnce(Return(false));
 
@@ -501,7 +509,8 @@ TEST_F(TestHeartbeatManager, test_reqEpoch_LargerThan_mdsRecord_UpdateFail) {
     ASSERT_EQ(HeartbeatStatusCode::hbOK, response.statuscode());
 }
 
-TEST_F(TestHeartbeatManager, test_reqEpoch_EqualTo_mdsRecord) {
+TEST_F(TestHeartbeatManager,
+        test_reqEpoch_EqualTo_mdsRecord_copysetmember_not_same) {
     auto request = GetMetaServerHeartbeatRequestForTest();
     MetaServerHeartbeatResponse response;
 
@@ -546,6 +555,244 @@ TEST_F(TestHeartbeatManager, test_reqEpoch_EqualTo_mdsRecord) {
 
     heartbeatManager_->MetaServerHeartbeat(request, &response);
     ASSERT_EQ(HeartbeatStatusCode::hbOK, response.statuscode());
+    ASSERT_EQ(0, response.needupdatecopysets_size());
+}
+
+TEST_F(TestHeartbeatManager, test_reqEpoch_EqualTo_mdsRecord_no_candidate) {
+    auto request = GetMetaServerHeartbeatRequestForTest();
+    MetaServerHeartbeatResponse response;
+
+    request.clear_copysetinfos();
+    ::curvefs::mds::heartbeat::CopySetInfo info;
+    info.set_poolid(1);
+    info.set_copysetid(1);
+    info.set_epoch(2);
+    for (int i = 1; i <= 3; i++) {
+        std::string ip = "192.168.10." + std::to_string(i) + ":9000:0";
+        auto replica = info.add_peers();
+        replica->set_address(ip);
+        if (i == 1) {
+            auto replica = new ::curvefs::common::Peer();
+            replica->set_address(ip);
+            info.set_allocated_leaderpeer(replica);
+        }
+    }
+    auto addInfos = request.add_copysetinfos();
+    *addInfos = info;
+    ::curvefs::mds::topology::MetaServer metaServer1(
+        1, "hostname", "hello", 1, "192.168.10.1", 9000, "", 9000);
+    EXPECT_CALL(*topology_, GetMetaServer(1, _))
+        .WillOnce(DoAll(SetArgPointee<1>(metaServer1), Return(true)))
+        .WillOnce(DoAll(SetArgPointee<1>(metaServer1), Return(true)));
+    ::curvefs::mds::topology::MetaServer leaderMetaServer(
+        2, "hostname", "hello", 1, "192.168.10.2", 9000, "", 9000);
+    EXPECT_CALL(*topology_, GetMetaServer("192.168.10.2", _, _))
+        .WillOnce(DoAll(SetArgPointee<2>(leaderMetaServer), Return(true)));
+    EXPECT_CALL(*topology_, GetMetaServer("192.168.10.1", _, _))
+        .WillOnce(DoAll(SetArgPointee<2>(metaServer1), Return(true)));
+    ::curvefs::mds::topology::MetaServer metaServer3(
+        3, "hostname", "hello", 1, "192.168.10.3", 9000, "", 9000);
+    EXPECT_CALL(*topology_, GetMetaServer("192.168.10.3", _, _))
+        .WillOnce(DoAll(SetArgPointee<2>(metaServer3), Return(true)));
+    ::curvefs::mds::topology::CopySetInfo recordCopySetInfo(1, 1);
+    recordCopySetInfo.SetEpoch(2);
+    recordCopySetInfo.SetLeader(2);
+    std::set<MetaServerIdType> peers;
+    for (int i = 1; i <= 3; i++) {
+        peers.emplace(i);
+    }
+    recordCopySetInfo.SetCopySetMembers(peers);
+
+    EXPECT_CALL(*topology_, GetCopySet(_, _))
+        .WillOnce(DoAll(SetArgPointee<1>(recordCopySetInfo), Return(true)))
+        .WillOnce(DoAll(SetArgPointee<1>(recordCopySetInfo), Return(true)));
+
+    heartbeatManager_->MetaServerHeartbeat(request, &response);
+    ASSERT_EQ(HeartbeatStatusCode::hbOK, response.statuscode());
+    ASSERT_EQ(0, response.needupdatecopysets_size());
+}
+
+TEST_F(TestHeartbeatManager, test_reqEpoch_EqualTo_mdsRecord_topo_candidate) {
+    auto request = GetMetaServerHeartbeatRequestForTest();
+    MetaServerHeartbeatResponse response;
+
+    request.clear_copysetinfos();
+    ::curvefs::mds::heartbeat::CopySetInfo info;
+    info.set_poolid(1);
+    info.set_copysetid(1);
+    info.set_epoch(2);
+    for (int i = 1; i <= 3; i++) {
+        std::string ip = "192.168.10." + std::to_string(i) + ":9000:0";
+        auto replica = info.add_peers();
+        replica->set_address(ip);
+        if (i == 1) {
+            auto replica = new ::curvefs::common::Peer();
+            replica->set_address(ip);
+            info.set_allocated_leaderpeer(replica);
+        }
+    }
+    auto addInfos = request.add_copysetinfos();
+    *addInfos = info;
+    ::curvefs::mds::topology::MetaServer metaServer1(
+        1, "hostname", "hello", 1, "192.168.10.1", 9000, "", 9000);
+    EXPECT_CALL(*topology_, GetMetaServer(1, _))
+        .WillOnce(DoAll(SetArgPointee<1>(metaServer1), Return(true)))
+        .WillOnce(DoAll(SetArgPointee<1>(metaServer1), Return(true)));
+    ::curvefs::mds::topology::MetaServer leaderMetaServer(
+        2, "hostname", "hello", 1, "192.168.10.2", 9000, "", 9000);
+    EXPECT_CALL(*topology_, GetMetaServer("192.168.10.2", _, _))
+        .WillOnce(DoAll(SetArgPointee<2>(leaderMetaServer), Return(true)));
+    EXPECT_CALL(*topology_, GetMetaServer("192.168.10.1", _, _))
+        .WillOnce(DoAll(SetArgPointee<2>(metaServer1), Return(true)));
+    ::curvefs::mds::topology::MetaServer metaServer3(
+        3, "hostname", "hello", 1, "192.168.10.3", 9000, "", 9000);
+    EXPECT_CALL(*topology_, GetMetaServer("192.168.10.3", _, _))
+        .WillOnce(DoAll(SetArgPointee<2>(metaServer3), Return(true)));
+    ::curvefs::mds::topology::CopySetInfo recordCopySetInfo(1, 1);
+    recordCopySetInfo.SetEpoch(2);
+    recordCopySetInfo.SetLeader(2);
+    std::set<MetaServerIdType> peers;
+    for (int i = 1; i <= 3; i++) {
+        peers.emplace(i);
+    }
+    recordCopySetInfo.SetCopySetMembers(peers);
+    recordCopySetInfo.SetCandidate(4);
+    EXPECT_CALL(*topology_, GetCopySet(_, _))
+        .WillOnce(DoAll(SetArgPointee<1>(recordCopySetInfo), Return(true)))
+        .WillOnce(DoAll(SetArgPointee<1>(recordCopySetInfo), Return(true)));
+
+    heartbeatManager_->MetaServerHeartbeat(request, &response);
+    ASSERT_EQ(HeartbeatStatusCode::hbOK, response.statuscode());
+    ASSERT_EQ(0, response.needupdatecopysets_size());
+}
+
+TEST_F(TestHeartbeatManager, test_reqEpoch_EqualTo_mdsRecord_report_candidate) {
+    auto request = GetMetaServerHeartbeatRequestForTest();
+    MetaServerHeartbeatResponse response;
+
+    request.clear_copysetinfos();
+    ::curvefs::mds::heartbeat::CopySetInfo info;
+    info.set_poolid(1);
+    info.set_copysetid(1);
+    info.set_epoch(2);
+    auto candidate = new ConfigChangeInfo;
+    for (int i = 1; i <= 3; i++) {
+        std::string ip = "192.168.10." + std::to_string(i) + ":9000:0";
+        auto replica = info.add_peers();
+        replica->set_address(ip);
+        if (i == 1) {
+            auto replica = new ::curvefs::common::Peer();
+            replica->set_address(ip);
+            info.set_allocated_leaderpeer(replica);
+        }
+
+        if (i == 4) {
+            auto replica = new ::curvefs::common::Peer();
+            replica->set_address(ip);
+            candidate->set_allocated_peer(replica);
+            candidate->set_finished(false);
+            candidate->set_type(ConfigChangeType::ADD_PEER);
+            continue;
+        }
+    }
+    info.set_allocated_configchangeinfo(candidate);
+    auto addInfos = request.add_copysetinfos();
+    *addInfos = info;
+    ::curvefs::mds::topology::MetaServer metaServer1(
+        1, "hostname", "hello", 1, "192.168.10.1", 9000, "", 9000);
+    EXPECT_CALL(*topology_, GetMetaServer(1, _))
+        .WillOnce(DoAll(SetArgPointee<1>(metaServer1), Return(true)))
+        .WillOnce(DoAll(SetArgPointee<1>(metaServer1), Return(true)));
+    ::curvefs::mds::topology::MetaServer leaderMetaServer(
+        2, "hostname", "hello", 1, "192.168.10.2", 9000, "", 9000);
+    EXPECT_CALL(*topology_, GetMetaServer("192.168.10.2", _, _))
+        .WillOnce(DoAll(SetArgPointee<2>(leaderMetaServer), Return(true)));
+    EXPECT_CALL(*topology_, GetMetaServer("192.168.10.1", _, _))
+        .WillOnce(DoAll(SetArgPointee<2>(metaServer1), Return(true)));
+    ::curvefs::mds::topology::MetaServer metaServer3(
+        3, "hostname", "hello", 1, "192.168.10.3", 9000, "", 9000);
+    EXPECT_CALL(*topology_, GetMetaServer("192.168.10.3", _, _))
+        .WillOnce(DoAll(SetArgPointee<2>(metaServer3), Return(true)));
+    ::curvefs::mds::topology::CopySetInfo recordCopySetInfo(1, 1);
+    recordCopySetInfo.SetEpoch(2);
+    recordCopySetInfo.SetLeader(2);
+    std::set<MetaServerIdType> peers;
+    for (int i = 1; i <= 3; i++) {
+        peers.emplace(i);
+    }
+    recordCopySetInfo.SetCopySetMembers(peers);
+    EXPECT_CALL(*topology_, GetCopySet(_, _))
+        .WillOnce(DoAll(SetArgPointee<1>(recordCopySetInfo), Return(true)))
+        .WillOnce(DoAll(SetArgPointee<1>(recordCopySetInfo), Return(true)));
+
+    heartbeatManager_->MetaServerHeartbeat(request, &response);
+    ASSERT_EQ(HeartbeatStatusCode::hbOK, response.statuscode());
+    ASSERT_EQ(0, response.needupdatecopysets_size());
+}
+
+TEST_F(TestHeartbeatManager, test_reqEpoch_EqualTo_mdsRecord_has_candidate) {
+    auto request = GetMetaServerHeartbeatRequestForTest();
+    MetaServerHeartbeatResponse response;
+
+    request.clear_copysetinfos();
+    ::curvefs::mds::heartbeat::CopySetInfo info;
+    info.set_poolid(1);
+    info.set_copysetid(1);
+    info.set_epoch(2);
+    auto candidate = new ConfigChangeInfo;
+    for (int i = 1; i <= 3; i++) {
+        std::string ip = "192.168.10." + std::to_string(i) + ":9000:0";
+        auto replica = info.add_peers();
+        replica->set_address(ip);
+        if (i == 1) {
+            auto replica = new ::curvefs::common::Peer();
+            replica->set_address(ip);
+            info.set_allocated_leaderpeer(replica);
+        }
+
+        if (i == 4) {
+            auto replica = new ::curvefs::common::Peer();
+            replica->set_address(ip);
+            candidate->set_allocated_peer(replica);
+            candidate->set_finished(false);
+            candidate->set_type(ConfigChangeType::ADD_PEER);
+            continue;
+        }
+    }
+    info.set_allocated_configchangeinfo(candidate);
+    auto addInfos = request.add_copysetinfos();
+    *addInfos = info;
+    ::curvefs::mds::topology::MetaServer metaServer1(
+        1, "hostname", "hello", 1, "192.168.10.1", 9000, "", 9000);
+    EXPECT_CALL(*topology_, GetMetaServer(1, _))
+        .WillOnce(DoAll(SetArgPointee<1>(metaServer1), Return(true)))
+        .WillOnce(DoAll(SetArgPointee<1>(metaServer1), Return(true)));
+    ::curvefs::mds::topology::MetaServer leaderMetaServer(
+        2, "hostname", "hello", 1, "192.168.10.2", 9000, "", 9000);
+    EXPECT_CALL(*topology_, GetMetaServer("192.168.10.2", _, _))
+        .WillOnce(DoAll(SetArgPointee<2>(leaderMetaServer), Return(true)));
+    EXPECT_CALL(*topology_, GetMetaServer("192.168.10.1", _, _))
+        .WillOnce(DoAll(SetArgPointee<2>(metaServer1), Return(true)));
+    ::curvefs::mds::topology::MetaServer metaServer3(
+        3, "hostname", "hello", 1, "192.168.10.3", 9000, "", 9000);
+    EXPECT_CALL(*topology_, GetMetaServer("192.168.10.3", _, _))
+        .WillOnce(DoAll(SetArgPointee<2>(metaServer3), Return(true)));
+    ::curvefs::mds::topology::CopySetInfo recordCopySetInfo(1, 1);
+    recordCopySetInfo.SetEpoch(2);
+    recordCopySetInfo.SetLeader(2);
+    std::set<MetaServerIdType> peers;
+    for (int i = 1; i <= 3; i++) {
+        peers.emplace(i);
+    }
+    recordCopySetInfo.SetCopySetMembers(peers);
+    recordCopySetInfo.SetCandidate(4);
+    EXPECT_CALL(*topology_, GetCopySet(_, _))
+        .WillOnce(DoAll(SetArgPointee<1>(recordCopySetInfo), Return(true)))
+        .WillOnce(DoAll(SetArgPointee<1>(recordCopySetInfo), Return(true)));
+
+    heartbeatManager_->MetaServerHeartbeat(request, &response);
+    ASSERT_EQ(HeartbeatStatusCode::hbOK, response.statuscode());
+    ASSERT_EQ(0, response.needupdatecopysets_size());
 }
 
 TEST_F(TestHeartbeatManager, test_reqEpoch_SmallThan_mdsRecord) {

--- a/curvefs/test/mds/topology/test_topology.cpp
+++ b/curvefs/test/mds/topology/test_topology.cpp
@@ -1932,12 +1932,13 @@ TEST_F(TestTopology, UpdateCopySetTopo_success) {
     PrepareAddCopySet(copysetId, poolId, replicas);
 
     std::set<MetaServerIdType> replicas2;
-    replicas.insert(0x41);
-    replicas.insert(0x42);
-    replicas.insert(0x44);
+    replicas2.insert(0x41);
+    replicas2.insert(0x42);
+    replicas2.insert(0x44);
 
     CopySetInfo csInfo(poolId, copysetId);
     csInfo.SetCopySetMembers(replicas2);
+    csInfo.SetCandidate(0x45);
 
     int ret = topology_->UpdateCopySetTopo(csInfo);
 


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #1061

Problem Summary: 

The tool shows that some copysets were not migrated successfully. Because the copyset did not update its candidate from heartbeat. So it will fail when change peer copyset.

### What is changed and how it works?

What's Changed:  Update copyset cadidate when heartbeat

Side effects(Breaking backward compatibility? Performance regression?):  no

### Check List

- [x] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license
