### PR TITLE
curvefs/metaserver: fixed sseek so slow which caused by unusing

### DIFF
--- a/curvefs/src/metaserver/storage/rocksdb_storage.h
+++ b/curvefs/src/metaserver/storage/rocksdb_storage.h
@@ -33,6 +33,7 @@
 #include "rocksdb/slice.h"
 #include "rocksdb/table.h"
 #include "rocksdb/options.h"
+#include "rocksdb/filter_policy.h"
 #include "rocksdb/slice_transform.h"
 #include "rocksdb/utilities/transaction.h"
 #include "rocksdb/utilities/transaction_db.h"
@@ -56,7 +57,8 @@ using ROCKSDB_NAMESPACE::BlockBasedTableOptions;
 using ROCKSDB_NAMESPACE::Transaction;
 using ROCKSDB_NAMESPACE::TransactionDB;
 using ROCKSDB_NAMESPACE::NewLRUCache;
-using ROCKSDB_NAMESPACE::NewFixedPrefixTransform;
+using ROCKSDB_NAMESPACE::NewBloomFilterPolicy;
+using ROCKSDB_NAMESPACE::NewCappedPrefixTransform;
 using ROCKSDB_NAMESPACE::NewBlockBasedTableFactory;
 using STORAGE_TYPE = KVStorage::STORAGE_TYPE;
 

--- a/curvefs/src/metaserver/storage/storage_fstream.h
+++ b/curvefs/src/metaserver/storage/storage_fstream.h
@@ -92,11 +92,17 @@ static std::pair<std::string, std::string> UserKey(const std::string& ikey) {
     if (items.size() >= 2) {
         prefix = items[0];
         ukey = ikey.substr(prefix.size() + 1);
+    } else if (items.size() == 1) {  // e.g: t3:
+        prefix = items[0];
     }
     return std::make_pair(prefix, ukey);
 }
 
 static std::pair<ENTRY_TYPE, uint32_t> Extract(const std::string& prefix) {
+    if (prefix.size() == 0) {
+        return std::make_pair(ENTRY_TYPE::UNKNOWN, 0);
+    }
+
     std::vector<std::string> items{
         prefix.substr(0, 1),  // eg: i
         prefix.substr(1),  // eg: 100

--- a/curvefs/test/metaserver/storage/storage_fstream_test.cpp
+++ b/curvefs/test/metaserver/storage/storage_fstream_test.cpp
@@ -180,9 +180,33 @@ TEST_F(StorageFstreamTest, MiscTest) {
     ASSERT_EQ(Str2Type("x"), ENTRY_TYPE::UNKNOWN);
     ASSERT_EQ(Str2Type("y"), ENTRY_TYPE::UNKNOWN);
 
-    auto ret = Extract("i:-1");
-    ASSERT_EQ(ret.first, ENTRY_TYPE::INODE);
-    ASSERT_EQ(ret.second, 0);
+    {
+        auto ret = Extract("d100");
+        ASSERT_EQ(ret.first, ENTRY_TYPE::DENTRY);
+        ASSERT_EQ(ret.second, 100);
+
+        ret = Extract("i0");
+        ASSERT_EQ(ret.first, ENTRY_TYPE::INODE);
+        ASSERT_EQ(ret.second, 0);
+
+        ret = Extract("");
+        ASSERT_EQ(ret.first, ENTRY_TYPE::UNKNOWN);
+        ASSERT_EQ(ret.second, 0);
+    }
+
+    {
+        auto ret = UserKey("t3:");
+        ASSERT_EQ(ret.first, "t3");
+        ASSERT_EQ(ret.second, "");
+
+        ret = UserKey("i100:000");
+        ASSERT_EQ(ret.first, "i100");
+        ASSERT_EQ(ret.second, "000");
+
+        ret = UserKey("");
+        ASSERT_EQ(ret.first, "");
+        ASSERT_EQ(ret.second, "");
+    }
 
     // CASE 2: open file failed when save
     ASSERT_FALSE(SaveToFile("/__not_found__/dumpfile", nullptr, false));


### PR DESCRIPTION
rocksdb's table prefix bloom filter and fixed extract empty key prefix.

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #xxx <!-- replace xxx with issue number -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
