### PR TITLE
curvefs/metaserver: fixed sseek so slow which caused by

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,4 @@ docker/*/curvebs
 
 curvefs/docker/curvefs
 curvefs/docker/*/curvefs
+storage_*

--- a/curvefs/conf/metaserver.conf
+++ b/curvefs/conf/metaserver.conf
@@ -231,3 +231,7 @@ storage.rocksdb.ordered_write_buffer_size=134217728
 storage.rocksdb.ordered_max_write_buffer_number=15
 # rocksdb block cache(LRU) capacity (default: 128MB)
 storage.rocksdb.block_cache_capacity=134217728
+# if the number of inode's s3chunkinfo exceed the limit_size,
+# we will sending its with rpc streaming instead of
+# padding its into inode (default: 25000, about 25000 * 41 (byte) = 1MB)
+storage.s3_meta_inside_inode.limit_size=25000

--- a/curvefs/proto/metaserver.proto
+++ b/curvefs/proto/metaserver.proto
@@ -46,6 +46,7 @@ enum MetaStatusCode {
     PARSE_FROM_STRING_FAILED = 23;
     STORAGE_INTERNAL_ERROR = 24;
     RPC_STREAM_ERROR = 25;
+    INODE_S3_META_TOO_LARGE = 26;
 }
 
 // dentry interface
@@ -148,6 +149,7 @@ message GetInodeRequest {
     required uint32 fsId = 4;
     required uint64 inodeId = 5;
     optional uint64 appliedIndex = 6;
+    optional bool supportStreaming = 7;  // for backward compatibility
 }
 
 enum FsFileType {
@@ -212,6 +214,7 @@ message GetInodeResponse {
     required MetaStatusCode statusCode = 1;
     optional Inode inode = 2;
     optional uint64 appliedIndex = 3;
+    optional bool streaming = 4;
 }
 
 message CreateInodeRequest {
@@ -335,6 +338,7 @@ message GetOrModifyS3ChunkInfoRequest {
     required bool returnS3ChunkInfoMap = 8;
     optional bool fromS3Compaction = 9;
     // todo: we only need a bit flag to indicate a lot of bool
+    optional bool supportStreaming = 10;  // for backward compatibility
 }
 
 message GetOrModifyS3ChunkInfoResponse {

--- a/curvefs/src/client/curve_fuse_op.cpp
+++ b/curvefs/src/client/curve_fuse_op.cpp
@@ -227,9 +227,6 @@ void FuseReplyErrByErrCode(fuse_req_t req, CURVEFS_ERROR errcode) {
     case CURVEFS_ERROR::OUT_OF_RANGE:
         fuse_reply_err(req, ERANGE);
         break;
-    case CURVEFS_ERROR::NODATA:
-        fuse_reply_err(req, ENODATA);
-        break;
     default:
         fuse_reply_err(req, EIO);
         break;
@@ -266,17 +263,20 @@ void FuseOpGetXattr(fuse_req_t req, fuse_ino_t ino, const char *name,
     size_t size) {
     InflightGuard guard(&g_clientOpMetric->opGetXattr.inflightOpNum);
     LatencyUpdater updater(&g_clientOpMetric->opGetXattr.latency);
-    char buf[MAXXATTRLENGTH] = {0};
+    std::unique_ptr<char[]> buf(new char[MAXXATTRLENGTH]);
+    std::memset(buf.get(), 0, MAXXATTRLENGTH);
+    CURVEFS_ERROR ret = g_ClientInstance->FuseOpGetXattr(req, ino, name,
+                                                         buf.get(), size);
+    if (ret != CURVEFS_ERROR::OK && ret != CURVEFS_ERROR::NODATA) {
+        g_clientOpMetric->opGetXattr.ecount << 1;
+        FuseReplyErrByErrCode(req, ret);
+        return;
+    }
+
     if (size == 0) {
-        fuse_reply_xattr(req, MAXXATTRLENGTH);
+        fuse_reply_xattr(req, strlen(buf.get()));
     } else {
-        CURVEFS_ERROR ret = g_ClientInstance->FuseOpGetXattr(req, ino, name,
-                                                             buf, size);
-        if (ret != CURVEFS_ERROR::OK) {
-            FuseReplyErrByErrCode(req, ret);
-            return;
-        }
-        fuse_reply_buf(req, buf, strlen(buf));
+        fuse_reply_buf(req, buf.get(), strlen(buf.get()));
     }
 }
 

--- a/curvefs/src/client/rpcclient/metaserver_client.cpp
+++ b/curvefs/src/client/rpcclient/metaserver_client.cpp
@@ -412,7 +412,7 @@ MetaServerClientImpl::PrepareRenameTx(const std::vector<Dentry> &dentrys) {
 }
 
 MetaStatusCode MetaServerClientImpl::GetInode(uint32_t fsId, uint64_t inodeid,
-                                              Inode *out) {
+                                              Inode *out, bool* streaming) {
     auto task = RPCTask {
         metaserverClientMetric_->getInode.qps.count << 1;
         LatencyUpdater updater(&metaserverClientMetric_->getInode.latency);
@@ -425,6 +425,7 @@ MetaStatusCode MetaServerClientImpl::GetInode(uint32_t fsId, uint64_t inodeid,
         request.set_inodeid(inodeid);
         request.set_appliedindex(
             metaCache_->GetApplyIndex(CopysetGroupID(poolID, copysetID)));
+        request.set_supportstreaming(true);
 
         curvefs::metaserver::MetaServerService_Stub stub(channel);
         stub.GetInode(cntl, &request, &response, nullptr);
@@ -454,6 +455,7 @@ MetaStatusCode MetaServerClientImpl::GetInode(uint32_t fsId, uint64_t inodeid,
             return -1;
         }
 
+        *streaming = response.has_streaming() ? response.streaming() : false;
         auto &s3chunkinfoMap = response.inode().s3chunkinfomap();
         for (auto &item : s3chunkinfoMap) {
             VLOG(9) << "inodeInfo, inodeId:" << inodeid
@@ -912,6 +914,7 @@ MetaStatusCode MetaServerClientImpl::GetOrModifyS3ChunkInfo(
         request.set_inodeid(inodeId);
         request.set_returns3chunkinfomap(returnS3ChunkInfoMap);
         *(request.mutable_s3chunkinfoadd()) = s3ChunkInfos;
+        request.set_supportstreaming(true);
 
         curvefs::metaserver::MetaServerService_Stub stub(channel);
 

--- a/curvefs/src/client/rpcclient/metaserver_client.h
+++ b/curvefs/src/client/rpcclient/metaserver_client.h
@@ -89,7 +89,7 @@ class MetaServerClient {
     PrepareRenameTx(const std::vector<Dentry> &dentrys) = 0;
 
     virtual MetaStatusCode GetInode(uint32_t fsId, uint64_t inodeid,
-                                    Inode *out) = 0;
+                                    Inode *out, bool* streaming) = 0;
 
     virtual MetaStatusCode BatchGetInodeAttr(uint32_t fsId,
         std::set<uint64_t> *inodeIds,
@@ -162,7 +162,7 @@ class MetaServerClientImpl : public MetaServerClient {
     MetaStatusCode PrepareRenameTx(const std::vector<Dentry> &dentrys) override;
 
     MetaStatusCode GetInode(uint32_t fsId, uint64_t inodeid,
-                            Inode *out) override;
+                            Inode *out, bool* streaming) override;
 
     MetaStatusCode BatchGetInodeAttr(uint32_t fsId,
         std::set<uint64_t> *inodeIds,

--- a/curvefs/src/metaserver/copyset/meta_operator.cpp
+++ b/curvefs/src/metaserver/copyset/meta_operator.cpp
@@ -182,7 +182,6 @@ void GetOrModifyS3ChunkInfoOperator::OnApply(int64_t index,
     MetaStatusCode rc;
     auto request = static_cast<const GetOrModifyS3ChunkInfoRequest*>(request_);
     auto response = static_cast<GetOrModifyS3ChunkInfoResponse*>(response_);
-    bool streaming = request->returns3chunkinfomap();
     auto metastore = node_->GetMetaStore();
     std::shared_ptr<StreamConnection> connection;
     std::shared_ptr<Iterator> iterator;
@@ -205,7 +204,9 @@ void GetOrModifyS3ChunkInfoOperator::OnApply(int64_t index,
         }
 
         brpc::Controller* cntl = static_cast<brpc::Controller*>(cntl_);
-        if (rc != MetaStatusCode::OK || !streaming) {
+        if (rc != MetaStatusCode::OK ||
+            !request->returns3chunkinfomap() ||
+            !request->supportstreaming()) {
             return;
         }
 

--- a/curvefs/src/metaserver/inode_manager.cpp
+++ b/curvefs/src/metaserver/inode_manager.cpp
@@ -25,6 +25,7 @@
 #include <glog/logging.h>
 #include <google/protobuf/util/message_differencer.h>
 #include <list>
+#include <unordered_map>
 
 #include "curvefs/src/common/define.h"
 #include "src/common/timeutility.h"
@@ -130,21 +131,27 @@ void InodeManager::GenerateInodeInternal(uint64_t inodeId,
     return;
 }
 
-MetaStatusCode InodeManager::GetInode(uint32_t fsId, uint64_t inodeId,
-                                      Inode *inode) {
+MetaStatusCode InodeManager::GetInode(uint32_t fsId,
+                                      uint64_t inodeId,
+                                      Inode *inode,
+                                      bool paddingS3ChunkInfo) {
     VLOG(1) << "GetInode, fsId = " << fsId << ", inodeId = " << inodeId;
     NameLockGuard lg(inodeLock_, GetInodeLockName(fsId, inodeId));
-    MetaStatusCode ret = inodeStorage_->Get(Key4Inode(fsId, inodeId), inode);
-    if (ret != MetaStatusCode::OK) {
+    MetaStatusCode rc = inodeStorage_->Get(Key4Inode(fsId, inodeId), inode);
+    if (rc == MetaStatusCode::OK && paddingS3ChunkInfo) {
+        rc = PaddingInodeS3ChunkInfo(fsId, inodeId,
+                                     inode->mutable_s3chunkinfomap());
+    }
+
+    if (rc != MetaStatusCode::OK) {
         LOG(ERROR) << "GetInode fail, fsId = " << fsId
                    << ", inodeId = " << inodeId
-                   << ", ret = " << MetaStatusCode_Name(ret);
-        return ret;
+                   << ", retCode = " << MetaStatusCode_Name(rc);
+        return rc;
     }
 
     VLOG(1) << "GetInode success, fsId = " << fsId << ", inodeId = " << inodeId
             << ", " << inode->ShortDebugString();
-
     return MetaStatusCode::OK;
 }
 
@@ -308,23 +315,44 @@ MetaStatusCode InodeManager::UpdateInode(const UpdateInodeRequest &request) {
 MetaStatusCode InodeManager::GetOrModifyS3ChunkInfo(
     uint32_t fsId, uint64_t inodeId,
     const S3ChunkInfoMap& map2add,
-    std::shared_ptr<Iterator>* iterator,
+    const S3ChunkInfoMap& map2del,
     bool returnS3ChunkInfoMap,
-    bool compaction) {
+    std::shared_ptr<Iterator>* iterator) {
     VLOG(1) << "GetOrModifyS3ChunkInfo, fsId: " << fsId
             << ", inodeId: " << inodeId;
 
     NameLockGuard lg(inodeLock_, GetInodeLockName(fsId, inodeId));
 
-    if (!map2add.empty()) {
-        for (const auto& item : map2add) {
-            uint64_t chunkIndex = item.first;
-            auto list2add = item.second;
-            MetaStatusCode rc = inodeStorage_->AppendS3ChunkInfoList(
-                fsId, inodeId, chunkIndex, list2add, compaction);
-            if (rc != MetaStatusCode::OK) {
-                return rc;
-            }
+    std::unordered_map<uint64_t, bool> deleted;
+    for (const auto& item : map2add) {
+        uint64_t chunkIndex = item.first;
+        auto list2add = item.second;
+        S3ChunkInfoList list2del;
+        auto iter = map2del.find(chunkIndex);
+        if (iter != map2del.end()) {
+            list2del = iter->second;
+        }
+
+        MetaStatusCode rc = inodeStorage_->ModifyInodeS3ChunkInfoList(
+            fsId, inodeId, chunkIndex, list2add, list2del);
+        if (rc != MetaStatusCode::OK) {
+            return rc;
+        }
+        deleted[chunkIndex] = true;
+    }
+
+    for (const auto& item : map2del) {
+        uint64_t chunkIndex = item.first;
+        if (deleted[chunkIndex]) {
+            continue;
+        }
+
+        auto list2del = item.second;
+        S3ChunkInfoList dummy;
+        MetaStatusCode rc = inodeStorage_->ModifyInodeS3ChunkInfoList(
+            fsId, inodeId, chunkIndex, dummy, list2del);
+        if (rc != MetaStatusCode::OK) {
+            return rc;
         }
     }
 
@@ -343,10 +371,11 @@ MetaStatusCode InodeManager::GetOrModifyS3ChunkInfo(
 
 MetaStatusCode InodeManager::PaddingInodeS3ChunkInfo(int32_t fsId,
                                                      uint64_t inodeId,
-                                                     Inode* inode) {
+                                                     S3ChunkInfoMap* m,
+                                                     uint64_t limit) {
     VLOG(1) << "PaddingInodeS3ChunkInfo, fsId: " << fsId
             << ", inodeId: " << inodeId;
-    return inodeStorage_->PaddingInodeS3ChunkInfo(fsId, inodeId, inode);
+    return inodeStorage_->PaddingInodeS3ChunkInfo(fsId, inodeId, m, limit);
 }
 
 MetaStatusCode InodeManager::UpdateInodeWhenCreateOrRemoveSubNode(

--- a/curvefs/src/metaserver/inode_manager.h
+++ b/curvefs/src/metaserver/inode_manager.h
@@ -61,7 +61,11 @@ class InodeManager {
     MetaStatusCode CreateInode(uint64_t inodeId, const InodeParam &param,
                                Inode *inode);
     MetaStatusCode CreateRootInode(const InodeParam &param);
-    MetaStatusCode GetInode(uint32_t fsId, uint64_t inodeId, Inode *inode);
+
+    MetaStatusCode GetInode(uint32_t fsId,
+                            uint64_t inodeId,
+                            Inode *inode,
+                            bool paddingS3ChunkInfo = false);
 
     MetaStatusCode GetInodeAttr(uint32_t fsId, uint64_t inodeId,
                                 InodeAttr *attr);
@@ -75,13 +79,14 @@ class InodeManager {
     MetaStatusCode GetOrModifyS3ChunkInfo(uint32_t fsId,
                                           uint64_t inodeId,
                                           const S3ChunkInfoMap& map2add,
-                                          std::shared_ptr<Iterator>* iterator,
+                                          const S3ChunkInfoMap& map2del,
                                           bool returnS3ChunkInfoMap,
-                                          bool compaction);
+                                          std::shared_ptr<Iterator>* iterator);
 
     MetaStatusCode PaddingInodeS3ChunkInfo(int32_t fsId,
                                            uint64_t inodeId,
-                                           Inode* inode);
+                                           S3ChunkInfoMap* m,
+                                           uint64_t limit = 0);
 
     MetaStatusCode UpdateInodeWhenCreateOrRemoveSubNode(uint32_t fsId,
         uint64_t inodeId, bool isCreate);

--- a/curvefs/src/metaserver/inode_storage.cpp
+++ b/curvefs/src/metaserver/inode_storage.cpp
@@ -179,7 +179,10 @@ MetaStatusCode InodeStorage::AddS3ChunkInfoList(
     uint64_t inodeId,
     uint64_t chunkIndex,
     const S3ChunkInfoList& list2add) {
-    // key
+    if (list2add.s3chunks_size() == 0) {
+        return MetaStatusCode::OK;
+    }
+
     size_t size = list2add.s3chunks_size();
     uint64_t firstChunkId = list2add.s3chunks(0).chunkid();
     uint64_t lastChunkId = list2add.s3chunks(size - 1).chunkid();
@@ -192,13 +195,39 @@ MetaStatusCode InodeStorage::AddS3ChunkInfoList(
                     MetaStatusCode::STORAGE_INTERNAL_ERROR;
 }
 
-// NOTE: s3chunkinfo which its chunkid equal or
-// less then min chunkid should be removed
-MetaStatusCode InodeStorage::RemoveS3ChunkInfoList(Transaction txn,
-                                                   uint32_t fsId,
-                                                   uint64_t inodeId,
-                                                   uint64_t chunkIndex,
-                                                   uint64_t minChunkId) {
+bool InodeStorage::SplitS3ChunkInfoList(const std::string& value,
+                                        uint64_t delFirstChunkId,
+                                        S3ChunkInfoList* list2add) {
+    if (!conv_->ParseFromString(value, list2add)) {
+        LOG(ERROR) << "ParseFromString failed for S3ChunkInfoList";
+        return false;
+    }
+
+    size_t size = list2add->s3chunks_size();
+    for (size_t i = 0; i < size; i++) {
+        if (list2add->s3chunks(i).chunkid() >= delFirstChunkId) {
+            list2add->mutable_s3chunks()->DeleteSubrange(i, size - i);
+            break;
+        }
+    }
+    return true;
+}
+
+MetaStatusCode InodeStorage::DelS3ChunkInfoList(
+    Transaction txn,
+    uint32_t fsId,
+    uint64_t inodeId,
+    uint64_t chunkIndex,
+    const S3ChunkInfoList& list2del) {
+    if (list2del.s3chunks_size() == 0) {
+        return MetaStatusCode::OK;
+    }
+
+    size_t size = list2del.s3chunks_size();
+    uint64_t delFirstChunkId = list2del.s3chunks(0).chunkid();
+    uint64_t delLastChunkId = list2del.s3chunks(size - 1).chunkid();
+
+    // prefix
     Prefix4ChunkIndexS3ChunkInfoList prefix(fsId, inodeId, chunkIndex);
     std::string sprefix = conv_->SerializeToString(prefix);
     auto iterator = txn->SSeek(table4s3chunkinfo_, sprefix);
@@ -206,21 +235,56 @@ MetaStatusCode InodeStorage::RemoveS3ChunkInfoList(Transaction txn,
         return MetaStatusCode::STORAGE_INTERNAL_ERROR;
     }
 
-    uint64_t lastChunkId;
     Key4S3ChunkInfoList key;
     std::vector<std::string> key2del;
+    std::vector<S3ChunkInfoList> lists2add;
     for (iterator->SeekToFirst(); iterator->Valid(); iterator->Next()) {
         std::string skey = iterator->Key();
         if (!StringStartWith(skey, sprefix)) {
             break;
         } else if (!conv_->ParseFromString(skey, &key)) {
             return MetaStatusCode::PARSE_FROM_STRING_FAILED;
-        } else if (key.firstChunkId >= minChunkId) {
-            break;
         }
 
-        // firstChunkId < minChunkId
-        key2del.push_back(skey);
+        // delete list range :  [     ]
+        // current list range:   [  ]
+        if (delFirstChunkId <= key.firstChunkId &&
+            delLastChunkId >= key.lastChunkId) {
+            key2del.push_back(skey);
+        // delete list range :    [   ]
+        // current list range:  [  ]
+        } else if (delFirstChunkId >= key.firstChunkId &&
+            delFirstChunkId <= key.lastChunkId &&
+            delLastChunkId >= key.lastChunkId) {
+            S3ChunkInfoList list;
+            bool succ = SplitS3ChunkInfoList(
+                iterator->Value(), delFirstChunkId, &list);
+            if (!succ) {
+                return MetaStatusCode::STORAGE_INTERNAL_ERROR;
+            }
+            key2del.push_back(skey);
+            lists2add.push_back(list);
+        // delete list range :        [  ]
+        // current list range:  [  ]
+        }  else if (delFirstChunkId > key.lastChunkId) {
+            continue;
+        // delete list range :  [  ]
+        // current list range:       [  ]
+        } else if (delLastChunkId < key.firstChunkId) {
+            continue;
+        } else {
+            LOG(ERROR) << "wrong delete list range (" << delFirstChunkId
+                       << "," << delLastChunkId << "), skey=" << skey;
+            return MetaStatusCode::STORAGE_INTERNAL_ERROR;
+        }
+    }
+
+    for (const auto& list : lists2add) {
+        MetaStatusCode rc = AddS3ChunkInfoList(
+            txn, fsId, inodeId, chunkIndex, list);
+        if (rc != MetaStatusCode::OK) {
+            return rc;
+        }
     }
 
     for (const auto& skey : key2del) {
@@ -231,28 +295,21 @@ MetaStatusCode InodeStorage::RemoveS3ChunkInfoList(Transaction txn,
     return MetaStatusCode::OK;
 }
 
-MetaStatusCode InodeStorage::AppendS3ChunkInfoList(
+MetaStatusCode InodeStorage::ModifyInodeS3ChunkInfoList(
     uint32_t fsId,
     uint64_t inodeId,
     uint64_t chunkIndex,
     const S3ChunkInfoList& list2add,
-    bool compaction) {
+    const S3ChunkInfoList& list2del) {
     WriteLockGuard writeLockGuard(rwLock_);
-    size_t size = list2add.s3chunks_size();
-    if (size == 0) {
-        return MetaStatusCode::OK;
-    }
-
     auto txn = kvStorage_->BeginTransaction();
     if (nullptr == txn) {
         return MetaStatusCode::STORAGE_INTERNAL_ERROR;
     }
 
-    MetaStatusCode rc;
-    rc = AddS3ChunkInfoList(txn, fsId, inodeId, chunkIndex, list2add);
-    if (rc == MetaStatusCode::OK && compaction) {
-        uint64_t minChunkId = list2add.s3chunks(0).chunkid();
-        rc = RemoveS3ChunkInfoList(txn, fsId, inodeId, chunkIndex, minChunkId);
+    auto rc = AddS3ChunkInfoList(txn, fsId, inodeId, chunkIndex, list2add);
+    if (rc == MetaStatusCode::OK) {
+        rc = DelS3ChunkInfoList(txn, fsId, inodeId, chunkIndex, list2del);
     }
 
     if (rc != MetaStatusCode::OK) {
@@ -260,13 +317,29 @@ MetaStatusCode InodeStorage::AppendS3ChunkInfoList(
     } else if (!txn->Commit().ok()) {
         rc = MetaStatusCode::STORAGE_INTERNAL_ERROR;
     }
+
+    if (rc != MetaStatusCode::OK) {
+        return rc;
+    }
+
+    // rc == MetaStatusCode::OK
+    uint64_t size4add = list2add.s3chunks_size();
+    uint64_t size4del = list2del.s3chunks_size();
+    if (!UpdateInodeS3MetaSize(fsId, inodeId, size4add, size4del)) {
+        return MetaStatusCode::STORAGE_INTERNAL_ERROR;
+    }
     return rc;
 }
 
 MetaStatusCode InodeStorage::PaddingInodeS3ChunkInfo(int32_t fsId,
                                                      uint64_t inodeId,
-                                                     Inode* inode) {
+                                                     S3ChunkInfoMap* m,
+                                                     uint64_t limit) {
     ReadLockGuard readLockGuard(rwLock_);
+    if (limit != 0 && GetInodeS3MetaSize(fsId, inodeId) > limit) {
+        return MetaStatusCode::INODE_S3_META_TOO_LARGE;
+    }
+
     auto iterator = GetInodeS3ChunkInfoList(fsId, inodeId);
     if (iterator->Status() != 0) {
         LOG(ERROR) << "Get inode s3chunkinfo failed";
@@ -282,7 +355,6 @@ MetaStatusCode InodeStorage::PaddingInodeS3ChunkInfo(int32_t fsId,
 
     Key4S3ChunkInfoList key;
     S3ChunkInfoList list;
-    auto m = inode->mutable_s3chunkinfomap();
     for (iterator->SeekToFirst(); iterator->Valid(); iterator->Next()) {
         std::string skey = iterator->Key();
         std::string svalue = iterator->Value();

--- a/curvefs/src/metaserver/metaserver.cpp
+++ b/curvefs/src/metaserver/metaserver.cpp
@@ -500,6 +500,9 @@ void Metaserver::InitStorage() {
     LOG_IF(FATAL, !conf_->GetUInt64Value(
         "storage.rocksdb.block_cache_capacity",
         &storageOptions_.blockCacheCapacity));
+    LOG_IF(FATAL, !conf_->GetUInt64Value(
+        "storage.s3_meta_inside_inode.limit_size",
+        &storageOptions_.s3MetaLimitSizeInsideInode));
 
     bool succ = ::curvefs::metaserver::storage::InitStorage(storageOptions_);
     LOG_IF(FATAL, !succ) << "Init storage failed";

--- a/curvefs/src/metaserver/metastore.cpp
+++ b/curvefs/src/metaserver/metastore.cpp
@@ -397,13 +397,29 @@ MetaStatusCode MetaStoreImpl::GetInode(const GetInodeRequest* request,
         return status;
     }
 
-    MetaStatusCode status =
-        partition->GetInode(fsId, inodeId, response->mutable_inode());
-    if (status != MetaStatusCode::OK) {
+    Inode* inode = response->mutable_inode();
+    MetaStatusCode rc = partition->GetInode(fsId, inodeId, inode);
+    // NOTE: the following two cases we should padding inode's s3chunkinfo:
+    // (1): for RPC requests which unsupport streaming
+    // (2): inode's s3chunkinfo is small enough
+    if (rc == MetaStatusCode::OK) {
+        uint64_t limit = 0;
+        if (request->supportstreaming()) {
+            limit = kvStorage_->GetStorageOptions().s3MetaLimitSizeInsideInode;
+        }
+        rc = partition->PaddingInodeS3ChunkInfo(
+            fsId, inodeId, inode->mutable_s3chunkinfomap(), limit);
+        if (rc == MetaStatusCode::INODE_S3_META_TOO_LARGE) {
+            response->set_streaming(true);
+            rc = MetaStatusCode::OK;
+        }
+    }
+
+    if (rc != MetaStatusCode::OK) {
         response->clear_inode();
     }
-    response->set_statuscode(status);
-    return status;
+    response->set_statuscode(rc);
+    return rc;
 }
 
 MetaStatusCode MetaStoreImpl::BatchGetInodeAttr(
@@ -509,13 +525,20 @@ MetaStatusCode MetaStoreImpl::GetOrModifyS3ChunkInfo(
     auto partition = GetPartition(request->partitionid());
     if (nullptr == partition) {
         rc = MetaStatusCode::PARTITION_NOT_FOUND;
-    } else {
-        rc = partition->GetOrModifyS3ChunkInfo(request->fsid(),
-                                               request->inodeid(),
-                                               request->s3chunkinfoadd(),
-                                               iterator,
-                                               request->returns3chunkinfomap(),
-                                               request->froms3compaction());
+        response->set_statuscode(rc);
+        return rc;
+    }
+
+    uint32_t fsId = request->fsid();
+    uint64_t inodeId = request->inodeid();
+    rc = partition->GetOrModifyS3ChunkInfo(fsId, inodeId,
+                                           request->s3chunkinfoadd(),
+                                           request->s3chunkinforemove(),
+                                           request->returns3chunkinfomap(),
+                                           iterator);
+    if (rc == MetaStatusCode::OK && !request->supportstreaming()) {
+        rc = partition->PaddingInodeS3ChunkInfo(
+            fsId, inodeId, response->mutable_s3chunkinfomap(), 0);
     }
     response->set_statuscode(rc);
     return rc;

--- a/curvefs/src/metaserver/metastore.h
+++ b/curvefs/src/metaserver/metastore.h
@@ -77,6 +77,7 @@ using ::curvefs::metaserver::copyset::OnSnapshotSaveDoneClosure;
 using ::curvefs::metaserver::storage::Iterator;
 using ::curvefs::common::StreamServer;
 using ::curvefs::common::StreamConnection;
+using S3ChunkInfoMap = google::protobuf::Map<uint64_t, S3ChunkInfoList>;
 
 class MetaStore {
  public:

--- a/curvefs/src/metaserver/metastore_fstream.cpp
+++ b/curvefs/src/metaserver/metastore_fstream.cpp
@@ -170,11 +170,12 @@ bool MetaStoreFStream::LoadInodeS3ChunkInfoList(uint32_t partitionId,
         return false;
     }
 
-    std::shared_ptr<Iterator> iterator;
     S3ChunkInfoMap map2add;
+    S3ChunkInfoMap map2del;
+    std::shared_ptr<Iterator> iterator;
     map2add.insert({key4list.chunkIndex, list});
     MetaStatusCode rc = partition->GetOrModifyS3ChunkInfo(
-        key4list.fsId, key4list.inodeId, map2add, &iterator, false, false);
+        key4list.fsId, key4list.inodeId, map2add, map2del, false, &iterator);
     if (rc != MetaStatusCode::OK) {
         LOG(ERROR) << "GetOrModifyS3ChunkInfo failed, retCode = "
                    << MetaStatusCode_Name(rc);

--- a/curvefs/src/metaserver/partition.cpp
+++ b/curvefs/src/metaserver/partition.cpp
@@ -262,20 +262,30 @@ MetaStatusCode Partition::UpdateInode(const UpdateInodeRequest& request) {
 MetaStatusCode Partition::GetOrModifyS3ChunkInfo(
     uint32_t fsId,
     uint64_t inodeId,
-    const S3ChunkInfoMap& list2add,
-    std::shared_ptr<Iterator>* iterator,
+    const S3ChunkInfoMap& map2add,
+    const S3ChunkInfoMap& map2del,
     bool returnS3ChunkInfoMap,
-    bool compaction) {
+    std::shared_ptr<Iterator>* iterator) {
     if (!IsInodeBelongs(fsId, inodeId)) {
         return MetaStatusCode::PARTITION_ID_MISSMATCH;
-    }
-
-    if (GetStatus() == PartitionStatus::DELETING) {
+    } else if (GetStatus() == PartitionStatus::DELETING) {
         return MetaStatusCode::PARTITION_DELETING;
     }
 
     return inodeManager_->GetOrModifyS3ChunkInfo(
-        fsId, inodeId, list2add, iterator, returnS3ChunkInfoMap, compaction);
+        fsId, inodeId, map2add, map2del, returnS3ChunkInfoMap, iterator);
+}
+
+MetaStatusCode Partition::PaddingInodeS3ChunkInfo(int32_t fsId,
+                                                  uint64_t inodeId,
+                                                  S3ChunkInfoMap* m,
+                                                  uint64_t limit) {
+    if (!IsInodeBelongs(fsId, inodeId)) {
+        return MetaStatusCode::PARTITION_ID_MISSMATCH;
+    } else if (GetStatus() == PartitionStatus::DELETING) {
+        return MetaStatusCode::PARTITION_DELETING;
+    }
+    return inodeManager_->PaddingInodeS3ChunkInfo(fsId, inodeId, m, limit);
 }
 
 MetaStatusCode Partition::InsertInode(const Inode& inode) {

--- a/curvefs/src/metaserver/partition.h
+++ b/curvefs/src/metaserver/partition.h
@@ -92,10 +92,15 @@ class Partition {
 
     MetaStatusCode GetOrModifyS3ChunkInfo(uint32_t fsId,
                                           uint64_t inodeId,
-                                          const S3ChunkInfoMap& list2add,
-                                          std::shared_ptr<Iterator>* iterator,
+                                          const S3ChunkInfoMap& map2add,
+                                          const S3ChunkInfoMap& map2del,
                                           bool returnS3ChunkInfoMap,
-                                          bool compaction);
+                                          std::shared_ptr<Iterator>* iterator);
+
+    MetaStatusCode PaddingInodeS3ChunkInfo(int32_t fsId,
+                                           uint64_t inodeId,
+                                           S3ChunkInfoMap* m,
+                                           uint64_t limit = 0);
 
     MetaStatusCode InsertInode(const Inode& inode);
 

--- a/curvefs/src/metaserver/s3compact_wq_impl.cpp
+++ b/curvefs/src/metaserver/s3compact_wq_impl.cpp
@@ -424,7 +424,7 @@ bool S3CompactWorkQueueImpl::CompactPrecheck(
 
     // inode exist?
     MetaStatusCode ret = task.inodeManager->GetInode(
-        task.inodeKey.fsId, task.inodeKey.inodeId, inode);
+        task.inodeKey.fsId, task.inodeKey.inodeId, inode, true);
     if (ret != MetaStatusCode::OK) {
         LOG(WARNING) << "s3compact: GetInode fail, inodeKey = "
                      << task.inodeKey.fsId << "," << task.inodeKey.inodeId
@@ -438,22 +438,9 @@ bool S3CompactWorkQueueImpl::CompactPrecheck(
         return false;
     }
 
-    // pandding s3chunkinfomap for inode
-    {
-        auto inodeKey = task.inodeKey;
-        auto inodeManager = task.inodeManager;
-        MetaStatusCode rc = inodeManager->PaddingInodeS3ChunkInfo(
-            inodeKey.fsId, inodeKey.inodeId, inode);
-        if (rc != MetaStatusCode::OK) {
-            LOG(ERROR) << "Padding inode s3chunkinfo failed, "
-                       << "retCode = " << MetaStatusCode_Name(ret);
-            return false;
-        }
-
-        if (inode->s3chunkinfomap().size() == 0) {
-            VLOG(6) << "Inode s3chunkinfo is empty";
-            return false;
-        }
+    if (inode->s3chunkinfomap().size() == 0) {
+        VLOG(6) << "Inode s3chunkinfo is empty";
+        return false;
     }
 
     // need compact?

--- a/curvefs/src/metaserver/storage/config.h
+++ b/curvefs/src/metaserver/storage/config.h
@@ -53,6 +53,9 @@ struct StorageOptions {
     uint64_t orderedMaxWriteBufferNumber;
 
     uint64_t blockCacheCapacity;
+
+    // misc config item
+    uint64_t s3MetaLimitSizeInsideInode;
 };
 
 }  // namespace storage

--- a/curvefs/src/metaserver/storage/memory_storage.cpp
+++ b/curvefs/src/metaserver/storage/memory_storage.cpp
@@ -321,6 +321,10 @@ bool MemoryStorage::GetStatistics(StorageStatistics* statistics) {
     return true;
 }
 
+StorageOptions MemoryStorage::GetStorageOptions() {
+    return options_;
+}
+
 }  // namespace storage
 }  // namespace metaserver
 }  // namespace curvefs

--- a/curvefs/src/metaserver/storage/memory_storage.h
+++ b/curvefs/src/metaserver/storage/memory_storage.h
@@ -97,6 +97,8 @@ class MemoryStorage : public KVStorage, public StorageTransaction {
 
     bool GetStatistics(StorageStatistics* Statistics) override;
 
+    StorageOptions GetStorageOptions() override;
+
     Status HGet(const std::string& name,
                 const std::string& key,
                 ValueType* value) override;

--- a/curvefs/src/metaserver/storage/rocksdb_storage.cpp
+++ b/curvefs/src/metaserver/storage/rocksdb_storage.cpp
@@ -51,7 +51,7 @@ RocksDBOptions::RocksDBOptions(StorageOptions options) {
     dbOptions_.max_background_compactions = 4;
     dbOptions_.bytes_per_sync = 1048576;
     dbOptions_.compaction_pri = ROCKSDB_NAMESPACE::kMinOverlappingRatio;
-    dbOptions_.prefix_extractor.reset(NewFixedPrefixTransform(3));
+    dbOptions_.prefix_extractor.reset(NewCappedPrefixTransform(3));
 
     // table options
     std::shared_ptr<ROCKSDB_NAMESPACE::Cache> cache =
@@ -61,6 +61,7 @@ RocksDBOptions::RocksDBOptions(StorageOptions options) {
     tableOptions.block_size = 16 * 1024;  // 16MB
     tableOptions.cache_index_and_filter_blocks = true;
     tableOptions.pin_l0_filter_and_index_blocks_in_cache = true;
+    tableOptions.filter_policy.reset(NewBloomFilterPolicy(10, true));
     dbOptions_.table_factory.reset(NewBlockBasedTableFactory(tableOptions));
 
     // column failmy options
@@ -281,7 +282,7 @@ Status RocksDBStorage::Get(const std::string& name,
 
     std::string iname = ToInternalName(name, ordered);
     std::string ikey = ToInternalKey(iname, key);
-    if (!FindKey(iname, ikey)) {
+    if (!InTransaction_ && !FindKey(iname, ikey)) {
         return Status::NotFound();
     }
 
@@ -332,7 +333,7 @@ Status RocksDBStorage::Del(const std::string& name,
 
     std::string iname = ToInternalName(name, ordered);
     std::string ikey = ToInternalKey(iname, key);
-    if (!counter_->Find(iname, ikey)) {
+    if (!InTransaction_ && !counter_->Find(iname, ikey)) {
         return Status::NotFound();
     }
 
@@ -351,7 +352,7 @@ Status RocksDBStorage::Del(const std::string& name,
 }
 
 std::shared_ptr<Iterator> RocksDBStorage::Seek(const std::string& name,
-                                                const std::string& prefix) {
+                                               const std::string& prefix) {
     size_t size = 0;
     int status = inited_ ? 0 : -1;
     std::string iname = ToInternalName(name, true);
@@ -440,6 +441,10 @@ bool RocksDBStorage::GetStatistics(StorageStatistics* statistics) {
     statistics->diskUsageBytes = total - available;
 
     return true;
+}
+
+StorageOptions RocksDBStorage::GetStorageOptions() {
+    return options_;
 }
 
 }  // namespace storage

--- a/curvefs/src/metaserver/storage/storage.h
+++ b/curvefs/src/metaserver/storage/storage.h
@@ -110,6 +110,8 @@ class KVStorage : public BaseStorage {
 
     virtual bool GetStatistics(StorageStatistics* Statistics) = 0;
 
+    virtual StorageOptions GetStorageOptions() = 0;
+
     virtual std::shared_ptr<StorageTransaction> BeginTransaction() = 0;
 };
 

--- a/curvefs/src/metaserver/storage/storage_fstream.h
+++ b/curvefs/src/metaserver/storage/storage_fstream.h
@@ -92,11 +92,17 @@ static std::pair<std::string, std::string> UserKey(const std::string& ikey) {
     if (items.size() >= 2) {
         prefix = items[0];
         ukey = ikey.substr(prefix.size() + 1);
+    } else if (items.size() == 1) {  // e.g: t3:
+        prefix = items[0];
     }
     return std::make_pair(prefix, ukey);
 }
 
 static std::pair<ENTRY_TYPE, uint32_t> Extract(const std::string& prefix) {
+    if (prefix.size() == 0) {
+        return std::make_pair(ENTRY_TYPE::UNKNOWN, 0);
+    }
+
     std::vector<std::string> items{
         prefix.substr(0, 1),  // eg: i
         prefix.substr(1),  // eg: 100

--- a/curvefs/test/client/mock_metaserver_client.h
+++ b/curvefs/test/client/mock_metaserver_client.h
@@ -72,8 +72,8 @@ class MockMetaServerClient : public MetaServerClient {
     MOCK_METHOD1(PrepareRenameTx,
                  MetaStatusCode(const std::vector<Dentry>& dentrys));
 
-    MOCK_METHOD3(GetInode, MetaStatusCode(
-            uint32_t fsId, uint64_t inodeid, Inode *out));
+    MOCK_METHOD4(GetInode, MetaStatusCode(
+            uint32_t fsId, uint64_t inodeid, Inode *out, bool* streaming));
 
     MOCK_METHOD3(BatchGetInodeAttr, MetaStatusCode(
         uint32_t fsId, std::set<uint64_t> *inodeIds,

--- a/curvefs/test/client/test_inode_cache_manager.cpp
+++ b/curvefs/test/client/test_inode_cache_manager.cpp
@@ -83,7 +83,7 @@ TEST_F(TestInodeCacheManager, GetInode) {
     inode.set_fsid(fsId_);
     inode.set_length(fileLength);
 
-    EXPECT_CALL(*metaClient_, GetInode(fsId_, inodeId, _))
+    EXPECT_CALL(*metaClient_, GetInode(fsId_, inodeId, _, _))
         .WillOnce(Return(MetaStatusCode::NOT_FOUND))
         .WillOnce(DoAll(SetArgPointee<2>(inode), Return(MetaStatusCode::OK)));
 
@@ -109,7 +109,7 @@ TEST_F(TestInodeCacheManager, GetInode) {
 
     curvefs::client::common::FLAGS_enableCto = true;
     inodeWrapper->SetOpenCount(0);
-    EXPECT_CALL(*metaClient_, GetInode(fsId_, inodeId, _))
+    EXPECT_CALL(*metaClient_, GetInode(fsId_, inodeId, _, _))
         .WillOnce(Return(MetaStatusCode::NOT_FOUND));
     ret = iCacheManager_->GetInode(inodeId, inodeWrapper);
     ASSERT_EQ(CURVEFS_ERROR::NOTEXIST, ret);
@@ -118,7 +118,7 @@ TEST_F(TestInodeCacheManager, GetInode) {
     ASSERT_EQ(fileLength, out.length());
 
     inodeWrapper->SetOpenCount(1);
-    EXPECT_CALL(*metaClient_, GetInode(fsId_, inodeId, _))
+    EXPECT_CALL(*metaClient_, GetInode(fsId_, inodeId, _, _))
         .WillOnce(Return(MetaStatusCode::NOT_FOUND));
     ret = iCacheManager_->GetInode(inodeId, inodeWrapper);
     ASSERT_EQ(CURVEFS_ERROR::NOTEXIST, ret);

--- a/curvefs/test/metaserver/inode_manager_test.cpp
+++ b/curvefs/test/metaserver/inode_manager_test.cpp
@@ -149,6 +149,24 @@ class InodeManagerTest : public ::testing::Test {
         return list;
     }
 
+    void CHECK_ITERATOR_S3CHUNKINFOLIST(
+        std::shared_ptr<Iterator> iterator,
+        const std::vector<uint64_t> chunkIndexs,
+        const std::vector<S3ChunkInfoList> lists) {
+        size_t size = 0;
+        Key4S3ChunkInfoList key;
+        S3ChunkInfoList list4get;
+        ASSERT_EQ(iterator->Status(), 0);
+        for (iterator->SeekToFirst(); iterator->Valid(); iterator->Next()) {
+            ASSERT_TRUE(conv_->ParseFromString(iterator->Key(), &key));
+            ASSERT_TRUE(conv_->ParseFromString(iterator->Value(), &list4get));
+            ASSERT_EQ(key.chunkIndex, chunkIndexs[size]);
+            ASSERT_TRUE(EqualS3ChunkInfoList(list4get, lists[size]));
+            size++;
+        }
+        ASSERT_EQ(size, chunkIndexs.size());
+    }
+
  protected:
     std::shared_ptr<InodeManager> manager;
     InodeParam param_;
@@ -230,97 +248,114 @@ TEST_F(InodeManagerTest, test1) {
 }
 
 TEST_F(InodeManagerTest, GetOrModifyS3ChunkInfo) {
-    google::protobuf::Map<uint64_t, S3ChunkInfoList> map4add;
     uint32_t fsId = 1;
     uint32_t inodeId = 1;
-    S3ChunkInfoList list4add = GenS3ChunkInfoList(1, 100);
-    for (int i = 0; i < 10; i++) {
-        map4add[i] = list4add;
-    }
 
     // CASE 1: GetOrModifyS3ChunkInfo() success
     {
+        LOG(INFO) << "CASE 1: GetOrModifyS3ChunkInfo() success";
+        google::protobuf::Map<uint64_t, S3ChunkInfoList> map2add;
+        google::protobuf::Map<uint64_t, S3ChunkInfoList> map2del;
+
+        map2add[1] = GenS3ChunkInfoList(1, 1);
+        map2add[2] = GenS3ChunkInfoList(2, 2);
+        map2add[3] = GenS3ChunkInfoList(3, 3);
+
         std::shared_ptr<Iterator> iterator;
         MetaStatusCode rc = manager->GetOrModifyS3ChunkInfo(
-            fsId, inodeId, map4add, &iterator, true, false);
+            fsId, inodeId, map2add, map2del, true, &iterator);
         ASSERT_EQ(rc, MetaStatusCode::OK);
 
-        size_t size = 0;
-        Key4S3ChunkInfoList key;
-        S3ChunkInfoList list4get;
-        ASSERT_EQ(iterator->Status(), 0);
-        for (iterator->SeekToFirst(); iterator->Valid(); iterator->Next()) {
-            ASSERT_TRUE(conv_->ParseFromString(iterator->Key(), &key));
-            ASSERT_TRUE(conv_->ParseFromString(iterator->Value(), &list4get));
-            ASSERT_EQ(key.chunkIndex, size);
-            ASSERT_TRUE(EqualS3ChunkInfoList(list4add, list4get));
-            size++;
-        }
-        ASSERT_EQ(size, 10);
+        CHECK_ITERATOR_S3CHUNKINFOLIST(iterator,
+            std::vector<uint64_t>{ 1, 2, 3 },
+            std::vector<S3ChunkInfoList>{
+                GenS3ChunkInfoList(1, 1),
+                GenS3ChunkInfoList(2, 2),
+                GenS3ChunkInfoList(3, 3),
+            });
+
+        LOG(INFO) << "CASE 1.1: check idempotent for GetOrModifyS3ChunkInfo()";
+        rc = manager->GetOrModifyS3ChunkInfo(
+            fsId, inodeId, map2add, map2del, true, &iterator);
+        ASSERT_EQ(rc, MetaStatusCode::OK);
+
+        CHECK_ITERATOR_S3CHUNKINFOLIST(iterator,
+            std::vector<uint64_t>{ 1, 2, 3 },
+            std::vector<S3ChunkInfoList>{
+                GenS3ChunkInfoList(1, 1),
+                GenS3ChunkInfoList(2, 2),
+                GenS3ChunkInfoList(3, 3),
+            });
     }
 
-    // CASE 2: idempotent request
+    // CASE 2: GetOrModifyS3ChunkInfo() with delete
     {
+        LOG(INFO) << "CASE 2: GetOrModifyS3ChunkInfo() with delete";
+        google::protobuf::Map<uint64_t, S3ChunkInfoList> map2add;
+        google::protobuf::Map<uint64_t, S3ChunkInfoList> map2del;
+
+        map2del[1] = GenS3ChunkInfoList(1, 1);
+        map2del[2] = GenS3ChunkInfoList(2, 2);
+        map2del[3] = GenS3ChunkInfoList(3, 3);
+
         std::shared_ptr<Iterator> iterator;
         MetaStatusCode rc = manager->GetOrModifyS3ChunkInfo(
-            fsId, inodeId, map4add, &iterator, true, false);
+            fsId, inodeId, map2add, map2del, true, &iterator);
         ASSERT_EQ(rc, MetaStatusCode::OK);
 
-        size_t size = 0;
-        Key4S3ChunkInfoList key;
-        S3ChunkInfoList list4get;
-        ASSERT_EQ(iterator->Status(), 0);
-        for (iterator->SeekToFirst(); iterator->Valid(); iterator->Next()) {
-            ASSERT_TRUE(conv_->ParseFromString(iterator->Key(), &key));
-            ASSERT_TRUE(conv_->ParseFromString(iterator->Value(), &list4get));
-            ASSERT_EQ(key.chunkIndex, size);
-            ASSERT_TRUE(EqualS3ChunkInfoList(list4add, list4get));
-            size++;
-        }
-        ASSERT_EQ(size, 10);
+        CHECK_ITERATOR_S3CHUNKINFOLIST(iterator,
+            std::vector<uint64_t>{},
+            std::vector<S3ChunkInfoList>{});
     }
 
-    // CASE 3: compaction
+    // CASE 3: GetOrModifyS3ChunkInfo() with add and delete
     {
-        map4add.clear();
-        map4add[0] = GenS3ChunkInfoList(100, 100);
-        map4add[1] = GenS3ChunkInfoList(100, 100);
-        map4add[2] = GenS3ChunkInfoList(100, 100);
-        map4add[7] = GenS3ChunkInfoList(100, 100);
-        map4add[8] = GenS3ChunkInfoList(100, 100);
-        map4add[9] = GenS3ChunkInfoList(100, 100);
+        LOG(INFO) << "CASE 3: GetOrModifyS3ChunkInfo() with add and delete";
+        google::protobuf::Map<uint64_t, S3ChunkInfoList> map2add;
+        google::protobuf::Map<uint64_t, S3ChunkInfoList> map2del;
+
+        map2add[0] = GenS3ChunkInfoList(1, 100);
+        map2add[1] = GenS3ChunkInfoList(1, 100);
+        map2add[2] = GenS3ChunkInfoList(1, 100);
+        map2add[7] = GenS3ChunkInfoList(1, 100);
+        map2add[8] = GenS3ChunkInfoList(1, 100);
+        map2add[9] = GenS3ChunkInfoList(1, 100);
+
+        map2del[0] = GenS3ChunkInfoList(1, 100);
+        map2del[2] = GenS3ChunkInfoList(51, 100);
+        map2del[7] = GenS3ChunkInfoList(1, 100);
+        map2del[8] = GenS3ChunkInfoList(1, 100);
+        map2del[9] = GenS3ChunkInfoList(1, 100);
 
         std::shared_ptr<Iterator> iterator;
         MetaStatusCode rc = manager->GetOrModifyS3ChunkInfo(
-            fsId, inodeId, map4add, &iterator, true, true);
+            fsId, inodeId, map2add, map2del, true, &iterator);
         ASSERT_EQ(rc, MetaStatusCode::OK);
         ASSERT_EQ(iterator->Status(), 0);
 
-        size_t size = 0;
-        Key4S3ChunkInfoList key;
-        S3ChunkInfoList list4get;
-        std::vector<S3ChunkInfoList> lists{
-            GenS3ChunkInfoList(100, 100),
-            GenS3ChunkInfoList(100, 100),
-            GenS3ChunkInfoList(100, 100),
-            GenS3ChunkInfoList(1, 100),
-            GenS3ChunkInfoList(1, 100),
-            GenS3ChunkInfoList(1, 100),
-            GenS3ChunkInfoList(1, 100),
-            GenS3ChunkInfoList(100, 100),
-            GenS3ChunkInfoList(100, 100),
-            GenS3ChunkInfoList(100, 100),
-        };
-        for (iterator->SeekToFirst(); iterator->Valid(); iterator->Next()) {
-            LOG(INFO) << "check chunkIndex(" << size << ")"
-                      << ", key=" << iterator->Key();
-            ASSERT_TRUE(conv_->ParseFromString(iterator->Key(), &key));
-            ASSERT_TRUE(conv_->ParseFromString(iterator->Value(), &list4get));
-            ASSERT_EQ(key.chunkIndex, size);
-            ASSERT_TRUE(EqualS3ChunkInfoList(lists[size], list4get));
-            size++;
-        }
-        ASSERT_EQ(size, 10);
+        CHECK_ITERATOR_S3CHUNKINFOLIST(iterator,
+            std::vector<uint64_t>{ 1, 2 },
+            std::vector<S3ChunkInfoList>{
+                GenS3ChunkInfoList(1, 100),
+                GenS3ChunkInfoList(1, 50),
+            });
+
+        LOG(INFO) << "CASE 3.1: GetOrModifyS3ChunkInfo() with only delete";
+        map2add.clear();
+        map2del.clear();
+        map2del[1] = GenS3ChunkInfoList(1, 100);
+        map2del[2] = GenS3ChunkInfoList(11, 50);
+
+        rc = manager->GetOrModifyS3ChunkInfo(
+            fsId, inodeId, map2add, map2del, true, &iterator);
+        ASSERT_EQ(rc, MetaStatusCode::OK);
+        ASSERT_EQ(iterator->Status(), 0);
+
+        CHECK_ITERATOR_S3CHUNKINFOLIST(iterator,
+            std::vector<uint64_t>{ 2 },
+            std::vector<S3ChunkInfoList>{
+                GenS3ChunkInfoList(1, 10),
+            });
     }
 }
 
@@ -394,9 +429,8 @@ TEST_F(InodeManagerTest, testGetXAttr) {
 
     Inode inode2;
     param_.type = FsFileType::TYPE_DIRECTORY;
-    ASSERT_EQ(
-        manager->CreateInode(3, param_, &inode2),
-        MetaStatusCode::OK);
+    ASSERT_EQ(manager->CreateInode(3, param_, &inode2),
+              MetaStatusCode::OK);
     ASSERT_FALSE(inode2.xattr().empty());
     ASSERT_EQ(inode2.xattr().find(XATTRFILES)->second, "0");
     ASSERT_EQ(inode2.xattr().find(XATTRSUBDIRS)->second, "0");

--- a/curvefs/test/metaserver/inode_storage_test.cpp
+++ b/curvefs/test/metaserver/inode_storage_test.cpp
@@ -155,9 +155,8 @@ class InodeStorageTest : public ::testing::Test {
         Key4S3ChunkInfoList key;
         S3ChunkInfoList list4get;
         for (iterator->SeekToFirst(); iterator->Valid(); iterator->Next()) {
-            LOG(INFO) << "checking chunkIndex(" << size << "), key="
-                      << iterator->Key();
             ASSERT_TRUE(conv_->ParseFromString(iterator->Key(), &key));
+            LOG(INFO) << "key" << size << "=" << iterator->Key();
             ASSERT_TRUE(iterator->ParseFromValue(&list4get));
             ASSERT_EQ(key.chunkIndex, chunkIndexs[size]);
             ASSERT_TRUE(EqualS3ChunkInfoList(list4get, lists[size]));
@@ -316,16 +315,17 @@ TEST_F(InodeStorageTest, testGetXAttr) {
     ASSERT_EQ(xattr.xattrinfos().find(XATTRRFBYTES)->second, "1000");
 }
 
-TEST_F(InodeStorageTest, GetOrModifyS3ChunkInfo) {
+TEST_F(InodeStorageTest, ModifyInodeS3ChunkInfoList) {
     uint32_t fsId = 1;
     uint64_t inodeId = 1;
     InodeStorage storage(kvStorage_, tablename_);
 
-    // CASE 1: empty s3chunkinfo
+    // CASE 1: get empty s3chunkinfo
     {
-        LOG(INFO) << "CASE 1:";
+        LOG(INFO) << "CASE 1: get empty s3chukninfo";
         Inode inode = GenInode(fsId, inodeId);
         ASSERT_EQ(storage.Insert(inode), MetaStatusCode::OK);
+        S3ChunkInfoList list2del;
 
         size_t size = 0;
         auto iterator = storage.GetInodeS3ChunkInfoList(fsId, inodeId);
@@ -338,56 +338,59 @@ TEST_F(InodeStorageTest, GetOrModifyS3ChunkInfo) {
 
     // CASE 2: append one s3chunkinfo
     {
-        LOG(INFO) << "CASE 2:";
+        LOG(INFO) << "CASE 2: append one s3chunkinfo";
         ASSERT_EQ(storage.Clear(), MetaStatusCode::OK);
         std::vector<uint64_t> chunkIndexs{ 1 };
-        std::vector<S3ChunkInfoList> lists{ GenS3ChunkInfoList(1, 1) };
+        std::vector<S3ChunkInfoList> lists2add{ GenS3ChunkInfoList(1, 1) };
+        S3ChunkInfoList list2del;
 
-        for (size_t size = 0; size < chunkIndexs.size(); size++) {
-            MetaStatusCode rc = storage.AppendS3ChunkInfoList(
-                fsId, inodeId, chunkIndexs[size], lists[size], false);
+        for (size_t i = 0; i < chunkIndexs.size(); i++) {
+            MetaStatusCode rc = storage.ModifyInodeS3ChunkInfoList(
+                fsId, inodeId, chunkIndexs[i], lists2add[i], list2del);
             ASSERT_EQ(rc, MetaStatusCode::OK);
         }
 
-        CHECK_INODE_S3CHUNKINFOLIST(
-            &storage, fsId, inodeId, chunkIndexs, lists);
+        CHECK_INODE_S3CHUNKINFOLIST(&storage, fsId, inodeId,
+                                    chunkIndexs, lists2add);
     }
 
     // CASE 3: append multi s3chunkinfos
     {
-        LOG(INFO) << "CASE 3:";
+        LOG(INFO) << "CASE 3: append multi s3chunkinfos";
         ASSERT_EQ(storage.Clear(), MetaStatusCode::OK);
         std::vector<uint64_t> chunkIndexs{ 1, 2, 3 };
-        std::vector<S3ChunkInfoList> lists{
+        std::vector<S3ChunkInfoList> lists2add{
             GenS3ChunkInfoList(1, 1),
             GenS3ChunkInfoList(2, 2),
             GenS3ChunkInfoList(3, 3),
         };
+        S3ChunkInfoList list2del;
 
-        for (size_t size = 0; size < chunkIndexs.size(); size++) {
-            MetaStatusCode rc = storage.AppendS3ChunkInfoList(
-                fsId, inodeId, chunkIndexs[size], lists[size], false);
+        for (size_t i = 0; i < chunkIndexs.size(); i++) {
+            MetaStatusCode rc = storage.ModifyInodeS3ChunkInfoList(
+                fsId, inodeId, chunkIndexs[i], lists2add[i], list2del);
             ASSERT_EQ(rc, MetaStatusCode::OK);
         }
 
-        CHECK_INODE_S3CHUNKINFOLIST(
-            &storage, fsId, inodeId, chunkIndexs, lists);
+        CHECK_INODE_S3CHUNKINFOLIST(&storage, fsId, inodeId,
+                                    chunkIndexs, lists2add);
     }
 
     // CASE 4: check order for s3chunkinfo's chunk index
     {
-        LOG(INFO) << "CASE 4:";
+        LOG(INFO) << "CASE 4: check order for s3chunkinfo's chunk index";
         ASSERT_EQ(storage.Clear(), MetaStatusCode::OK);
         std::vector<uint64_t> chunkIndexs{ 2, 1, 3 };
-        std::vector<S3ChunkInfoList> lists{
+        std::vector<S3ChunkInfoList> lists2add{
             GenS3ChunkInfoList(2, 2),
             GenS3ChunkInfoList(1, 1),
             GenS3ChunkInfoList(3, 3),
         };
+        S3ChunkInfoList list2del;
 
-        for (size_t size = 0; size < chunkIndexs.size(); size++) {
-            MetaStatusCode rc = storage.AppendS3ChunkInfoList(
-                fsId, inodeId, chunkIndexs[size], lists[size], false);
+        for (size_t i = 0; i < chunkIndexs.size(); i++) {
+            MetaStatusCode rc = storage.ModifyInodeS3ChunkInfoList(
+                fsId, inodeId, chunkIndexs[i], lists2add[i], list2del);
             ASSERT_EQ(rc, MetaStatusCode::OK);
         }
 
@@ -402,20 +405,21 @@ TEST_F(InodeStorageTest, GetOrModifyS3ChunkInfo) {
 
     // CASE 5: check order for s3chunkinfo's chunk id
     {
-        LOG(INFO) << "CASE 5:";
+        LOG(INFO) << "CASE 5: check order for s3chunkinfo's chunk id";
         ASSERT_EQ(storage.Clear(), MetaStatusCode::OK);
         std::vector<uint64_t> chunkIndexs{ 2, 1, 3, 1, 2 };
-        std::vector<S3ChunkInfoList> lists{
+        std::vector<S3ChunkInfoList> lists2add{
             GenS3ChunkInfoList(200, 210),
             GenS3ChunkInfoList(120, 130),
             GenS3ChunkInfoList(300, 310),
             GenS3ChunkInfoList(100, 110),
             GenS3ChunkInfoList(220, 230),
         };
+        S3ChunkInfoList list2del;
 
-        for (size_t size = 0; size < chunkIndexs.size(); size++) {
-            MetaStatusCode rc = storage.AppendS3ChunkInfoList(
-                fsId, inodeId, chunkIndexs[size], lists[size], false);
+        for (size_t i = 0; i < chunkIndexs.size(); i++) {
+            MetaStatusCode rc = storage.ModifyInodeS3ChunkInfoList(
+                fsId, inodeId, chunkIndexs[i], lists2add[i], list2del);
             ASSERT_EQ(rc, MetaStatusCode::OK);
         }
 
@@ -429,12 +433,98 @@ TEST_F(InodeStorageTest, GetOrModifyS3ChunkInfo) {
                 GenS3ChunkInfoList(300, 310),
             });
     }
+
+    // CASE 6: delete s3chunkinfo list
+    {
+        LOG(INFO) << "CASE 6: delete s3chukninfo list";
+        ASSERT_EQ(storage.Clear(), MetaStatusCode::OK);
+        std::vector<uint64_t> chunkIndexs{ 1, 2, 3 };
+        std::vector<S3ChunkInfoList> lists2add{
+            GenS3ChunkInfoList(100, 199),
+            GenS3ChunkInfoList(200, 299),
+            GenS3ChunkInfoList(300, 399),
+        };
+        std::vector<S3ChunkInfoList> lists2del{
+            GenS3ChunkInfoList(100, 199),
+            GenS3ChunkInfoList(250, 299),
+            GenS3ChunkInfoList(400, 499),
+        };
+
+        for (size_t i = 0; i < chunkIndexs.size(); i++) {
+            MetaStatusCode rc = storage.ModifyInodeS3ChunkInfoList(
+                fsId, inodeId, chunkIndexs[i], lists2add[i], lists2del[i]);
+            ASSERT_EQ(rc, MetaStatusCode::OK);
+        }
+
+        CHECK_INODE_S3CHUNKINFOLIST(&storage, fsId, inodeId,
+            std::vector<uint64_t>{ 2, 3 },
+            std::vector<S3ChunkInfoList>{
+                GenS3ChunkInfoList(200, 249),
+                GenS3ChunkInfoList(300, 399),
+            });
+    }
+
+    // CASE 7: delete s3chunkinfo list with wrong range
+    {
+        LOG(INFO) << "CASE 6: delete s3chunkinfo list with wrong range";
+        ASSERT_EQ(storage.Clear(), MetaStatusCode::OK);
+        std::vector<uint64_t> chunkIndexs{ 1, 2, 3 };
+        std::vector<S3ChunkInfoList> lists2add{
+            GenS3ChunkInfoList(100, 199),
+            GenS3ChunkInfoList(200, 299),
+            GenS3ChunkInfoList(300, 399),
+        };
+        std::vector<S3ChunkInfoList> lists2del{
+            GenS3ChunkInfoList(100, 199),
+            GenS3ChunkInfoList(250, 299),
+            GenS3ChunkInfoList(300, 301),
+        };
+
+        size_t size = chunkIndexs.size();
+        for (size_t i = 0; i < size; i++) {
+            MetaStatusCode rc = storage.ModifyInodeS3ChunkInfoList(
+                fsId, inodeId, chunkIndexs[i], lists2add[i], lists2del[i]);
+            if (i == size - 1) {
+                ASSERT_EQ(rc, MetaStatusCode::STORAGE_INTERNAL_ERROR);
+            } else {
+                ASSERT_EQ(rc, MetaStatusCode::OK);
+            }
+        }
+    }
+
+    // CASE 8: delete all s3chunkinfo list
+    {
+        LOG(INFO) << "CASE 8: delete all s3chukninfo list";
+        ASSERT_EQ(storage.Clear(), MetaStatusCode::OK);
+        std::vector<uint64_t> chunkIndexs{ 1, 2, 3 };
+        std::vector<S3ChunkInfoList> lists2add{
+            GenS3ChunkInfoList(100, 199),
+            GenS3ChunkInfoList(200, 299),
+            GenS3ChunkInfoList(300, 399),
+        };
+        std::vector<S3ChunkInfoList> lists2del{
+            GenS3ChunkInfoList(100, 199),
+            GenS3ChunkInfoList(200, 299),
+            GenS3ChunkInfoList(300, 399),
+        };
+
+        for (size_t i = 0; i < chunkIndexs.size(); i++) {
+            MetaStatusCode rc = storage.ModifyInodeS3ChunkInfoList(
+                fsId, inodeId, chunkIndexs[i], lists2add[i], lists2del[i]);
+            ASSERT_EQ(rc, MetaStatusCode::OK);
+        }
+
+        CHECK_INODE_S3CHUNKINFOLIST(&storage, fsId, inodeId,
+            std::vector<uint64_t>{},
+            std::vector<S3ChunkInfoList>{});
+    }
 }
 
 TEST_F(InodeStorageTest, PaddingInodeS3ChunkInfo) {
     uint32_t fsId = 1;
     uint64_t inodeId = 1;
     InodeStorage storage(kvStorage_, tablename_);
+    S3ChunkInfoList list2del;
 
     // step1: insert inode
     Inode inode = GenInode(fsId, inodeId);
@@ -442,7 +532,7 @@ TEST_F(InodeStorageTest, PaddingInodeS3ChunkInfo) {
 
     // step2: append s3chunkinfo
     std::vector<uint64_t> chunkIndexs{ 1, 3, 2, 1, 2 };
-    std::vector<S3ChunkInfoList> lists{
+    std::vector<S3ChunkInfoList> lists2add{
         GenS3ChunkInfoList(100, 109),
         GenS3ChunkInfoList(300, 310),
         GenS3ChunkInfoList(200, 209),
@@ -450,36 +540,69 @@ TEST_F(InodeStorageTest, PaddingInodeS3ChunkInfo) {
         GenS3ChunkInfoList(210, 220),
     };
 
-    for (size_t size = 0; size < chunkIndexs.size(); size++) {
-        MetaStatusCode rc = storage.AppendS3ChunkInfoList(
-            fsId, inodeId, chunkIndexs[size], lists[size], false);
+    for (size_t i = 0; i < chunkIndexs.size(); i++) {
+        MetaStatusCode rc = storage.ModifyInodeS3ChunkInfoList(
+            fsId, inodeId, chunkIndexs[i], lists2add[i], list2del);
         ASSERT_EQ(rc, MetaStatusCode::OK);
     }
-
-    // step3: padding inode s3chunkinfo
     ASSERT_EQ(inode.mutable_s3chunkinfomap()->size(), 0);
 
-    MetaStatusCode rc = storage.PaddingInodeS3ChunkInfo(fsId, inodeId, &inode);
-    ASSERT_EQ(rc, MetaStatusCode::OK);
-    auto m = inode.s3chunkinfomap();
-    ASSERT_EQ(m.size(), 3);
-    ASSERT_TRUE(EqualS3ChunkInfoList(m[1], GenS3ChunkInfoList(100, 120)));
-    ASSERT_TRUE(EqualS3ChunkInfoList(m[2], GenS3ChunkInfoList(200, 220)));
-    ASSERT_TRUE(EqualS3ChunkInfoList(m[3], GenS3ChunkInfoList(300, 310)));
+    // CASE 1: padding inode s3chunkinfo success
+    {
+        LOG(INFO) << "CASE 1: padding inode s3chunkinfo success";
+        Inode out;
+        MetaStatusCode rc = storage.PaddingInodeS3ChunkInfo(
+            fsId, inodeId, out.mutable_s3chunkinfomap());
+        ASSERT_EQ(rc, MetaStatusCode::OK);
+
+        auto m = out.s3chunkinfomap();
+        ASSERT_EQ(m.size(), 3);
+        ASSERT_TRUE(EqualS3ChunkInfoList(m[1], GenS3ChunkInfoList(100, 120)));
+        ASSERT_TRUE(EqualS3ChunkInfoList(m[2], GenS3ChunkInfoList(200, 220)));
+        ASSERT_TRUE(EqualS3ChunkInfoList(m[3], GenS3ChunkInfoList(300, 310)));
+    }
+
+    // CASE 2: padding inode s3chunkinfo within limit
+    {
+        LOG(INFO) << "CASE 2: padding inode s3chunkinfo within limit";
+        Inode out;
+        MetaStatusCode rc = storage.PaddingInodeS3ChunkInfo(
+            fsId, inodeId, out.mutable_s3chunkinfomap(), 53);
+        ASSERT_EQ(rc, MetaStatusCode::OK);
+
+        auto m = out.s3chunkinfomap();
+        ASSERT_EQ(m.size(), 3);
+        ASSERT_TRUE(EqualS3ChunkInfoList(m[1], GenS3ChunkInfoList(100, 120)));
+        ASSERT_TRUE(EqualS3ChunkInfoList(m[2], GenS3ChunkInfoList(200, 220)));
+        ASSERT_TRUE(EqualS3ChunkInfoList(m[3], GenS3ChunkInfoList(300, 310)));
+    }
+
+    // CASE 3: padding inode s3chunkinfo exceed limit
+    {
+        LOG(INFO) << "CASE 3: padding inode s3chunkinfo exceed limit";
+        Inode out;
+        MetaStatusCode rc = storage.PaddingInodeS3ChunkInfo(
+            fsId, inodeId, out.mutable_s3chunkinfomap(), 52);
+        ASSERT_EQ(rc, MetaStatusCode::INODE_S3_META_TOO_LARGE);
+
+        auto m = out.s3chunkinfomap();
+        ASSERT_EQ(m.size(), 0);
+    }
 }
 
 TEST_F(InodeStorageTest, GetAllS3ChunkInfoList) {
     InodeStorage storage(kvStorage_, tablename_);
     uint64_t chunkIndex = 1;
-    S3ChunkInfoList list4add = GenS3ChunkInfoList(1, 10);
+    S3ChunkInfoList list2add = GenS3ChunkInfoList(1, 10);
+    S3ChunkInfoList list2del;
 
     // step1: prepare inode and its s3chunkinfo
     auto prepareInode = [&](uint32_t fsId, uint64_t inodeId) {
         Inode inode = GenInode(fsId, inodeId);
         ASSERT_EQ(storage.Insert(inode), MetaStatusCode::OK);
 
-        MetaStatusCode rc = storage.AppendS3ChunkInfoList(
-            fsId, inodeId, chunkIndex, list4add, false);
+        MetaStatusCode rc = storage.ModifyInodeS3ChunkInfoList(
+            fsId, inodeId, chunkIndex, list2add, list2del);
         ASSERT_EQ(rc, MetaStatusCode::OK);
     };
 
@@ -499,7 +622,7 @@ TEST_F(InodeStorageTest, GetAllS3ChunkInfoList) {
         ASSERT_EQ(key.chunkIndex, chunkIndex);
         ASSERT_EQ(key.fsId, fsIds[size]);
         ASSERT_EQ(key.inodeId, inodeIds[size]);
-        ASSERT_TRUE(EqualS3ChunkInfoList(list4add, list4get));
+        ASSERT_TRUE(EqualS3ChunkInfoList(list2add, list4get));
         size++;
     }
     ASSERT_EQ(size, 2);

--- a/curvefs/test/metaserver/metastore_test.cpp
+++ b/curvefs/test/metaserver/metastore_test.cpp
@@ -58,6 +58,7 @@ class MetastoreTest : public ::testing::Test {
         dataDir_ = RandomStoragePath();;
         StorageOptions options;
         options.dataDir = dataDir_;
+        options.s3MetaLimitSizeInsideInode = 100;
         kvStorage_ = std::make_shared<RocksDBStorage>(options);
         ASSERT_TRUE(kvStorage_->Open());
 
@@ -186,6 +187,24 @@ class MetastoreTest : public ::testing::Test {
             info->set_zero(false);
         }
         return list;
+    }
+
+    void CHECK_ITERATOR_S3CHUNKINFOLIST(
+        std::shared_ptr<Iterator> iterator,
+        const std::vector<uint64_t> chunkIndexs,
+        const std::vector<S3ChunkInfoList> lists) {
+        size_t size = 0;
+        Key4S3ChunkInfoList key;
+        S3ChunkInfoList list4get;
+        ASSERT_EQ(iterator->Status(), 0);
+        for (iterator->SeekToFirst(); iterator->Valid(); iterator->Next()) {
+            ASSERT_TRUE(conv_->ParseFromString(iterator->Key(), &key));
+            ASSERT_TRUE(conv_->ParseFromString(iterator->Value(), &list4get));
+            ASSERT_EQ(key.chunkIndex, chunkIndexs[size]);
+            ASSERT_TRUE(EqualS3ChunkInfoList(list4get, lists[size]));
+            size++;
+        }
+        ASSERT_EQ(size, chunkIndexs.size());
     }
 
     class OnSnapshotSaveDoneImpl : public OnSnapshotSaveDoneClosure {
@@ -1397,6 +1416,7 @@ TEST_F(MetastoreTest, GetOrModifyS3ChunkInfo) {
 
     // CASE 1: partition not found -> failed
     {
+        LOG(INFO) << "CASE 1: partition not found -> failed";
         GetOrModifyS3ChunkInfoRequest request;
         GetOrModifyS3ChunkInfoResponse response;
         request.set_partitionid(100);
@@ -1409,18 +1429,95 @@ TEST_F(MetastoreTest, GetOrModifyS3ChunkInfo) {
 
     // CASE 2: GetOrModifyS3ChunkInfo success
     {
+        LOG(INFO) << "CASE 2: GetOrModifyS3ChunkInfo success";
+        GetOrModifyS3ChunkInfoRequest request;
+        GetOrModifyS3ChunkInfoResponse response;
         std::vector<uint64_t> chunkIndexs{ 1, 2 };
-        std::vector<S3ChunkInfoList> list2add{
+        std::vector<S3ChunkInfoList> lists2add{
             GenS3ChunkInfoList(100, 200),
             GenS3ChunkInfoList(300, 400),
         };
 
-        GetOrModifyS3ChunkInfoRequest request;
-        GetOrModifyS3ChunkInfoResponse response;
         request.set_partitionid(partitionId);
         request.set_fsid(fsId);
         request.set_inodeid(inodeId);
         request.set_returns3chunkinfomap(true);
+        for (size_t i = 0; i < chunkIndexs.size(); i++) {
+            request.mutable_s3chunkinfoadd()->insert(
+                { chunkIndexs[i], lists2add[i] });
+        }
+
+        std::shared_ptr<Iterator> iterator;
+        MetaStatusCode rc = metastore.GetOrModifyS3ChunkInfo(
+            &request, &response, &iterator);
+        ASSERT_EQ(rc, MetaStatusCode::OK);
+        ASSERT_EQ(response.statuscode(), rc);
+
+        CHECK_ITERATOR_S3CHUNKINFOLIST(iterator, chunkIndexs, lists2add);
+    }
+}
+
+TEST_F(MetastoreTest, GetInodeWithPaddingS3Meta) {
+    MetaStoreImpl metastore(nullptr, kvStorage_);
+    uint32_t poolId = 1;
+    uint32_t copysetId = 1;
+    uint32_t partitionId = 1;
+    uint32_t fsId = 1;
+    uint64_t inodeId = 1;
+
+    // init: create partition
+    {
+        CreatePartitionRequest request;
+        CreatePartitionResponse response;
+
+        PartitionInfo partitionInfo;
+        partitionInfo.set_poolid(poolId);
+        partitionInfo.set_copysetid(copysetId);
+        partitionInfo.set_partitionid(partitionId);
+        partitionInfo.set_fsid(fsId);
+        partitionInfo.set_start(1);
+        partitionInfo.set_end(100);
+        request.mutable_partition()->CopyFrom(partitionInfo);
+        MetaStatusCode rc = metastore.CreatePartition(&request, &response);
+        ASSERT_EQ(rc, MetaStatusCode::OK);
+        ASSERT_EQ(response.statuscode(), rc);
+    }
+
+    // step1: create inode
+    {
+        CreateInodeRequest request;
+        CreateInodeResponse response;
+
+        request.set_poolid(poolId);
+        request.set_copysetid(copysetId);
+        request.set_partitionid(partitionId);
+        request.set_fsid(fsId);
+        request.set_length(1);
+        request.set_uid(1);
+        request.set_gid(1);
+        request.set_mode(777);
+        request.set_type(FsFileType::TYPE_FILE);
+
+        auto rc = metastore.CreateInode(&request, &response);
+        ASSERT_EQ(response.statuscode(), MetaStatusCode::OK);
+        inodeId = response.inode().inodeid();
+    }
+
+    // step2: append s3chunkinfo within limit
+    {
+        GetOrModifyS3ChunkInfoRequest request;
+        GetOrModifyS3ChunkInfoResponse response;
+
+        std::vector<uint64_t> chunkIndexs{ 1, 2 };
+        std::vector<S3ChunkInfoList> list2add{
+            GenS3ChunkInfoList(100, 149),
+            GenS3ChunkInfoList(200, 249),
+        };
+
+        request.set_partitionid(partitionId);
+        request.set_fsid(fsId);
+        request.set_inodeid(inodeId);
+        request.set_returns3chunkinfomap(false);
         for (size_t i = 0; i < chunkIndexs.size(); i++) {
             request.mutable_s3chunkinfoadd()->insert(
                 { chunkIndexs[i], list2add[i] });
@@ -1432,20 +1529,93 @@ TEST_F(MetastoreTest, GetOrModifyS3ChunkInfo) {
             &request, &response, &iterator);
         ASSERT_EQ(rc, MetaStatusCode::OK);
         ASSERT_EQ(response.statuscode(), rc);
+    }
 
-        size_t size = 0;
-        Key4S3ChunkInfoList key;
-        S3ChunkInfoList list4get;
-        for (iterator->SeekToFirst(); iterator->Valid(); iterator->Next()) {
-            LOG(INFO) << "check chunkIndex(" << size << ")"
-                      << ", key=" << iterator->Key();
-            ASSERT_TRUE(conv_->ParseFromString(iterator->Key(), &key));
-            ASSERT_TRUE(conv_->ParseFromString(iterator->Value(), &list4get));
-            ASSERT_EQ(key.chunkIndex, chunkIndexs[size]);
-            ASSERT_TRUE(EqualS3ChunkInfoList(list2add[size], list4get));
-            size++;
+    // step3: get inode with support streaming
+    {
+        GetInodeRequest request;
+        GetInodeResponse response;
+
+        request.set_poolid(poolId);
+        request.set_copysetid(copysetId);
+        request.set_partitionid(partitionId);
+        request.set_fsid(fsId);
+        request.set_inodeid(inodeId);
+        request.set_supportstreaming(true);
+
+        auto rc = metastore.GetInode(&request, &response);
+        ASSERT_EQ(response.statuscode(), MetaStatusCode::OK);
+        ASSERT_EQ(rc, MetaStatusCode::OK);
+        auto inode = response.mutable_inode();
+        ASSERT_EQ(response.streaming(), false);
+        ASSERT_EQ(inode->mutable_s3chunkinfomap()->size(), 2);
+    }
+
+    // step4: append s3chunkinfo exceed limit
+    {
+        GetOrModifyS3ChunkInfoRequest request;
+        GetOrModifyS3ChunkInfoResponse response;
+
+        std::vector<uint64_t> chunkIndexs{ 3 };
+        std::vector<S3ChunkInfoList> list2add{
+            GenS3ChunkInfoList(1, 1),
+        };
+
+        request.set_partitionid(partitionId);
+        request.set_fsid(fsId);
+        request.set_inodeid(inodeId);
+        request.set_returns3chunkinfomap(false);
+        for (size_t i = 0; i < chunkIndexs.size(); i++) {
+            request.mutable_s3chunkinfoadd()->insert(
+                { chunkIndexs[i], list2add[i] });
         }
-        ASSERT_EQ(size, 2);
+
+        // ModifyS3ChunkInfo()
+        std::shared_ptr<Iterator> iterator;
+        MetaStatusCode rc = metastore.GetOrModifyS3ChunkInfo(
+            &request, &response, &iterator);
+        ASSERT_EQ(rc, MetaStatusCode::OK);
+        ASSERT_EQ(response.statuscode(), rc);
+    }
+
+    // step5: get inode with support straming
+    {
+        GetInodeRequest request;
+        GetInodeResponse response;
+
+        request.set_poolid(poolId);
+        request.set_copysetid(copysetId);
+        request.set_partitionid(partitionId);
+        request.set_fsid(fsId);
+        request.set_inodeid(inodeId);
+        request.set_supportstreaming(true);
+
+        auto rc = metastore.GetInode(&request, &response);
+        ASSERT_EQ(response.statuscode(), MetaStatusCode::OK);
+        ASSERT_EQ(rc, MetaStatusCode::OK);
+        auto inode = response.mutable_inode();
+        ASSERT_EQ(response.streaming(), true);
+        ASSERT_EQ(inode->mutable_s3chunkinfomap()->size(), 0);
+    }
+
+    // step6: get inode without unsupport streaming
+    {
+        GetInodeRequest request;
+        GetInodeResponse response;
+
+        request.set_poolid(poolId);
+        request.set_copysetid(copysetId);
+        request.set_partitionid(partitionId);
+        request.set_fsid(fsId);
+        request.set_inodeid(inodeId);
+        request.set_supportstreaming(false);
+
+        auto rc = metastore.GetInode(&request, &response);
+        ASSERT_EQ(response.statuscode(), MetaStatusCode::OK);
+        ASSERT_EQ(rc, MetaStatusCode::OK);
+        auto inode = response.mutable_inode();
+        ASSERT_EQ(response.streaming(), false);
+        ASSERT_EQ(inode->mutable_s3chunkinfomap()->size(), 3);
     }
 }
 

--- a/curvefs/test/metaserver/s3compactwq_test.cpp
+++ b/curvefs/test/metaserver/s3compactwq_test.cpp
@@ -627,8 +627,9 @@ TEST_F(S3CompactWorkQueueImplTest, test_CompactChunks) {
         ref->set_size(5);
         ref->set_zero(false);
     }
-    auto rc = inodeStorage_->AppendS3ChunkInfoList(
-        inode1.fsid(), inode1.inodeid(), 0, l0, false);
+    S3ChunkInfoList dummy;
+    auto rc = inodeStorage_->ModifyInodeS3ChunkInfoList(
+        inode1.fsid(), inode1.inodeid(), 0, l0, dummy);
     ASSERT_EQ(rc, MetaStatusCode::OK);
     ASSERT_EQ(inodeStorage_->Update(inode1), MetaStatusCode::OK);
     mockImpl_->CompactChunks(t);

--- a/curvefs/test/metaserver/storage/storage_fstream_test.cpp
+++ b/curvefs/test/metaserver/storage/storage_fstream_test.cpp
@@ -180,9 +180,33 @@ TEST_F(StorageFstreamTest, MiscTest) {
     ASSERT_EQ(Str2Type("x"), ENTRY_TYPE::UNKNOWN);
     ASSERT_EQ(Str2Type("y"), ENTRY_TYPE::UNKNOWN);
 
-    auto ret = Extract("i:-1");
-    ASSERT_EQ(ret.first, ENTRY_TYPE::INODE);
-    ASSERT_EQ(ret.second, 0);
+    {
+        auto ret = Extract("d100");
+        ASSERT_EQ(ret.first, ENTRY_TYPE::DENTRY);
+        ASSERT_EQ(ret.second, 100);
+
+        ret = Extract("i0");
+        ASSERT_EQ(ret.first, ENTRY_TYPE::INODE);
+        ASSERT_EQ(ret.second, 0);
+
+        ret = Extract("");
+        ASSERT_EQ(ret.first, ENTRY_TYPE::UNKNOWN);
+        ASSERT_EQ(ret.second, 0);
+    }
+
+    {
+        auto ret = UserKey("t3:");
+        ASSERT_EQ(ret.first, "t3");
+        ASSERT_EQ(ret.second, "");
+
+        ret = UserKey("i100:000");
+        ASSERT_EQ(ret.first, "i100");
+        ASSERT_EQ(ret.second, "000");
+
+        ret = UserKey("");
+        ASSERT_EQ(ret.first, "");
+        ASSERT_EQ(ret.second, "");
+    }
 
     // CASE 2: open file failed when save
     ASSERT_FALSE(SaveToFile("/__not_found__/dumpfile", nullptr, false));


### PR DESCRIPTION
What's Changed
---

* fixed sseek so slow which caused by unusing rocksdb's table prefix bloom filter
* speed up getting inode's s3chunkinfo by padding inode's s3chunkinfo which small enought in GetInode RPC response