### PR TITLE
curvefs: prefetch inodes when readdir to improve meta data performance

### DIFF
--- a/curvefs/conf/client.conf
+++ b/curvefs/conf/client.conf
@@ -52,7 +52,10 @@ excutorOpt.maxRPCTimeoutMS=8000
 excutorOpt.maxRetrySleepIntervalUS=8000000
 excutorOpt.minRetryTimesForceTimeoutBackoff=5
 excutorOpt.maxRetryTimesBeforeConsiderSuspend=20
-excutorOpt.batchLimit=10000
+# batch limit of get inode attr and xattr
+excutorOpt.batchInodeAttrLimit=10000
+# batch limit of get inode
+excutorOpt.batchInodeLimit=100
 
 #### spaceserver
 spaceserver.spaceaddr=127.0.0.1:19999  # __ANSIBLE_TEMPLATE__ {{ groups.space | join_peer(hostvars, "space_listen_port") }} __ANSIBLE_TEMPLATE__

--- a/curvefs/proto/metaserver.proto
+++ b/curvefs/proto/metaserver.proto
@@ -368,6 +368,22 @@ message InodeAttr {
     optional uint32 openmpcount = 18;
 }
 
+message BatchGetInodeRequest {
+    required uint32 poolId = 1;
+    required uint32 copysetId = 2;
+    required uint32 partitionId = 3;
+    required uint32 fsId = 4;
+    repeated uint64 inodeId = 5;
+    optional uint64 appliedIndex = 6;
+}
+
+message BatchGetInodeResponse {
+    required MetaStatusCode statusCode = 1;
+    repeated Inode inode = 2;
+    optional uint64 appliedIndex = 3;
+}
+
+
 message BatchGetInodeAttrRequest {
     required uint32 poolId = 1;
     required uint32 copysetId = 2;
@@ -421,6 +437,7 @@ service MetaServerService {
                                             (CreateRootInodeResponse);
     rpc GetOrModifyS3ChunkInfo(GetOrModifyS3ChunkInfoRequest) returns (GetOrModifyS3ChunkInfoResponse);
     rpc BatchGetInodeAttr(BatchGetInodeAttrRequest) returns (BatchGetInodeAttrResponse);
+    rpc BatchGetInode(BatchGetInodeRequest) returns (BatchGetInodeResponse);
     rpc BatchGetXAttr(BatchGetXAttrRequest) returns (BatchGetXAttrResponse);
 
     // partition interface

--- a/curvefs/src/client/common/common.h
+++ b/curvefs/src/client/common/common.h
@@ -50,6 +50,7 @@ enum class MetaServerOpType {
     DeleteDentry,
     PrepareRenameTx,
     GetInode,
+    BatchGetInode,
     BatchGetInodeAttr,
     BatchGetXAttr,
     UpdateInode,

--- a/curvefs/src/client/common/config.cpp
+++ b/curvefs/src/client/common/config.cpp
@@ -88,7 +88,10 @@ void InitExcutorOption(Configuration *conf, ExcutorOpt *opts) {
                               &opts->minRetryTimesForceTimeoutBackoff);
     conf->GetValueFatalIfFail("excutorOpt.maxRetryTimesBeforeConsiderSuspend",
                               &opts->maxRetryTimesBeforeConsiderSuspend);
-    conf->GetValueFatalIfFail("excutorOpt.batchLimit", &opts->batchLimit);
+    conf->GetValueFatalIfFail("excutorOpt.batchInodeAttrLimit",
+                              &opts->batchInodeAttrLimit);
+    conf->GetValueFatalIfFail("excutorOpt.batchInodeLimit",
+                              &opts->batchInodeLimit);
 }
 
 void InitBlockDeviceOption(Configuration *conf,

--- a/curvefs/src/client/common/config.h
+++ b/curvefs/src/client/common/config.h
@@ -65,7 +65,8 @@ struct ExcutorOpt {
     uint64_t maxRetrySleepIntervalUS = 64ull * 1000 * 1000;
     uint64_t minRetryTimesForceTimeoutBackoff = 5;
     uint64_t maxRetryTimesBeforeConsiderSuspend = 20;
-    uint32_t batchLimit = 100;
+    uint32_t batchInodeAttrLimit = 10000;
+    uint32_t batchInodeLimit = 100;
 };
 
 struct LeaseOpt {

--- a/curvefs/src/client/fuse_client.cpp
+++ b/curvefs/src/client/fuse_client.cpp
@@ -257,6 +257,7 @@ CURVEFS_ERROR FuseClient::FuseOpLookup(fuse_req_t req, fuse_ino_t parent,
     if (strlen(name) > option_.maxNameLength) {
         return CURVEFS_ERROR::NAMETOOLONG;
     }
+
     Dentry dentry;
     CURVEFS_ERROR ret = dentryManager_->GetDentry(parent, name, &dentry);
     if (ret != CURVEFS_ERROR::OK) {
@@ -267,6 +268,7 @@ CURVEFS_ERROR FuseClient::FuseOpLookup(fuse_req_t req, fuse_ino_t parent,
         }
         return ret;
     }
+
     std::shared_ptr<InodeWrapper> inodeWrapper;
     fuse_ino_t ino = dentry.inodeid();
     ret = inodeManager_->GetInode(ino, inodeWrapper);
@@ -315,9 +317,13 @@ CURVEFS_ERROR FuseClient::FuseOpOpen(fuse_req_t req, fuse_ino_t ino,
             inode->set_ctime_ns(now.tv_nsec);
             inode->set_mtime(now.tv_sec);
             inode->set_mtime_ns(now.tv_nsec);
-            ret = inodeWrapper->Sync();
-            if (ret != CURVEFS_ERROR::OK) {
-                return ret;
+            if (length != 0) {
+                ret = inodeWrapper->Sync();
+                if (ret != CURVEFS_ERROR::OK) {
+                    return ret;
+                }
+            } else {
+                inodeWrapper->MarkDirty();
             }
 
             if (enableSumInDir_ && length != 0) {
@@ -558,6 +564,7 @@ CURVEFS_ERROR FuseClient::RemoveNode(fuse_req_t req, fuse_ino_t parent,
 
 CURVEFS_ERROR FuseClient::FuseOpOpenDir(fuse_req_t req, fuse_ino_t ino,
                                         struct fuse_file_info *fi) {
+    VLOG(1) << "FuseOpOpenDir ino = " << ino;
     std::shared_ptr<InodeWrapper> inodeWrapper;
     CURVEFS_ERROR ret = inodeManager_->GetInode(ino, inodeWrapper);
     if (ret != CURVEFS_ERROR::OK) {
@@ -571,7 +578,6 @@ CURVEFS_ERROR FuseClient::FuseOpOpenDir(fuse_req_t req, fuse_ino_t ino,
     uint64_t dindex = dirBuf_->DirBufferNew();
     fi->fh = dindex;
     VLOG(1) << "FuseOpOpenDir, ino: " << ino << ", dindex: " << dindex;
-
     return ret;
 }
 
@@ -613,6 +619,7 @@ CURVEFS_ERROR FuseClient::FuseOpReadDir(fuse_req_t req, fuse_ino_t ino,
 
     uint64_t dindex = fi->fh;
     DirBufferHead *bufHead = dirBuf_->DirBufferGet(dindex);
+    std::set<uint64_t> inodeIds;
     if (!bufHead->wasRead) {
         std::list<Dentry> dentryList;
         auto limit = option_.listDentryLimit;
@@ -624,6 +631,7 @@ CURVEFS_ERROR FuseClient::FuseOpReadDir(fuse_req_t req, fuse_ino_t ino,
         }
         for (const auto &dentry : dentryList) {
             dirbuf_add(req, bufHead, dentry);
+            inodeIds.emplace(dentry.inodeid());
         }
         bufHead->wasRead = true;
     }
@@ -634,6 +642,13 @@ CURVEFS_ERROR FuseClient::FuseOpReadDir(fuse_req_t req, fuse_ino_t ino,
         *buffer = nullptr;
         *rSize = 0;
     }
+
+    VLOG(1) << "batch get inode size = " << inodeIds.size();
+    auto rt = inodeManager_->BatchGetInodeAsync(&inodeIds);
+    if (rt != CURVEFS_ERROR::OK) {
+        LOG(ERROR) << "BatchGetInode failed when FuseOpReadDir";
+    }
+
     return ret;
 }
 
@@ -746,12 +761,14 @@ CURVEFS_ERROR FuseClient::UpdateParentXattrAfterRename(fuse_ino_t parent,
             return rc;
         }
     }
+
     return rc;
 }
 
 CURVEFS_ERROR FuseClient::FuseOpGetAttr(fuse_req_t req, fuse_ino_t ino,
                                         struct fuse_file_info *fi,
                                         struct stat *attr) {
+    VLOG(1) << "FuseOpGetAttr ino = " << ino;
     std::shared_ptr<InodeWrapper> inodeWrapper;
     CURVEFS_ERROR ret = inodeManager_->GetInode(ino, inodeWrapper);
     if (ret != CURVEFS_ERROR::OK) {
@@ -954,9 +971,7 @@ CURVEFS_ERROR FuseClient::CalAllLayerSumInfo(Inode *inode) {
     std::list<InodeAttr> attrs;
     auto ino = inode->inodeid();
     auto limit = option_.listDentryLimit;
-    // the attrsLimit is protect attrs and inodeIds at huge files,
-    // also can use a sigle config item, but not much sense.
-    auto attrsLimit = 10 * option_.excutorOpt.batchLimit;
+    auto attrsLimit = option_.excutorOpt.batchInodeAttrLimit;
 
     iStack.emplace(ino);
     uint64_t rfiles = 0;
@@ -1031,9 +1046,7 @@ CURVEFS_ERROR FuseClient::FastCalAllLayerSumInfo(Inode *inode) {
     std::list<XAttr> xattrs;
     auto ino = inode->inodeid();
     auto limit = option_.listDentryLimit;
-    // the xattrsLimit is protect xattrs and inodeIds at huge files,
-    // also can use a sigle config item, but not much sense.
-    auto xattrsLimit = 10 * option_.excutorOpt.batchLimit;
+    auto xattrsLimit = option_.excutorOpt.batchInodeAttrLimit;
 
     iStack.emplace(ino);
     if (!AddUllStringToFirst(
@@ -1317,6 +1330,7 @@ CURVEFS_ERROR FuseClient::FuseOpLink(fuse_req_t req, fuse_ino_t ino,
     LOG(INFO) << "FuseOpLink, ino: " << ino
               << ", newparent: " << newparent
               << ", newname: " << newname;
+
     if (strlen(newname) > option_.maxNameLength) {
         return CURVEFS_ERROR::NAMETOOLONG;
     }

--- a/curvefs/src/client/inode_cache_manager.h
+++ b/curvefs/src/client/inode_cache_manager.h
@@ -29,6 +29,7 @@
 #include <map>
 #include <set>
 #include <list>
+#include <vector>
 
 #include "src/common/lru_cache.h"
 
@@ -50,6 +51,7 @@ namespace client {
 using rpcclient::MetaServerClient;
 using rpcclient::MetaServerClientImpl;
 using rpcclient::InodeParam;
+using rpcclient::MetaServerClientDone;
 
 class InodeCacheManager {
  public:
@@ -63,8 +65,10 @@ class InodeCacheManager {
 
     virtual CURVEFS_ERROR Init(uint64_t cacheSize, bool enableCacheMetrics) = 0;
 
-    virtual CURVEFS_ERROR GetInode(uint64_t inodeid,
+    virtual CURVEFS_ERROR GetInode(uint64_t inodeId,
         std::shared_ptr<InodeWrapper> &out) = 0;   // NOLINT
+
+    virtual CURVEFS_ERROR BatchGetInodeAsync(std::set<uint64_t> *inodeIds) = 0;
 
     virtual CURVEFS_ERROR BatchGetInodeAttr(
         std::set<uint64_t> *inodeIds,
@@ -76,9 +80,11 @@ class InodeCacheManager {
     virtual CURVEFS_ERROR CreateInode(const InodeParam &param,
         std::shared_ptr<InodeWrapper> &out) = 0;   // NOLINT
 
-    virtual CURVEFS_ERROR DeleteInode(uint64_t inodeid) = 0;
+    virtual CURVEFS_ERROR DeleteInode(uint64_t inodeId) = 0;
 
-    virtual void ClearInodeCache(uint64_t inodeid) = 0;
+    virtual void AddInode(const Inode& inode) = 0;
+
+    virtual void ClearInodeCache(uint64_t inodeId) = 0;
 
     virtual void ShipToFlush(
         const std::shared_ptr<InodeWrapper> &inodeWrapper) = 0;
@@ -91,7 +97,8 @@ class InodeCacheManager {
     uint32_t fsId_;
 };
 
-class InodeCacheManagerImpl : public InodeCacheManager {
+class InodeCacheManagerImpl : public InodeCacheManager,
+    public std::enable_shared_from_this<InodeCacheManagerImpl> {
  public:
     InodeCacheManagerImpl()
       : metaClient_(std::make_shared<MetaServerClientImpl>()),
@@ -114,8 +121,10 @@ class InodeCacheManagerImpl : public InodeCacheManager {
         return CURVEFS_ERROR::OK;
     }
 
-    CURVEFS_ERROR GetInode(uint64_t inodeid,
-        std::shared_ptr<InodeWrapper> &out) override;    // NOLINT
+    CURVEFS_ERROR GetInode(uint64_t inodeId,
+        std::shared_ptr<InodeWrapper> &out) override;
+
+    CURVEFS_ERROR BatchGetInodeAsync(std::set<uint64_t> *inodeIds) override;
 
     CURVEFS_ERROR BatchGetInodeAttr(std::set<uint64_t> *inodeIds,
         std::list<InodeAttr> *attrs) override;
@@ -124,11 +133,13 @@ class InodeCacheManagerImpl : public InodeCacheManager {
         std::list<XAttr> *xattrs) override;
 
     CURVEFS_ERROR CreateInode(const InodeParam &param,
-        std::shared_ptr<InodeWrapper> &out) override;    // NOLINT
+        std::shared_ptr<InodeWrapper> &out) override;
 
-    CURVEFS_ERROR DeleteInode(uint64_t inodeid) override;
+    CURVEFS_ERROR DeleteInode(uint64_t inodeId) override;
 
-    void ClearInodeCache(uint64_t inodeid) override;
+    void AddInode(const Inode& inode) override;
+
+    void ClearInodeCache(uint64_t inodeId) override;
 
     void ShipToFlush(
         const std::shared_ptr<InodeWrapper> &inodeWrapper) override;
@@ -148,6 +159,32 @@ class InodeCacheManagerImpl : public InodeCacheManager {
     curve::common::GenericNameLock<Mutex> nameLock_;
 };
 
+class BatchGetInodeAsyncDone : public MetaServerClientDone {
+ public:
+    BatchGetInodeAsyncDone(
+        const std::shared_ptr<InodeCacheManager> &inodeCacheManager):
+        inodeCacheManager_(inodeCacheManager) {}
+    ~BatchGetInodeAsyncDone() {}
+
+    void Run() override {
+        std::unique_ptr<BatchGetInodeAsyncDone> self_guard(this);
+        MetaStatusCode ret = GetStatusCode();
+        if (ret != MetaStatusCode::OK) {
+            LOG(ERROR) << "BatchGetInodeAsync failed, "
+                       << "MetaStatusCode: " << ret
+                       << ", MetaStatusCode_Name: " << MetaStatusCode_Name(ret);
+        } else {
+            auto inodes = GetInodes();
+            VLOG(6) << "update inodeCache size = " << inodes.size();
+            for (const auto &it : inodes) {
+                inodeCacheManager_ -> AddInode(it);
+            }
+        }
+    };
+
+ private:
+    std::shared_ptr<InodeCacheManager> inodeCacheManager_;
+};
 
 }  // namespace client
 }  // namespace curvefs

--- a/curvefs/src/client/metric/client_metric.h
+++ b/curvefs/src/client/metric/client_metric.h
@@ -69,6 +69,7 @@ struct MetaServerClientMetric {
 
     // inode
     InterfaceMetric getInode;
+    InterfaceMetric batchGetInode;
     InterfaceMetric batchGetInodeAttr;
     InterfaceMetric batchGetXattr;
     InterfaceMetric createInode;
@@ -92,6 +93,7 @@ struct MetaServerClientMetric {
           createDentry(prefix, "createDentry"),
           deleteDentry(prefix, "deleteDentry"),
           getInode(prefix, "getInode"),
+          batchGetInode(prefix, "batchGetInode"),
           batchGetInodeAttr(prefix, "batchGetInodeAttr"),
           batchGetXattr(prefix, "batchGetXattr"),
           createInode(prefix, "createInode"),

--- a/curvefs/src/client/rpcclient/metaserver_client.h
+++ b/curvefs/src/client/rpcclient/metaserver_client.h
@@ -91,6 +91,9 @@ class MetaServerClient {
     virtual MetaStatusCode GetInode(uint32_t fsId, uint64_t inodeid,
                                     Inode *out, bool* streaming) = 0;
 
+    virtual MetaStatusCode BatchGetInodeAsync(uint32_t fsId,
+        const std::list<uint64_t> &inodeIds, MetaServerClientDone *done) = 0;
+
     virtual MetaStatusCode BatchGetInodeAttr(uint32_t fsId,
         std::set<uint64_t> *inodeIds,
         std::list<InodeAttr> *attr) = 0;
@@ -128,6 +131,10 @@ class MetaServerClient {
     virtual MetaStatusCode CreateInode(const InodeParam &param, Inode *out) = 0;
 
     virtual MetaStatusCode DeleteInode(uint32_t fsId, uint64_t inodeid) = 0;
+
+    virtual bool SplitRequestInodes(uint32_t fsId,
+        std::set<uint64_t> *inodeIds,
+        std::vector<std::list<uint64_t>> *inodeGroups) = 0;
 };
 
 class MetaServerClientImpl : public MetaServerClient {
@@ -163,6 +170,10 @@ class MetaServerClientImpl : public MetaServerClient {
 
     MetaStatusCode GetInode(uint32_t fsId, uint64_t inodeid,
                             Inode *out, bool* streaming) override;
+
+    MetaStatusCode BatchGetInodeAsync(uint32_t fsId,
+        const std::list<uint64_t> &inodeIds,
+        MetaServerClientDone *done) override;
 
     MetaStatusCode BatchGetInodeAttr(uint32_t fsId,
         std::set<uint64_t> *inodeIds,
@@ -200,6 +211,15 @@ class MetaServerClientImpl : public MetaServerClient {
     MetaStatusCode CreateInode(const InodeParam &param, Inode *out) override;
 
     MetaStatusCode DeleteInode(uint32_t fsId, uint64_t inodeid) override;
+
+    bool SplitRequestInodes(uint32_t fsId,
+        std::set<uint64_t> *inodeIds,
+        std::vector<std::list<uint64_t>> *inodeGroups) override;
+
+ private:
+    bool GroupInodeIdByPartition(uint32_t fsId,
+        std::set<uint64_t> *inodeIds,
+        std::unordered_map<uint32_t, std::list<uint64_t>> *inodeGroups);
 
  private:
     bool ParseS3MetaStreamBuffer(butil::IOBuf* buffer,

--- a/curvefs/src/client/rpcclient/task_excutor.h
+++ b/curvefs/src/client/rpcclient/task_excutor.h
@@ -45,6 +45,8 @@ using ::curvefs::client::common::MetaserverID;
 using ::curvefs::client::common::MetaServerOpType;
 using ::curvefs::common::PartitionInfo;
 using ::curvefs::metaserver::MetaStatusCode;
+using ::google::protobuf::RepeatedPtrField;
+using ::curvefs::metaserver::Inode;
 
 namespace curvefs {
 namespace client {
@@ -172,8 +174,17 @@ class MetaServerClientDone : public google::protobuf::Closure {
         return code_;
     }
 
+    void SetInodes(const RepeatedPtrField<Inode>& inodes) {
+        inodes_ = inodes;
+    }
+
+    const RepeatedPtrField<Inode>& GetInodes() const {
+        return inodes_;
+    }
+
  private:
     MetaStatusCode code_;
+    RepeatedPtrField<Inode> inodes_;
 };
 
 class TaskExecutorDone : public google::protobuf::Closure {
@@ -198,6 +209,10 @@ class TaskExecutorDone : public google::protobuf::Closure {
         return excutor_;
     }
 
+    MetaServerClientDone* GetMetaServerClientDone() {
+        return done_;
+    }
+
  private:
     friend class TaskExecutor;
 
@@ -205,6 +220,26 @@ class TaskExecutorDone : public google::protobuf::Closure {
     std::shared_ptr<TaskExecutor> excutor_;
     MetaServerClientDone *done_;
     int code_;
+};
+
+class BatchGetInodeTaskExecutorDone : public TaskExecutorDone {
+ public:
+    BatchGetInodeTaskExecutorDone(const std::shared_ptr<TaskExecutor> excutor,
+        MetaServerClientDone *done) : TaskExecutorDone(excutor, done) {}
+    virtual ~BatchGetInodeTaskExecutorDone() {}
+
+    void Run() override;
+
+    void SetInodes(const RepeatedPtrField<Inode>& inodes) {
+        inodes_ = inodes;
+    }
+
+    const RepeatedPtrField<Inode>& GetInodes() const {
+        return inodes_;
+    }
+
+ private:
+    RepeatedPtrField<Inode> inodes_;
 };
 
 class CreateInodeExcutor : public TaskExecutor {

--- a/curvefs/src/metaserver/common/operator_type.h
+++ b/curvefs/src/metaserver/common/operator_type.h
@@ -34,6 +34,7 @@ enum class OperatorType : uint32_t {
     CreateDentry,
     DeleteDentry,
     GetInode,
+    BatchGetInode,
     BatchGetInodeAttr,
     BatchGetXAttr,
     CreateInode,

--- a/curvefs/src/metaserver/copyset/meta_operator.cpp
+++ b/curvefs/src/metaserver/copyset/meta_operator.cpp
@@ -122,6 +122,12 @@ bool BatchGetInodeAttrOperator::CanBypassPropose() const {
            node_->GetAppliedIndex() >= req->appliedindex();
 }
 
+bool BatchGetInodeOperator::CanBypassPropose() const {
+    auto* req = static_cast<const BatchGetInodeRequest*>(request_);
+    return req->has_appliedindex() &&
+           node_->GetAppliedIndex() >= req->appliedindex();
+}
+
 bool BatchGetXAttrOperator::CanBypassPropose() const {
     auto* req = static_cast<const BatchGetXAttrRequest*>(request_);
     return req->has_appliedindex() &&
@@ -161,6 +167,7 @@ OPERATOR_ON_APPLY(ListDentry);
 OPERATOR_ON_APPLY(CreateDentry);
 OPERATOR_ON_APPLY(DeleteDentry);
 OPERATOR_ON_APPLY(GetInode);
+OPERATOR_ON_APPLY(BatchGetInode);
 OPERATOR_ON_APPLY(BatchGetInodeAttr);
 OPERATOR_ON_APPLY(BatchGetXAttr);
 OPERATOR_ON_APPLY(CreateInode);
@@ -272,6 +279,7 @@ void GetOrModifyS3ChunkInfoOperator::OnApplyFromLog(uint64_t startTimeUs) {
 READONLY_OPERATOR_ON_APPLY_FROM_LOG(GetDentry);
 READONLY_OPERATOR_ON_APPLY_FROM_LOG(ListDentry);
 READONLY_OPERATOR_ON_APPLY_FROM_LOG(GetInode);
+READONLY_OPERATOR_ON_APPLY_FROM_LOG(BatchGetInode);
 READONLY_OPERATOR_ON_APPLY_FROM_LOG(BatchGetInodeAttr);
 READONLY_OPERATOR_ON_APPLY_FROM_LOG(BatchGetXAttr);
 
@@ -288,6 +296,7 @@ OPERATOR_REDIRECT(ListDentry);
 OPERATOR_REDIRECT(CreateDentry);
 OPERATOR_REDIRECT(DeleteDentry);
 OPERATOR_REDIRECT(GetInode);
+OPERATOR_REDIRECT(BatchGetInode);
 OPERATOR_REDIRECT(BatchGetInodeAttr);
 OPERATOR_REDIRECT(BatchGetXAttr);
 OPERATOR_REDIRECT(CreateInode);
@@ -311,6 +320,7 @@ OPERATOR_ON_FAILED(ListDentry);
 OPERATOR_ON_FAILED(CreateDentry);
 OPERATOR_ON_FAILED(DeleteDentry);
 OPERATOR_ON_FAILED(GetInode);
+OPERATOR_ON_FAILED(BatchGetInode);
 OPERATOR_ON_FAILED(BatchGetInodeAttr);
 OPERATOR_ON_FAILED(BatchGetXAttr);
 OPERATOR_ON_FAILED(CreateInode);
@@ -334,6 +344,7 @@ OPERATOR_HASH_CODE(ListDentry);
 OPERATOR_HASH_CODE(CreateDentry);
 OPERATOR_HASH_CODE(DeleteDentry);
 OPERATOR_HASH_CODE(GetInode);
+OPERATOR_HASH_CODE(BatchGetInode);
 OPERATOR_HASH_CODE(BatchGetInodeAttr);
 OPERATOR_HASH_CODE(BatchGetXAttr);
 OPERATOR_HASH_CODE(CreateInode);
@@ -367,6 +378,7 @@ OPERATOR_TYPE(ListDentry);
 OPERATOR_TYPE(CreateDentry);
 OPERATOR_TYPE(DeleteDentry);
 OPERATOR_TYPE(GetInode);
+OPERATOR_TYPE(BatchGetInode);
 OPERATOR_TYPE(BatchGetInodeAttr);
 OPERATOR_TYPE(BatchGetXAttr);
 OPERATOR_TYPE(CreateInode);

--- a/curvefs/src/metaserver/copyset/meta_operator.h
+++ b/curvefs/src/metaserver/copyset/meta_operator.h
@@ -262,6 +262,27 @@ class GetInodeOperator : public MetaOperator {
     OperatorType GetOperatorType() const override;
 };
 
+class BatchGetInodeOperator : public MetaOperator {
+ public:
+    using MetaOperator::MetaOperator;
+
+    void OnApply(int64_t index, google::protobuf::Closure* done,
+                 uint64_t startTimeUs) override;
+
+    void OnApplyFromLog(uint64_t startTimeUs) override;
+
+    uint64_t HashCode() const override;
+
+ private:
+    void Redirect() override;
+
+    void OnFailed(MetaStatusCode code) override;
+
+    bool CanBypassPropose() const override;
+
+    OperatorType GetOperatorType() const override;
+};
+
 class BatchGetInodeAttrOperator : public MetaOperator {
  public:
     using MetaOperator::MetaOperator;

--- a/curvefs/src/metaserver/metaserver_service.cpp
+++ b/curvefs/src/metaserver/metaserver_service.cpp
@@ -38,6 +38,7 @@ using ::curvefs::metaserver::copyset::ListDentryOperator;
 using ::curvefs::metaserver::copyset::CreateDentryOperator;
 using ::curvefs::metaserver::copyset::DeleteDentryOperator;
 using ::curvefs::metaserver::copyset::GetInodeOperator;
+using ::curvefs::metaserver::copyset::BatchGetInodeOperator;
 using ::curvefs::metaserver::copyset::BatchGetInodeAttrOperator;
 using ::curvefs::metaserver::copyset::BatchGetXAttrOperator;
 using ::curvefs::metaserver::copyset::CreateInodeOperator;
@@ -161,6 +162,18 @@ void MetaServerServiceImpl::BatchGetInodeAttr(
                                                  done,
                                                  request->poolid(),
                                                  request->copysetid());
+}
+
+void MetaServerServiceImpl::BatchGetInode(
+    ::google::protobuf::RpcController* controller,
+    const ::curvefs::metaserver::BatchGetInodeRequest* request,
+    ::curvefs::metaserver::BatchGetInodeResponse* response,
+    ::google::protobuf::Closure* done) {
+    OperatorHelper helper(copysetNodeManager_, inflightThrottle_);
+    helper.operator()<BatchGetInodeOperator>(controller, request, response,
+                                             done,
+                                             request->poolid(),
+                                             request->copysetid());
 }
 
 void MetaServerServiceImpl::BatchGetXAttr(

--- a/curvefs/src/metaserver/metaserver_service.h
+++ b/curvefs/src/metaserver/metaserver_service.h
@@ -62,6 +62,10 @@ class MetaServerServiceImpl : public MetaServerService {
                   const ::curvefs::metaserver::GetInodeRequest* request,
                   ::curvefs::metaserver::GetInodeResponse* response,
                   ::google::protobuf::Closure* done) override;
+    void BatchGetInode(::google::protobuf::RpcController* controller,
+                const ::curvefs::metaserver::BatchGetInodeRequest* request,
+                ::curvefs::metaserver::BatchGetInodeResponse* response,
+                ::google::protobuf::Closure* done) override;
     void BatchGetInodeAttr(::google::protobuf::RpcController* controller,
                 const ::curvefs::metaserver::BatchGetInodeAttrRequest* request,
                 ::curvefs::metaserver::BatchGetInodeAttrResponse* response,

--- a/curvefs/src/metaserver/metastore.cpp
+++ b/curvefs/src/metaserver/metastore.cpp
@@ -60,7 +60,8 @@ bool MetaStoreImpl::Load(const std::string& pathname) {
         if (it->second->GetStatus() == PartitionStatus::DELETING) {
             uint32_t partitionId = it->second->GetPartitionId();
             std::shared_ptr<PartitionCleaner> partitionCleaner =
-                std::make_shared<PartitionCleaner>(GetPartition(partitionId));
+                std::make_shared<PartitionCleaner>(
+                    GetPartitionUnLock(partitionId));
             PartitionCleanManager::GetInstance().Add(
                 partitionId, partitionCleaner, copysetNode_);
         }
@@ -154,7 +155,7 @@ MetaStatusCode MetaStoreImpl::DeletePartition(
                   << ", partitionId = " << partitionId;
         it->second->ClearDentry();
         std::shared_ptr<PartitionCleaner> partitionCleaner =
-            std::make_shared<PartitionCleaner>(GetPartition(partitionId));
+            std::make_shared<PartitionCleaner>(GetPartitionUnLock(partitionId));
         PartitionCleanManager::GetInstance().Add(partitionId, partitionCleaner,
                                                  copysetNode_);
         it->second->SetStatus(PartitionStatus::DELETING);
@@ -189,7 +190,6 @@ std::shared_ptr<StreamServer> MetaStoreImpl::GetStreamServer() {
 // dentry
 MetaStatusCode MetaStoreImpl::CreateDentry(const CreateDentryRequest* request,
                                            CreateDentryResponse* response) {
-    ReadLockGuard readLockGuard(rwLock_);
     std::shared_ptr<Partition> partition = GetPartition(request->partitionid());
     if (partition == nullptr) {
         MetaStatusCode status = MetaStatusCode::PARTITION_NOT_FOUND;
@@ -207,7 +207,6 @@ MetaStatusCode MetaStoreImpl::GetDentry(const GetDentryRequest* request,
     uint64_t parentInodeId = request->parentinodeid();
     std::string name = request->name();
     auto txId = request->txid();
-    ReadLockGuard readLockGuard(rwLock_);
     std::shared_ptr<Partition> partition = GetPartition(request->partitionid());
     if (partition == nullptr) {
         MetaStatusCode status = MetaStatusCode::PARTITION_NOT_FOUND;
@@ -236,7 +235,6 @@ MetaStatusCode MetaStoreImpl::DeleteDentry(const DeleteDentryRequest* request,
     uint64_t parentInodeId = request->parentinodeid();
     std::string name = request->name();
     auto txId = request->txid();
-    ReadLockGuard readLockGuard(rwLock_);
     std::shared_ptr<Partition> partition = GetPartition(request->partitionid());
     if (partition == nullptr) {
         MetaStatusCode status = MetaStatusCode::PARTITION_NOT_FOUND;
@@ -261,7 +259,6 @@ MetaStatusCode MetaStoreImpl::ListDentry(const ListDentryRequest* request,
     uint32_t fsId = request->fsid();
     uint64_t parentInodeId = request->dirinodeid();
     auto txId = request->txid();
-    ReadLockGuard readLockGuard(rwLock_);
     std::shared_ptr<Partition> partition = GetPartition(request->partitionid());
     if (partition == nullptr) {
         MetaStatusCode status = MetaStatusCode::PARTITION_NOT_FOUND;
@@ -295,7 +292,6 @@ MetaStatusCode MetaStoreImpl::ListDentry(const ListDentryRequest* request,
 
 MetaStatusCode MetaStoreImpl::PrepareRenameTx(
     const PrepareRenameTxRequest* request, PrepareRenameTxResponse* response) {
-    ReadLockGuard readLockGuard(rwLock_);
     MetaStatusCode rc;
     auto partitionId = request->partitionid();
     auto partition = GetPartition(partitionId);
@@ -337,13 +333,13 @@ MetaStatusCode MetaStoreImpl::CreateInode(const CreateInodeRequest* request,
         }
     }
 
-    ReadLockGuard readLockGuard(rwLock_);
     std::shared_ptr<Partition> partition = GetPartition(request->partitionid());
     if (partition == nullptr) {
         MetaStatusCode status = MetaStatusCode::PARTITION_NOT_FOUND;
         response->set_statuscode(status);
         return status;
     }
+
     MetaStatusCode status =
         partition->CreateInode(param, response->mutable_inode());
     response->set_statuscode(status);
@@ -365,7 +361,6 @@ MetaStatusCode MetaStoreImpl::CreateRootInode(
     param.rdev = 0;
     param.parent = 0;
 
-    ReadLockGuard readLockGuard(rwLock_);
     std::shared_ptr<Partition> partition = GetPartition(request->partitionid());
     if (partition == nullptr) {
         MetaStatusCode status = MetaStatusCode::PARTITION_NOT_FOUND;
@@ -389,7 +384,6 @@ MetaStatusCode MetaStoreImpl::GetInode(const GetInodeRequest* request,
     uint32_t fsId = request->fsid();
     uint64_t inodeId = request->inodeid();
 
-    ReadLockGuard readLockGuard(rwLock_);
     std::shared_ptr<Partition> partition = GetPartition(request->partitionid());
     if (partition == nullptr) {
         MetaStatusCode status = MetaStatusCode::PARTITION_NOT_FOUND;
@@ -425,7 +419,6 @@ MetaStatusCode MetaStoreImpl::GetInode(const GetInodeRequest* request,
 MetaStatusCode MetaStoreImpl::BatchGetInodeAttr(
     const BatchGetInodeAttrRequest* request,
     BatchGetInodeAttrResponse* response) {
-    ReadLockGuard readLockGuard(rwLock_);
     std::shared_ptr<Partition> partition = GetPartition(request->partitionid());
     if (partition == nullptr) {
         MetaStatusCode status = MetaStatusCode::PARTITION_NOT_FOUND;
@@ -448,10 +441,34 @@ MetaStatusCode MetaStoreImpl::BatchGetInodeAttr(
     return status;
 }
 
+MetaStatusCode MetaStoreImpl::BatchGetInode(
+    const BatchGetInodeRequest* request,
+    BatchGetInodeResponse* response) {
+    std::shared_ptr<Partition> partition = GetPartition(request->partitionid());
+    if (partition == nullptr) {
+        MetaStatusCode status = MetaStatusCode::PARTITION_NOT_FOUND;
+        response->set_statuscode(status);
+        return status;
+    }
+
+    uint32_t fsId = request->fsid();
+    MetaStatusCode status = MetaStatusCode::OK;
+    for (int i = 0; i < request->inodeid_size(); i++) {
+        status = partition->GetInode(fsId, request->inodeid(i),
+                                     response->add_inode());
+        if (status != MetaStatusCode::OK) {
+            response->clear_inode();
+            response->set_statuscode(status);
+            return status;
+        }
+    }
+    response->set_statuscode(status);
+    return status;
+}
+
 MetaStatusCode MetaStoreImpl::BatchGetXAttr(
     const BatchGetXAttrRequest* request,
     BatchGetXAttrResponse* response) {
-    ReadLockGuard readLockGuard(rwLock_);
     std::shared_ptr<Partition> partition = GetPartition(request->partitionid());
     if (partition == nullptr) {
         MetaStatusCode status = MetaStatusCode::PARTITION_NOT_FOUND;
@@ -479,7 +496,6 @@ MetaStatusCode MetaStoreImpl::DeleteInode(const DeleteInodeRequest* request,
     uint32_t fsId = request->fsid();
     uint64_t inodeId = request->inodeid();
 
-    ReadLockGuard readLockGuard(rwLock_);
     std::shared_ptr<Partition> partition = GetPartition(request->partitionid());
     if (partition == nullptr) {
         MetaStatusCode status = MetaStatusCode::PARTITION_NOT_FOUND;
@@ -503,7 +519,6 @@ MetaStatusCode MetaStoreImpl::UpdateInode(const UpdateInodeRequest* request,
         return MetaStatusCode::PARAM_ERROR;
     }
 
-    ReadLockGuard readLockGuard(rwLock_);
     std::shared_ptr<Partition> partition = GetPartition(request->partitionid());
     if (partition == nullptr) {
         MetaStatusCode status = MetaStatusCode::PARTITION_NOT_FOUND;
@@ -521,7 +536,6 @@ MetaStatusCode MetaStoreImpl::GetOrModifyS3ChunkInfo(
     GetOrModifyS3ChunkInfoResponse* response,
     std::shared_ptr<Iterator>* iterator) {
     MetaStatusCode rc;
-    ReadLockGuard readLockGuard(rwLock_);
     auto partition = GetPartition(request->partitionid());
     if (nullptr == partition) {
         rc = MetaStatusCode::PARTITION_NOT_FOUND;
@@ -582,6 +596,12 @@ MetaStatusCode MetaStoreImpl::SendS3ChunkInfoByStream(
 }
 
 std::shared_ptr<Partition> MetaStoreImpl::GetPartition(uint32_t partitionId) {
+    ReadLockGuard readLockGuard(rwLock_);
+    return GetPartitionUnLock(partitionId);
+}
+
+std::shared_ptr<Partition> MetaStoreImpl::GetPartitionUnLock(
+    uint32_t partitionId) {
     auto it = partitionMap_.find(partitionId);
     if (it != partitionMap_.end()) {
         return it->second;

--- a/curvefs/src/metaserver/metastore.h
+++ b/curvefs/src/metaserver/metastore.h
@@ -54,6 +54,8 @@ using curvefs::metaserver::DeleteDentryResponse;
 // inode
 using curvefs::metaserver::GetInodeRequest;
 using curvefs::metaserver::GetInodeResponse;
+using curvefs::metaserver::BatchGetInodeRequest;
+using curvefs::metaserver::BatchGetInodeResponse;
 using curvefs::metaserver::BatchGetInodeAttrRequest;
 using curvefs::metaserver::BatchGetInodeAttrResponse;
 using curvefs::metaserver::BatchGetXAttrRequest;
@@ -127,6 +129,10 @@ class MetaStore {
     virtual MetaStatusCode GetInode(const GetInodeRequest* request,
                                     GetInodeResponse* response) = 0;
 
+    virtual MetaStatusCode BatchGetInode(
+                                    const BatchGetInodeRequest* request,
+                                    BatchGetInodeResponse* response) = 0;
+
     virtual MetaStatusCode BatchGetInodeAttr(
                                     const BatchGetInodeAttrRequest* request,
                                     BatchGetInodeAttrResponse* response) = 0;
@@ -196,6 +202,9 @@ class MetaStoreImpl : public MetaStore {
     MetaStatusCode GetInode(const GetInodeRequest* request,
                             GetInodeResponse* response) override;
 
+    MetaStatusCode BatchGetInode(const BatchGetInodeRequest* request,
+                                BatchGetInodeResponse* response) override;
+
     MetaStatusCode BatchGetInodeAttr(const BatchGetInodeAttrRequest* request,
                                 BatchGetInodeAttrResponse* response) override;
 
@@ -218,6 +227,8 @@ class MetaStoreImpl : public MetaStore {
     MetaStatusCode SendS3ChunkInfoByStream(
         std::shared_ptr<StreamConnection> connection,
         std::shared_ptr<Iterator> iterator) override;
+
+    std::shared_ptr<Partition> GetPartitionUnLock(uint32_t partitionId);
 
  private:
     void PrepareStreamBuffer(butil::IOBuf* buffer,

--- a/curvefs/test/client/mock_inode_cache_manager.h
+++ b/curvefs/test/client/mock_inode_cache_manager.h
@@ -44,6 +44,11 @@ class MockInodeCacheManager : public InodeCacheManager {
     MOCK_METHOD2(GetInode, CURVEFS_ERROR(
         uint64_t inodeid, std::shared_ptr<InodeWrapper> &out));     // NOLINT
 
+    MOCK_METHOD1(BatchGetInode, CURVEFS_ERROR(std::set<uint64_t> *inodeIds));
+
+    MOCK_METHOD1(BatchGetInodeAsync,
+        CURVEFS_ERROR(std::set<uint64_t> *inodeIds));
+
     MOCK_METHOD2(BatchGetInodeAttr, CURVEFS_ERROR(
         std::set<uint64_t> *inodeIds, std::list<InodeAttr> *attrs));
 
@@ -54,6 +59,8 @@ class MockInodeCacheManager : public InodeCacheManager {
         std::shared_ptr<InodeWrapper> &out));     // NOLINT
 
     MOCK_METHOD1(DeleteInode, CURVEFS_ERROR(uint64_t inodeid));
+
+    MOCK_METHOD1(AddInode, void(const Inode& inode));
 
     MOCK_METHOD1(ClearInodeCache, void(uint64_t inodeid));
 

--- a/curvefs/test/client/mock_metaserver_client.h
+++ b/curvefs/test/client/mock_metaserver_client.h
@@ -75,6 +75,14 @@ class MockMetaServerClient : public MetaServerClient {
     MOCK_METHOD4(GetInode, MetaStatusCode(
             uint32_t fsId, uint64_t inodeid, Inode *out, bool* streaming));
 
+    MOCK_METHOD3(BatchGetInode, MetaStatusCode(
+        uint32_t fsId, std::set<uint64_t> *inodeIds,
+        std::list<Inode> *inodes));
+
+    MOCK_METHOD3(BatchGetInodeAsync, MetaStatusCode(
+        uint32_t fsId, const std::list<uint64_t> &inodeIds,
+        MetaServerClientDone *done));
+
     MOCK_METHOD3(BatchGetInodeAttr, MetaStatusCode(
         uint32_t fsId, std::set<uint64_t> *inodeIds,
         std::list<InodeAttr> *attr));
@@ -112,6 +120,10 @@ class MockMetaServerClient : public MetaServerClient {
             const InodeParam &param, Inode *out));
 
     MOCK_METHOD2(DeleteInode, MetaStatusCode(uint32_t fsId, uint64_t inodeid));
+
+    MOCK_METHOD3(SplitRequestInodes, bool(uint32_t fsId,
+        std::set<uint64_t> *inodeIds,
+        std::vector<std::list<uint64_t>> *inodeGroups));
 };
 
 }  // namespace rpcclient

--- a/curvefs/test/metaserver/metastore_test.cpp
+++ b/curvefs/test/metaserver/metastore_test.cpp
@@ -1273,6 +1273,79 @@ TEST_F(MetastoreTest, testBatchGetInodeAttr) {
     }
 }
 
+TEST_F(MetastoreTest, testBatchGetInode) {
+    MetaStoreImpl metastore(nullptr, kvStorage_);
+
+    // create partition1
+    CreatePartitionRequest createPartitionRequest;
+    CreatePartitionResponse createPartitionResponse;
+    PartitionInfo partitionInfo1;
+    partitionInfo1.set_fsid(1);
+    partitionInfo1.set_poolid(2);
+    partitionInfo1.set_copysetid(3);
+    partitionInfo1.set_partitionid(1);
+    partitionInfo1.set_start(100);
+    partitionInfo1.set_end(1000);
+    createPartitionRequest.mutable_partition()->CopyFrom(partitionInfo1);
+    MetaStatusCode ret = metastore.CreatePartition(&createPartitionRequest,
+                                                   &createPartitionResponse);
+    ASSERT_EQ(ret, MetaStatusCode::OK);
+    ASSERT_EQ(createPartitionResponse.statuscode(), ret);
+
+    // CreateInde
+    CreateInodeRequest createRequest;
+    CreateInodeResponse createResponse;
+
+    uint32_t poolId = 2;
+    uint32_t copysetId = 3;
+    uint32_t partitionId = 1;
+    uint32_t fsId = 1;
+    uint64_t length = 2;
+    uint32_t uid = 100;
+    uint32_t gid = 200;
+    uint32_t mode = 777;
+    FsFileType type = FsFileType::TYPE_DIRECTORY;
+
+    createRequest.set_poolid(poolId);
+    createRequest.set_copysetid(copysetId);
+    createRequest.set_partitionid(partitionId);
+    createRequest.set_fsid(fsId);
+    createRequest.set_length(length);
+    createRequest.set_uid(uid);
+    createRequest.set_gid(gid);
+    createRequest.set_mode(mode);
+    createRequest.set_type(type);
+
+    ret = metastore.CreateInode(&createRequest, &createResponse);
+    ASSERT_EQ(createResponse.statuscode(), MetaStatusCode::OK);
+    uint64_t inodeId1 = createResponse.inode().inodeid();
+
+    createRequest.set_length(3);
+    ret = metastore.CreateInode(&createRequest, &createResponse);
+    ASSERT_EQ(createResponse.statuscode(), MetaStatusCode::OK);
+    uint64_t inodeId2 = createResponse.inode().inodeid();
+
+    BatchGetInodeRequest batchRequest;
+    BatchGetInodeResponse batchResponse;
+    batchRequest.set_poolid(poolId);
+    batchRequest.set_copysetid(copysetId);
+    batchRequest.set_partitionid(partitionId);
+    batchRequest.set_fsid(fsId);
+    batchRequest.add_inodeid(inodeId1);
+    batchRequest.add_inodeid(inodeId2);
+
+    ret = metastore.BatchGetInode(&batchRequest, &batchResponse);
+    ASSERT_EQ(batchResponse.statuscode(), MetaStatusCode::OK);
+    ASSERT_EQ(batchResponse.inode_size(), 2);
+    if (batchResponse.inode(0).inodeid() == inodeId1) {
+        ASSERT_EQ(batchResponse.inode(0).length(), 2);
+        ASSERT_EQ(batchResponse.inode(1).length(), 3);
+    } else {
+        ASSERT_EQ(batchResponse.inode(0).length(), 3);
+        ASSERT_EQ(batchResponse.inode(1).length(), 2);
+    }
+}
+
 TEST_F(MetastoreTest, testBatchGetXAttr) {
     MetaStoreImpl metastore(nullptr, kvStorage_);
 

--- a/curvefs/test/metaserver/mock/mock_metastore.h
+++ b/curvefs/test/metaserver/mock/mock_metastore.h
@@ -62,6 +62,9 @@ class MockMetaStore : public curvefs::metaserver::MetaStore {
                                                  CreateRootInodeResponse*));
     MOCK_METHOD2(GetInode,
                  MetaStatusCode(const GetInodeRequest*, GetInodeResponse*));
+    MOCK_METHOD2(BatchGetInode,
+                 MetaStatusCode(const BatchGetInodeRequest*,
+                 BatchGetInodeResponse*));
     MOCK_METHOD2(BatchGetInodeAttr,
                  MetaStatusCode(const BatchGetInodeAttrRequest*,
                  BatchGetInodeAttrResponse*));


### PR DESCRIPTION
prefetch inode when readdir through a asynchronous rpc request

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #xxx <!-- replace xxx with issue number -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
