### PR TITLE
curvefs/metaserver: s3compat support "truncate smaller" correctly

### DIFF
--- a/curvefs/src/metaserver/s3compact_wq_impl.h
+++ b/curvefs/src/metaserver/s3compact_wq_impl.h
@@ -174,9 +174,9 @@ class S3CompactWorkQueueImpl : public TaskThreadPool<> {
 
     std::vector<uint64_t> GetNeedCompact(
         const ::google::protobuf::Map<uint64_t, S3ChunkInfoList>&
-            s3chunkinfoMap);
-    bool CompactPrecheck(const struct S3CompactTask& task, Inode* inode,
-                         std::vector<uint64_t>* needCompact);
+            s3chunkinfoMap,
+        uint64_t inodeLen, uint64_t chunkSize);
+    bool CompactPrecheck(const struct S3CompactTask& task, Inode* inode);
     S3Adapter* SetupS3Adapter(uint64_t fsid, uint64_t* s3adapterIndex,
                               uint64_t* blockSize, uint64_t* chunkSize);
     void DeleteObjs(const std::vector<std::string>& objsAdded,


### PR DESCRIPTION
s3compact now will process two kinds of chunk
1. the whole chunk is useless; chunkSize * chunkIndex > inodeLen-1
2. part of the chunk is useless; some info in list off+len-1 > inodeLen -1


i wll delete these useless data