### PR TITLE
curvefs: a curve filesystem can be mounted by multi fuse clients

### DIFF
--- a/curvefs/conf/client.conf
+++ b/curvefs/conf/client.conf
@@ -71,6 +71,9 @@ fuseClient.iCacheLruSize=65536
 fuseClient.dCacheLruSize=65536
 fuseClient.enableICacheMetrics=true
 fuseClient.enableDCacheMetrics=true
+fuseClient.cto=true
+# FuseOpFlush retry intervel, default is 2s
+fuseClient.flushRetryIntervalMs=2000
 
 #### volume
 volume.bigFileSize=1048576

--- a/curvefs/proto/metaserver.proto
+++ b/curvefs/proto/metaserver.proto
@@ -195,7 +195,7 @@ message Inode {
     optional VolumeExtentList volumeExtentList = 17;  // TYPE_FILE only
     map<uint64, S3ChunkInfoList> s3ChunkInfoMap = 18; // TYPE_S3 only, first is chunk index
     optional uint32 dtime = 19;
-    optional bool openflag = 20;
+    optional uint32 openmpcount = 20; // openmpcount mount points had the file open
 }
 
 message GetInodeResponse {
@@ -239,6 +239,12 @@ message CreateRootInodeResponse {
     optional uint64 appliedIndex = 2;
 }
 
+enum InodeOpenStatusChange {
+    OPEN = 1;
+    CLOSE = 2;
+    NOCHANGE = 3;
+}
+
 message UpdateInodeRequest {
     required uint32 poolId = 1;
     required uint32 copysetId = 2;
@@ -258,7 +264,7 @@ message UpdateInodeRequest {
     optional VolumeExtentList volumeExtentList = 16;
     map<uint64, S3ChunkInfoList> s3ChunkInfoMap = 17;
     optional uint32 nlink = 18;
-    optional bool openflag = 19;
+    optional InodeOpenStatusChange inodeOpenstatusChange = 19;
 }
 
 message UpdateInodeResponse {

--- a/curvefs/src/client/common/config.cpp
+++ b/curvefs/src/client/common/config.cpp
@@ -38,6 +38,8 @@ DECLARE_int32(health_check_interval);
 namespace curvefs {
 namespace client {
 namespace common {
+DEFINE_bool(enableCto, true, "acheieve cto consistency");
+
 void InitMdsOption(Configuration *conf, MdsOption *mdsOpt) {
     conf->GetValueFatalIfFail("mdsOpt.mdsMaxRetryMS", &mdsOpt->mdsMaxRetryMS);
     conf->GetValueFatalIfFail("mdsOpt.rpcRetryOpt.maxRPCTimeoutMS",
@@ -210,7 +212,9 @@ void InitFuseClientOption(Configuration *conf, FuseClientOption *clientOption) {
                               &clientOption->enableICacheMetrics);
     conf->GetValueFatalIfFail("fuseClient.enableDCacheMetrics",
                               &clientOption->enableDCacheMetrics);
-
+    conf->GetValueFatalIfFail("fuseClient.cto", &FLAGS_enableCto);
+    conf->GetValueFatalIfFail("fuseClient.flushRetryIntervalMs",
+                              &clientOption->flushRetryIntervalMS);
     conf->GetValueFatalIfFail("client.dummyserver.startport",
                               &clientOption->dummyServerStartPort);
 

--- a/curvefs/src/client/common/config.h
+++ b/curvefs/src/client/common/config.h
@@ -142,6 +142,7 @@ struct FuseClientOption {
     ExtentManagerOption extentManagerOpt;
     VolumeOption volumeOpt;
 
+    uint32_t flushRetryIntervalMS;
     double attrTimeOut;
     double entryTimeOut;
     uint32_t listDentryLimit;

--- a/curvefs/src/client/fuse_client.cpp
+++ b/curvefs/src/client/fuse_client.cpp
@@ -52,6 +52,7 @@ using ::curvefs::mds::FSStatusCode_Name;
         }                                                                      \
     } while (0)
 
+
 namespace curvefs {
 namespace client {
 
@@ -819,8 +820,9 @@ CURVEFS_ERROR FuseClient::FuseOpReadLink(fuse_req_t req, fuse_ino_t ino,
 CURVEFS_ERROR FuseClient::FuseOpRelease(fuse_req_t req, fuse_ino_t ino,
                                         struct fuse_file_info *fi) {
     LOG(INFO) << "FuseOpRelease, ino: " << ino;
+    CURVEFS_ERROR ret = CURVEFS_ERROR::OK;
     std::shared_ptr<InodeWrapper> inodeWrapper;
-    CURVEFS_ERROR ret = inodeManager_->GetInode(ino, inodeWrapper);
+    ret = inodeManager_->GetInode(ino, inodeWrapper);
     if (ret != CURVEFS_ERROR::OK) {
         LOG(ERROR) << "inodeManager get inode fail, ret = " << ret
                    << ", inodeid = " << ino;
@@ -830,6 +832,11 @@ CURVEFS_ERROR FuseClient::FuseOpRelease(fuse_req_t req, fuse_ino_t ino,
     ::curve::common::UniqueLock lgGuard = inodeWrapper->GetUniqueLock();
 
     ret = inodeWrapper->Release();
+    if (ret != CURVEFS_ERROR::OK) {
+        LOG(ERROR) << "inodeManager release inode fail, ret = " << ret
+                   << ", inodeid = " << ino;
+        return ret;
+    }
     return ret;
 }
 

--- a/curvefs/src/client/fuse_client.h
+++ b/curvefs/src/client/fuse_client.h
@@ -187,6 +187,9 @@ class FuseClient {
                                       int datasync,
                                       struct fuse_file_info* fi) = 0;
 
+    virtual CURVEFS_ERROR FuseOpFlush(fuse_req_t req, fuse_ino_t ino,
+                                      struct fuse_file_info *fi) = 0;
+
     void SetFsInfo(std::shared_ptr<FsInfo> fsInfo) {
         fsInfo_ = fsInfo;
         init_ = true;

--- a/curvefs/src/client/fuse_s3_client.h
+++ b/curvefs/src/client/fuse_s3_client.h
@@ -74,6 +74,12 @@ class FuseS3Client : public FuseClient {
     CURVEFS_ERROR FuseOpFsync(fuse_req_t req, fuse_ino_t ino, int datasync,
            struct fuse_file_info *fi) override;
 
+    CURVEFS_ERROR FuseOpFlush(fuse_req_t req, fuse_ino_t ino,
+                              struct fuse_file_info *fi) override;
+
+    CURVEFS_ERROR FuseOpRelease(fuse_req_t req, fuse_ino_t ino,
+                                struct fuse_file_info *fi) override;
+
  private:
     CURVEFS_ERROR Truncate(Inode *inode, uint64_t length) override;
 

--- a/curvefs/src/client/fuse_volume_client.cpp
+++ b/curvefs/src/client/fuse_volume_client.cpp
@@ -319,6 +319,12 @@ CURVEFS_ERROR FuseVolumeClient::FuseOpFsync(fuse_req_t req, fuse_ino_t ino,
     return CURVEFS_ERROR::NOTSUPPORT;
 }
 
+CURVEFS_ERROR FuseVolumeClient::FuseOpFlush(fuse_req_t req, fuse_ino_t ino,
+                                            struct fuse_file_info *fi) {
+    // TODO(wuhangqin): implement me
+    return CURVEFS_ERROR::OK;
+}
+
 CURVEFS_ERROR FuseVolumeClient::Truncate(Inode *inode, uint64_t length) {
     // Todo: call volume truncate
     return CURVEFS_ERROR::OK;

--- a/curvefs/src/client/fuse_volume_client.h
+++ b/curvefs/src/client/fuse_volume_client.h
@@ -88,6 +88,9 @@ class FuseVolumeClient : public FuseClient {
     CURVEFS_ERROR FuseOpFsync(fuse_req_t req, fuse_ino_t ino, int datasync,
            struct fuse_file_info *fi) override;
 
+    CURVEFS_ERROR FuseOpFlush(fuse_req_t req, fuse_ino_t ino,
+                              struct fuse_file_info *fi) override;
+
  private:
     CURVEFS_ERROR Truncate(Inode *inode, uint64_t length) override;
 

--- a/curvefs/src/client/rpcclient/metaserver_client.cpp
+++ b/curvefs/src/client/rpcclient/metaserver_client.cpp
@@ -434,7 +434,9 @@ MetaStatusCode MetaServerClientImpl::GetInode(uint32_t fsId, uint64_t inodeid,
     return ConvertToMetaStatusCode(excutor.DoRPCTask());
 }
 
-MetaStatusCode MetaServerClientImpl::UpdateInode(const Inode &inode) {
+MetaStatusCode
+MetaServerClientImpl::UpdateInode(const Inode &inode,
+                                  InodeOpenStatusChange statusChange) {
     auto task = RPCTask {
         metaserverClientMetric_->updateInode.qps.count << 1;
         UpdateInodeResponse response;
@@ -452,7 +454,7 @@ MetaStatusCode MetaServerClientImpl::UpdateInode(const Inode &inode) {
         request.set_gid(inode.gid());
         request.set_mode(inode.mode());
         request.set_nlink(inode.nlink());
-        request.set_openflag(inode.openflag());
+        request.set_inodeopenstatuschange(statusChange);
         if (inode.has_volumeextentlist()) {
             curvefs::metaserver::VolumeExtentList *vlist =
                 new curvefs::metaserver::VolumeExtentList;
@@ -547,8 +549,9 @@ void UpdateInodeRpcDone::Run() {
     return;
 }
 
-void MetaServerClientImpl::UpdateInodeAsync(const Inode &inode,
-    MetaServerClientDone *done) {
+void MetaServerClientImpl::UpdateInodeAsync(
+    const Inode &inode, MetaServerClientDone *done,
+    InodeOpenStatusChange statusChange) {
     auto task = AsyncRPCTask {
         metaserverClientMetric_->updateInode.qps.count << 1;
 
@@ -566,7 +569,7 @@ void MetaServerClientImpl::UpdateInodeAsync(const Inode &inode,
         request.set_gid(inode.gid());
         request.set_mode(inode.mode());
         request.set_nlink(inode.nlink());
-        request.set_openflag(inode.openflag());
+        request.set_inodeopenstatuschange(statusChange);
         if (inode.has_volumeextentlist()) {
             curvefs::metaserver::VolumeExtentList *vlist =
                 new curvefs::metaserver::VolumeExtentList;

--- a/curvefs/src/client/rpcclient/metaserver_client.h
+++ b/curvefs/src/client/rpcclient/metaserver_client.h
@@ -39,6 +39,7 @@ using ::curvefs::client::metric::MetaServerClientMetric;
 using ::curvefs::metaserver::Dentry;
 using ::curvefs::metaserver::FsFileType;
 using ::curvefs::metaserver::Inode;
+using ::curvefs::metaserver::InodeOpenStatusChange;
 using ::curvefs::metaserver::MetaStatusCode;
 using ::curvefs::space::AllocateType;
 using ::curvefs::metaserver::S3ChunkInfoList;
@@ -80,10 +81,14 @@ class MetaServerClient {
     virtual MetaStatusCode GetInode(uint32_t fsId, uint64_t inodeid,
                                     Inode *out) = 0;
 
-    virtual MetaStatusCode UpdateInode(const Inode &inode) = 0;
+    virtual MetaStatusCode UpdateInode(const Inode &inode,
+                                       InodeOpenStatusChange statusChange =
+                                           InodeOpenStatusChange::NOCHANGE) = 0;
 
     virtual void UpdateInodeAsync(const Inode &inode,
-        MetaServerClientDone *done) = 0;
+                                  MetaServerClientDone *done,
+                                  InodeOpenStatusChange statusChange =
+                                      InodeOpenStatusChange::NOCHANGE) = 0;
 
     virtual MetaStatusCode GetOrModifyS3ChunkInfo(
         uint32_t fsId, uint64_t inodeId,
@@ -136,10 +141,13 @@ class MetaServerClientImpl : public MetaServerClient {
     MetaStatusCode GetInode(uint32_t fsId, uint64_t inodeid,
                             Inode *out) override;
 
-    MetaStatusCode UpdateInode(const Inode &inode) override;
+    MetaStatusCode UpdateInode(const Inode &inode,
+                               InodeOpenStatusChange statusChange =
+                                   InodeOpenStatusChange::NOCHANGE) override;
 
-    void UpdateInodeAsync(const Inode &inode,
-        MetaServerClientDone *done) override;
+    void UpdateInodeAsync(const Inode &inode, MetaServerClientDone *done,
+                          InodeOpenStatusChange statusChange =
+                              InodeOpenStatusChange::NOCHANGE) override;
 
     MetaStatusCode GetOrModifyS3ChunkInfo(
         uint32_t fsId, uint64_t inodeId,

--- a/curvefs/src/metaserver/trash.cpp
+++ b/curvefs/src/metaserver/trash.cpp
@@ -118,8 +118,8 @@ bool TrashImpl::NeedDelete(const TrashItem &item) {
                      << ", ret = " << MetaStatusCode_Name(ret);
         return false;
     }
-    if (inode.openflag()) {
-        return false;
+    if (inode.has_openmpcount() && inode.openmpcount() > 0) {
+            return false;
     } else {
         return ((now - item.dtime) >= options_.expiredAfterSec);
     }

--- a/curvefs/test/client/mock_metaserver_client.h
+++ b/curvefs/test/client/mock_metaserver_client.h
@@ -74,10 +74,13 @@ class MockMetaServerClient : public MetaServerClient {
     MOCK_METHOD3(GetInode, MetaStatusCode(
             uint32_t fsId, uint64_t inodeid, Inode *out));
 
-    MOCK_METHOD1(UpdateInode, MetaStatusCode(const Inode &inode));
+    MOCK_METHOD2(UpdateInode,
+                 MetaStatusCode(const Inode &inode,
+                                InodeOpenStatusChange statusChange));
 
-    MOCK_METHOD2(UpdateInodeAsync, void(const Inode &inode,
-        MetaServerClientDone *done));
+    MOCK_METHOD3(UpdateInodeAsync,
+                 void(const Inode &inode, MetaServerClientDone *done,
+                      InodeOpenStatusChange statusChange));
 
     MOCK_METHOD5(GetOrModifyS3ChunkInfo, MetaStatusCode(
         uint32_t fsId, uint64_t inodeId,

--- a/curvefs/test/client/test_inodeWrapper.cpp
+++ b/curvefs/test/client/test_inodeWrapper.cpp
@@ -34,12 +34,12 @@ using ::google::protobuf::util::MessageDifferencer;
 namespace curvefs {
 namespace client {
 
-using ::testing::Return;
 using ::testing::_;
 using ::testing::Contains;
+using ::testing::DoAll;
+using ::testing::Return;
 using ::testing::SetArgPointee;
 using ::testing::SetArgReferee;
-using ::testing::DoAll;
 
 using rpcclient::MockMetaServerClient;
 
@@ -76,8 +76,8 @@ TEST(TestAppendS3ChunkInfoToMap, testAppendS3ChunkInfoToMap) {
     AppendS3ChunkInfoToMap(chunkIndex1, info1, &s3ChunkInfoMap);
     ASSERT_EQ(1, s3ChunkInfoMap.size());
     ASSERT_EQ(1, s3ChunkInfoMap[chunkIndex1].s3chunks_size());
-    ASSERT_TRUE(MessageDifferencer::Equals(info1,
-        s3ChunkInfoMap[chunkIndex1].s3chunks(0)));
+    ASSERT_TRUE(MessageDifferencer::Equals(
+        info1, s3ChunkInfoMap[chunkIndex1].s3chunks(0)));
 
 
     // add to same chunkIndex
@@ -91,10 +91,10 @@ TEST(TestAppendS3ChunkInfoToMap, testAppendS3ChunkInfoToMap) {
     AppendS3ChunkInfoToMap(chunkIndex1, info2, &s3ChunkInfoMap);
     ASSERT_EQ(1, s3ChunkInfoMap.size());
     ASSERT_EQ(2, s3ChunkInfoMap[chunkIndex1].s3chunks_size());
-    ASSERT_TRUE(MessageDifferencer::Equals(info1,
-        s3ChunkInfoMap[chunkIndex1].s3chunks(0)));
-    ASSERT_TRUE(MessageDifferencer::Equals(info2,
-        s3ChunkInfoMap[chunkIndex1].s3chunks(1)));
+    ASSERT_TRUE(MessageDifferencer::Equals(
+        info1, s3ChunkInfoMap[chunkIndex1].s3chunks(0)));
+    ASSERT_TRUE(MessageDifferencer::Equals(
+        info2, s3ChunkInfoMap[chunkIndex1].s3chunks(1)));
 
     // add to diff chunkIndex
     S3ChunkInfo info3;
@@ -108,14 +108,14 @@ TEST(TestAppendS3ChunkInfoToMap, testAppendS3ChunkInfoToMap) {
     AppendS3ChunkInfoToMap(chunkIndex2, info3, &s3ChunkInfoMap);
     ASSERT_EQ(2, s3ChunkInfoMap.size());
     ASSERT_EQ(2, s3ChunkInfoMap[chunkIndex1].s3chunks_size());
-    ASSERT_TRUE(MessageDifferencer::Equals(info1,
-        s3ChunkInfoMap[chunkIndex1].s3chunks(0)));
-    ASSERT_TRUE(MessageDifferencer::Equals(info2,
-        s3ChunkInfoMap[chunkIndex1].s3chunks(1)));
+    ASSERT_TRUE(MessageDifferencer::Equals(
+        info1, s3ChunkInfoMap[chunkIndex1].s3chunks(0)));
+    ASSERT_TRUE(MessageDifferencer::Equals(
+        info2, s3ChunkInfoMap[chunkIndex1].s3chunks(1)));
 
     ASSERT_EQ(1, s3ChunkInfoMap[chunkIndex2].s3chunks_size());
-    ASSERT_TRUE(MessageDifferencer::Equals(info3,
-        s3ChunkInfoMap[chunkIndex2].s3chunks(0)));
+    ASSERT_TRUE(MessageDifferencer::Equals(
+        info3, s3ChunkInfoMap[chunkIndex2].s3chunks(0)));
 }
 
 TEST_F(TestInodeWrapper, testSyncSuccess) {
@@ -132,7 +132,7 @@ TEST_F(TestInodeWrapper, testSyncSuccess) {
     uint64_t chunkIndex1 = 1;
     inodeWrapper_->AppendS3ChunkInfo(chunkIndex1, info1);
 
-    EXPECT_CALL(*metaClient_, UpdateInode(_))
+    EXPECT_CALL(*metaClient_, UpdateInode(_, _))
         .WillOnce(Return(MetaStatusCode::OK));
 
     EXPECT_CALL(*metaClient_, GetOrModifyS3ChunkInfo(_, _, _, _, _))
@@ -156,7 +156,7 @@ TEST_F(TestInodeWrapper, testSyncFailed) {
     uint64_t chunkIndex1 = 1;
     inodeWrapper_->AppendS3ChunkInfo(chunkIndex1, info1);
 
-    EXPECT_CALL(*metaClient_, UpdateInode(_))
+    EXPECT_CALL(*metaClient_, UpdateInode(_, _))
         .WillOnce(Return(MetaStatusCode::NOT_FOUND))
         .WillOnce(Return(MetaStatusCode::OK));
 

--- a/curvefs/test/metaserver/test_helper.cpp
+++ b/curvefs/test/metaserver/test_helper.cpp
@@ -49,7 +49,6 @@ UpdateInodeRequest MakeUpdateInodeRequestFromInode(const Inode &inode,
     request.set_allocated_volumeextentlist(vlist);
     *(request.mutable_s3chunkinfomap()) = inode.s3chunkinfomap();
     request.set_nlink(inode.nlink());
-    request.set_openflag(inode.openflag());
     return request;
 }
 


### PR DESCRIPTION
NOTES:
Now we implemented close-to-open consistency and multi-mountpoint for one filesystem.
A file written by a client, closed, and then opened by any client can read the latest data.
The scenario where multiple mount points modify the same resource ( Any modification to a
file ) at the same time is not guaranteed.

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?): 

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
