### PR TITLE
curvefs/metaserver: let s3 compact task store a shared copyset node

### DIFF
--- a/curvefs/src/metaserver/copyset/copyset_node.h
+++ b/curvefs/src/metaserver/copyset/copyset_node.h
@@ -58,7 +58,7 @@ class CopysetNode : public braft::StateMachine {
                 const braft::Configuration& conf,
                 CopysetNodeManager* nodeManager);
 
-    ~CopysetNode();
+    ~CopysetNode() override;
 
     bool Init(const CopysetNodeOptions& options);
 

--- a/curvefs/src/metaserver/copyset/copyset_node_manager.h
+++ b/curvefs/src/metaserver/copyset/copyset_node_manager.h
@@ -57,6 +57,9 @@ class CopysetNodeManager {
 
     virtual CopysetNode* GetCopysetNode(PoolId poolId, CopysetId copysetId);
 
+    virtual std::shared_ptr<CopysetNode> GetSharedCopysetNode(
+        PoolId poolId, CopysetId copysetId);
+
     /**
      * @return 0: not exist; 1: key exist and peers are exactly same;
      * -1: key exist but peers are not exactly same
@@ -76,8 +79,14 @@ class CopysetNodeManager {
     virtual bool IsLoadFinished() const;
 
  public:
-    CopysetNodeManager();
+    CopysetNodeManager()
+        : options_(),
+          running_(false),
+          loadFinished_(false),
+          lock_(),
+          copysets_() {}
 
+ public:
     /**
      * @brief Add raft related services to server
      */
@@ -89,7 +98,7 @@ class CopysetNodeManager {
 
  private:
     using CopysetNodeMap =
-        std::unordered_map<braft::GroupId, std::unique_ptr<CopysetNode>>;
+        std::unordered_map<braft::GroupId, std::shared_ptr<CopysetNode>>;
 
     CopysetNodeOptions options_;
 

--- a/curvefs/src/metaserver/s3compact_wq_impl.cpp
+++ b/curvefs/src/metaserver/s3compact_wq_impl.cpp
@@ -33,6 +33,7 @@
 
 #include "curvefs/src/common/s3util.h"
 #include "curvefs/src/metaserver/copyset/meta_operator.h"
+#include "curvefs/src/metaserver/copyset/copyset_node_manager.h"
 
 using curve::common::Configuration;
 using curve::common::InitS3AdaptorOptionExceptS3InfoOption;
@@ -45,8 +46,7 @@ namespace curvefs {
 namespace metaserver {
 
 void S3CompactWorkQueueImpl::Enqueue(std::shared_ptr<InodeManager> inodeManager,
-                                     InodeKey inodeKey, PartitionInfo pinfo,
-                                     CopysetNode* copysetNode) {
+                                     InodeKey inodeKey, PartitionInfo pinfo) {
     std::unique_lock<std::mutex> guard(mutex_);
 
     // inodeKey already in working queue, just return
@@ -58,12 +58,26 @@ void S3CompactWorkQueueImpl::Enqueue(std::shared_ptr<InodeManager> inodeManager,
     while (IsFullUnlock()) {
         notFull_.wait(guard);
     }
+
+    auto copysetNode = copysetNodeMgr_->GetSharedCopysetNode(pinfo.poolid(),
+                                                             pinfo.copysetid());
+    if (!copysetNode) {
+        VLOG(6) << "Copyset node not found, poolid: " << pinfo.poolid()
+                << ", copysetid: " << pinfo.copysetid()
+                << ", fsid: " << inodeKey.fsId
+                << ", inodeid: " << inodeKey.inodeId;
+        return;
+    }
+
     compactingInodes_.push_back(inodeKey);
+
     struct S3CompactTask t {
         inodeManager, inodeKey, pinfo,
             std::make_shared<CopysetNodeWrapper>(copysetNode)
     };
-    auto task = std::bind(&S3CompactWorkQueueImpl::CompactChunks, this, t);
+
+    auto task =
+        std::bind(&S3CompactWorkQueueImpl::CompactChunks, this, std::move(t));
     // am i copysetnode leader?_
     queue_.push_back(std::move(task));
     notEmpty_.notify_one();
@@ -101,7 +115,8 @@ std::vector<uint64_t> S3CompactWorkQueueImpl::GetNeedCompact(
             VLOG(9) << "s3compact: reach max chunks to compact per time";
             break;
         }
-        if (item.second.s3chunks_size() > opts_.fragmentThreshold) {
+        if (static_cast<uint64_t>(item.second.s3chunks_size()) >
+            opts_.fragmentThreshold) {
             needCompact.push_back(item.first);
         }
     }

--- a/curvefs/test/metaserver/BUILD
+++ b/curvefs/test/metaserver/BUILD
@@ -160,6 +160,7 @@ cc_test(
         "//curvefs/src/metaserver:curvefs_metaserver",
         "@com_google_googletest//:gtest_main",
         "@com_google_googletest//:gtest",
+        "//curvefs/test/metaserver/copyset/mock:metaserver_copyset_test_mock",
     ],
 )
 

--- a/curvefs/test/metaserver/copyset/meta_operator_test.cpp
+++ b/curvefs/test/metaserver/copyset/meta_operator_test.cpp
@@ -91,6 +91,7 @@ using ::testing::_;
 using ::testing::DoAll;
 using ::testing::Invoke;
 using ::testing::Return;
+using ::testing::AtLeast;
 
 class MetaOperatorTest : public testing::Test {
  protected:
@@ -396,9 +397,9 @@ TEST_F(MetaOperatorTest, PropostTest_RequestCanBypassProcess) {
     EXPECT_CALL(*mockRaftNode, apply(_))
         .Times(0);
     EXPECT_CALL(*mockRaftNode, shutdown(_))
-        .Times(1);
+        .Times(AtLeast(1));
     EXPECT_CALL(*mockRaftNode, join())
-        .Times(1);
+        .Times(AtLeast(1));
     EXPECT_CALL(*mockMetaStore, GetDentry(_, _))
         .WillOnce(Return(MetaStatusCode::OK));
 

--- a/curvefs/test/metaserver/mock_s3compactwq_impl.h
+++ b/curvefs/test/metaserver/mock_s3compactwq_impl.h
@@ -44,8 +44,8 @@ class MockS3CompactWorkQueueImpl : public S3CompactWorkQueueImpl {
     MockS3CompactWorkQueueImpl(
         std::shared_ptr<S3AdapterManager> s3AdapterManager,
         std::shared_ptr<S3InfoCache> s3infoCache,
-        const S3CompactWorkQueueOption& opts)
-        : S3CompactWorkQueueImpl(s3AdapterManager, s3infoCache, opts) {}
+        const S3CompactWorkQueueOption& opts, copyset::CopysetNodeManager* mgr)
+        : S3CompactWorkQueueImpl(s3AdapterManager, s3infoCache, opts, mgr) {}
     MetaStatusCode UpdateInode(
         CopysetNode* copysetNode, const PartitionInfo& pinfo, uint64_t inodeId,
         ::google::protobuf::Map<uint64_t, S3ChunkInfoList>&& s3ChunkInfoAdd,


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: close #1155 

Problem Summary:

previously, s3 compact task stores a raw pointer of copyset,
so after copyset is been purged, s3 compact task will cause
curvefs-metaserver process exited.

### What is changed and how it works?

What's Changed:

now, let s3 compact task store a shared copyset node.

Side effects(Breaking backward compatibility? Performance regression?): 

### Check List

- [x] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license
