### PR TITLE
curvefs: add leader scheduler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,9 @@ bazel-testlogs
 *.log
 runlog/
 
+# history
+.gdb_history
+
 .clang-format
 !curve-snapshotcloneserver-nginx/app/lib
 !nebd/nebd-package/usr/bin
@@ -108,6 +111,8 @@ curvefs/BUILD_MODE
 
 .BUILD_MODE
 __not_found__
+
+# thirdparties
 thirdparties/rocksdb/lib/
 thirdparties/rocksdb/include/
 thirdparties/rocksdb/rocksdb/

--- a/curvefs/conf/mds.conf
+++ b/curvefs/conf/mds.conf
@@ -42,8 +42,6 @@ leader.electionTimeoutMs=0
 #
 # time interval flush data to db
 mds.topology.TopologyUpdateToRepoSec=60
-# the policy of choose pool 0:Random, 1:Weight
-mds.topology.ChoosePoolPolicy=0
 # max partition number in copyset 2^8
 mds.topology.MaxPartitionNumberInCopyset=256
 # id number in each partition 2^24 [0, 2^24-1]
@@ -79,10 +77,14 @@ mds.heartbeat.clean_follower_afterMs=1200000
 mds.enable.recover.scheduler=true
 # copysetScheduler switch
 mds.enable.copyset.scheduler=true
+# leaderScheduler switch
+mds.enable.leader.scheduler=true
 # RecoverScheduler round interval, the unit is second
 mds.recover.scheduler.intervalSec=5
 # copysetScheduler round interval, the unit is second
 mds.copyset.scheduler.intervalSec=5
+# leaderScheduler round interval, the unit is second
+mds.leader.scheduler.intervalSec=5
 # the percentage difference for copysetScheduler to
 # determine whether resource balancing is required
 # based on the difference in resource usage percent, default is 30%

--- a/curvefs/src/mds/mds.cpp
+++ b/curvefs/src/mds/mds.cpp
@@ -89,8 +89,6 @@ void MDS::InitTopologyOption(TopologyOption* topologyOption) {
                                &topologyOption->maxPartitionNumberInCopyset);
     conf_->GetValueFatalIfFail("mds.topology.IdNumberInPartition",
                                &topologyOption->idNumberInPartition);
-    conf_->GetValueFatalIfFail("mds.topology.ChoosePoolPolicy",
-                               &topologyOption->choosePoolPolicy);
     conf_->GetValueFatalIfFail("mds.topology.InitialCopysetNumber",
                                &topologyOption->initialCopysetNumber);
     conf_->GetValueFatalIfFail("mds.topology.MinAvailableCopysetNum",
@@ -108,6 +106,8 @@ void MDS::InitScheduleOption(ScheduleOption* scheduleOption) {
                                &scheduleOption->enableRecoverScheduler);
     conf_->GetValueFatalIfFail("mds.enable.copyset.scheduler",
                                &scheduleOption->enableCopysetScheduler);
+    conf_->GetValueFatalIfFail("mds.enable.leader.scheduler",
+                               &scheduleOption->enableLeaderScheduler);
     conf_->GetValueFatalIfFail("mds.copyset.scheduler.balanceRatioPercent",
                                &scheduleOption->balanceRatioPercent);
 
@@ -115,6 +115,8 @@ void MDS::InitScheduleOption(ScheduleOption* scheduleOption) {
                                &scheduleOption->recoverSchedulerIntervalSec);
     conf_->GetValueFatalIfFail("mds.copyset.scheduler.intervalSec",
                                &scheduleOption->copysetSchedulerIntervalSec);
+    conf_->GetValueFatalIfFail("mds.leader.scheduler.intervalSec",
+                               &scheduleOption->leaderSchedulerIntervalSec);
 
     conf_->GetValueFatalIfFail("mds.schduler.operator.concurrent",
                                &scheduleOption->operatorConcurrent);

--- a/curvefs/src/mds/schedule/coordinator.cpp
+++ b/curvefs/src/mds/schedule/coordinator.cpp
@@ -43,7 +43,8 @@ DEFINE_bool(enableRecoverScheduler, true, "switch of recover scheduler");
 DEFINE_validator(enableRecoverScheduler, &pass_bool);
 DEFINE_bool(enableCopySetScheduler, true, "switch of copyset scheduler");
 DEFINE_validator(enableCopySetScheduler, &pass_bool);
-
+DEFINE_bool(enableLeaderScheduler, true, "switch of leader scheduler");
+DEFINE_validator(enableLeaderScheduler, &pass_bool);
 
 Coordinator::Coordinator(const std::shared_ptr<TopoAdapter> &topo) {
     this->topo_ = topo;
@@ -68,6 +69,12 @@ void Coordinator::InitScheduler(const ScheduleOption &conf,
         schedulerController_[SchedulerType::CopysetSchedulerType] =
             std::make_shared<CopySetScheduler>(conf, topo_, opController_);
         LOG(INFO) << "init copyset scheduler ok!";
+    }
+
+    if (conf.enableLeaderScheduler) {
+        schedulerController_[SchedulerType::LeaderSchedulerType] =
+            std::make_shared<LeaderScheduler>(conf, topo_, opController_);
+        LOG(INFO) << "init leader scheduler ok!";
     }
 }
 
@@ -289,6 +296,8 @@ bool Coordinator::ScheduleNeedRun(SchedulerType type) {
             return FLAGS_enableRecoverScheduler;
         case SchedulerType::CopysetSchedulerType:
             return FLAGS_enableCopySetScheduler;
+        case SchedulerType::LeaderSchedulerType:
+            return FLAGS_enableLeaderScheduler;
         default:
             return false;
     }
@@ -300,6 +309,8 @@ std::string Coordinator::ScheduleName(SchedulerType type) {
             return "RecoverScheduler";
         case SchedulerType::CopysetSchedulerType:
             return "CopySetScheduler";
+        case SchedulerType::LeaderSchedulerType:
+            return "LeaderScheduler";
         default:
             return "Unknown";
     }

--- a/curvefs/src/mds/schedule/copysetSchedule.cpp
+++ b/curvefs/src/mds/schedule/copysetSchedule.cpp
@@ -256,7 +256,7 @@ int CopySetScheduler::CopySetScheduleForPool(PoolIdType poolId) {
     return genOpCount;
 }
 
-int64_t CopySetScheduler::GetRunningInterval() { return runInterval_; }
+int64_t CopySetScheduler::GetRunningInterval() const { return runInterval_; }
 
 }  // namespace schedule
 }  // namespace mds

--- a/curvefs/src/mds/schedule/leaderScheduler.cpp
+++ b/curvefs/src/mds/schedule/leaderScheduler.cpp
@@ -1,0 +1,388 @@
+/*
+ *  Copyright (c) 2022 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * @Project: curve
+ * @Date: 2022-04-07 14:15:49
+ * @Author: chenwei
+ */
+
+#include "curvefs/src/mds/schedule/operatorFactory.h"
+#include "curvefs/src/mds/schedule/scheduler.h"
+
+namespace curvefs {
+namespace mds {
+namespace schedule {
+/**
+ * use curl -L mdsIp:port/flags/enableRapidLeaderScheduler?setvalue=true
+ * for dynamic parameter configuration
+ *
+ * If this value is set true, ignore metaserverCoolingTimeSec_
+ * when choose metaserver as a leader when leader schedule.
+ *
+ * if this value is set true, when no leader schedule operation at this round,
+ * set the value to false automaticlly.
+ */
+static bool pass_bool(const char *, bool) { return true; }
+DEFINE_bool(enableRapidLeaderScheduler, false, "rapid leader scheduler once");
+DEFINE_validator(enableRapidLeaderScheduler, &pass_bool);
+
+int LeaderScheduler::Schedule() {
+    LOG(INFO) << "LeaderScheduler begin";
+
+    int oneRoundGenOp = 0;
+    for (auto poolId : topo_->Getpools()) {
+        oneRoundGenOp += LeaderSchedulerForPool(poolId);
+    }
+
+    LOG(INFO) << "LeaderScheduler generate " << oneRoundGenOp
+              << " operators at this round";
+
+    if (FLAGS_enableRapidLeaderScheduler && oneRoundGenOp == 0) {
+        LOG(INFO) << "LeaderScheduler enable rapid leader scheduler and "
+                  << " generate no operation in this round, "
+                  << "set enableRapidLeaderScheduler to false";
+        FLAGS_enableRapidLeaderScheduler = false;
+    }
+    return oneRoundGenOp;
+}
+
+int64_t LeaderScheduler::GetRunningInterval() const { return runInterval_; }
+
+int LeaderScheduler::LeaderSchedulerForPool(PoolIdType poolId) {
+    int oneRoundGenOp = 0;
+    uint16_t replicaNum = topo_->GetStandardReplicaNumInPool(poolId);
+    if (replicaNum == 0) {
+        LOG(ERROR) << "leader scheduler for pool = " << poolId
+                   << " fail, replicaNum is 0";
+        return 0;
+    }
+
+    // find metaserver with maximum and minimum number of leaders
+    double maxMoreNum = -1;
+    int maxId = -1;
+    double minLessNum = 0;
+    int minId = -1;
+    MetaServerInfo moreLeaderMetaserver;
+    MetaServerInfo lessLeaderMetaserver;
+    std::vector<MetaServerInfo> msInfos = topo_->GetMetaServersInPool(poolId);
+    thread_local static std::random_device rd;
+    thread_local static std::mt19937 randomGenerator(rd());
+    std::shuffle(msInfos.begin(), msInfos.end(), randomGenerator);
+
+    for (const auto& msInfo : msInfos) {
+        // skip unhealthy metaserver
+        if (!msInfo.IsHealthy()) {
+            continue;
+        }
+
+        double standardLeaderNum = msInfo.copysetNum * 1.0 / replicaNum;
+        // if different > 0, it means the leader num on metaserver is more than
+        // stardard leader num, vice versa
+        double different = msInfo.leaderNum - standardLeaderNum;
+
+        // if leader num is appropriate, skip this metaserver.
+        if (different > -1 && different < 1) {
+            continue;
+        }
+
+        // leader too less
+        if (different < -1) {
+            if (minId == -1 || different < minLessNum) {
+                // the metaserver with minLeaderCount and not in coolingTime
+                // can be the transfer target
+                if (!FLAGS_enableRapidLeaderScheduler &&
+                    !CoolingTimeExpired(msInfo.startUpTime)) {
+                    continue;
+                }
+                minId = msInfo.info.id;
+                minLessNum = different;
+                lessLeaderMetaserver = msInfo;
+            }
+            continue;
+        }
+
+        // leader too many
+        if (different > 1) {
+            if (maxId == -1 || different > maxMoreNum) {
+                maxId = msInfo.info.id;
+                maxMoreNum = different;
+                moreLeaderMetaserver = msInfo;
+            }
+        }
+    }
+
+    if (maxId == -1 && minId == -1) {
+        LOG(INFO) << "leaderScheduler find no metaserver need transfer leader"
+                  << " in pool, poolId = " << poolId;
+        return 0;
+    }
+
+    // for metaserver that has the most leaders, pick a leader copyset (the
+    // copyset with the metaserver as its leader) randomly and transfer the
+    // leader replica (the leader role) to the replica (in the same copyset)
+    // that has the least leader number
+    if (maxId != -1) {
+        LOG(INFO) << "leaderScheduler select one metaserver on pool " << poolId
+                  << ", which has more leader, metaserverId = " << maxId
+                  << ", leaderNum = " << moreLeaderMetaserver.leaderNum
+                  << ", copysetNum = " << moreLeaderMetaserver.copysetNum;
+        Operator transferLeaderOutOp;
+        CopySetInfo selectedCopySet;
+        if (TransferLeaderOut(maxId, replicaNum, poolId, &transferLeaderOutOp,
+                              &selectedCopySet)) {
+            if (opController_->AddOperator(transferLeaderOutOp)) {
+                oneRoundGenOp += 1;
+                LOG(INFO) << "leaderScheduler generate operator "
+                          << transferLeaderOutOp.OpToString() << " for "
+                          << selectedCopySet.CopySetInfoStr()
+                          << " from transfer leader out";
+                return oneRoundGenOp;
+            } else {
+                LOG(WARNING) << "leaderScheduler generate operator "
+                          << transferLeaderOutOp.OpToString() << " for "
+                          << selectedCopySet.CopySetInfoStr()
+                          << " from transfer leader out, but add operator fail";
+            }
+        }
+    }
+
+    // for the metaserver that has the least leaders, choose a follower copyset
+    // (the copyset that has a follower replica on the metaserver) randomly and
+    // transfer the leader (role) to this metaserver
+    if (minId != -1) {
+        LOG(INFO) << "leaderScheduler select one metaserver on pool " << poolId
+                  << ", which has less leader, metaserverId = " << minId
+                  << ", leaderNum = " << lessLeaderMetaserver.leaderNum
+                  << ", copysetNum = " << lessLeaderMetaserver.copysetNum;
+        Operator transferLeaderInOp;
+        CopySetInfo selectedCopySet;
+        if (TransferLeaderIn(minId, replicaNum, poolId, &transferLeaderInOp,
+                             &selectedCopySet)) {
+            if (opController_->AddOperator(transferLeaderInOp)) {
+                oneRoundGenOp += 1;
+                LOG(INFO) << "leaderScheduler generate operator "
+                          << transferLeaderInOp.OpToString() << " for "
+                          << selectedCopySet.CopySetInfoStr()
+                          << " from transfer leader in";
+                return oneRoundGenOp;
+            } else {
+                LOG(WARNING) << "leaderScheduler generate operator "
+                          << transferLeaderInOp.OpToString() << " for "
+                          << selectedCopySet.CopySetInfoStr()
+                          << " from transfer leader in, but add operator fail";
+            }
+        }
+    }
+
+    return oneRoundGenOp;
+}
+
+// 1. select copyset in the target same pool, skip the copyset which leader not
+//    the target, has candidata, not healthy.
+// 2. shuffle the copyset
+// 3. for each copyset, select the largest leader num less than the standard num
+//    metaserver, transfer the leader from source to the selected metaserver
+// 4. create the operator
+bool LeaderScheduler::TransferLeaderOut(MetaServerIdType source,
+                                        uint16_t replicaNum, PoolIdType poolId,
+                                        Operator *op,
+                                        CopySetInfo *selectedCopySet) {
+    // find all copyset with source metaserver as its leader as the candidate
+    std::vector<CopySetInfo> candidateInfos;
+    for (auto &cInfo : topo_->GetCopySetInfosInMetaServer(source)) {
+        // skip those copysets that the source is the follower in it
+        if (cInfo.leader != source) {
+            continue;
+        }
+
+        // skip the copyset under configuration changing
+        if (cInfo.HasCandidate()) {
+            LOG(INFO) << cInfo.CopySetInfoStr() << " is on config change";
+            continue;
+        }
+
+        // skip copyset with any offline metaserver
+        if (CopySetHealthy(cInfo)) {
+            candidateInfos.emplace_back(std::move(cInfo));
+        }
+    }
+
+    if (candidateInfos.empty()) {
+        LOG(INFO) << "can not find enough candidate copyset for metaserver "
+                  << source << " to transfer leader out";
+        return false;
+    }
+
+    thread_local static std::random_device rd;
+    thread_local static std::mt19937 randomGenerator(rd());
+    std::shuffle(candidateInfos.begin(), candidateInfos.end(), randomGenerator);
+
+    for (const auto &copysetInfo : candidateInfos) {
+        MetaServerIdType targetId = UNINITIALIZE_ID;
+        double minDifferent = 1;
+        for (auto peerInfo : copysetInfo.peers) {
+            // can not transfer to myself
+            if (source == peerInfo.id) {
+                continue;
+            }
+
+            MetaServerInfo msInfo;
+            if (!topo_->GetMetaServerInfo(peerInfo.id, &msInfo)) {
+                LOG(WARNING) << "leaderScheduler cannot get info of"
+                             << " metaServer: " << peerInfo.id;
+                break;
+            }
+
+            // if metaserver is unhealthy in the selected copyset,
+            // skip to next copyset
+            if (!msInfo.IsHealthy()) {
+                break;
+            }
+
+            if (!FLAGS_enableRapidLeaderScheduler &&
+                !CoolingTimeExpired(msInfo.startUpTime)) {
+                continue;
+            }
+
+            // select the largest leader num less than the standard num
+            double standardLeaderNum = msInfo.copysetNum * 1.0 / replicaNum;
+            double different = (msInfo.leaderNum + 1.0) - standardLeaderNum;
+            if (different < 1 && different < minDifferent) {
+                targetId = msInfo.info.id;
+                minDifferent = different;
+            }
+        }
+
+        if (targetId != UNINITIALIZE_ID) {
+            *selectedCopySet = copysetInfo;
+            *op = operatorFactory.CreateTransferLeaderOperator(
+                copysetInfo, targetId, OperatorPriority::NormalPriority);
+            op->timeLimit = std::chrono::seconds(transTimeSec_);
+            return true;
+        }
+    }
+
+    LOG(INFO) << "can not select target metaserver for metaserver " << source
+              << " to transfer leader out";
+    return false;
+}
+
+// 1. select copyset in the target same pool, skip the copyset which leader is
+//    target, not contain the target, has candidata, not healthy.
+// 2. shuffle the copyset
+// 3. for each copyset, determine whether the copyset can migrate
+//    its leader to the target
+// 4. create the operator
+bool LeaderScheduler::TransferLeaderIn(MetaServerIdType target,
+                                       uint16_t replicaNum, PoolIdType poolId,
+                                       Operator *op,
+                                       CopySetInfo *selectedCopySet) {
+    // find the copyset on follower and transfer leader to the target
+    std::vector<CopySetInfo> candidateInfos;
+    for (auto &cInfo : topo_->GetCopySetInfosInPool(poolId)) {
+        // skip those copyset with the target metaserver as its leader and
+        // and without the copyset
+        if (cInfo.leader == target || !cInfo.ContainPeer(target)) {
+            continue;
+        }
+
+        // skip copyset with configuration changing undergoing
+        if (cInfo.HasCandidate()) {
+            LOG(INFO) << cInfo.CopySetInfoStr() << " is on config change";
+            continue;
+        }
+
+        // skip copyset with any offline metaserver
+        if (CopySetHealthy(cInfo)) {
+            candidateInfos.emplace_back(std::move(cInfo));
+        }
+    }
+
+    if (candidateInfos.empty()) {
+        LOG(INFO) << "can not find enough candidate copyset for metaserver "
+                  << target << " to transfer leader in";
+        return false;
+    }
+
+    thread_local static std::random_device rd;
+    thread_local static std::mt19937 randomGenerator(rd());
+    std::shuffle(candidateInfos.begin(), candidateInfos.end(), randomGenerator);
+
+    for (const auto &copysetInfo : candidateInfos) {
+        // fetch the leader number of the leader of the selected copyset and
+        // the target
+        MetaServerInfo msInfo;
+        if (!topo_->GetMetaServerInfo(copysetInfo.leader, &msInfo)) {
+            LOG(WARNING) << "leaderScheduler cannot get info of metaServer:"
+                         << copysetInfo.leader;
+            continue;
+        }
+
+        double standardLeaderNum = msInfo.copysetNum * 1.0 / replicaNum;
+        double different = (msInfo.leaderNum - 1.0) - standardLeaderNum;
+        if (different < -1) {
+            continue;
+        }
+
+        // transfer leader to the target
+        *selectedCopySet = copysetInfo;
+        *op = operatorFactory.CreateTransferLeaderOperator(
+            copysetInfo, target, OperatorPriority::NormalPriority);
+        op->timeLimit = std::chrono::seconds(transTimeSec_);
+        return true;
+    }
+
+    LOG(INFO) << "can not select metaserver for metaserver " << target
+              << " to transfer leader in";
+    return false;
+}
+
+bool LeaderScheduler::CoolingTimeExpired(uint64_t startUpTime) {
+    if (startUpTime == 0) {
+        return false;
+    }
+
+    uint64_t currentTime = ::curve::common::TimeUtility::GetTimeofDaySec();
+    return currentTime - startUpTime > metaserverCoolingTimeSec_;
+}
+
+bool LeaderScheduler::CopySetHealthy(const CopySetInfo &cInfo) {
+    for (auto peer : cInfo.peers) {
+        MetaServerInfo msInfo;
+        if (!topo_->GetMetaServerInfo(peer.id, &msInfo)) {
+            LOG(ERROR) << "leaderScheduler cannot get info of metaserver:"
+                       << peer.id;
+            return false;
+        }
+
+        if (msInfo.IsOffline()) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool LeaderScheduler::GetRapidLeaderSchedulerFlag() {
+    return FLAGS_enableRapidLeaderScheduler;
+}
+
+void LeaderScheduler::SetRapidLeaderSchedulerFlag(bool flag) {
+    FLAGS_enableRapidLeaderScheduler = flag;
+}
+}  // namespace schedule
+}  // namespace mds
+}  // namespace curvefs

--- a/curvefs/src/mds/schedule/recoverScheduler.cpp
+++ b/curvefs/src/mds/schedule/recoverScheduler.cpp
@@ -125,7 +125,7 @@ int RecoverScheduler::Schedule() {
     return oneRoundGenOp;
 }
 
-int64_t RecoverScheduler::GetRunningInterval() { return runInterval_; }
+int64_t RecoverScheduler::GetRunningInterval() const { return runInterval_; }
 
 bool RecoverScheduler::FixOfflinePeer(const CopySetInfo &info,
                                       MetaServerIdType offlinePeer,

--- a/curvefs/src/mds/schedule/schedule_define.h
+++ b/curvefs/src/mds/schedule/schedule_define.h
@@ -31,18 +31,21 @@ namespace schedule {
 enum class SchedulerType {
     RecoverSchedulerType,
     CopysetSchedulerType,
+    LeaderSchedulerType,
 };
 
 struct ScheduleOption {
- public:
     // recover switch
     bool enableRecoverScheduler;
     // copyset scheduler switch
     bool enableCopysetScheduler;
+    // copyset leader schedule switch
+    bool enableLeaderScheduler;
 
     // xxxSchedulerIntervalSec: time interval of calculation for xxx scheduling
     uint32_t recoverSchedulerIntervalSec;
     uint32_t copysetSchedulerIntervalSec;
+    uint32_t leaderSchedulerIntervalSec;
 
     // number of copyset that can operate configuration changing at the same time on single metaserver //NOLINT
     uint32_t operatorConcurrent;

--- a/curvefs/src/mds/schedule/scheduler.cpp
+++ b/curvefs/src/mds/schedule/scheduler.cpp
@@ -33,7 +33,7 @@ namespace schedule {
 // for test use, need a default implementation
 int Scheduler::Schedule() { return 0; }
 
-int64_t Scheduler::GetRunningInterval() { return 0; }
+int64_t Scheduler::GetRunningInterval() const { return 0; }
 
 /**
  * process for SelectBestPlacementMetaServer process description:

--- a/curvefs/src/mds/schedule/topoAdapter.cpp
+++ b/curvefs/src/mds/schedule/topoAdapter.cpp
@@ -88,14 +88,6 @@ std::string CopySetInfo::CopySetInfoStr() const {
     return res;
 }
 
-MetaServerInfo::MetaServerInfo(const PeerInfo &info, OnlineState state,
-                               const MetaServerSpace &space) {
-    this->info = info;
-    this->state = state;
-    this->space = space;
-    this->startUpTime = 0;
-}
-
 bool MetaServerInfo::IsOnline() const { return state == OnlineState::ONLINE; }
 
 bool MetaServerInfo::IsOffline() const { return state == OnlineState::OFFLINE; }
@@ -312,7 +304,7 @@ bool TopoAdapterImpl::MetaServerFromTopoToSchedule(
         out->info = PeerInfo{origin.GetId(), server.GetZoneId(), server.GetId(),
                              origin.GetInternalIp(), origin.GetInternalPort()};
     } else {
-        LOG(ERROR) << "can not get server:" << origin.GetId()
+        LOG(ERROR) << "can not get server:" << origin.GetServerId()
                    << ", ip:" << origin.GetInternalIp()
                    << ", port:" << origin.GetInternalPort() << " from topology";
 
@@ -322,6 +314,8 @@ bool TopoAdapterImpl::MetaServerFromTopoToSchedule(
     out->startUpTime = origin.GetStartUpTime();
     out->state = origin.GetOnlineState();
     out->space = origin.GetMetaServerSpace();
+    out->leaderNum = topo_->GetLeaderNumInMetaserver(origin.GetId());
+    out->copysetNum =  topo_->GetCopysetNumInMetaserver(origin.GetId());
     return true;
 }
 

--- a/curvefs/src/mds/schedule/topoAdapter.h
+++ b/curvefs/src/mds/schedule/topoAdapter.h
@@ -115,7 +115,10 @@ struct MetaServerInfo {
  public:
     MetaServerInfo() : startUpTime(0) {}
     MetaServerInfo(const PeerInfo &info, OnlineState state,
-                   const MetaServerSpace &space);
+                   const MetaServerSpace &space, uint32_t copysetNum = 0,
+                   uint32_t leaderNum = 0) : info(info), state(state),
+                   space(space), copysetNum(copysetNum), leaderNum(leaderNum),
+                   startUpTime(0) {}
 
     bool IsOnline() const;
     bool IsOffline() const;
@@ -128,6 +131,8 @@ struct MetaServerInfo {
     uint64_t startUpTime;
     PeerInfo info;
     OnlineState state;
+    uint32_t copysetNum;
+    uint32_t leaderNum;
     mutable MetaServerSpace space;
 };
 

--- a/curvefs/src/mds/topology/topology.h
+++ b/curvefs/src/mds/topology/topology.h
@@ -155,6 +155,7 @@ class Topology {
     virtual bool GetCopysetOfPartition(PartitionIdType id,
                                        CopySetInfo *out) const = 0;
     virtual uint32_t GetCopysetNumInMetaserver(MetaServerIdType id) const = 0;
+    virtual uint32_t GetLeaderNumInMetaserver(MetaServerIdType id) const = 0;
     virtual bool GetAvailableCopyset(CopySetInfo *out) const = 0;
     virtual int GetAvailableCopysetNum() const = 0;
     virtual std::list<CopySetKey> GetAvailableCopysetList() const = 0;
@@ -195,7 +196,7 @@ class Topology {
             return true;
         }) const = 0;
 
-    virtual void GetAvailableMetaserversInPoolUnlock(
+    virtual void GetAvailableMetaserversUnlock(
                     std::vector<const MetaServer *>* vec) = 0;
 
     // get server list
@@ -252,6 +253,10 @@ class Topology {
 
     virtual TopoStatusCode GenInitialCopysetAddrBatch(uint32_t needCreateNum,
         std::list<CopysetCreateInfo>* copysetList) = 0;
+
+    virtual TopoStatusCode GenInitialCopysetAddrBatchForPool(PoolIdType poolId,
+    uint16_t replicaNum, uint32_t needCreateNum,
+    std::list<CopysetCreateInfo>* copysetList) = 0;
 
     virtual TopoStatusCode GenCopysetAddrByResourceUsage(
         std::set<MetaServerIdType> *replicas, PoolIdType *poolId) = 0;
@@ -353,6 +358,7 @@ class TopologyImpl : public Topology {
     bool GetCopysetOfPartition(PartitionIdType id,
                                CopySetInfo *out) const override;
     uint32_t GetCopysetNumInMetaserver(MetaServerIdType id) const override;
+    uint32_t GetLeaderNumInMetaserver(MetaServerIdType id) const override;
     bool GetAvailableCopyset(CopySetInfo *out) const override;
     int GetAvailableCopysetNum() const override;
 
@@ -411,7 +417,7 @@ class TopologyImpl : public Topology {
                                                         [](const MetaServer &) {
                                                             return true;
                                                         }) const override;
-    void GetAvailableMetaserversInPoolUnlock(
+    void GetAvailableMetaserversUnlock(
                     std::vector<const MetaServer *>* vec) override;
 
     // get server list
@@ -474,6 +480,10 @@ class TopologyImpl : public Topology {
     TopoStatusCode GenInitialCopysetAddrBatch(uint32_t needCreateNum,
         std::list<CopysetCreateInfo>* copysetList) override;
 
+    TopoStatusCode GenInitialCopysetAddrBatchForPool(PoolIdType poolId,
+    uint16_t replicaNum, uint32_t needCreateNum,
+    std::list<CopysetCreateInfo>* copysetList) override;
+
     TopoStatusCode GenCopysetAddrByResourceUsage(
         std::set<MetaServerIdType> *metaServers, PoolIdType *poolId) override;
 
@@ -505,14 +515,8 @@ class TopologyImpl : public Topology {
 
     int GetOneRandomNumber(int start, int end) const;
 
-    std::set<MetaServerIdType>  RandomGetMetaserverIds(
-        const std::map<ZoneIdType, std::list<MetaServerIdType>>& zoneMap,
-        uint16_t num);
-
-    TopoStatusCode GenCandidateMapUnlock(
-        const std::map<PoolIdType, uint16_t> &replicaMap,
-        std::map<PoolIdType, std::map<ZoneIdType, std::list<MetaServerIdType>>>
-                                                * candidateMap);
+    TopoStatusCode GenCandidateMapUnlock(PoolIdType poolId,
+        std::map<ZoneIdType, std::vector<MetaServerIdType>> * candidateMap);
 
  private:
     std::unordered_map<PoolIdType, Pool> poolMap_;

--- a/curvefs/src/mds/topology/topology_config.h
+++ b/curvefs/src/mds/topology/topology_config.h
@@ -36,8 +36,6 @@ struct TopologyOption {
     uint64_t maxPartitionNumberInCopyset;
     // id number in each partition
     uint64_t idNumberInPartition;
-    // policy of pool choosing
-    int choosePoolPolicy;
     // initial create copyset number
     uint32_t initialCopysetNumber;
     // min available copyset num
@@ -53,7 +51,6 @@ struct TopologyOption {
         : topologyUpdateToRepoSec(0),
           maxPartitionNumberInCopyset(256),
           idNumberInPartition(16777216),
-          choosePoolPolicy(0),
           initialCopysetNumber(10),
           minAvailableCopysetNum(10),
           createPartitionNumber(3),

--- a/curvefs/src/mds/topology/topology_item.h
+++ b/curvefs/src/mds/topology/topology_item.h
@@ -27,6 +27,7 @@
 #include <set>
 #include <string>
 #include <utility>
+#include <algorithm>
 
 #include "curvefs/proto/common.pb.h"
 #include "curvefs/proto/topology.pb.h"
@@ -272,19 +273,17 @@ class MetaServerSpace {
     }
 
     double GetResourceUseRatioPercent() {
-        if (memoryCopySetMinRequireByte_ == 0) {
-            if (diskThresholdByte_ != 0) {
-                return 100.0 * diskUsedByte_ / diskThresholdByte_;
-            } else {
-                return 0;
-            }
-        } else {
-            if (memoryThresholdByte_ != 0) {
-                return 100.0 * memoryUsedByte_ / memoryThresholdByte_;
-            } else {
-                return 0;
-            }
+        double diskUseRatio = 0;
+        if (diskThresholdByte_ != 0) {
+            diskUseRatio = 100.0 * diskUsedByte_ / diskThresholdByte_;
         }
+
+        double memUseRatio = 0;
+        if (memoryThresholdByte_ != 0) {
+            memUseRatio = 100.0 * memoryUsedByte_ / memoryThresholdByte_;
+        }
+
+        return std::max(memUseRatio, diskUseRatio);
     }
 
     bool IsMetaserverResourceAvailable() {

--- a/curvefs/src/metaserver/heartbeat.cpp
+++ b/curvefs/src/metaserver/heartbeat.cpp
@@ -300,6 +300,10 @@ void Heartbeat::DumpHeartbeatRequest(const HeartbeatRequest& request) {
 void Heartbeat::DumpHeartbeatResponse(const HeartbeatResponse &response) {
     VLOG(3) << "Received heartbeat response, statusCode = "
             << response.statuscode();
+
+    for (auto& conf : response.needupdatecopysets()) {
+        VLOG(3) << "need update copyset: " << conf.ShortDebugString();
+    }
 }
 
 int Heartbeat::SendHeartbeat(const HeartbeatRequest &request,

--- a/curvefs/test/mds/mock/mock_topology.h
+++ b/curvefs/test/mds/mock/mock_topology.h
@@ -269,6 +269,9 @@ class MockTopology : public TopologyImpl {
     MOCK_CONST_METHOD2(GetCopySet, bool(CopySetKey key, CopySetInfo *out));
     MOCK_CONST_METHOD2(GetCopysetOfPartition,
                        bool(PartitionIdType id, CopySetInfo *out));
+    MOCK_CONST_METHOD1(GetCopysetNumInMetaserver,
+                       uint32_t(MetaServerIdType id));
+    MOCK_CONST_METHOD1(GetLeaderNumInMetaserver, uint32_t(MetaServerIdType id));
     MOCK_CONST_METHOD1(GetAvailableCopyset, bool(CopySetInfo *out));
     MOCK_CONST_METHOD0(GetAvailableCopysetNum, int());
     MOCK_CONST_METHOD0(GetAvailableCopysetList, std::list<CopySetKey>());

--- a/curvefs/test/mds/schedule/leaderScheduler_test.cpp
+++ b/curvefs/test/mds/schedule/leaderScheduler_test.cpp
@@ -1,0 +1,632 @@
+/*
+ *  Copyright (c) 2021 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * @Project: curve
+ * @Date: 2022-04-08 16:32:16
+ * @Author: chenwei
+ */
+
+#include <glog/logging.h>
+#include "curvefs/src/mds/common/mds_define.h"
+#include "curvefs/src/mds/schedule/operatorController.h"
+#include "curvefs/src/mds/schedule/scheduleMetrics.h"
+#include "curvefs/src/mds/schedule/scheduler.h"
+#include "curvefs/src/mds/topology/topology_id_generator.h"
+#include "curvefs/test/mds/mock/mock_topology.h"
+#include "curvefs/test/mds/schedule/common.h"
+#include "curvefs/test/mds/schedule/mock_topoAdapter.h"
+
+using ::curvefs::mds::topology::MockTopology;
+using ::curvefs::mds::topology::MockIdGenerator;
+using ::curvefs::mds::topology::MockTokenGenerator;
+using ::curvefs::mds::topology::MockStorage;
+using ::std::chrono::steady_clock;
+
+using ::testing::_;
+using ::testing::Return;
+using ::testing::AtLeast;
+using ::testing::SetArgPointee;
+using ::testing::DoAll;
+
+namespace curvefs {
+namespace mds {
+namespace schedule {
+class TestLeaderSchedule : public ::testing::Test {
+ protected:
+    TestLeaderSchedule() {}
+    ~TestLeaderSchedule() {}
+
+    void SetUp() override {
+        topo_ = std::make_shared<MockTopology>(idGenerator_, tokenGenerator_,
+                                               storage_);
+        metric_ = std::make_shared<ScheduleMetrics>(topo_);
+        opController_ = std::make_shared<OperatorController>(2, metric_);
+        topoAdapter_ = std::make_shared<MockTopoAdapter>();
+
+        opt_.transferLeaderTimeLimitSec = 10;
+        opt_.removePeerTimeLimitSec = 100;
+        opt_.addPeerTimeLimitSec = 1000;
+        opt_.changePeerTimeLimitSec = 1000;
+        opt_.leaderSchedulerIntervalSec = 1;
+        opt_.metaserverCoolingTimeSec = 10;
+        leaderScheduler_ = std::make_shared<LeaderScheduler>(
+            opt_, topoAdapter_, opController_);
+    }
+
+    void TearDown() override {
+        topoAdapter_ = nullptr;
+        opController_ = nullptr;
+        leaderScheduler_ = nullptr;
+        metric_ = nullptr;
+        topo_ = nullptr;
+        storage_ = nullptr;
+        tokenGenerator_ = nullptr;
+        idGenerator_ = nullptr;
+    }
+
+ protected:
+    std::shared_ptr<MockTopoAdapter> topoAdapter_;
+    std::shared_ptr<OperatorController> opController_;
+    std::shared_ptr<LeaderScheduler> leaderScheduler_;
+    std::shared_ptr<MockIdGenerator> idGenerator_;
+    std::shared_ptr<MockTokenGenerator> tokenGenerator_;
+    std::shared_ptr<MockStorage> storage_;
+    std::shared_ptr<MockTopology> topo_;
+    std::shared_ptr<ScheduleMetrics> metric_;
+    ScheduleOption opt_;
+};
+
+TEST_F(TestLeaderSchedule, test_no_pool) {
+    EXPECT_CALL(*topoAdapter_, Getpools())
+        .WillOnce(Return(std::vector<PoolIdType>({})));
+    ASSERT_EQ(leaderScheduler_->Schedule(), 0);
+    ASSERT_EQ(0, opController_->GetOperators().size());
+}
+
+TEST_F(TestLeaderSchedule, test_get_replica_num_fail) {
+    PoolIdType poolId = 1;
+    EXPECT_CALL(*topoAdapter_, Getpools())
+        .WillOnce(Return(std::vector<PoolIdType>({poolId})));
+    EXPECT_CALL(*topoAdapter_, GetStandardReplicaNumInPool(poolId))
+        .WillOnce(Return(0));
+    ASSERT_EQ(leaderScheduler_->Schedule(), 0);
+    ASSERT_EQ(0, opController_->GetOperators().size());
+}
+
+TEST_F(TestLeaderSchedule, test_no_metaserverInfos) {
+    PoolIdType poolId = 1;
+    EXPECT_CALL(*topoAdapter_, Getpools())
+        .WillOnce(Return(std::vector<PoolIdType>({poolId})));
+    EXPECT_CALL(*topoAdapter_, GetStandardReplicaNumInPool(poolId))
+        .WillOnce(Return(3));
+    EXPECT_CALL(*topoAdapter_, GetMetaServersInPool(poolId))
+        .WillOnce(Return(std::vector<MetaServerInfo>()));
+    ASSERT_EQ(leaderScheduler_->Schedule(), 0);
+    ASSERT_EQ(0, opController_->GetOperators().size());
+}
+
+TEST_F(TestLeaderSchedule, test_has_metaServer_offline) {
+    PeerInfo peer1(1, 1, 1, "192.168.10.1", 9000);
+    PeerInfo peer2(2, 2, 2, "192.168.10.2", 9000);
+    PeerInfo peer3(3, 3, 3, "192.168.10.3", 9000);
+    MetaServerSpace space(100, 20);
+    MetaServerInfo msInfo1(peer1, OnlineState::OFFLINE, space);
+    MetaServerInfo msInfo2(peer2, OnlineState::ONLINE, space);
+    MetaServerInfo msInfo3(peer3, OnlineState::ONLINE, space);
+    std::vector<MetaServerInfo> msInfos({msInfo1, msInfo2, msInfo3});
+
+    PoolIdType poolId = 1;
+    EXPECT_CALL(*topoAdapter_, Getpools())
+        .WillOnce(Return(std::vector<PoolIdType>({poolId})));
+    EXPECT_CALL(*topoAdapter_, GetStandardReplicaNumInPool(poolId))
+        .WillOnce(Return(3));
+    EXPECT_CALL(*topoAdapter_, GetMetaServersInPool(poolId))
+        .WillOnce(Return(msInfos));
+    EXPECT_CALL(*topoAdapter_, GetMetaServerInfo(1, _))
+        .WillRepeatedly(DoAll(SetArgPointee<1>(msInfo1), Return(true)));
+
+    ASSERT_EQ(leaderScheduler_->Schedule(), 0);
+    ASSERT_EQ(0, opController_->GetOperators().size());
+}
+
+TEST_F(TestLeaderSchedule, test_copySet_has_candidate) {
+    PeerInfo peer1(1, 1, 1, "192.168.10.1", 9000);
+    PeerInfo peer2(2, 2, 2, "192.168.10.2", 9000);
+    PeerInfo peer3(3, 3, 3, "192.168.10.3", 9000);
+    MetaServerSpace space(100, 20);
+    MetaServerInfo msInfo1(peer1, OnlineState::ONLINE, space, 10, 2);
+    MetaServerInfo msInfo2(peer2, OnlineState::ONLINE, space, 10, 5);
+    MetaServerInfo msInfo3(peer3, OnlineState::ONLINE, space, 10, 3);
+    std::vector<MetaServerInfo> msInfos({msInfo1, msInfo2, msInfo3});
+
+    PoolIdType poolId = 1;
+    CopySetIdType copysetId = 1;
+    CopySetKey copySetKey;
+    copySetKey.first = poolId;
+    copySetKey.second = copysetId;
+    EpochType epoch = 1;
+    MetaServerIdType leader = 2;
+    std::vector<PeerInfo> peers({peer1, peer2, peer3});
+    CopySetInfo copySet1(copySetKey, epoch, leader, peers, ConfigChangeInfo{});
+    copySet1.candidatePeerInfo = peer1;
+    std::vector<CopySetInfo> copySetInfos({copySet1});
+
+    EXPECT_CALL(*topoAdapter_, Getpools())
+        .WillOnce(Return(std::vector<PoolIdType>({poolId})));
+    EXPECT_CALL(*topoAdapter_, GetStandardReplicaNumInPool(poolId))
+        .WillOnce(Return(3));
+    EXPECT_CALL(*topoAdapter_, GetMetaServersInPool(poolId))
+        .WillOnce(Return(msInfos));
+    EXPECT_CALL(*topoAdapter_, GetCopySetInfosInPool(poolId))
+        .WillRepeatedly(Return(copySetInfos));
+
+    ASSERT_EQ(leaderScheduler_->Schedule(), 0);
+    ASSERT_EQ(0, opController_->GetOperators().size());
+}
+
+TEST_F(TestLeaderSchedule, test_cannot_get_metaServerInfo) {
+    PeerInfo peer1(1, 1, 1, "192.168.10.1", 9000);
+    PeerInfo peer2(2, 2, 2, "192.168.10.2", 9000);
+    PeerInfo peer3(3, 3, 3, "192.168.10.3", 9000);
+    MetaServerSpace space(100, 20);
+    MetaServerInfo msInfo1(peer1, OnlineState::ONLINE, space, 10, 2);
+    MetaServerInfo msInfo2(peer2, OnlineState::ONLINE, space, 10, 5);
+    MetaServerInfo msInfo3(peer3, OnlineState::ONLINE, space, 10, 3);
+    std::vector<MetaServerInfo> msInfos({msInfo1, msInfo2, msInfo3});
+
+    PoolIdType poolId = 1;
+    CopySetIdType copysetId = 1;
+    CopySetKey copySetKey;
+    copySetKey.first = poolId;
+    copySetKey.second = copysetId;
+    EpochType epoch = 1;
+    MetaServerIdType leader = 2;
+    CopySetInfo copySet1(copySetKey, epoch, leader,
+        std::vector<PeerInfo>({peer1, peer2, peer3}),
+        ConfigChangeInfo{});
+    std::vector<CopySetInfo> copySetInfos({copySet1});
+
+    EXPECT_CALL(*topoAdapter_, Getpools())
+        .WillOnce(Return(std::vector<PoolIdType>({poolId})));
+    EXPECT_CALL(*topoAdapter_, GetStandardReplicaNumInPool(poolId))
+        .WillOnce(Return(3));
+    EXPECT_CALL(*topoAdapter_, GetMetaServersInPool(poolId))
+        .WillOnce(Return(msInfos));
+    EXPECT_CALL(*topoAdapter_, GetCopySetInfosInPool(poolId))
+        .WillRepeatedly(Return(copySetInfos));
+    EXPECT_CALL(*topoAdapter_, GetMetaServerInfo(1, _))
+        .WillRepeatedly(Return(false));
+
+
+    ASSERT_EQ(leaderScheduler_->Schedule(), 0);
+    ASSERT_EQ(0, opController_->GetOperators().size());
+}
+
+TEST_F(TestLeaderSchedule, test_no_need_tranferLeaderOut) {
+    PeerInfo peer1(1, 1, 1, "192.168.10.1", 9000);
+    PeerInfo peer2(2, 2, 2, "192.168.10.2", 9000);
+    PeerInfo peer3(3, 3, 3, "192.168.10.3", 9000);
+    MetaServerSpace space(100, 20);
+    MetaServerInfo msInfo1(peer1, OnlineState::ONLINE, space, 10, 5);
+    MetaServerInfo msInfo2(peer2, OnlineState::ONLINE, space, 10, 3);
+    MetaServerInfo msInfo3(peer3, OnlineState::ONLINE, space, 10, 3);
+    msInfo3.startUpTime = 3;
+    std::vector<MetaServerInfo> msInfos({msInfo1, msInfo2, msInfo3});
+
+    PoolIdType poolId = 1;
+    CopySetIdType copysetId = 1;
+    CopySetKey copySetKey;
+    copySetKey.first = poolId;
+    copySetKey.second = copysetId;
+    EpochType epoch = 1;
+    MetaServerIdType leader = 2;
+    std::vector<PeerInfo> peers({peer1, peer2, peer3});
+    CopySetInfo copySet1(copySetKey, epoch, leader, peers, ConfigChangeInfo{});
+    std::vector<CopySetInfo> copySetInfos({copySet1});
+
+    EXPECT_CALL(*topoAdapter_, Getpools())
+        .WillOnce(Return(std::vector<PoolIdType>({poolId})));
+    EXPECT_CALL(*topoAdapter_, GetStandardReplicaNumInPool(poolId))
+        .WillOnce(Return(3));
+    EXPECT_CALL(*topoAdapter_, GetCopySetInfosInPool(poolId))
+        .WillRepeatedly(Return(copySetInfos));
+    EXPECT_CALL(*topoAdapter_, GetMetaServersInPool(poolId))
+        .WillOnce(Return(msInfos));
+
+    ASSERT_EQ(leaderScheduler_->Schedule(), 0);
+    ASSERT_EQ(0, opController_->GetOperators().size());
+}
+
+TEST_F(TestLeaderSchedule, test_tranferLeaderout_normal) {
+    //                ms1     ms2    ms3    ms4     ms5    ms6
+    // leaderCount     3       5      2      3       3      3
+    // copyset         10      10     10     10      10     10
+    PeerInfo peer1(1, 1, 1, "192.168.10.1", 9000);
+    PeerInfo peer2(2, 2, 2, "192.168.10.2", 9000);
+    PeerInfo peer3(3, 3, 3, "192.168.10.3", 9000);
+    PeerInfo peer4(4, 4, 4, "192.168.10.4", 9000);
+    PeerInfo peer5(5, 5, 5, "192.168.10.5", 9000);
+    PeerInfo peer6(6, 6, 6, "192.168.10.6", 9000);
+    MetaServerSpace space(100, 20);
+    MetaServerInfo msInfo1(peer1, OnlineState::ONLINE, space, 10, 3);
+    MetaServerInfo msInfo2(peer2, OnlineState::ONLINE, space, 10, 5);
+    MetaServerInfo msInfo3(peer3, OnlineState::ONLINE, space, 10, 2);
+    MetaServerInfo msInfo4(peer4, OnlineState::ONLINE, space, 10, 3);
+    MetaServerInfo msInfo5(peer5, OnlineState::ONLINE, space, 10, 3);
+    MetaServerInfo msInfo6(peer5, OnlineState::ONLINE, space, 10, 3);
+    struct timeval tm;
+    gettimeofday(&tm, NULL);
+    msInfo3.startUpTime = tm.tv_sec - opt_.metaserverCoolingTimeSec - 1;
+    std::vector<MetaServerInfo> msInfos({msInfo1, msInfo2, msInfo3,
+                                          msInfo4, msInfo5, msInfo6});
+
+    PoolIdType poolId = 1;
+    CopySetIdType copysetId = 1;
+    CopySetKey copySetKey;
+    copySetKey.first = poolId;
+    copySetKey.second = copysetId;
+    EpochType epoch = 1;
+    MetaServerIdType leader = 2;
+    CopySetInfo copySet1(copySetKey, epoch, leader,
+        std::vector<PeerInfo>({peer1, peer2, peer3}),
+        ConfigChangeInfo{});
+    CopySetInfo copySet2(copySetKey, epoch, peer4.id,
+        std::vector<PeerInfo>({peer4, peer5, peer6}),
+        ConfigChangeInfo{});
+    std::vector<CopySetInfo> copySetInfos({copySet1, copySet2});
+
+    EXPECT_CALL(*topoAdapter_, Getpools())
+        .WillOnce(Return(std::vector<PoolIdType>({poolId})));
+    EXPECT_CALL(*topoAdapter_, GetStandardReplicaNumInPool(poolId))
+        .WillOnce(Return(3));
+    EXPECT_CALL(*topoAdapter_, GetMetaServersInPool(poolId))
+        .WillOnce(Return(msInfos));
+    EXPECT_CALL(*topoAdapter_, GetCopySetInfosInMetaServer(leader))
+        .WillOnce(Return(copySetInfos));
+    EXPECT_CALL(*topoAdapter_, GetMetaServerInfo(1, _))
+        .Times(2)
+        .WillRepeatedly(DoAll(SetArgPointee<1>(msInfo1), Return(true)));
+    EXPECT_CALL(*topoAdapter_, GetMetaServerInfo(2, _))
+        .WillOnce(DoAll(SetArgPointee<1>(msInfo2), Return(true)));
+    EXPECT_CALL(*topoAdapter_, GetMetaServerInfo(3, _))
+        .Times(2)
+        .WillRepeatedly(DoAll(SetArgPointee<1>(msInfo3), Return(true)));
+
+    leaderScheduler_->Schedule();
+    Operator op;
+    ASSERT_TRUE(opController_->GetOperatorById(copySet1.id, &op));
+    ASSERT_EQ(OperatorPriority::NormalPriority, op.priority);
+    ASSERT_EQ(std::chrono::seconds(10), op.timeLimit);
+    TransferLeader *res = dynamic_cast<TransferLeader *>(op.step.get());
+    ASSERT_TRUE(res != nullptr);
+    ASSERT_EQ(msInfo3.info.id, res->GetTargetPeer());
+}
+
+TEST_F(TestLeaderSchedule, test_tranferLeaderout_rapid) {
+    //                ms1     ms2    ms3    ms4     ms5    ms6
+    // leaderCount     3       5      2      3       3      3
+    // copyset         10      10     10     10      10     10
+    PeerInfo peer1(1, 1, 1, "192.168.10.1", 9000);
+    PeerInfo peer2(2, 2, 2, "192.168.10.2", 9000);
+    PeerInfo peer3(3, 3, 3, "192.168.10.3", 9000);
+    PeerInfo peer4(4, 4, 4, "192.168.10.4", 9000);
+    PeerInfo peer5(5, 5, 5, "192.168.10.5", 9000);
+    PeerInfo peer6(6, 6, 6, "192.168.10.6", 9000);
+    MetaServerSpace space(100, 20);
+    MetaServerInfo msInfo1(peer1, OnlineState::ONLINE, space, 10, 3);
+    MetaServerInfo msInfo2(peer2, OnlineState::ONLINE, space, 10, 5);
+    MetaServerInfo msInfo3(peer3, OnlineState::ONLINE, space, 10, 2);
+    MetaServerInfo msInfo4(peer4, OnlineState::ONLINE, space, 10, 3);
+    MetaServerInfo msInfo5(peer5, OnlineState::ONLINE, space, 10, 3);
+    MetaServerInfo msInfo6(peer6, OnlineState::ONLINE, space, 10, 3);
+    MetaServerInfo msInfo7(peer2, OnlineState::ONLINE, space, 10, 3);
+    MetaServerInfo msInfo8(peer3, OnlineState::ONLINE, space, 10, 3);
+    std::vector<MetaServerInfo> msInfos({msInfo1, msInfo2, msInfo3,
+                                          msInfo4, msInfo5, msInfo6});
+    std::vector<MetaServerInfo> msInfos2({msInfo1, msInfo7, msInfo8,
+                                          msInfo4, msInfo5, msInfo6});
+
+    PoolIdType poolId = 1;
+    CopySetIdType copysetId = 1;
+    CopySetKey copySetKey;
+    copySetKey.first = poolId;
+    copySetKey.second = copysetId;
+    EpochType epoch = 1;
+    MetaServerIdType leader = 2;
+    CopySetInfo copySet1(copySetKey, epoch, leader,
+        std::vector<PeerInfo>({peer1, peer2, peer3}),
+        ConfigChangeInfo{});
+    CopySetInfo copySet2(copySetKey, epoch, peer4.id,
+        std::vector<PeerInfo>({peer4, peer5, peer6}),
+        ConfigChangeInfo{});
+    std::vector<CopySetInfo> copySetInfos({copySet1, copySet2});
+
+    // default FLAGS_enableRapidLeaderScheduler is false, can not select target
+    {
+        EXPECT_CALL(*topoAdapter_, Getpools())
+            .WillOnce(Return(std::vector<PoolIdType>({poolId})));
+        EXPECT_CALL(*topoAdapter_, GetStandardReplicaNumInPool(poolId))
+            .WillOnce(Return(3));
+        EXPECT_CALL(*topoAdapter_, GetMetaServersInPool(poolId))
+            .WillOnce(Return(msInfos));
+        EXPECT_CALL(*topoAdapter_, GetCopySetInfosInMetaServer(leader))
+            .WillOnce(Return(copySetInfos));
+        EXPECT_CALL(*topoAdapter_, GetMetaServerInfo(1, _))
+            .Times(2)
+            .WillRepeatedly(DoAll(SetArgPointee<1>(msInfo1), Return(true)));
+        EXPECT_CALL(*topoAdapter_, GetMetaServerInfo(2, _))
+            .WillOnce(DoAll(SetArgPointee<1>(msInfo2), Return(true)));
+        EXPECT_CALL(*topoAdapter_, GetMetaServerInfo(3, _))
+            .Times(2)
+            .WillRepeatedly(DoAll(SetArgPointee<1>(msInfo3), Return(true)));
+
+        ASSERT_FALSE(leaderScheduler_->GetRapidLeaderSchedulerFlag());
+        ASSERT_EQ(0, leaderScheduler_->Schedule());
+        ASSERT_FALSE(leaderScheduler_->GetRapidLeaderSchedulerFlag());
+    }
+
+    {
+        // set FLAGS_enableRapidLeaderScheduler to true
+        EXPECT_CALL(*topoAdapter_, Getpools())
+            .WillOnce(Return(std::vector<PoolIdType>({poolId})));
+        EXPECT_CALL(*topoAdapter_, GetStandardReplicaNumInPool(poolId))
+            .WillOnce(Return(3));
+        EXPECT_CALL(*topoAdapter_, GetMetaServersInPool(poolId))
+            .WillOnce(Return(msInfos));
+        EXPECT_CALL(*topoAdapter_, GetCopySetInfosInMetaServer(leader))
+            .WillOnce(Return(copySetInfos));
+        EXPECT_CALL(*topoAdapter_, GetMetaServerInfo(1, _))
+            .Times(2)
+            .WillRepeatedly(DoAll(SetArgPointee<1>(msInfo1), Return(true)));
+        EXPECT_CALL(*topoAdapter_, GetMetaServerInfo(2, _))
+            .WillOnce(DoAll(SetArgPointee<1>(msInfo2), Return(true)));
+        EXPECT_CALL(*topoAdapter_, GetMetaServerInfo(3, _))
+            .Times(2)
+            .WillRepeatedly(DoAll(SetArgPointee<1>(msInfo3), Return(true)));
+
+        leaderScheduler_->SetRapidLeaderSchedulerFlag(true);
+        ASSERT_TRUE(leaderScheduler_->GetRapidLeaderSchedulerFlag());
+        ASSERT_EQ(1, leaderScheduler_->Schedule());
+        ASSERT_TRUE(leaderScheduler_->GetRapidLeaderSchedulerFlag());
+
+        Operator op;
+        ASSERT_TRUE(opController_->GetOperatorById(copySet1.id, &op));
+        ASSERT_EQ(OperatorPriority::NormalPriority, op.priority);
+        ASSERT_EQ(std::chrono::seconds(10), op.timeLimit);
+        TransferLeader *res = dynamic_cast<TransferLeader *>(op.step.get());
+        ASSERT_TRUE(res != nullptr);
+        ASSERT_EQ(msInfo3.info.id, res->GetTargetPeer());
+    }
+
+    {
+        // no schedule operator generate, FLAGS_enableRapidLeaderScheduler is
+        // set to false automaticlly
+        EXPECT_CALL(*topoAdapter_, Getpools())
+            .WillOnce(Return(std::vector<PoolIdType>({poolId})));
+        EXPECT_CALL(*topoAdapter_, GetStandardReplicaNumInPool(poolId))
+            .WillOnce(Return(3));
+        EXPECT_CALL(*topoAdapter_, GetMetaServersInPool(poolId))
+            .WillOnce(Return(msInfos2));
+        ASSERT_TRUE(leaderScheduler_->GetRapidLeaderSchedulerFlag());
+        ASSERT_EQ(0, leaderScheduler_->Schedule());
+        ASSERT_FALSE(leaderScheduler_->GetRapidLeaderSchedulerFlag());
+    }
+}
+
+TEST_F(TestLeaderSchedule, test_transferLeaderIn_normal) {
+    PeerInfo peer1(1, 1, 1, "192.168.10.1", 9000);
+    PeerInfo peer2(2, 2, 2, "192.168.10.2", 9000);
+    PeerInfo peer3(3, 3, 3, "192.168.10.3", 9000);
+    PeerInfo peer4(3, 4, 4, "192.168.10.4", 9000);
+    MetaServerSpace space(100, 20);
+    MetaServerInfo msInfo1(peer1, OnlineState::ONLINE, space, 10, 2);
+    msInfo1.startUpTime = ::curve::common::TimeUtility::GetTimeofDaySec()
+                                        - opt_.metaserverCoolingTimeSec - 1;
+    MetaServerInfo msInfo2(peer2, OnlineState::ONLINE, space, 10, 3);
+    MetaServerInfo msInfo3(peer3, OnlineState::ONLINE, space, 10, 4);
+    MetaServerInfo msInfo4(peer4, OnlineState::ONLINE, space, 10, 3);
+    std::vector<MetaServerInfo> msInfos({msInfo1, msInfo2, msInfo3, msInfo4});
+
+    PoolIdType poolId = 1;
+    CopySetIdType copysetId1 = 1;
+    CopySetIdType copysetId2 = 2;
+    EpochType epoch = 1;
+    // has operator
+    CopySetInfo copySet1(CopySetKey(poolId, copysetId1), epoch, 3,
+        std::vector<PeerInfo>({peer1, peer2, peer3}),
+        ConfigChangeInfo{});
+    // not include metaserver1
+    CopySetInfo copySet2(CopySetKey(poolId, copysetId2), epoch, 4,
+        std::vector<PeerInfo>({peer2, peer3, peer4}),
+        ConfigChangeInfo{});
+
+    EXPECT_CALL(*topoAdapter_, Getpools())
+        .WillOnce(Return(std::vector<PoolIdType>({poolId})));
+    EXPECT_CALL(*topoAdapter_, GetStandardReplicaNumInPool(poolId))
+        .WillOnce(Return(3));
+    EXPECT_CALL(*topoAdapter_, GetMetaServersInPool(poolId))
+        .WillOnce(Return(msInfos));
+    EXPECT_CALL(*topoAdapter_, GetCopySetInfosInPool(poolId))
+        .WillOnce(Return(std::vector<CopySetInfo>{copySet1, copySet2}));
+     EXPECT_CALL(*topoAdapter_, GetMetaServerInfo(1, _))
+        .Times(1)
+        .WillRepeatedly(DoAll(SetArgPointee<1>(msInfo1), Return(true)));
+    EXPECT_CALL(*topoAdapter_, GetMetaServerInfo(2, _))
+        .Times(1)
+        .WillRepeatedly(DoAll(SetArgPointee<1>(msInfo2), Return(true)));
+    EXPECT_CALL(*topoAdapter_, GetMetaServerInfo(3, _))
+        .Times(2)
+        .WillRepeatedly(DoAll(SetArgPointee<1>(msInfo3), Return(true)));
+
+    ASSERT_EQ(1, leaderScheduler_->Schedule());
+    Operator op;
+    ASSERT_TRUE(opController_->GetOperatorById(copySet1.id, &op));
+    ASSERT_EQ(OperatorPriority::NormalPriority, op.priority);
+    ASSERT_EQ(std::chrono::seconds(10), op.timeLimit);
+    TransferLeader *res = dynamic_cast<TransferLeader *>(op.step.get());
+    ASSERT_TRUE(res != nullptr);
+    ASSERT_EQ(1, res->GetTargetPeer());
+}
+
+TEST_F(TestLeaderSchedule, test_transferLeaderIn_rapid) {
+    PeerInfo peer1(1, 1, 1, "192.168.10.1", 9000);
+    PeerInfo peer2(2, 2, 2, "192.168.10.2", 9000);
+    PeerInfo peer3(3, 3, 3, "192.168.10.3", 9000);
+    PeerInfo peer4(3, 4, 4, "192.168.10.4", 9000);
+    MetaServerSpace space(100, 20);
+    MetaServerInfo msInfo1(peer1, OnlineState::ONLINE, space, 10, 2);
+    msInfo1.startUpTime = ::curve::common::TimeUtility::GetTimeofDaySec();
+    MetaServerInfo msInfo2(peer2, OnlineState::ONLINE, space, 10, 3);
+    MetaServerInfo msInfo3(peer3, OnlineState::ONLINE, space, 10, 4);
+    MetaServerInfo msInfo4(peer4, OnlineState::ONLINE, space, 10, 3);
+    MetaServerInfo msInfo5(peer1, OnlineState::ONLINE, space, 10, 3);
+    msInfo5.startUpTime = ::curve::common::TimeUtility::GetTimeofDaySec();
+    std::vector<MetaServerInfo> msInfos({msInfo1, msInfo2, msInfo3, msInfo4});
+    std::vector<MetaServerInfo> msInfos2({msInfo5, msInfo2, msInfo3, msInfo4});
+
+    PoolIdType poolId = 1;
+    CopySetIdType copysetId1 = 1;
+    CopySetIdType copysetId2 = 2;
+    EpochType epoch = 1;
+    // has operator
+    CopySetInfo copySet1(CopySetKey(poolId, copysetId1), epoch, 3,
+        std::vector<PeerInfo>({peer1, peer2, peer3}),
+        ConfigChangeInfo{});
+    // not include metaserver1
+    CopySetInfo copySet2(CopySetKey(poolId, copysetId2), epoch, 4,
+        std::vector<PeerInfo>({peer2, peer3, peer4}),
+        ConfigChangeInfo{});
+
+    // default FLAGS_enableRapidLeaderScheduler is false, can not select target
+    // to transfer leader in
+    {
+        EXPECT_CALL(*topoAdapter_, Getpools())
+            .WillOnce(Return(std::vector<PoolIdType>({poolId})));
+        EXPECT_CALL(*topoAdapter_, GetStandardReplicaNumInPool(poolId))
+            .WillOnce(Return(3));
+        EXPECT_CALL(*topoAdapter_, GetMetaServersInPool(poolId))
+            .WillOnce(Return(msInfos));
+
+        ASSERT_FALSE(leaderScheduler_->GetRapidLeaderSchedulerFlag());
+        ASSERT_EQ(0, leaderScheduler_->Schedule());
+        ASSERT_FALSE(leaderScheduler_->GetRapidLeaderSchedulerFlag());
+    }
+
+    // set FLAGS_enableRapidLeaderScheduler to true
+    {
+        EXPECT_CALL(*topoAdapter_, Getpools())
+            .WillOnce(Return(std::vector<PoolIdType>({poolId})));
+        EXPECT_CALL(*topoAdapter_, GetStandardReplicaNumInPool(poolId))
+            .WillOnce(Return(3));
+        EXPECT_CALL(*topoAdapter_, GetMetaServersInPool(poolId))
+            .WillOnce(Return(msInfos));
+        EXPECT_CALL(*topoAdapter_, GetCopySetInfosInPool(poolId))
+            .WillOnce(Return(std::vector<CopySetInfo>{copySet1, copySet2}));
+        EXPECT_CALL(*topoAdapter_, GetMetaServerInfo(1, _))
+            .Times(1)
+            .WillRepeatedly(DoAll(SetArgPointee<1>(msInfo1), Return(true)));
+        EXPECT_CALL(*topoAdapter_, GetMetaServerInfo(2, _))
+            .Times(1)
+            .WillRepeatedly(DoAll(SetArgPointee<1>(msInfo2), Return(true)));
+        EXPECT_CALL(*topoAdapter_, GetMetaServerInfo(3, _))
+            .Times(2)
+            .WillRepeatedly(DoAll(SetArgPointee<1>(msInfo3), Return(true)));
+
+        leaderScheduler_->SetRapidLeaderSchedulerFlag(true);
+        ASSERT_TRUE(leaderScheduler_->GetRapidLeaderSchedulerFlag());
+        ASSERT_EQ(1, leaderScheduler_->Schedule());
+        ASSERT_TRUE(leaderScheduler_->GetRapidLeaderSchedulerFlag());
+        Operator op;
+        ASSERT_TRUE(opController_->GetOperatorById(copySet1.id, &op));
+        ASSERT_EQ(OperatorPriority::NormalPriority, op.priority);
+        ASSERT_EQ(std::chrono::seconds(10), op.timeLimit);
+        TransferLeader *res = dynamic_cast<TransferLeader *>(op.step.get());
+        ASSERT_TRUE(res != nullptr);
+        ASSERT_EQ(1, res->GetTargetPeer());
+    }
+
+    // no schedule operator generate, FLAGS_enableRapidLeaderScheduler is
+    // set to false automaticlly
+    {
+        EXPECT_CALL(*topoAdapter_, Getpools())
+            .WillOnce(Return(std::vector<PoolIdType>({poolId})));
+        EXPECT_CALL(*topoAdapter_, GetStandardReplicaNumInPool(poolId))
+            .WillOnce(Return(3));
+        EXPECT_CALL(*topoAdapter_, GetMetaServersInPool(poolId))
+            .WillOnce(Return(msInfos2));
+
+        ASSERT_TRUE(leaderScheduler_->GetRapidLeaderSchedulerFlag());
+        ASSERT_EQ(0, leaderScheduler_->Schedule());
+        ASSERT_FALSE(leaderScheduler_->GetRapidLeaderSchedulerFlag());
+    }
+}
+
+TEST_F(TestLeaderSchedule, test_transferLeaderIn_add_operator_fail) {
+    PeerInfo peer1(1, 1, 1, "192.168.10.1", 9000);
+    PeerInfo peer2(2, 2, 2, "192.168.10.2", 9000);
+    PeerInfo peer3(3, 3, 3, "192.168.10.3", 9000);
+    PeerInfo peer4(3, 4, 4, "192.168.10.4", 9000);
+    MetaServerSpace space(100, 20);
+    MetaServerInfo msInfo1(peer1, OnlineState::ONLINE, space, 10, 2);
+    uint64_t currentTime = ::curve::common::TimeUtility::GetTimeofDaySec();
+    msInfo1.startUpTime = currentTime - opt_.metaserverCoolingTimeSec - 1;
+    MetaServerInfo msInfo2(peer2, OnlineState::ONLINE, space, 10, 3);
+    MetaServerInfo msInfo3(peer3, OnlineState::ONLINE, space, 10, 4);
+    MetaServerInfo msInfo4(peer4, OnlineState::ONLINE, space, 10, 3);
+    std::vector<MetaServerInfo> msInfos({msInfo1, msInfo2, msInfo3, msInfo4});
+
+    PoolIdType poolId = 1;
+    CopySetIdType copysetId1 = 1;
+    CopySetIdType copysetId2 = 2;
+    EpochType epoch = 1;
+    // has operator
+    CopySetInfo copySet1(CopySetKey(poolId, copysetId1), epoch, 3,
+        std::vector<PeerInfo>({peer1, peer2, peer3}),
+        ConfigChangeInfo{});
+    // not include metaserver1
+    CopySetInfo copySet2(CopySetKey(poolId, copysetId2), epoch, 4,
+        std::vector<PeerInfo>({peer2, peer3, peer4}),
+        ConfigChangeInfo{});
+
+    Operator testOperator(1, CopySetKey(poolId, copysetId1),
+                          OperatorPriority::NormalPriority,
+                          steady_clock::now(), std::make_shared<AddPeer>(1));
+    ASSERT_TRUE(opController_->AddOperator(testOperator));
+
+    EXPECT_CALL(*topoAdapter_, Getpools())
+        .WillOnce(Return(std::vector<PoolIdType>({poolId})));
+    EXPECT_CALL(*topoAdapter_, GetStandardReplicaNumInPool(poolId))
+        .WillOnce(Return(3));
+    EXPECT_CALL(*topoAdapter_, GetMetaServersInPool(poolId))
+        .WillOnce(Return(msInfos));
+    EXPECT_CALL(*topoAdapter_, GetCopySetInfosInPool(poolId))
+        .WillOnce(Return(std::vector<CopySetInfo>{copySet1, copySet2}));
+     EXPECT_CALL(*topoAdapter_, GetMetaServerInfo(1, _))
+        .Times(1)
+        .WillRepeatedly(DoAll(SetArgPointee<1>(msInfo1), Return(true)));
+    EXPECT_CALL(*topoAdapter_, GetMetaServerInfo(2, _))
+        .Times(1)
+        .WillRepeatedly(DoAll(SetArgPointee<1>(msInfo2), Return(true)));
+    EXPECT_CALL(*topoAdapter_, GetMetaServerInfo(3, _))
+        .Times(2)
+        .WillRepeatedly(DoAll(SetArgPointee<1>(msInfo3), Return(true)));
+
+    ASSERT_EQ(0, leaderScheduler_->Schedule());
+}
+}  // namespace schedule
+}  // namespace mds
+}  // namespace curvefs


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #1336 

1. Add a leader schedule for curvefs. The purpose is to make the leader in copyset more balanced.
2. Further optimize the creation of copyset. The purpose is to make the copy more balanced.
3. Adjust the calculation method of metaserver resource usage.
