### PR TITLE
client: fix cto consistency cannot be guaranteed under multiple mount…

### DIFF
--- a/curvefs/conf/client.conf
+++ b/curvefs/conf/client.conf
@@ -73,8 +73,6 @@ fuseClient.dCacheLruSize=65536
 fuseClient.enableICacheMetrics=true
 fuseClient.enableDCacheMetrics=true
 fuseClient.cto=true
-# FuseOpFlush retry intervel, default is 2s
-fuseClient.flushRetryIntervalMs=2000
 
 #### volume
 volume.bigFileSize=1048576

--- a/curvefs/src/client/common/config.cpp
+++ b/curvefs/src/client/common/config.cpp
@@ -211,8 +211,6 @@ void InitFuseClientOption(Configuration *conf, FuseClientOption *clientOption) {
     conf->GetValueFatalIfFail("fuseClient.enableDCacheMetrics",
                               &clientOption->enableDCacheMetrics);
     conf->GetValueFatalIfFail("fuseClient.cto", &FLAGS_enableCto);
-    conf->GetValueFatalIfFail("fuseClient.flushRetryIntervalMs",
-                              &clientOption->flushRetryIntervalMS);
     conf->GetValueFatalIfFail("client.dummyserver.startport",
                               &clientOption->dummyServerStartPort);
 

--- a/curvefs/src/client/common/config.h
+++ b/curvefs/src/client/common/config.h
@@ -145,7 +145,6 @@ struct FuseClientOption {
     ExtentManagerOption extentManagerOpt;
     VolumeOption volumeOpt;
 
-    uint32_t flushRetryIntervalMS;
     double attrTimeOut;
     double entryTimeOut;
     uint32_t listDentryLimit;

--- a/curvefs/src/client/fuse_client.cpp
+++ b/curvefs/src/client/fuse_client.cpp
@@ -199,6 +199,9 @@ void FuseClient::FuseOpDestroy(void *userdata) {
     if (retVal < 0) {
         return;
     }
+    LOG(INFO) << "Umount " << fsName << " on " << mountPointWithHost
+              << " start";
+
     FSStatusCode ret = mdsClient_->UmountFs(fsName, mountPointWithHost);
     if (ret != FSStatusCode::OK && ret != FSStatusCode::MOUNT_POINT_NOT_EXIST) {
         LOG(ERROR) << "UmountFs failed, FSStatusCode = " << ret

--- a/curvefs/src/client/fuse_client.h
+++ b/curvefs/src/client/fuse_client.h
@@ -196,9 +196,6 @@ class FuseClient {
                                       int datasync,
                                       struct fuse_file_info* fi) = 0;
 
-    virtual CURVEFS_ERROR FuseOpFlush(fuse_req_t req, fuse_ino_t ino,
-                                      struct fuse_file_info *fi) = 0;
-
     void SetFsInfo(std::shared_ptr<FsInfo> fsInfo) {
         fsInfo_ = fsInfo;
         init_ = true;

--- a/curvefs/src/client/fuse_s3_client.cpp
+++ b/curvefs/src/client/fuse_s3_client.cpp
@@ -252,55 +252,52 @@ CURVEFS_ERROR FuseS3Client::Truncate(Inode *inode, uint64_t length) {
     return s3Adaptor_->Truncate(inode, length);
 }
 
-CURVEFS_ERROR FuseS3Client::FuseOpFlush(fuse_req_t req, fuse_ino_t ino,
-                                        struct fuse_file_info *fi) {
-    LOG(INFO) << "FuseOpFlush, ino: " << ino;
-
-    if (curvefs::client::common::FLAGS_enableCto) {
-        // need retry until success
-        while (CURVEFS_ERROR::OK != FuseOpFsync(req, ino, 0, fi)) {
-            sleep(option_.flushRetryIntervalMS / 1000);
-        }
-
-        return CURVEFS_ERROR::OK;
-    } else {
-        return FuseOpFsync(req, ino, 0, fi);
-    }
-}
-
 CURVEFS_ERROR FuseS3Client::FuseOpRelease(fuse_req_t req, fuse_ino_t ino,
-                                        struct fuse_file_info *fi) {
+                                          struct fuse_file_info *fi) {
     LOG(INFO) << "FuseOpRelease, ino: " << ino;
     CURVEFS_ERROR ret = CURVEFS_ERROR::OK;
 
-    if (::curvefs::client::common::FLAGS_enableCto) {
-        ret = FuseOpFsync(req, ino, 0, fi);
+    // if enableCto, flush all write cache both in memory cache and disk cache
+    if (curvefs::client::common::FLAGS_enableCto) {
+        ret = s3Adaptor_->FlushAllCache(ino);
         if (ret != CURVEFS_ERROR::OK) {
-            LOG(INFO) << "FuseOpRelease, ino: " << ino
-                      << " do fsync error: " << ret;
+            LOG(ERROR) << "FuseOpRelease, flush all cache fail, ret = " << ret
+                       << ", inodeid = " << ino;
             return ret;
         }
+        VLOG(1) << "FuseOpRelease, FlushAllCache ok";
     }
 
     std::shared_ptr<InodeWrapper> inodeWrapper;
     ret = inodeManager_->GetInode(ino, inodeWrapper);
     if (ret != CURVEFS_ERROR::OK) {
-        LOG(ERROR) << "inodeManager get inode fail, ret = " << ret
-                   << ", inodeid = " << ino;
+        LOG(ERROR) << "FuseOpRelease, inodeManager get inode fail, ret = "
+                   << ret << ", inodeid = " << ino;
         return ret;
     }
 
     ::curve::common::UniqueLock lgGuard = inodeWrapper->GetUniqueLock();
+    // if enableCto, need sync inode meta
+    if (::curvefs::client::common::FLAGS_enableCto) {
+        ret = inodeWrapper->Sync();
+        if (ret != CURVEFS_ERROR::OK) {
+            LOG(ERROR) << "FuseOpRelease, inode sync s3 chunk info fail, ret = "
+                       << ret << ", inodeid = " << ino;
+            return ret;
+        }
+        VLOG(1) << "FuseOpRelease, inode" << ino << " sync ok";
+    }
+
+    // update opencount
     ret = inodeWrapper->Release();
     if (ret != CURVEFS_ERROR::OK) {
-        LOG(ERROR) << "inodeManager release inode fail, ret = " << ret
-                   << ", inodeid = " << ino;
+        LOG(ERROR) << "FuseOpRelease, inodeManager release inode fail, ret = "
+                   << ret << ", inodeid = " << ino;
         return ret;
     }
 
-    if (::curvefs::client::common::FLAGS_enableCto) {
-        inodeManager_->ClearInodeCache(ino);
-    }
+    LOG(INFO) << "FuseOpRelease, ino: " << ino << " success";
+
     return ret;
 }
 

--- a/curvefs/src/client/fuse_s3_client.h
+++ b/curvefs/src/client/fuse_s3_client.h
@@ -74,9 +74,6 @@ class FuseS3Client : public FuseClient {
     CURVEFS_ERROR FuseOpFsync(fuse_req_t req, fuse_ino_t ino, int datasync,
            struct fuse_file_info *fi) override;
 
-    CURVEFS_ERROR FuseOpFlush(fuse_req_t req, fuse_ino_t ino,
-                              struct fuse_file_info *fi) override;
-
     CURVEFS_ERROR FuseOpRelease(fuse_req_t req, fuse_ino_t ino,
                                 struct fuse_file_info *fi) override;
 

--- a/curvefs/src/client/fuse_volume_client.cpp
+++ b/curvefs/src/client/fuse_volume_client.cpp
@@ -291,12 +291,6 @@ CURVEFS_ERROR FuseVolumeClient::FuseOpFsync(fuse_req_t req, fuse_ino_t ino,
     return CURVEFS_ERROR::NOTSUPPORT;
 }
 
-CURVEFS_ERROR FuseVolumeClient::FuseOpFlush(fuse_req_t req, fuse_ino_t ino,
-                                            struct fuse_file_info *fi) {
-    // TODO(wuhangqin): implement me
-    return CURVEFS_ERROR::OK;
-}
-
 CURVEFS_ERROR FuseVolumeClient::Truncate(Inode *inode, uint64_t length) {
     // Todo: call volume truncate
     return CURVEFS_ERROR::OK;

--- a/curvefs/src/client/fuse_volume_client.h
+++ b/curvefs/src/client/fuse_volume_client.h
@@ -86,9 +86,6 @@ class FuseVolumeClient : public FuseClient {
         fuse_entry_param *e) override;
 
     CURVEFS_ERROR FuseOpFsync(fuse_req_t req, fuse_ino_t ino, int datasync,
-           struct fuse_file_info *fi) override;
-
-    CURVEFS_ERROR FuseOpFlush(fuse_req_t req, fuse_ino_t ino,
                               struct fuse_file_info *fi) override;
 
  private:

--- a/curvefs/src/client/inode_wrapper.h
+++ b/curvefs/src/client/inode_wrapper.h
@@ -66,6 +66,7 @@ class InodeWrapper : public std::enable_shared_from_this<InodeWrapper> {
       : inode_(inode),
         status_(InodeStatus::Normal),
         metaClient_(metaClient),
+        openCount_(0),
         dirty_(false) {}
 
     InodeWrapper(Inode &&inode,
@@ -73,6 +74,7 @@ class InodeWrapper : public std::enable_shared_from_this<InodeWrapper> {
       : inode_(std::move(inode)),
         status_(InodeStatus::Normal),
         metaClient_(metaClient),
+        openCount_(0),
         dirty_(false) {}
 
     ~InodeWrapper() {}
@@ -288,12 +290,14 @@ class InodeWrapper : public std::enable_shared_from_this<InodeWrapper> {
         return curve::common::UniqueLock(syncingS3ChunkInfoMtx_);
     }
 
+    void SetOpenCount(uint32_t openCount) { openCount_ = openCount; }
+
  private:
     CURVEFS_ERROR UpdateInodeStatus(InodeOpenStatusChange statusChange);
 
  private:
      Inode inode_;
-     bool openFlag_;
+     uint32_t openCount_;
      InodeStatus status_;
 
      google::protobuf::Map<uint64_t, S3ChunkInfoList> s3ChunkInfoAdd_;

--- a/curvefs/src/client/rpcclient/metaserver_client.cpp
+++ b/curvefs/src/client/rpcclient/metaserver_client.cpp
@@ -946,8 +946,8 @@ void GetOrModifyS3ChunkInfoRpcDone::Run() {
         done_->SetRetCode(-1);
         return;
     }
-    VLOG(6) << "GetOrModifyS3ChunkInfo success, "
-            << "response: " << response.DebugString();
+    VLOG(6) << "GetOrModifyS3ChunkInfo success, response: "
+            << response.DebugString();
     done_->SetRetCode(ret);
     return;
 }

--- a/curvefs/src/client/s3/disk_cache_base.h
+++ b/curvefs/src/client/s3/disk_cache_base.h
@@ -39,6 +39,7 @@ namespace client {
 using curvefs::common::PosixWrapper;
 using curvefs::client::metric::DiskCacheMetric;
 #define MODE 0644
+
 class DiskCacheBase {
  public:
     DiskCacheBase() {}
@@ -54,6 +55,8 @@ class DiskCacheBase {
      * @brief Get Read/Write Cache full Dir(include CacheDir_).
     */
     virtual std::string GetCacheIoFullDir();
+
+    virtual int LoadAllCacheFile(std::set<std::string> *cachedObj);
 
  private:
     std::string cacheIoDir_;

--- a/curvefs/src/client/s3/disk_cache_manager_impl.cpp
+++ b/curvefs/src/client/s3/disk_cache_manager_impl.cpp
@@ -23,6 +23,7 @@
 #include <errno.h>
 #include <string>
 #include <cstdio>
+#include <list>
 
 #include "curvefs/src/client/s3/client_s3_adaptor.h"
 #include "curvefs/src/client/s3/disk_cache_manager_impl.h"
@@ -100,7 +101,7 @@ int DiskCacheManagerImpl::WriteDiskFile(const std::string name, const char *buf,
 }
 
 int DiskCacheManagerImpl::WriteReadDirect(const std::string fileName,
-                    const char* buf, uint64_t length) {
+                                          const char *buf, uint64_t length) {
     if (diskCacheManager_->IsDiskCacheFull()) {
         LOG(ERROR) << "write disk file fail, disk full.";
         return -1;
@@ -157,6 +158,14 @@ int DiskCacheManagerImpl::UmountDiskCache() {
 
 void DiskCacheManagerImpl::InitMetrics(std::string fsName) {
     diskCacheManager_->InitMetrics(fsName);
+}
+
+int DiskCacheManagerImpl::UploadWriteCacheByInode(const std::string &inode) {
+    return diskCacheManager_->UploadWriteCacheByInode(inode);
+}
+
+int DiskCacheManagerImpl::ClearReadCache(const std::list<std::string> &files) {
+    return diskCacheManager_->ClearReadCache(files);
 }
 
 }  // namespace client

--- a/curvefs/src/client/s3/disk_cache_manager_impl.h
+++ b/curvefs/src/client/s3/disk_cache_manager_impl.h
@@ -27,6 +27,7 @@
 #include <string>
 #include <vector>
 #include <set>
+#include <list>
 
 #include "src/common/concurrent/concurrent.h"
 #include "src/common/interruptible_sleeper.h"
@@ -64,8 +65,9 @@ struct DiskCacheOption {
 
 class DiskCacheManagerImpl {
  public:
-    DiskCacheManagerImpl(std::shared_ptr<DiskCacheManager>
-      diskCacheManager, S3Client *client);
+    DiskCacheManagerImpl(std::shared_ptr<DiskCacheManager> diskCacheManager,
+                         S3Client *client);
+    DiskCacheManagerImpl() {}
     virtual ~DiskCacheManagerImpl() {}
     /**
      * @brief init DiskCacheManagerImpl
@@ -81,7 +83,7 @@ class DiskCacheManagerImpl {
      * @param[in] length wtite length
      * @return success: write length, fail : < 0
      */
-    int Write(const std::string name, const char* buf, uint64_t length);
+    int Write(const std::string name, const char *buf, uint64_t length);
     /**
      * @brief whether obj is cached in cached disk
      * @param[in] name obj name
@@ -96,8 +98,8 @@ class DiskCacheManagerImpl {
      * @param[in] length read length
      * @return success: length, fail : < length
      */
-    int Read(const std::string name,
-             char* buf, uint64_t offset, uint64_t length);
+    int Read(const std::string name, char *buf, uint64_t offset,
+             uint64_t length);
     /**
      * @brief umount disk cache
      * @return success: 0, fail : < 0
@@ -105,12 +107,16 @@ class DiskCacheManagerImpl {
     int UmountDiskCache();
 
     bool IsDiskCacheFull();
-    int WriteReadDirect(const std::string fileName,
-                        const char* buf, uint64_t length);
+    int WriteReadDirect(const std::string fileName, const char *buf,
+                        uint64_t length);
     void InitMetrics(std::string fsName);
 
+    virtual int UploadWriteCacheByInode(const std::string &inode);
+
+    virtual int ClearReadCache(const std::list<std::string> &files);
+
  private:
-    int WriteDiskFile(const std::string name, const char* buf, uint64_t length);
+    int WriteDiskFile(const std::string name, const char *buf, uint64_t length);
 
     std::shared_ptr<DiskCacheManager> diskCacheManager_;
     bool forceFlush_;

--- a/curvefs/src/client/s3/disk_cache_read.h
+++ b/curvefs/src/client/s3/disk_cache_read.h
@@ -36,7 +36,7 @@
 namespace curvefs {
 namespace client {
 
-using ::curve::common::SglLRUCache;
+using curve::common::SglLRUCache;
 using curvefs::common::PosixWrapper;
 
 class DiskCacheRead : public DiskCacheBase {
@@ -44,20 +44,21 @@ class DiskCacheRead : public DiskCacheBase {
     DiskCacheRead() {}
     virtual ~DiskCacheRead() {}
     virtual void Init(std::shared_ptr<PosixWrapper> posixWrapper,
-                   const std::string cacheDir);
-    virtual int ReadDiskFile(const std::string name,
-                  char* buf, uint64_t offset, uint64_t length);
-    virtual int WriteDiskFile(const std::string fileName,
-                              const char* buf, uint64_t length);
+                      const std::string cacheDir);
+    virtual int ReadDiskFile(const std::string name, char *buf, uint64_t offset,
+                             uint64_t length);
+    virtual int WriteDiskFile(const std::string fileName, const char *buf,
+                              uint64_t length);
     virtual int LinkWriteToRead(const std::string fileName,
-                   const std::string fullWriteDir,
-                   const std::string fullReadDir);
+                                const std::string fullWriteDir,
+                                const std::string fullReadDir);
 
     /**
-    * @brief after reboot，load all files that store in read cache.
-    */
-    virtual int LoadAllCacheReadFile(std::shared_ptr<
-      SglLRUCache<std::string>> cachedObj);
+     * @brief after reboot，load all files that store in read cache.
+     */
+    virtual int
+    LoadAllCacheReadFile(std::shared_ptr<SglLRUCache<std::string>> cachedObj);
+    virtual int ClearReadCache(const std::list<std::string> &files);
     virtual void InitMetrics(std::shared_ptr<DiskCacheMetric> metric) {
         metric_ = metric;
     }

--- a/curvefs/src/common/s3util.cpp
+++ b/curvefs/src/common/s3util.cpp
@@ -16,31 +16,22 @@
 
 /*
  * Project: curve
- * Created Date: Thur Oct 14 2021
- * Author: majie1
+ * Created Date: Thur Mar 02 2022
+ * Author: lixiaocui
  */
 
-#ifndef CURVEFS_SRC_COMMON_S3UTIL_H_
-#define CURVEFS_SRC_COMMON_S3UTIL_H_
-
-#include <string>
+#include <vector>
+#include "src/common/string_util.h"
+#include "curvefs/src/common/s3util.h"
 
 namespace curvefs {
 namespace common {
 namespace s3util {
-
-inline std::string GenObjName(uint64_t chunkid, uint64_t index,
-                              uint64_t compaction, uint64_t fsid,
-                              uint64_t inodeid) {
-    return std::to_string(fsid) + "_" + std::to_string(inodeid) + "_" +
-           std::to_string(chunkid) + "_" + std::to_string(index) + "_" +
-           std::to_string(compaction);
+bool ValidNameOfInode(const std::string &inode, const std::string &objName) {
+    std::vector<std::string> res;
+    curve::common::SplitString(objName, "_", &res);
+    return res.size() == 5 && res[1] == inode;
 }
-
-bool ValidNameOfInode(const std::string &inode, const std::string &objName);
-
 }  // namespace s3util
 }  // namespace common
 }  // namespace curvefs
-
-#endif  // CURVEFS_SRC_COMMON_S3UTIL_H_

--- a/curvefs/test/client/BUILD
+++ b/curvefs/test/client/BUILD
@@ -57,6 +57,7 @@ cc_binary(
     srcs = glob([
         "main.cpp",
         "client_s3_adaptor_test.cpp",
+        "client_s3_adaptor_test2.cpp",
         "client_s3_test.cpp",
         "*.h",
     ]),
@@ -83,6 +84,7 @@ cc_test(
        "*.h"],
        exclude = [ "block_device_client_test.cpp",
                    "client_s3_adaptor_test.cpp",
+                   "client_s3_adaptor_test2.cpp",
                    "client_s3_test.cpp" ]
    ),
    copts = CURVE_TEST_COPTS + ["-I/usr/local/include/fuse3"],

--- a/curvefs/test/client/client_s3_adaptor_test2.cpp
+++ b/curvefs/test/client/client_s3_adaptor_test2.cpp
@@ -1,0 +1,140 @@
+/*
+ *  Copyright (c) 2021 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * Project: curve
+ * Created Date: Thur Jun 22 2021
+ * Author: huyao
+ */
+
+
+#include <brpc/server.h>
+#include <google/protobuf/util/message_differencer.h>
+#include <gtest/gtest.h>
+
+#include "curvefs/test/client/mock_disk_cache_manager.h"
+#include "curvefs/test/client/mock_inode_cache_manager.h"
+#include "src/common/curve_define.h"
+#include "curvefs/src/client/s3/client_s3_adaptor.h"
+
+
+namespace curvefs {
+namespace client {
+using ::curve::common::kMB;
+using ::testing::_;
+using ::testing::DoAll;
+using ::testing::Invoke;
+using ::testing::Return;
+using ::testing::SetArgPointee;
+using ::testing::SetArgReferee;
+using ::testing::WithArg;
+
+class ClientS3AdaptorTest2 : public testing::Test {
+ protected:
+    ClientS3AdaptorTest2() {}
+    ~ClientS3AdaptorTest2() {}
+    void SetUp() override {
+        s3ClientAdaptor_ = std::make_shared<S3ClientAdaptorImpl>();
+        mockInodeManager_ = std::make_shared<MockInodeCacheManager>();
+        mockDiskcacheManagerImpl_ =
+            std::make_shared<MockDiskCacheManagerImpl>();
+        mockFsCacheManager_ = std::make_shared<MockFsCacheManager>();
+
+        s3ClientAdaptor_->InitForTest(mockDiskcacheManagerImpl_,
+                                      mockFsCacheManager_, mockInodeManager_);
+    }
+
+    void TearDown() override {}
+
+    void GetInode(curvefs::metaserver::Inode *inode) {
+        inode->set_inodeid(1);
+        inode->set_fsid(2);
+        inode->set_length(0);
+        inode->set_ctime(1623835517);
+        inode->set_ctime_ns(1623835517);
+        inode->set_mtime(1623835517);
+        inode->set_atime(1623835517);
+        inode->set_atime_ns(1623835517);
+        inode->set_uid(1);
+        inode->set_gid(1);
+        inode->set_mode(1);
+        inode->set_nlink(1);
+        inode->set_type(curvefs::metaserver::FsFileType::TYPE_S3);
+    }
+
+ protected:
+    std::shared_ptr<S3ClientAdaptorImpl> s3ClientAdaptor_;
+    std::shared_ptr<MockInodeCacheManager> mockInodeManager_;
+    std::shared_ptr<MockDiskCacheManagerImpl> mockDiskcacheManagerImpl_;
+    std::shared_ptr<MockFsCacheManager> mockFsCacheManager_;
+};
+
+
+TEST_F(ClientS3AdaptorTest2, FlushAllCache_no_filecachaeManager) {
+    EXPECT_CALL(*mockFsCacheManager_, FindFileCacheManager(_))
+        .WillOnce(Return(nullptr));
+    ASSERT_EQ(CURVEFS_ERROR::OK, s3ClientAdaptor_->FlushAllCache(1));
+}
+
+TEST_F(ClientS3AdaptorTest2, FlushAllCache_flush_fail) {
+    auto filecache = std::make_shared<MockFileCacheManager>();
+    EXPECT_CALL(*mockFsCacheManager_, FindFileCacheManager(_))
+        .WillOnce(Return(filecache));
+    EXPECT_CALL(*filecache, Flush(_, _))
+        .WillOnce(Return(CURVEFS_ERROR::INTERNAL));
+    ASSERT_EQ(CURVEFS_ERROR::INTERNAL, s3ClientAdaptor_->FlushAllCache(1));
+}
+
+TEST_F(ClientS3AdaptorTest2, FlushAllCache_with_no_cache) {
+    s3ClientAdaptor_->SetDiskCache(DiskCacheType::Disable);
+
+    LOG(INFO) << "############ case1: do not find file cache";
+    auto filecache = std::make_shared<MockFileCacheManager>();
+    EXPECT_CALL(*mockFsCacheManager_, FindFileCacheManager(_))
+        .WillOnce(Return(nullptr));
+    ASSERT_EQ(CURVEFS_ERROR::OK, s3ClientAdaptor_->FlushAllCache(1));
+
+    LOG(INFO) << "############ case2: find file cache";
+    EXPECT_CALL(*mockFsCacheManager_, FindFileCacheManager(_))
+        .WillOnce(Return(filecache));
+    EXPECT_CALL(*filecache, Flush(_, _)).WillOnce(Return(CURVEFS_ERROR::OK));
+    ASSERT_EQ(CURVEFS_ERROR::OK, s3ClientAdaptor_->FlushAllCache(1));
+}
+
+TEST_F(ClientS3AdaptorTest2, FlushAllCache_with_cache) {
+    s3ClientAdaptor_->SetDiskCache(DiskCacheType::ReadWrite);
+
+    LOG(INFO) << "############ case1: clear write cache fail";
+    auto filecache = std::make_shared<MockFileCacheManager>();
+    EXPECT_CALL(*mockFsCacheManager_, FindFileCacheManager(_))
+        .WillOnce(Return(filecache));
+    EXPECT_CALL(*filecache, Flush(_, _)).WillOnce(Return(CURVEFS_ERROR::OK));
+    EXPECT_CALL(*mockDiskcacheManagerImpl_, UploadWriteCacheByInode(_))
+        .WillOnce(Return(-1));
+    ASSERT_EQ(CURVEFS_ERROR::INTERNAL, s3ClientAdaptor_->FlushAllCache(1));
+
+    LOG(INFO)
+        << "############ case2: clear write cache ok, update write cache ok ";
+    EXPECT_CALL(*mockFsCacheManager_, FindFileCacheManager(_))
+        .WillOnce(Return(filecache));
+    EXPECT_CALL(*filecache, Flush(_, _)).WillOnce(Return(CURVEFS_ERROR::OK));
+    EXPECT_CALL(*mockDiskcacheManagerImpl_, UploadWriteCacheByInode(_))
+        .WillOnce(Return(0));
+    ASSERT_EQ(CURVEFS_ERROR::OK, s3ClientAdaptor_->FlushAllCache(1));
+}
+
+}  // namespace client
+}  // namespace curvefs

--- a/curvefs/test/client/common/BUILD
+++ b/curvefs/test/client/common/BUILD
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2021 NetEase Inc.
+#  Copyright (c) 2022 NetEase Inc.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -14,17 +14,17 @@
 #  limitations under the License.
 #
 
-load("//:copts.bzl", "CURVE_DEFAULT_COPTS")
+load("//:copts.bzl", "CURVE_TEST_COPTS")
 
-cc_library(
-    name = "curvefs_common",
+cc_test(
+    name = "curvefs_client_common_test",
     srcs = glob(["*.cpp"]),
-    hdrs = glob(["*.h"]),
-    copts = CURVE_DEFAULT_COPTS,
+    copts = CURVE_TEST_COPTS,
+    defines = ["UNIT_TEST"],
     visibility = ["//visibility:public"],
     deps = [
-        "//src/common:curve_common",
-        "//external:gflags",
-        "//external:glog",
+        "//curvefs/src/common:curvefs_common",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
     ],
 )

--- a/curvefs/test/client/common/test_s3util.cpp
+++ b/curvefs/test/client/common/test_s3util.cpp
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (c) 2021 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * Project: curve
+ * Created Date: Thur Mar 02 2022
+ * Author: lixiaocui
+ */
+
+#include <gtest/gtest.h>
+#include <glog/logging.h>
+#include "curvefs/src/common/s3util.h"
+
+namespace curvefs {
+namespace common {
+TEST(ValidNameOfInodeTest, test) {
+    LOG(INFO) << "inode = 1, name = 1_16777216_2_0_0";
+    ASSERT_FALSE(
+        curvefs::common::s3util::ValidNameOfInode("1", "1_16777216_2_0_0"));
+
+    LOG(INFO) << "inode = 16777216, name = 1_16777216_2_0_0";
+    ASSERT_TRUE(curvefs::common::s3util::ValidNameOfInode("16777216",
+                                                          "1_16777216_2_0_0"));
+
+    LOG(INFO) << "inode = 1, name = 1_16777216_2_0_0";
+    ASSERT_FALSE(
+        curvefs::common::s3util::ValidNameOfInode("1", "1_16777216_2_0_0"));
+
+    LOG(INFO) << "inode = 16777216, name = 1_1_1_16777216_0";
+    ASSERT_FALSE(curvefs::common::s3util::ValidNameOfInode("16777216",
+                                                           "1_1_1_16777216_0"));
+
+    LOG(INFO) << "inode = 16777216, name = 1_1_1_16777216";
+    ASSERT_FALSE(curvefs::common::s3util::ValidNameOfInode("16777216",
+                                                           "1_1_1_16777216"));
+}
+
+}  // namespace common
+}  // namespace curvefs

--- a/curvefs/test/client/mock_client_s3_adaptor.h
+++ b/curvefs/test/client/mock_client_s3_adaptor.h
@@ -49,6 +49,7 @@ class MockS3ClientAdaptor : public S3ClientAdaptor {
                            char* buf));
     MOCK_METHOD1(ReleaseCache, void(uint64_t inodeId));
     MOCK_METHOD1(Flush, CURVEFS_ERROR(uint64_t inodeId));
+    MOCK_METHOD1(FlushAllCache, CURVEFS_ERROR(uint64_t inodeId));
     MOCK_METHOD0(FsSync, CURVEFS_ERROR());
     MOCK_METHOD0(Stop, int());
     MOCK_METHOD2(Truncate, CURVEFS_ERROR(Inode* inode, uint64_t size));

--- a/curvefs/test/client/mock_disk_cache_manager.h
+++ b/curvefs/test/client/mock_disk_cache_manager.h
@@ -29,9 +29,11 @@
 #include <vector>
 #include <set>
 #include <memory>
+#include <list>
 
 #include "curvefs/src/client/s3/client_s3_adaptor.h"
 #include "curvefs/src/client/s3/disk_cache_manager.h"
+#include "curvefs/src/client/s3/disk_cache_manager_impl.h"
 
 namespace curvefs {
 namespace client {
@@ -53,6 +55,41 @@ class MockDiskCacheManager : public DiskCacheManager {
                       const char* buf, uint64_t length));
 };
 
+class MockDiskCacheManager2 : public DiskCacheManager {
+ public:
+    MockDiskCacheManager2() : DiskCacheManager() {}
+    ~MockDiskCacheManager2() {}
+
+    MOCK_METHOD2(Init,
+                 int(S3Client *client, const S3ClientAdaptorOption option));
+    MOCK_METHOD0(IsDiskCacheFull, bool());
+    MOCK_METHOD3(WriteReadDirect, int(const std::string fileName,
+                                      const char *buf, uint64_t length));
+};
+
+class MockDiskCacheManagerImpl : public DiskCacheManagerImpl {
+ public:
+    MockDiskCacheManagerImpl() : DiskCacheManagerImpl() {}
+    ~MockDiskCacheManagerImpl() {}
+
+    MOCK_METHOD1(UploadWriteCacheByInode, int(const std::string &inode));
+    MOCK_METHOD1(ClearReadCache, int(const std::list<std::string> &files));
+};
+
+class MockFsCacheManager : public FsCacheManager {
+ public:
+    MockFsCacheManager() : FsCacheManager() {}
+    ~MockFsCacheManager() {}
+
+    MOCK_METHOD1(FindFileCacheManager, FileCacheManagerPtr(uint64_t inodeId));
+};
+
+class MockFileCacheManager : public FileCacheManager {
+ public:
+    MockFileCacheManager() : FileCacheManager() {}
+    ~MockFileCacheManager() {}
+    MOCK_METHOD2(Flush, CURVEFS_ERROR(bool force, bool toS3));
+};
 
 }  // namespace client
 }  // namespace curvefs

--- a/curvefs/test/client/mock_disk_cache_read.h
+++ b/curvefs/test/client/mock_disk_cache_read.h
@@ -28,6 +28,7 @@
 #include <string>
 #include <vector>
 #include <set>
+#include <list>
 
 #include "curvefs/src/client/s3/disk_cache_read.h"
 
@@ -36,33 +37,27 @@ namespace client {
 
 class MockDiskCacheRead : public DiskCacheRead {
  public:
-    MockDiskCacheRead()  {}
+    MockDiskCacheRead() {}
     ~MockDiskCacheRead() {}
 
-    MOCK_METHOD4(ReadDiskFile,
-                 int(const std::string name, char* buf,
-                     uint64_t offset, uint64_t length));
+    MOCK_METHOD4(ReadDiskFile, int(const std::string name, char *buf,
+                                   uint64_t offset, uint64_t length));
 
-    MOCK_METHOD1(CreateIoDir,
-                 int(bool writreDir));
+    MOCK_METHOD1(CreateIoDir, int(bool writreDir));
 
-    MOCK_METHOD1(IsFileExist,
-                 bool(const std::string file));
+    MOCK_METHOD1(IsFileExist, bool(const std::string file));
 
-    MOCK_METHOD0(GetCacheIoFullDir,
-                 std::string());
+    MOCK_METHOD0(GetCacheIoFullDir, std::string());
 
     MOCK_METHOD3(LinkWriteToRead,
-                 int(const std::string fileName,
-                     const std::string fullWriteDir,
+                 int(const std::string fileName, const std::string fullWriteDir,
                      const std::string fullReadDir));
-    MOCK_METHOD3(WriteReadDirect,
-                  int(const std::string fileName,
-                      const char* buf, uint64_t length));
-    MOCK_METHOD1(LoadAllCacheReadFile,
-                 int(std::set<std::string>* cachedObj));
-    MOCK_METHOD3(WriteDiskFile, int(const std::string fileName,
-                 const char* buf, uint64_t length));
+    MOCK_METHOD3(WriteReadDirect, int(const std::string fileName,
+                                      const char *buf, uint64_t length));
+    MOCK_METHOD1(LoadAllCacheReadFile, int(std::set<std::string> *cachedObj));
+    MOCK_METHOD3(WriteDiskFile, int(const std::string fileName, const char *buf,
+                                    uint64_t length));
+    MOCK_METHOD1(ClearReadCache, int(const std::list<std::string> &files));
 };
 
 

--- a/curvefs/test/client/mock_disk_cache_write.h
+++ b/curvefs/test/client/mock_disk_cache_write.h
@@ -65,6 +65,7 @@ class MockDiskCacheWrite : public DiskCacheWrite {
 
     MOCK_METHOD1(AsyncUploadEnqueue,
                 void(const std::string objName));
+    MOCK_METHOD1(UploadFileByInode, int(const std::string &inode));
 };
 
 }  // namespace client

--- a/curvefs/test/client/test_disk_cache_read.cpp
+++ b/curvefs/test/client/test_disk_cache_read.cpp
@@ -33,19 +33,19 @@ namespace client {
 
 using ::testing::_;
 using ::testing::Contains;
+using ::testing::DoAll;
+using ::testing::ElementsAre;
 using ::testing::Ge;
 using ::testing::Gt;
 using ::testing::Mock;
-using ::testing::DoAll;
+using ::testing::NotNull;
 using ::testing::Return;
-using ::testing::ReturnRef;
+using ::testing::ReturnArg;
 using ::testing::ReturnNull;
 using ::testing::ReturnPointee;
-using ::testing::NotNull;
-using ::testing::StrEq;
-using ::testing::ElementsAre;
+using ::testing::ReturnRef;
 using ::testing::SetArgPointee;
-using ::testing::ReturnArg;
+using ::testing::StrEq;
 
 using ::curve::common::CacheMetrics;
 using ::curve::common::SglLRUCache;
@@ -72,178 +72,157 @@ class TestDiskCacheRead : public ::testing::Test {
 };
 
 TEST_F(TestDiskCacheRead, ReadDiskFile) {
-    EXPECT_CALL(*wrapper_, open(_, _, _))
-        .WillOnce(Return(-1));
+    EXPECT_CALL(*wrapper_, open(_, _, _)).WillOnce(Return(-1));
     std::string fileName = "test";
     uint64_t length = 10;
-    int ret = diskCacheRead_->ReadDiskFile(fileName,
-                                const_cast<char*>(fileName.c_str()),
-                                length, length);
+    int ret = diskCacheRead_->ReadDiskFile(
+        fileName, const_cast<char *>(fileName.c_str()), length, length);
     ASSERT_EQ(-1, ret);
 
-    EXPECT_CALL(*wrapper_, open(_, _, _))
-        .WillOnce(Return(0));
-    EXPECT_CALL(*wrapper_, lseek(_, _, _))
-        .WillOnce(Return(-1));
-    EXPECT_CALL(*wrapper_, close(_))
-        .WillOnce(Return(0));
-    ret = diskCacheRead_->ReadDiskFile(fileName,
-                            const_cast<char*>(fileName.c_str()),
-                            length, length);
+    EXPECT_CALL(*wrapper_, open(_, _, _)).WillOnce(Return(0));
+    EXPECT_CALL(*wrapper_, lseek(_, _, _)).WillOnce(Return(-1));
+    EXPECT_CALL(*wrapper_, close(_)).WillOnce(Return(0));
+    ret = diskCacheRead_->ReadDiskFile(
+        fileName, const_cast<char *>(fileName.c_str()), length, length);
     ASSERT_EQ(-1, ret);
 
-    EXPECT_CALL(*wrapper_, open(_, _, _))
-        .WillOnce(Return(0));
-    EXPECT_CALL(*wrapper_, lseek(_, _, _))
-        .WillOnce(Return(0));
-    EXPECT_CALL(*wrapper_, read(_, _, _))
-        .WillOnce(Return(-1));
-    EXPECT_CALL(*wrapper_, close(_))
-        .WillOnce(Return(0));
-    ret = diskCacheRead_->ReadDiskFile(fileName,
-                            const_cast<char*>(fileName.c_str()),
-                            length, length);
+    EXPECT_CALL(*wrapper_, open(_, _, _)).WillOnce(Return(0));
+    EXPECT_CALL(*wrapper_, lseek(_, _, _)).WillOnce(Return(0));
+    EXPECT_CALL(*wrapper_, read(_, _, _)).WillOnce(Return(-1));
+    EXPECT_CALL(*wrapper_, close(_)).WillOnce(Return(0));
+    ret = diskCacheRead_->ReadDiskFile(
+        fileName, const_cast<char *>(fileName.c_str()), length, length);
     ASSERT_EQ(-1, ret);
 
-    EXPECT_CALL(*wrapper_, open(_, _, _))
-        .WillOnce(Return(0));
-    EXPECT_CALL(*wrapper_, lseek(_, _, _))
-        .WillOnce(Return(0));
-    EXPECT_CALL(*wrapper_, read(_, _, _))
-        .WillOnce(Return(length-1));
-    EXPECT_CALL(*wrapper_, close(_))
-        .WillOnce(Return(0));
-    ret = diskCacheRead_->ReadDiskFile(fileName,
-                            const_cast<char*>(fileName.c_str()),
-                            length, length);
-    ASSERT_EQ(length-1, ret);
+    EXPECT_CALL(*wrapper_, open(_, _, _)).WillOnce(Return(0));
+    EXPECT_CALL(*wrapper_, lseek(_, _, _)).WillOnce(Return(0));
+    EXPECT_CALL(*wrapper_, read(_, _, _)).WillOnce(Return(length - 1));
+    EXPECT_CALL(*wrapper_, close(_)).WillOnce(Return(0));
+    ret = diskCacheRead_->ReadDiskFile(
+        fileName, const_cast<char *>(fileName.c_str()), length, length);
+    ASSERT_EQ(length - 1, ret);
 
-    EXPECT_CALL(*wrapper_, open(_, _, _))
-        .WillOnce(Return(0));
-    EXPECT_CALL(*wrapper_, lseek(_, _, _))
-        .WillOnce(Return(0));
-    EXPECT_CALL(*wrapper_, read(_, _, _))
-        .WillOnce(Return(length));
-    EXPECT_CALL(*wrapper_, close(_))
-        .WillOnce(Return(0));
-    ret = diskCacheRead_->ReadDiskFile(fileName,
-                            const_cast<char*>(fileName.c_str()),
-                            length, length);
+    EXPECT_CALL(*wrapper_, open(_, _, _)).WillOnce(Return(0));
+    EXPECT_CALL(*wrapper_, lseek(_, _, _)).WillOnce(Return(0));
+    EXPECT_CALL(*wrapper_, read(_, _, _)).WillOnce(Return(length));
+    EXPECT_CALL(*wrapper_, close(_)).WillOnce(Return(0));
+    ret = diskCacheRead_->ReadDiskFile(
+        fileName, const_cast<char *>(fileName.c_str()), length, length);
     ASSERT_EQ(length, ret);
 }
 
 TEST_F(TestDiskCacheRead, LinkWriteToRead) {
-    EXPECT_CALL(*wrapper_, stat(NotNull(), NotNull()))
-        .WillOnce(Return(-1));
+    EXPECT_CALL(*wrapper_, stat(NotNull(), NotNull())).WillOnce(Return(-1));
     std::string fileName = "test";
     int ret = diskCacheRead_->LinkWriteToRead(fileName, fileName, fileName);
     ASSERT_EQ(-1, ret);
 
-    EXPECT_CALL(*wrapper_, stat(NotNull(), NotNull()))
-        .WillOnce(Return(0));
-    EXPECT_CALL(*wrapper_, link(NotNull(), NotNull()))
-        .WillOnce(Return(-1));
+    EXPECT_CALL(*wrapper_, stat(NotNull(), NotNull())).WillOnce(Return(0));
+    EXPECT_CALL(*wrapper_, link(NotNull(), NotNull())).WillOnce(Return(-1));
     ret = diskCacheRead_->LinkWriteToRead(fileName, fileName, fileName);
     ASSERT_EQ(-1, ret);
 
-    EXPECT_CALL(*wrapper_, stat(NotNull(), NotNull()))
-        .WillOnce(Return(0));
-    EXPECT_CALL(*wrapper_, link(NotNull(), NotNull()))
-        .WillOnce(Return(0));
+    EXPECT_CALL(*wrapper_, stat(NotNull(), NotNull())).WillOnce(Return(0));
+    EXPECT_CALL(*wrapper_, link(NotNull(), NotNull())).WillOnce(Return(0));
     ret = diskCacheRead_->LinkWriteToRead(fileName, fileName, fileName);
     ASSERT_EQ(0, ret);
 }
 
-TEST_F(TestDiskCacheRead, LoadAllCacheReadFile) {
-    EXPECT_CALL(*wrapper_, stat(NotNull(), NotNull()))
-        .WillOnce(Return(-1));
+TEST_F(TestDiskCacheRead, LoadAllCacheFile) {
+    EXPECT_CALL(*wrapper_, stat(NotNull(), NotNull())).WillOnce(Return(-1));
     std::shared_ptr<SglLRUCache<std::string>> cachedObj;
-    cachedObj = std::make_shared<
-      SglLRUCache<std::string>>(0,
-      std::make_shared<CacheMetrics>("diskcache"));
+    cachedObj = std::make_shared<SglLRUCache<std::string>>(
+        0, std::make_shared<CacheMetrics>("diskcache"));
     int ret = diskCacheRead_->LoadAllCacheReadFile(cachedObj);
     ASSERT_EQ(-1, ret);
 
-    EXPECT_CALL(*wrapper_, stat(NotNull(), NotNull()))
-        .WillOnce(Return(0));
-    EXPECT_CALL(*wrapper_, opendir(NotNull()))
-        .WillOnce(ReturnNull());
+    EXPECT_CALL(*wrapper_, stat(NotNull(), NotNull())).WillOnce(Return(0));
+    EXPECT_CALL(*wrapper_, opendir(NotNull())).WillOnce(ReturnNull());
     ret = diskCacheRead_->LoadAllCacheReadFile(cachedObj);
     ASSERT_EQ(-1, ret);
 
-    DIR* dir = opendir(".");
-    EXPECT_CALL(*wrapper_, stat(NotNull(), NotNull()))
-        .WillOnce(Return(0));
-    EXPECT_CALL(*wrapper_, opendir(NotNull()))
-        .WillOnce(Return(dir));
-    EXPECT_CALL(*wrapper_, closedir(NotNull()))
-        .WillOnce(Return(0));
-    EXPECT_CALL(*wrapper_, readdir(NotNull()))
-        .WillOnce(ReturnNull());
+    DIR *dir = opendir(".");
+    EXPECT_CALL(*wrapper_, stat(NotNull(), NotNull())).WillOnce(Return(0));
+    EXPECT_CALL(*wrapper_, opendir(NotNull())).WillOnce(Return(dir));
+    EXPECT_CALL(*wrapper_, closedir(NotNull())).WillOnce(Return(0));
+    EXPECT_CALL(*wrapper_, readdir(NotNull())).WillOnce(ReturnNull());
     ret = diskCacheRead_->LoadAllCacheReadFile(cachedObj);
     ASSERT_EQ(0, ret);
 
-    struct dirent* dirent;
+    struct dirent *dirent;
     dir = opendir(".");
     dirent = readdir(dir);
-    EXPECT_CALL(*wrapper_, stat(NotNull(), NotNull()))
-        .WillOnce(Return(0));
-    EXPECT_CALL(*wrapper_, opendir(NotNull()))
-        .WillOnce(Return(dir));
+    EXPECT_CALL(*wrapper_, stat(NotNull(), NotNull())).WillOnce(Return(0));
+    EXPECT_CALL(*wrapper_, opendir(NotNull())).WillOnce(Return(dir));
     EXPECT_CALL(*wrapper_, readdir(NotNull()))
         .Times(2)
         .WillOnce(Return(dirent))
         .WillOnce(ReturnNull());
-    EXPECT_CALL(*wrapper_, closedir(NotNull()))
-        .WillOnce(Return(0));
+    EXPECT_CALL(*wrapper_, closedir(NotNull())).WillOnce(Return(0));
     ret = diskCacheRead_->LoadAllCacheReadFile(cachedObj);
     ASSERT_EQ(0, ret);
 }
 
 TEST_F(TestDiskCacheRead, WriteDiskFile) {
-    EXPECT_CALL(*wrapper_, open(_, _, _))
-        .WillOnce(Return(-1));
+    EXPECT_CALL(*wrapper_, open(_, _, _)).WillOnce(Return(-1));
     std::string fileName = "test";
     uint64_t length = 10;
-    int ret = diskCacheRead_->WriteDiskFile(fileName,
-                                 const_cast<char*>(fileName.c_str()),
-                                 length);
+    int ret = diskCacheRead_->WriteDiskFile(
+        fileName, const_cast<char *>(fileName.c_str()), length);
     ASSERT_EQ(-1, ret);
 
-    EXPECT_CALL(*wrapper_, open(_, _, _))
-        .WillOnce(Return(0));
-    EXPECT_CALL(*wrapper_, write(_, _, length))
-        .WillOnce(Return(-1));
-    EXPECT_CALL(*wrapper_, close(_))
-        .WillOnce(Return(0));
-    ret = diskCacheRead_->WriteDiskFile(fileName,
-                                 const_cast<char*>(fileName.c_str()),
-                                 length);
+    EXPECT_CALL(*wrapper_, open(_, _, _)).WillOnce(Return(0));
+    EXPECT_CALL(*wrapper_, write(_, _, length)).WillOnce(Return(-1));
+    EXPECT_CALL(*wrapper_, close(_)).WillOnce(Return(0));
+    ret = diskCacheRead_->WriteDiskFile(
+        fileName, const_cast<char *>(fileName.c_str()), length);
     ASSERT_EQ(-1, ret);
 
-    EXPECT_CALL(*wrapper_, open(_, _, _))
-        .WillOnce(Return(0));
-    EXPECT_CALL(*wrapper_, write(_, _, length))
-        .WillOnce(Return(length+1));
-    EXPECT_CALL(*wrapper_, close(_))
-        .WillOnce(Return(-1));
-    ret = diskCacheRead_->WriteDiskFile(fileName,
-                                 const_cast<char*>(fileName.c_str()),
-                                 length);
+    EXPECT_CALL(*wrapper_, open(_, _, _)).WillOnce(Return(0));
+    EXPECT_CALL(*wrapper_, write(_, _, length)).WillOnce(Return(length + 1));
+    EXPECT_CALL(*wrapper_, close(_)).WillOnce(Return(-1));
+    ret = diskCacheRead_->WriteDiskFile(
+        fileName, const_cast<char *>(fileName.c_str()), length);
     ASSERT_EQ(-1, ret);
 
-    EXPECT_CALL(*wrapper_, open(_, _, _))
-        .WillOnce(Return(0));
-    EXPECT_CALL(*wrapper_, write(_, _, length))
-        .WillOnce(Return(length));
-    EXPECT_CALL(*wrapper_, close(_))
-        .WillOnce(Return(0));
-    ret = diskCacheRead_->WriteDiskFile(fileName,
-                                 const_cast<char*>(fileName.c_str()),
-                                 length);
+    EXPECT_CALL(*wrapper_, open(_, _, _)).WillOnce(Return(0));
+    EXPECT_CALL(*wrapper_, write(_, _, length)).WillOnce(Return(length));
+    EXPECT_CALL(*wrapper_, close(_)).WillOnce(Return(0));
+    ret = diskCacheRead_->WriteDiskFile(
+        fileName, const_cast<char *>(fileName.c_str()), length);
     ASSERT_EQ(length, ret);
+}
+
+TEST_F(TestDiskCacheRead, ClearReadCache) {
+    std::list<std::string> files{"16777216"};
+
+    LOG(INFO) << "##############case1: load cache file fail.";
+    EXPECT_CALL(*wrapper_, stat(NotNull(), NotNull())).WillOnce(Return(-1));
+    std::set<std::string> cachedObj;
+    ASSERT_EQ(-1, diskCacheRead_->ClearReadCache(files));
+
+    LOG(INFO) << "##############case2: remove file fail, and file not exist";
+    struct dirent fake;
+    strcpy(fake.d_name, "1_16777216_2_0_0");  // NOLINT
+    EXPECT_CALL(*wrapper_, stat(NotNull(), NotNull()))
+        .Times(2)
+        .WillRepeatedly(Return(0));
+    EXPECT_CALL(*wrapper_, remove(NotNull())).WillOnce(Return(-1));
+    ASSERT_EQ(-1, diskCacheRead_->ClearReadCache(files));
+
+    LOG(INFO) << "##############case3: remove file ok";
+    EXPECT_CALL(*wrapper_, stat(NotNull(), NotNull())).WillOnce(Return(0));
+    EXPECT_CALL(*wrapper_, remove(NotNull())).WillOnce(Return(0));
+    ASSERT_EQ(0, diskCacheRead_->ClearReadCache(files));
+
+    LOG(INFO) << "##############case4: remove file fail, and file not exist";
+    strcpy(fake.d_name, "1_16777216_2_0_0");  // NOLINT
+    EXPECT_CALL(*wrapper_, stat(NotNull(), NotNull()))
+        .WillOnce(Return(0))
+        .WillOnce(Return(-1));
+    EXPECT_CALL(*wrapper_, remove(NotNull())).WillOnce(Return(-1));
+    ASSERT_EQ(0, diskCacheRead_->ClearReadCache(files));
 }
 
 }  // namespace client
 }  // namespace curvefs
-

--- a/curvefs/test/client/test_disk_cache_write.cpp
+++ b/curvefs/test/client/test_disk_cache_write.cpp
@@ -27,6 +27,7 @@
 #include "curvefs/test/client/mock_client_s3.h"
 #include "curvefs/src/client/s3/disk_cache_write.h"
 #include "curvefs/src/client/s3/client_s3_adaptor.h"
+#include "src/common/concurrent/concurrent.h"
 
 namespace curvefs {
 namespace client {
@@ -62,11 +63,6 @@ class TestDiskCacheWrite : public ::testing::Test {
 
         std::shared_ptr<PosixWrapper> wrapper =
             std::make_shared<PosixWrapper>();
-        std::shared_ptr<DiskCacheRead> diskCacheRead =
-            std::make_shared<DiskCacheRead>();
-        std::shared_ptr<DiskCacheManager> diskCacheManager =
-            std::make_shared<DiskCacheManager>(wrapper, diskCacheWrite_,
-                                               diskCacheRead);
         diskCacheWrite_->Init(client_, wrapper_, "test", 1);
     }
 
@@ -453,6 +449,76 @@ TEST_F(TestDiskCacheWrite, AsyncUploadRun) {
         std::thread(&DiskCacheWrite::AsyncUploadEnqueue, diskCacheWrite_, t1);
     diskCacheWrite_->AsyncUploadStop();
     backEndThread.join();
+}
+
+TEST_F(TestDiskCacheWrite, UploadFileByInode) {
+    std::string inode("100"), obj1("1_16777216_2_0_0");
+
+    LOG(INFO) << "#############case1: write cache invalid";
+    EXPECT_CALL(*wrapper_, stat(NotNull(), NotNull())).WillOnce(Return(-1));
+    ASSERT_EQ(-1, diskCacheWrite_->UploadFileByInode(inode));
+
+    LOG(INFO) << "#############case2: no file need upload";
+    diskCacheWrite_->AsyncUploadEnqueue(obj1);
+    DIR *dir = opendir(".");
+    EXPECT_CALL(*wrapper_, stat(NotNull(), NotNull()))
+        .Times(2)
+        .WillRepeatedly(Return(0));
+    EXPECT_CALL(*wrapper_, opendir(NotNull())).WillOnce(Return(dir));
+    EXPECT_CALL(*wrapper_, closedir(NotNull()))
+        .WillOnce(Return(0));
+    EXPECT_CALL(*wrapper_, readdir(NotNull())).WillOnce(ReturnNull());
+    ASSERT_EQ(0, diskCacheWrite_->UploadFileByInode(inode));
+
+    LOG(INFO) << "#############case3: file need to upload";
+    std::string path("test");
+    EXPECT_CALL(*wrapper_, stat(NotNull(), NotNull()))
+        .Times(4)
+        .WillRepeatedly(Return(0));
+    EXPECT_CALL(*wrapper_, close(_)).WillOnce(Return(0));
+    EXPECT_CALL(*wrapper_, readdir(NotNull())).WillOnce(ReturnNull());
+    EXPECT_CALL(*wrapper_, open(_, _, _)).WillOnce(Return(10));
+    EXPECT_CALL(*wrapper_, malloc(_)).WillOnce(Return(&path));
+    EXPECT_CALL(*wrapper_, memset(_, _, _)).WillOnce(Return(&path));
+    EXPECT_CALL(*wrapper_, free(_)).WillRepeatedly(Return());
+    EXPECT_CALL(*wrapper_, read(_, _, _)).WillOnce(Return(239772865546436));
+    EXPECT_CALL(*wrapper_, remove(_)).WillRepeatedly(Return(0));
+    EXPECT_CALL(*client_, UploadAsync(_))
+        .WillOnce(
+            Invoke([&](const std::shared_ptr<PutObjectAsyncContext> &context) {
+                context->key = obj1;
+                context->retCode = 0;
+                context->cb(context);
+            }));
+    EXPECT_CALL(*wrapper_, opendir(NotNull())).WillOnce(Return(dir));
+    EXPECT_CALL(*wrapper_, closedir(NotNull())).WillOnce(Return(0));
+    ASSERT_EQ(0, diskCacheWrite_->UploadFileByInode("16777216"));
+
+    LOG(INFO) << "#############case4: no file need to upload, but need other "
+                 "upload task finish";
+    struct dirent fake;
+    strcpy(fake.d_name, obj1.c_str());  // NOLINT
+    EXPECT_CALL(*wrapper_, stat(NotNull(), NotNull()))
+        .Times(3)
+        .WillRepeatedly(Return(0));
+    EXPECT_CALL(*wrapper_, opendir(NotNull()))
+        .Times(2)
+        .WillRepeatedly(Return(dir));
+    EXPECT_CALL(*wrapper_, closedir(NotNull()))
+        .Times(2)
+        .WillRepeatedly(Return(0));
+    EXPECT_CALL(*wrapper_, readdir(NotNull()))
+        .WillOnce(Return(&fake))
+        .WillRepeatedly(ReturnNull());
+    ASSERT_EQ(0, diskCacheWrite_->UploadFileByInode("16777216"));
+}
+
+TEST_F(TestDiskCacheWrite, test_SynchronizationTask) {
+    auto syncTask = std::make_shared<DiskCacheWrite::SynchronizationTask>(1);
+    auto task = [&] { syncTask->Signal(); };
+    std::thread t1(task);
+    t1.join();
+    syncTask->Wait();
 }
 
 }  // namespace client


### PR DESCRIPTION
…points

NOTES:
When disk cache and memory cache are enabled, we need to upload the write cache in memory
and on disk to S3 and delete the read cache in memory and on disk.

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?): 

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
