### PR TITLE
curvefs/conf: modify metaserver.conf storage max quota

### DIFF
--- a/curvefs/conf/metaserver.conf
+++ b/curvefs/conf/metaserver.conf
@@ -207,7 +207,7 @@ mdsOpt.rpcRetryOpt.addrs=127.0.0.1:6700,127.0.0.1:6701,127.0.0.1:6702  # __CURVE
 #
 # metaserver storage data directory
 storage.data_dir=/tmp/storage  # __CURVEADM_TEMPLATE__ ${prefix}/data __CURVEADM_TEMPLATE__
-# metaserver max memory quota bytes (default: 500GB)
-storage.max_memory_quota_bytes=536870912000
+# metaserver max memory quota bytes (default: 30GB)
+storage.max_memory_quota_bytes=32212254720
 # metaserver max disk quota bytes (default: 2TB)
 storage.max_disk_quota_bytes=2199023255552


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary: modify metaserver.conf storage max quota

### What is changed and how it works?

What's Changed:

storage.max_memory_quota_bytes from 500GB to 30GB


