### PR TITLE
 backport-2.2: add s3.useVirtualAddressing config 

### DIFF
--- a/conf/s3.conf
+++ b/conf/s3.conf
@@ -27,3 +27,4 @@ s3.throttle.iopsWriteLimit=5000
 s3.throttle.bpsTotalMB=1280
 s3.throttle.bpsReadMB=1280
 s3.throttle.bpsWriteMB=1280
+s3.useVirtualAddressing=false

--- a/curvefs/conf/client.conf
+++ b/curvefs/conf/client.conf
@@ -146,6 +146,7 @@ s3.throttle.iopsWriteLimit=0
 s3.throttle.bpsTotalMB=0
 s3.throttle.bpsReadMB=0
 s3.throttle.bpsWriteMB=0
+s3.useVirtualAddressing=false
 
 # TODO(hongsong): limit bytes、iops/bps
 #### disk cache options

--- a/curvefs/conf/mds.conf
+++ b/curvefs/conf/mds.conf
@@ -128,3 +128,4 @@ s3.throttle.iopsWriteLimit=0
 s3.throttle.bpsTotalMB=0
 s3.throttle.bpsReadMB=0
 s3.throttle.bpsWriteMB=0
+s3.useVirtualAddressing=false

--- a/curvefs/conf/metaserver.conf
+++ b/curvefs/conf/metaserver.conf
@@ -26,6 +26,7 @@ s3.throttle.iopsWriteLimit=0
 s3.throttle.bpsTotalMB=0
 s3.throttle.bpsReadMB=0
 s3.throttle.bpsWriteMB=0
+s3.useVirtualAddressing=false
 # s3 workqueue
 s3compactwq.enable=True
 s3compactwq.thread_num=2

--- a/curvefs/conf/tools.conf
+++ b/curvefs/conf/tools.conf
@@ -29,5 +29,6 @@ s3.endpoint=endpoint
 s3.bucket_name=bucket
 s3.blocksize=4194304
 s3.chunksize=67108864
+s3.useVirtualAddressing=false
 # statistic info in xattr, hardlink will not be supported when enable
 enableSumInDir=true

--- a/src/common/s3_adapter.h
+++ b/src/common/s3_adapter.h
@@ -85,6 +85,7 @@ struct S3AdapterOption {
     uint64_t bpsTotalMB;
     uint64_t bpsReadMB;
     uint64_t bpsWriteMB;
+    bool useVirtualAddressing;
 };
 
 struct S3InfoOption {


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

We do not support virtual host.

### What is changed and how it works?

What's Changed:

Support both virtual host and path style

How it Works:

Add a config, init client with config

Side effects(Breaking backward compatibility? Performance regression?): 

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
