### PR TITLE
curvefs/client: fix bug of support summary info in dir xattr

### DIFF
--- a/curvefs/conf/tools.conf
+++ b/curvefs/conf/tools.conf
@@ -26,5 +26,5 @@ s3.endpoint=endpoint
 s3.bucket_name=bucket
 s3.blocksize=4194304
 s3.chunksize=67108864
-# statistic info in xattr
+# statistic info in xattr, hardlink will not be supported when enable
 enableSumInDir=false

--- a/curvefs/src/client/curve_fuse_op.cpp
+++ b/curvefs/src/client/curve_fuse_op.cpp
@@ -209,7 +209,7 @@ void FuseReplyErrByErrCode(fuse_req_t req, CURVEFS_ERROR errcode) {
         fuse_reply_err(req, ENOTEMPTY);
         break;
     case CURVEFS_ERROR::NOTSUPPORT:
-        fuse_reply_err(req, ENOSYS);
+        fuse_reply_err(req, EOPNOTSUPP);
         break;
     case CURVEFS_ERROR::NAMETOOLONG:
         fuse_reply_err(req, ENAMETOOLONG);

--- a/curvefs/src/client/fuse_client.cpp
+++ b/curvefs/src/client/fuse_client.cpp
@@ -855,7 +855,7 @@ CURVEFS_ERROR FuseClient::CalOneLayerSumInfo(Inode *inode) {
     for (const auto &it : dentryList) {
         inodeIds.emplace(it.inodeid());
     }
-    ret = inodeManager_->BatchGetInodeAttr(inodeIds, &attrs);
+    ret = inodeManager_->BatchGetInodeAttr(&inodeIds, &attrs);
     if (ret == CURVEFS_ERROR::OK) {
         uint64_t files = 0;
         uint64_t subdirs = 0;
@@ -923,7 +923,7 @@ CURVEFS_ERROR FuseClient::CalAllLayerSumInfo(Inode *inode) {
         }
         // check size
         if (inodeIds.size() >= attrsLimit || iStack.empty()) {
-            ret = inodeManager_->BatchGetInodeAttr(inodeIds, &attrs);
+            ret = inodeManager_->BatchGetInodeAttr(&inodeIds, &attrs);
             if (ret == CURVEFS_ERROR::OK) {
                 for (const auto &it : attrs) {
                     if (it.type() == FsFileType::TYPE_DIRECTORY) {
@@ -1008,7 +1008,7 @@ CURVEFS_ERROR FuseClient::FastCalAllLayerSumInfo(Inode *inode) {
         }
         // check size
         if (inodeIds.size() >= xattrsLimit || iStack.empty()) {
-            ret = inodeManager_->BatchGetXAttr(inodeIds, &xattrs);
+            ret = inodeManager_->BatchGetXAttr(&inodeIds, &xattrs);
             if (ret == CURVEFS_ERROR::OK) {
                 for (const auto &it : xattrs) {
                     if (it.xattrinfos().count(XATTRFILES)) {

--- a/curvefs/src/client/fuse_client.h
+++ b/curvefs/src/client/fuse_client.h
@@ -240,7 +240,7 @@ class FuseClient {
         return 0;
     }
 
-    CURVEFS_ERROR UpdateParentInodeXattr(const std::list<uint64_t> &parentIds,
+    CURVEFS_ERROR UpdateParentInodeXattr(uint64_t parentId,
         const XAttr &xattr, bool direction);
 
  private:

--- a/curvefs/src/client/fuse_s3_client.cpp
+++ b/curvefs/src/client/fuse_s3_client.cpp
@@ -129,9 +129,9 @@ CURVEFS_ERROR FuseS3Client::FuseOpWrite(fuse_req_t req, fuse_ino_t ino,
         XAttr xattr;
         xattr.mutable_xattrinfos()->insert({XATTRFBYTES,
             std::to_string(*wSize)});
-        std::list<uint64_t> parentIds;
-        if (inodeManager_->GetParent(ino, &parentIds)) {
-            ret = UpdateParentInodeXattr(parentIds, xattr, true);
+        uint64_t parentId;
+        if (inodeManager_->GetParent(ino, &parentId)) {
+            ret = UpdateParentInodeXattr(parentId, xattr, true);
         } else {
             LOG(ERROR) << "inodeManager getParent failed, inodeId = " << ino;
             return CURVEFS_ERROR::INTERNAL;

--- a/curvefs/src/client/inode_cache_manager.h
+++ b/curvefs/src/client/inode_cache_manager.h
@@ -89,15 +89,11 @@ class InodeCacheManager {
 
     virtual void AddParent(uint64_t inodeId, uint64_t parentId) = 0;
 
-    virtual void RemoveParent(uint64_t inodeId, uint64_t parentId) = 0;
-
     virtual void ClearParent(uint64_t inodeId) = 0;
 
-    virtual bool GetParent(uint64_t inodeId,
-        std::list<uint64_t> *parentIds) = 0;
+    virtual bool GetParent(uint64_t inodeId, uint64_t *parentId) = 0;
 
-    virtual bool UpdateParent(uint64_t inodeId, uint64_t oldParentId,
-        uint64_t newParentId) = 0;
+    virtual bool UpdateParent(uint64_t inodeId, uint64_t newParentId) = 0;
 
  protected:
     uint32_t fsId_;
@@ -151,14 +147,11 @@ class InodeCacheManagerImpl : public InodeCacheManager {
 
     void AddParent(uint64_t inodeId, uint64_t parentId) override;
 
-    void RemoveParent(uint64_t inodeId, uint64_t parentId) override;
-
     void ClearParent(uint64_t inodeId) override;
 
-    bool GetParent(uint64_t inodeId, std::list<uint64_t> *parentIds) override;
+    bool GetParent(uint64_t inodeId, uint64_t *parentId) override;
 
-    bool UpdateParent(uint64_t inodeId, uint64_t oldParentId,
-        uint64_t newParentId) override;
+    bool UpdateParent(uint64_t inodeId, uint64_t newParentId) override;
 
  private:
     std::shared_ptr<MetaServerClient> metaClient_;
@@ -168,8 +161,8 @@ class InodeCacheManagerImpl : public InodeCacheManager {
     std::map<uint64_t, std::shared_ptr<InodeWrapper>> dirtyMap_;
     curve::common::Mutex dirtyMapMutex_;
 
-    // inodeid to parent inodeid, may have more parent at hard link
-    std::map<uint64_t, std::list<uint64_t>> parentIdMap_;
+    // inodeid to parent inodeid
+    std::map<uint64_t, uint64_t> parentIdMap_;
     curve::common::Mutex parentIdMapMutex_;
 
     curve::common::GenericNameLock<Mutex> nameLock_;

--- a/curvefs/src/client/inode_cache_manager.h
+++ b/curvefs/src/client/inode_cache_manager.h
@@ -67,10 +67,10 @@ class InodeCacheManager {
         std::shared_ptr<InodeWrapper> &out) = 0;   // NOLINT
 
     virtual CURVEFS_ERROR BatchGetInodeAttr(
-        const std::set<uint64_t> &inodeIds,
+        std::set<uint64_t> *inodeIds,
         std::list<InodeAttr> *attrs) = 0;
 
-    virtual CURVEFS_ERROR BatchGetXAttr(const std::set<uint64_t> &inodeIds,
+    virtual CURVEFS_ERROR BatchGetXAttr(std::set<uint64_t> *inodeIds,
         std::list<XAttr> *xattrs) = 0;
 
     virtual CURVEFS_ERROR CreateInode(const InodeParam &param,
@@ -125,10 +125,10 @@ class InodeCacheManagerImpl : public InodeCacheManager {
     CURVEFS_ERROR GetInode(uint64_t inodeid,
         std::shared_ptr<InodeWrapper> &out) override;    // NOLINT
 
-    CURVEFS_ERROR BatchGetInodeAttr(const std::set<uint64_t> &inodeIds,
+    CURVEFS_ERROR BatchGetInodeAttr(std::set<uint64_t> *inodeIds,
         std::list<InodeAttr> *attrs) override;
 
-    CURVEFS_ERROR BatchGetXAttr(const std::set<uint64_t> &inodeIds,
+    CURVEFS_ERROR BatchGetXAttr(std::set<uint64_t> *inodeIds,
         std::list<XAttr> *xattrs) override;
 
     CURVEFS_ERROR CreateInode(const InodeParam &param,

--- a/curvefs/src/client/inode_wrapper.cpp
+++ b/curvefs/src/client/inode_wrapper.cpp
@@ -180,12 +180,9 @@ void InodeWrapper::FlushAttrAsync() {
 }
 
 void InodeWrapper::FlushXattrAsync() {
-    if (dirty_) {
-        LockSyncingXattr();
-        auto *done = new UpdateXattrAsyncDone(shared_from_this());
-        metaClient_->UpdateXattrAsync(inode_, done);
-        dirty_ = false;
-    }
+    LockSyncingXattr();
+    auto *done = new UpdateXattrAsyncDone(shared_from_this());
+    metaClient_->UpdateXattrAsync(inode_, done);
 }
 
 void InodeWrapper::FlushS3ChunkInfoAsync() {

--- a/curvefs/src/client/inode_wrapper.h
+++ b/curvefs/src/client/inode_wrapper.h
@@ -176,6 +176,43 @@ class InodeWrapper : public std::enable_shared_from_this<InodeWrapper> {
         return;
     }
 
+    void GetInodeAttrLocked(InodeAttr *attr) {
+        curve::common::UniqueLock lg(mtx_);
+        attr->set_inodeid(inode_.inodeid());
+        attr->set_fsid(inode_.fsid());
+        attr->set_length(inode_.length());
+        attr->set_ctime(inode_.ctime());
+        attr->set_ctime_ns(inode_.ctime_ns());
+        attr->set_mtime(inode_.mtime());
+        attr->set_mtime_ns(inode_.mtime_ns());
+        attr->set_atime(inode_.atime());
+        attr->set_atime_ns(inode_.atime_ns());
+        attr->set_uid(inode_.uid());
+        attr->set_gid(inode_.gid());
+        attr->set_mode(inode_.mode());
+        attr->set_nlink(inode_.nlink());
+        attr->set_type(inode_.type());
+        if (inode_.has_symlink()) {
+            attr->set_symlink(inode_.symlink());
+        }
+        if (inode_.has_rdev()) {
+            attr->set_rdev(inode_.rdev());
+        }
+        if (inode_.has_dtime()) {
+            attr->set_dtime(inode_.dtime());
+        }
+        if (inode_.has_openmpcount()) {
+            attr->set_openmpcount(inode_.openmpcount());
+        }
+    }
+
+    void GetXattrLocked(XAttr *xattr) {
+        curve::common::UniqueLock lg(mtx_);
+        xattr->set_fsid(inode_.fsid());
+        xattr->set_inodeid(inode_.inodeid());
+        *(xattr->mutable_xattrinfos()) = inode_.xattr();
+    }
+
     bool GetXattrUnLocked(const char *name, std::string *value) {
         auto it = inode_.xattr().find(name);
         if (it != inode_.xattr().end()) {

--- a/curvefs/src/client/rpcclient/metaserver_client.cpp
+++ b/curvefs/src/client/rpcclient/metaserver_client.cpp
@@ -448,9 +448,9 @@ MetaStatusCode MetaServerClientImpl::GetInode(uint32_t fsId, uint64_t inodeid,
 bool GroupInodeIdByPartition(
     uint32_t fsId,
     std::shared_ptr<MetaCache> metaCache,
-    const std::set<uint64_t> &inodeIds,
+    std::set<uint64_t> *inodeIds,
     std::unordered_map<uint32_t, std::list<uint64_t>> *inodeGroups) {
-    for (const auto &it : inodeIds) {
+    for (const auto &it : *inodeIds) {
         uint32_t pId = 0;
         if (metaCache->GetPartitionIdByInodeId(fsId, it, &pId)) {
             auto iter = inodeGroups->find(pId);
@@ -469,7 +469,7 @@ bool GroupInodeIdByPartition(
 }
 
 MetaStatusCode MetaServerClientImpl::BatchGetInodeAttr(uint32_t fsId,
-    const std::set<uint64_t> &inodeIds,
+    std::set<uint64_t> *inodeIds,
     std::list<InodeAttr> *attr) {
     uint32_t limit = opt_.batchLimit;
     // group inodeid by partition
@@ -548,7 +548,7 @@ MetaStatusCode MetaServerClientImpl::BatchGetInodeAttr(uint32_t fsId,
 }
 
 MetaStatusCode MetaServerClientImpl::BatchGetXAttr(uint32_t fsId,
-    const std::set<uint64_t> &inodeIds,
+    std::set<uint64_t> *inodeIds,
     std::list<XAttr> *xattr) {
     uint32_t limit = opt_.batchLimit;
     // group inodeid by partition

--- a/curvefs/src/client/rpcclient/metaserver_client.h
+++ b/curvefs/src/client/rpcclient/metaserver_client.h
@@ -87,11 +87,11 @@ class MetaServerClient {
                                     Inode *out) = 0;
 
     virtual MetaStatusCode BatchGetInodeAttr(uint32_t fsId,
-        const std::set<uint64_t> &inodeIds,
+        std::set<uint64_t> *inodeIds,
         std::list<InodeAttr> *attr) = 0;
 
     virtual MetaStatusCode BatchGetXAttr(uint32_t fsId,
-        const std::set<uint64_t> &inodeIds,
+        std::set<uint64_t> *inodeIds,
         std::list<XAttr> *xattr) = 0;
 
     virtual MetaStatusCode UpdateInode(const Inode &inode,
@@ -159,11 +159,11 @@ class MetaServerClientImpl : public MetaServerClient {
                             Inode *out) override;
 
     MetaStatusCode BatchGetInodeAttr(uint32_t fsId,
-        const std::set<uint64_t> &inodeIds,
+        std::set<uint64_t> *inodeIds,
         std::list<InodeAttr> *attr) override;
 
     MetaStatusCode BatchGetXAttr(uint32_t fsId,
-        const std::set<uint64_t> &inodeIds,
+        std::set<uint64_t> *inodeIds,
         std::list<XAttr> *xattr) override;
 
     MetaStatusCode UpdateInode(const Inode &inode,

--- a/curvefs/test/client/mock_inode_cache_manager.h
+++ b/curvefs/test/client/mock_inode_cache_manager.h
@@ -45,10 +45,10 @@ class MockInodeCacheManager : public InodeCacheManager {
         uint64_t inodeid, std::shared_ptr<InodeWrapper> &out));     // NOLINT
 
     MOCK_METHOD2(BatchGetInodeAttr, CURVEFS_ERROR(
-        const std::set<uint64_t> &inodeIds, std::list<InodeAttr> *attrs));
+        std::set<uint64_t> *inodeIds, std::list<InodeAttr> *attrs));
 
     MOCK_METHOD2(BatchGetXAttr, CURVEFS_ERROR(
-        const std::set<uint64_t> &inodeIds, std::list<XAttr> *xattrs));
+        std::set<uint64_t> *inodeIds, std::list<XAttr> *xattrs));
 
     MOCK_METHOD2(CreateInode, CURVEFS_ERROR(const InodeParam &param,
         std::shared_ptr<InodeWrapper> &out));     // NOLINT

--- a/curvefs/test/client/mock_inode_cache_manager.h
+++ b/curvefs/test/client/mock_inode_cache_manager.h
@@ -67,16 +67,13 @@ class MockInodeCacheManager : public InodeCacheManager {
     MOCK_METHOD2(AddParent, void(uint64_t inodeId,
         uint64_t parentId));
 
-    MOCK_METHOD2(RemoveParent, void(uint64_t inodeId,
-        uint64_t parentId));
-
     MOCK_METHOD1(ClearParent, void(uint64_t inodeId));
 
     MOCK_METHOD2(GetParent, bool(uint64_t inodeId,
-        std::list<uint64_t> *parentId));
+        uint64_t *parentId));
 
-    MOCK_METHOD3(UpdateParent, bool(uint64_t inodeId,
-        uint64_t oldParentId, uint64_t newParentId));
+    MOCK_METHOD2(UpdateParent, bool(uint64_t inodeId,
+        uint64_t newParentId));
 };
 
 }  // namespace client

--- a/curvefs/test/client/mock_metaserver_client.h
+++ b/curvefs/test/client/mock_metaserver_client.h
@@ -76,11 +76,11 @@ class MockMetaServerClient : public MetaServerClient {
             uint32_t fsId, uint64_t inodeid, Inode *out));
 
     MOCK_METHOD3(BatchGetInodeAttr, MetaStatusCode(
-        uint32_t fsId, const std::set<uint64_t> &inodeIds,
+        uint32_t fsId, std::set<uint64_t> *inodeIds,
         std::list<InodeAttr> *attr));
 
     MOCK_METHOD3(BatchGetXAttr, MetaStatusCode(
-        uint32_t fsId, const std::set<uint64_t> &inodeIds,
+        uint32_t fsId, std::set<uint64_t> *inodeIds,
         std::list<XAttr> *xattr));
 
     MOCK_METHOD2(UpdateInode,

--- a/curvefs/test/client/rpcclient/metaserver_client_test.cpp
+++ b/curvefs/test/client/rpcclient/metaserver_client_test.cpp
@@ -1059,7 +1059,7 @@ TEST_F(MetaServerClientImplTest, test_BatchGetInodeAttr) {
                               SetArgPointee<3>(applyIndex), Return(true)));
 
     MetaStatusCode status = metaserverCli_.BatchGetInodeAttr(
-        fsid, inodeIds, &attr);
+        fsid, &inodeIds, &attr);
     ASSERT_EQ(MetaStatusCode::RPC_ERROR, status);
 
     // test1: batchGetInodeAttr ok
@@ -1081,7 +1081,7 @@ TEST_F(MetaServerClientImplTest, test_BatchGetInodeAttr) {
                   BatchGetInodeAttrResponse>)));
     EXPECT_CALL(*mockMetacache_.get(), UpdateApplyIndex(_, _));
 
-    status = metaserverCli_.BatchGetInodeAttr(fsid, inodeIds, &attr);
+    status = metaserverCli_.BatchGetInodeAttr(fsid, &inodeIds, &attr);
     ASSERT_EQ(MetaStatusCode::OK, status);
     ASSERT_EQ(attr.size(), 2);
     ASSERT_THAT(attr.begin()->inodeid(), AnyOf(inodeId1, inodeId2));
@@ -1097,7 +1097,7 @@ TEST_F(MetaServerClientImplTest, test_BatchGetInodeAttr) {
             DoAll(SetArgPointee<2>(response),
                   Invoke(SetRpcService<BatchGetInodeAttrRequest,
                   BatchGetInodeAttrResponse>)));
-    status = metaserverCli_.BatchGetInodeAttr(fsid, inodeIds, &attr);
+    status = metaserverCli_.BatchGetInodeAttr(fsid, &inodeIds, &attr);
     ASSERT_EQ(MetaStatusCode::NOT_FOUND, status);
 
     // test3: test response do not have applyindex
@@ -1113,7 +1113,7 @@ TEST_F(MetaServerClientImplTest, test_BatchGetInodeAttr) {
                   Invoke(SetRpcService<BatchGetInodeAttrRequest,
                   BatchGetInodeAttrResponse>)));
 
-    status = metaserverCli_.BatchGetInodeAttr(fsid, inodeIds, &attr);
+    status = metaserverCli_.BatchGetInodeAttr(fsid, &inodeIds, &attr);
     ASSERT_EQ(MetaStatusCode::RPC_ERROR, status);
 }
 
@@ -1161,7 +1161,7 @@ TEST_F(MetaServerClientImplTest, test_BatchGetXAttr) {
                               SetArgPointee<3>(applyIndex), Return(true)));
 
     MetaStatusCode status = metaserverCli_.BatchGetXAttr(
-        fsid, inodeIds, &xattr);
+        fsid, &inodeIds, &xattr);
     ASSERT_EQ(MetaStatusCode::RPC_ERROR, status);
 
     // test1: batchGetXAttr ok
@@ -1183,7 +1183,7 @@ TEST_F(MetaServerClientImplTest, test_BatchGetXAttr) {
                   BatchGetXAttrResponse>)));
     EXPECT_CALL(*mockMetacache_.get(), UpdateApplyIndex(_, _));
 
-    status = metaserverCli_.BatchGetXAttr(fsid, inodeIds, &xattr);
+    status = metaserverCli_.BatchGetXAttr(fsid, &inodeIds, &xattr);
     ASSERT_EQ(MetaStatusCode::OK, status);
     ASSERT_EQ(xattr.size(), 2);
     ASSERT_THAT(xattr.begin()->inodeid(), AnyOf(inodeId1, inodeId2));
@@ -1199,7 +1199,7 @@ TEST_F(MetaServerClientImplTest, test_BatchGetXAttr) {
             DoAll(SetArgPointee<2>(response),
                   Invoke(SetRpcService<BatchGetXAttrRequest,
                   BatchGetXAttrResponse>)));
-    status = metaserverCli_.BatchGetXAttr(fsid, inodeIds, &xattr);
+    status = metaserverCli_.BatchGetXAttr(fsid, &inodeIds, &xattr);
     ASSERT_EQ(MetaStatusCode::NOT_FOUND, status);
 
     // test3: test response do not have applyindex
@@ -1215,7 +1215,7 @@ TEST_F(MetaServerClientImplTest, test_BatchGetXAttr) {
                   Invoke(SetRpcService<BatchGetXAttrRequest,
                   BatchGetXAttrResponse>)));
 
-    status = metaserverCli_.BatchGetXAttr(fsid, inodeIds, &xattr);
+    status = metaserverCli_.BatchGetXAttr(fsid, &inodeIds, &xattr);
     ASSERT_EQ(MetaStatusCode::RPC_ERROR, status);
 }
 

--- a/curvefs/test/client/test_inode_cache_manager.cpp
+++ b/curvefs/test/client/test_inode_cache_manager.cpp
@@ -298,36 +298,23 @@ TEST_F(TestInodeCacheManager, ParentMap) {
     uint64_t p2 = 200;
     uint64_t p3 = 300;
 
-    std::list<uint64_t> parents;
-    ASSERT_FALSE(iCacheManager_->GetParent(inodeId1, &parents));
+    uint64_t parent;
+    ASSERT_FALSE(iCacheManager_->GetParent(inodeId1, &parent));
 
     iCacheManager_->AddParent(inodeId1, p1);
-    ASSERT_TRUE(iCacheManager_->GetParent(inodeId1, &parents));
-    ASSERT_EQ(parents.size(), 1);
-    ASSERT_EQ(*(parents.begin()), p1);
+    ASSERT_TRUE(iCacheManager_->GetParent(inodeId1, &parent));
+    ASSERT_EQ(parent, p1);
 
-    parents.clear();
     iCacheManager_->AddParent(inodeId1, p2);
-    ASSERT_TRUE(iCacheManager_->GetParent(inodeId1, &parents));
-    ASSERT_EQ(parents.size(), 2);
-    ASSERT_EQ(*(parents.begin()), p1);
-    ASSERT_EQ(*(++parents.begin()), p2);
+    ASSERT_TRUE(iCacheManager_->GetParent(inodeId1, &parent));
+    ASSERT_EQ(parent, p2);
 
-    parents.clear();
-    ASSERT_TRUE(iCacheManager_->UpdateParent(inodeId1, p1, p3));
-    ASSERT_TRUE(iCacheManager_->GetParent(inodeId1, &parents));
-    ASSERT_EQ(parents.size(), 2);
-    ASSERT_EQ(*(parents.begin()), p3);
+    ASSERT_TRUE(iCacheManager_->UpdateParent(inodeId1, p3));
+    ASSERT_TRUE(iCacheManager_->GetParent(inodeId1, &parent));
+    ASSERT_EQ(parent, p3);
 
-    parents.clear();
-    iCacheManager_->RemoveParent(inodeId1, p3);
-    ASSERT_TRUE(iCacheManager_->GetParent(inodeId1, &parents));
-    ASSERT_EQ(parents.size(), 1);
-    ASSERT_EQ(*(parents.begin()), p2);
-
-    parents.clear();
     iCacheManager_->ClearParent(inodeId1);
-    ASSERT_FALSE(iCacheManager_->GetParent(inodeId1, &parents));
+    ASSERT_FALSE(iCacheManager_->GetParent(inodeId1, &parent));
 }
 
 }  // namespace client

--- a/curvefs/test/client/test_inode_cache_manager.cpp
+++ b/curvefs/test/client/test_inode_cache_manager.cpp
@@ -234,16 +234,16 @@ TEST_F(TestInodeCacheManager, BatchGetInodeAttr) {
     attr.set_inodeid(inodeId2);
     attrs.emplace_back(attr);
 
-    EXPECT_CALL(*metaClient_, BatchGetInodeAttr(fsId_, inodeIds, _))
+    EXPECT_CALL(*metaClient_, BatchGetInodeAttr(fsId_, &inodeIds, _))
         .WillOnce(Return(MetaStatusCode::NOT_FOUND))
         .WillOnce(DoAll(SetArgPointee<2>(attrs),
                 Return(MetaStatusCode::OK)));
 
     std::list<InodeAttr> getAttrs;
-    CURVEFS_ERROR ret = iCacheManager_->BatchGetInodeAttr(inodeIds, &getAttrs);
+    CURVEFS_ERROR ret = iCacheManager_->BatchGetInodeAttr(&inodeIds, &getAttrs);
     ASSERT_EQ(CURVEFS_ERROR::NOTEXIST, ret);
 
-    ret = iCacheManager_->BatchGetInodeAttr(inodeIds, &getAttrs);
+    ret = iCacheManager_->BatchGetInodeAttr(&inodeIds, &getAttrs);
     ASSERT_EQ(CURVEFS_ERROR::OK, ret);
     ASSERT_EQ(getAttrs.size(), 2);
     ASSERT_THAT(getAttrs.begin()->inodeid(), AnyOf(inodeId1, inodeId2));
@@ -274,16 +274,16 @@ TEST_F(TestInodeCacheManager, BatchGetXAttr) {
     xattr.mutable_xattrinfos()->find(XATTRFBYTES)->second = "200";
     xattrs.emplace_back(xattr);
 
-    EXPECT_CALL(*metaClient_, BatchGetXAttr(fsId_, inodeIds, _))
+    EXPECT_CALL(*metaClient_, BatchGetXAttr(fsId_, &inodeIds, _))
         .WillOnce(Return(MetaStatusCode::NOT_FOUND))
         .WillOnce(DoAll(SetArgPointee<2>(xattrs),
                 Return(MetaStatusCode::OK)));
 
     std::list<XAttr> getXAttrs;
-    CURVEFS_ERROR ret = iCacheManager_->BatchGetXAttr(inodeIds, &getXAttrs);
+    CURVEFS_ERROR ret = iCacheManager_->BatchGetXAttr(&inodeIds, &getXAttrs);
     ASSERT_EQ(CURVEFS_ERROR::NOTEXIST, ret);
 
-    ret = iCacheManager_->BatchGetXAttr(inodeIds, &getXAttrs);
+    ret = iCacheManager_->BatchGetXAttr(&inodeIds, &getXAttrs);
     ASSERT_EQ(CURVEFS_ERROR::OK, ret);
     ASSERT_EQ(getXAttrs.size(), 2);
     ASSERT_THAT(getXAttrs.begin()->inodeid(), AnyOf(inodeId1, inodeId2));

--- a/curvefs/test/mds/mds_test.cpp
+++ b/curvefs/test/mds/mds_test.cpp
@@ -91,7 +91,7 @@ class MdsTest : public ::testing::Test {
         EtcdConf conf{const_cast<char*>(kEtcdAddr), strlen(kEtcdAddr), 1000};
         uint64_t now = curve::common::TimeUtility::GetTimeofDaySec();
         bool initSucc = false;
-        while (curve::common::TimeUtility::GetTimeofDaySec() - now <= 5) {
+        while (curve::common::TimeUtility::GetTimeofDaySec() - now <= 50) {
             if (0 == client->Init(conf, 0, 3)) {
                 initSucc = true;
                 break;


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:
1. Fix the summary info of hardlink when enableSumInDIr if false. Because batch get inodeAttr is divided by batch limit, the struct std::set will not deal with hardlink.
2. Fix UpdateParentInodeXattr dirty flag, the update of xattr doesn't based on dirty flag.
3. Disable hardlink when  enableSumInDIr is true.
4. batchGetInodeAttr and batchGetXattr from metaserver after find in inodeCache.

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?): 

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
