### PR TITLE
curvefs/client: fix the problem that chunkCacheManager has been relea…

### DIFF
--- a/curvefs/src/client/s3/client_s3_cache_manager.cpp
+++ b/curvefs/src/client/s3/client_s3_cache_manager.cpp
@@ -541,7 +541,7 @@ int FileCacheManager::ReadFromS3(const std::vector<S3ReadRequest> &requests,
         WriteLockGuard writeLockGuard(chunkCacheManager->rwLockChunk_);
         for (auto &chunkPos : DataCacheVec) {
             DataCachePtr dataCache = std::make_shared<DataCache>(
-            s3ClientAdaptor_, chunkCacheManager.get(), chunkPos,
+            s3ClientAdaptor_, chunkCacheManager, chunkPos,
             (*responses)[i].GetBufLen(), (*responses)[i].GetDataBuf());
             if (!curvefs::client::common::FLAGS_enableCto) {
                 chunkCacheManager->AddReadDataCache(dataCache);
@@ -1236,11 +1236,10 @@ DataCachePtr ChunkCacheManager::FindWriteableDataCache(
 void ChunkCacheManager::WriteNewDataCache(S3ClientAdaptorImpl *s3ClientAdaptor,
                                           uint32_t chunkPos, uint32_t len,
                                           const char *data) {
-    DataCachePtr dataCache =
-        std::make_shared<DataCache>(s3ClientAdaptor, this, chunkPos, len, data);
+    DataCachePtr dataCache = std::make_shared<DataCache>(
+        s3ClientAdaptor, this->shared_from_this(), chunkPos, len, data);
     VLOG(9) << "WriteNewDataCache chunkPos:" << chunkPos << ", len:" << len
-            << ", new len:" << dataCache->GetLen()
-            << ",chunkIndex:" << index_;
+            << ", new len:" << dataCache->GetLen() << ",chunkIndex:" << index_;
     WriteLockGuard writeLockGuard(rwLockWrite_);
 
     auto ret = dataWCacheMap_.emplace(chunkPos, dataCache);
@@ -1453,7 +1452,7 @@ void ChunkCacheManager::UpdateWriteCacheMap(uint64_t oldChunkPos,
 }
 
 DataCache::DataCache(S3ClientAdaptorImpl *s3ClientAdaptor,
-                     ChunkCacheManager *chunkCacheManager, uint64_t chunkPos,
+                     ChunkCacheManagerPtr chunkCacheManager, uint64_t chunkPos,
                      uint64_t len, const char *data)
     : s3ClientAdaptor_(s3ClientAdaptor), chunkCacheManager_(chunkCacheManager),
       dirty_(true), delete_(false), inReadCache_(false) {

--- a/curvefs/src/client/s3/client_s3_cache_manager.h
+++ b/curvefs/src/client/s3/client_s3_cache_manager.h
@@ -98,7 +98,7 @@ using PageDataMap = std::map<uint64_t, PageData *>;
 class DataCache : public std::enable_shared_from_this<DataCache> {
  public:
     DataCache(S3ClientAdaptorImpl *s3ClientAdaptor,
-              ChunkCacheManager *chunkCacheManager, uint64_t chunkPos,
+              ChunkCacheManagerPtr chunkCacheManager, uint64_t chunkPos,
               uint64_t len, const char *data);
     virtual ~DataCache() {
         auto iter = dataMap_.begin();
@@ -171,7 +171,7 @@ class DataCache : public std::enable_shared_from_this<DataCache> {
 
  private:
     S3ClientAdaptorImpl *s3ClientAdaptor_;
-    ChunkCacheManager* chunkCacheManager_;
+    ChunkCacheManagerPtr chunkCacheManager_;
     uint64_t chunkPos_;  // useful chunkPos
     uint64_t len_;  // useful len
     uint64_t actualChunkPos_;  // after alignment the actual chunkPos
@@ -203,7 +203,8 @@ class S3ReadResponse {
     uint64_t len_;
 };
 
-class ChunkCacheManager {
+class ChunkCacheManager
+    : public std::enable_shared_from_this<ChunkCacheManager> {
  public:
     ChunkCacheManager(uint64_t index, S3ClientAdaptorImpl *s3ClientAdaptor)
         : index_(index), s3ClientAdaptor_(s3ClientAdaptor) {}

--- a/curvefs/test/client/fs_cache_manager_test.cpp
+++ b/curvefs/test/client/fs_cache_manager_test.cpp
@@ -59,7 +59,7 @@ TEST(FsCacheManagerTest, test_read_lru_cache_size) {
 
         for (size_t i = 0; i < maxReadCacheByte / smallDataCacheByte; ++i) {
             manager.Set(std::make_shared<DataCache>(s3ClientAdaptor_,
-                                                    mockCacheMgr.get(), 0,
+                                                    mockCacheMgr, 0,
                                                     smallDataCacheByte, buf),
                         &outIter);
         }
@@ -73,7 +73,7 @@ TEST(FsCacheManagerTest, test_read_lru_cache_size) {
             .Times(expectCallTimes)
             .WillRepeatedly(Invoke([&counter](uint64_t) { counter.Signal(); }));
         manager.Set(std::make_shared<DataCache>(s3ClientAdaptor_,
-                                                mockCacheMgr.get(), 0,
+                                                mockCacheMgr, 0,
                                                 dataCacheByte, buf),
                     &outIter);
 
@@ -89,7 +89,7 @@ TEST(FsCacheManagerTest, test_read_lru_cache_size) {
             .WillRepeatedly(Invoke([&counter](uint64_t) { counter.Signal(); }));
 
         manager.Set(std::make_shared<DataCache>(s3ClientAdaptor_,
-                                                mockCacheMgr.get(), 0,
+                                                mockCacheMgr, 0,
                                                 dataCacheByte, buf),
                     &outIter);
         counter.Wait();


### PR DESCRIPTION
…sed in advance during the Release process of dataCache

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?
curvefs/client: fix the problem that chunkCacheManager has been released in advance during the Release process of dataCache
Issue Number: close #1163  <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?): 

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
