### PR TITLE
curvefs/metaserver: fixed the `s3ChunkInfoRemove` field not used in `…

### DIFF
--- a/curvefs/src/metaserver/inode_manager.h
+++ b/curvefs/src/metaserver/inode_manager.h
@@ -60,7 +60,11 @@ class InodeManager {
     MetaStatusCode CreateInode(uint64_t inodeId, const InodeParam &param,
                                Inode *inode);
     MetaStatusCode CreateRootInode(const InodeParam &param);
-    MetaStatusCode GetInode(uint32_t fsId, uint64_t inodeId, Inode *inode);
+
+    MetaStatusCode GetInode(uint32_t fsId,
+                            uint64_t inodeId,
+                            Inode *inode,
+                            bool paddingS3ChunkInfo = false);
 
     MetaStatusCode GetInodeAttr(uint32_t fsId, uint64_t inodeId,
                                 InodeAttr *attr);
@@ -74,9 +78,9 @@ class InodeManager {
     MetaStatusCode GetOrModifyS3ChunkInfo(uint32_t fsId,
                                           uint64_t inodeId,
                                           const S3ChunkInfoMap& map2add,
-                                          std::shared_ptr<Iterator>* iterator,
+                                          const S3ChunkInfoMap& map2del,
                                           bool returnS3ChunkInfoMap,
-                                          bool compaction);
+                                          std::shared_ptr<Iterator>* iterator);
 
     MetaStatusCode PaddingInodeS3ChunkInfo(int32_t fsId,
                                            uint64_t inodeId,

--- a/curvefs/src/metaserver/inode_storage.h
+++ b/curvefs/src/metaserver/inode_storage.h
@@ -45,6 +45,7 @@ using ::curvefs::metaserver::storage::Status;
 using ::curvefs::metaserver::storage::Iterator;
 using ::curvefs::metaserver::storage::KVStorage;
 using ::curvefs::metaserver::storage::StorageTransaction;
+using ::curvefs::metaserver::storage::Hash;
 
 namespace curvefs {
 namespace metaserver {
@@ -108,11 +109,11 @@ class InodeStorage {
      */
     MetaStatusCode Update(const Inode& inode);
 
-    MetaStatusCode AppendS3ChunkInfoList(uint32_t fsId,
-                                         uint64_t inodeId,
-                                         uint64_t chunkIndex,
-                                         const S3ChunkInfoList& list2add,
-                                         bool compaction);
+    MetaStatusCode ModifyInodeS3ChunkInfoList(uint32_t fsId,
+                                              uint64_t inodeId,
+                                              uint64_t chunkIndex,
+                                              const S3ChunkInfoList& list2add,
+                                              const S3ChunkInfoList& list2del);
 
     MetaStatusCode PaddingInodeS3ChunkInfo(int32_t fsId,
                                            uint64_t inodeId,
@@ -140,13 +141,16 @@ class InodeStorage {
         uint64_t chunkIndex,
         const S3ChunkInfoList& list2add);
 
-    MetaStatusCode RemoveS3ChunkInfoList(
+    MetaStatusCode DelS3ChunkInfoList(
         std::shared_ptr<StorageTransaction> txn,
         uint32_t fsId,
         uint64_t inodeId,
         uint64_t chunkIndex,
-        uint64_t minChunkId,
-        uint64_t* size4del);
+        const S3ChunkInfoList& list2del);
+
+    bool SplitS3ChunkInfoList(const std::string& value,
+                              uint64_t delFirstChunkId,
+                              S3ChunkInfoList* list2add);
 
     std::string RealTablename(TABLE_TYPE type, std::string tablename) {
         std::ostringstream oss;

--- a/curvefs/src/metaserver/metastore.h
+++ b/curvefs/src/metaserver/metastore.h
@@ -77,6 +77,7 @@ using ::curvefs::metaserver::copyset::OnSnapshotSaveDoneClosure;
 using ::curvefs::metaserver::storage::Iterator;
 using ::curvefs::common::StreamServer;
 using ::curvefs::common::StreamConnection;
+using S3ChunkInfoMap = google::protobuf::Map<uint64_t, S3ChunkInfoList>;
 
 class MetaStore {
  public:

--- a/curvefs/src/metaserver/metastore_fstream.cpp
+++ b/curvefs/src/metaserver/metastore_fstream.cpp
@@ -170,11 +170,12 @@ bool MetaStoreFStream::LoadInodeS3ChunkInfoList(uint32_t partitionId,
         return false;
     }
 
-    std::shared_ptr<Iterator> iterator;
     S3ChunkInfoMap map2add;
+    S3ChunkInfoMap map2del;
+    std::shared_ptr<Iterator> iterator;
     map2add.insert({key4list.chunkIndex, list});
     MetaStatusCode rc = partition->GetOrModifyS3ChunkInfo(
-        key4list.fsId, key4list.inodeId, map2add, &iterator, false, false);
+        key4list.fsId, key4list.inodeId, map2add, map2del, false, &iterator);
     if (rc != MetaStatusCode::OK) {
         LOG(ERROR) << "GetOrModifyS3ChunkInfo failed, retCode = "
                    << MetaStatusCode_Name(rc);

--- a/curvefs/src/metaserver/partition.cpp
+++ b/curvefs/src/metaserver/partition.cpp
@@ -262,20 +262,18 @@ MetaStatusCode Partition::UpdateInode(const UpdateInodeRequest& request) {
 MetaStatusCode Partition::GetOrModifyS3ChunkInfo(
     uint32_t fsId,
     uint64_t inodeId,
-    const S3ChunkInfoMap& list2add,
-    std::shared_ptr<Iterator>* iterator,
+    const S3ChunkInfoMap& map2add,
+    const S3ChunkInfoMap& map2del,
     bool returnS3ChunkInfoMap,
-    bool compaction) {
+    std::shared_ptr<Iterator>* iterator) {
     if (!IsInodeBelongs(fsId, inodeId)) {
         return MetaStatusCode::PARTITION_ID_MISSMATCH;
-    }
-
-    if (GetStatus() == PartitionStatus::DELETING) {
+    } else if (GetStatus() == PartitionStatus::DELETING) {
         return MetaStatusCode::PARTITION_DELETING;
     }
 
     return inodeManager_->GetOrModifyS3ChunkInfo(
-        fsId, inodeId, list2add, iterator, returnS3ChunkInfoMap, compaction);
+        fsId, inodeId, map2add, map2del, returnS3ChunkInfoMap, iterator);
 }
 
 MetaStatusCode Partition::PaddingInodeS3ChunkInfo(int32_t fsId,

--- a/curvefs/src/metaserver/partition.h
+++ b/curvefs/src/metaserver/partition.h
@@ -92,10 +92,10 @@ class Partition {
 
     MetaStatusCode GetOrModifyS3ChunkInfo(uint32_t fsId,
                                           uint64_t inodeId,
-                                          const S3ChunkInfoMap& list2add,
-                                          std::shared_ptr<Iterator>* iterator,
+                                          const S3ChunkInfoMap& map2add,
+                                          const S3ChunkInfoMap& map2del,
                                           bool returnS3ChunkInfoMap,
-                                          bool compaction);
+                                          std::shared_ptr<Iterator>* iterator);
 
     MetaStatusCode PaddingInodeS3ChunkInfo(int32_t fsId,
                                            uint64_t inodeId,

--- a/curvefs/src/metaserver/s3compact_wq_impl.cpp
+++ b/curvefs/src/metaserver/s3compact_wq_impl.cpp
@@ -442,7 +442,7 @@ bool S3CompactWorkQueueImpl::CompactPrecheck(const struct S3CompactTask& task,
 
     // inode exist?
     MetaStatusCode ret = task.inodeManager->GetInode(
-        task.inodeKey.fsId, task.inodeKey.inodeId, inode);
+        task.inodeKey.fsId, task.inodeKey.inodeId, inode, true);
     if (ret != MetaStatusCode::OK) {
         LOG(WARNING) << "s3compact: GetInode fail, inodeKey = "
                      << task.inodeKey.fsId << "," << task.inodeKey.inodeId
@@ -456,22 +456,9 @@ bool S3CompactWorkQueueImpl::CompactPrecheck(const struct S3CompactTask& task,
         return false;
     }
 
-    // pandding s3chunkinfomap for inode
-    {
-        auto inodeKey = task.inodeKey;
-        auto inodeManager = task.inodeManager;
-        MetaStatusCode rc = inodeManager->PaddingInodeS3ChunkInfo(
-            inodeKey.fsId, inodeKey.inodeId, inode->mutable_s3chunkinfomap());
-        if (rc != MetaStatusCode::OK) {
-            LOG(ERROR) << "Padding inode s3chunkinfo failed, "
-                       << "retCode = " << MetaStatusCode_Name(ret);
-            return false;
-        }
-
-        if (inode->s3chunkinfomap().size() == 0) {
-            VLOG(6) << "Inode s3chunkinfo is empty";
-            return false;
-        }
+    if (inode->s3chunkinfomap().size() == 0) {
+        VLOG(6) << "Inode s3chunkinfo is empty";
+        return false;
     }
 
     // pass

--- a/curvefs/test/metaserver/inode_manager_test.cpp
+++ b/curvefs/test/metaserver/inode_manager_test.cpp
@@ -149,6 +149,24 @@ class InodeManagerTest : public ::testing::Test {
         return list;
     }
 
+    void CHECK_ITERATOR_S3CHUNKINFOLIST(
+        std::shared_ptr<Iterator> iterator,
+        const std::vector<uint64_t> chunkIndexs,
+        const std::vector<S3ChunkInfoList> lists) {
+        size_t size = 0;
+        Key4S3ChunkInfoList key;
+        S3ChunkInfoList list4get;
+        ASSERT_EQ(iterator->Status(), 0);
+        for (iterator->SeekToFirst(); iterator->Valid(); iterator->Next()) {
+            ASSERT_TRUE(conv_->ParseFromString(iterator->Key(), &key));
+            ASSERT_TRUE(conv_->ParseFromString(iterator->Value(), &list4get));
+            ASSERT_EQ(key.chunkIndex, chunkIndexs[size]);
+            ASSERT_TRUE(EqualS3ChunkInfoList(list4get, lists[size]));
+            size++;
+        }
+        ASSERT_EQ(size, chunkIndexs.size());
+    }
+
  protected:
     std::shared_ptr<InodeManager> manager;
     InodeParam param_;
@@ -230,97 +248,114 @@ TEST_F(InodeManagerTest, test1) {
 }
 
 TEST_F(InodeManagerTest, GetOrModifyS3ChunkInfo) {
-    google::protobuf::Map<uint64_t, S3ChunkInfoList> map4add;
     uint32_t fsId = 1;
     uint32_t inodeId = 1;
-    S3ChunkInfoList list4add = GenS3ChunkInfoList(1, 100);
-    for (int i = 0; i < 10; i++) {
-        map4add[i] = list4add;
-    }
 
     // CASE 1: GetOrModifyS3ChunkInfo() success
     {
+        LOG(INFO) << "CASE 1: GetOrModifyS3ChunkInfo() success";
+        google::protobuf::Map<uint64_t, S3ChunkInfoList> map2add;
+        google::protobuf::Map<uint64_t, S3ChunkInfoList> map2del;
+
+        map2add[1] = GenS3ChunkInfoList(1, 1);
+        map2add[2] = GenS3ChunkInfoList(2, 2);
+        map2add[3] = GenS3ChunkInfoList(3, 3);
+
         std::shared_ptr<Iterator> iterator;
         MetaStatusCode rc = manager->GetOrModifyS3ChunkInfo(
-            fsId, inodeId, map4add, &iterator, true, false);
+            fsId, inodeId, map2add, map2del, true, &iterator);
         ASSERT_EQ(rc, MetaStatusCode::OK);
 
-        size_t size = 0;
-        Key4S3ChunkInfoList key;
-        S3ChunkInfoList list4get;
-        ASSERT_EQ(iterator->Status(), 0);
-        for (iterator->SeekToFirst(); iterator->Valid(); iterator->Next()) {
-            ASSERT_TRUE(conv_->ParseFromString(iterator->Key(), &key));
-            ASSERT_TRUE(conv_->ParseFromString(iterator->Value(), &list4get));
-            ASSERT_EQ(key.chunkIndex, size);
-            ASSERT_TRUE(EqualS3ChunkInfoList(list4add, list4get));
-            size++;
-        }
-        ASSERT_EQ(size, 10);
+        CHECK_ITERATOR_S3CHUNKINFOLIST(iterator,
+            std::vector<uint64_t>{ 1, 2, 3 },
+            std::vector<S3ChunkInfoList>{
+                GenS3ChunkInfoList(1, 1),
+                GenS3ChunkInfoList(2, 2),
+                GenS3ChunkInfoList(3, 3),
+            });
+
+        LOG(INFO) << "CASE 1.1: check idempotent for GetOrModifyS3ChunkInfo()";
+        rc = manager->GetOrModifyS3ChunkInfo(
+            fsId, inodeId, map2add, map2del, true, &iterator);
+        ASSERT_EQ(rc, MetaStatusCode::OK);
+
+        CHECK_ITERATOR_S3CHUNKINFOLIST(iterator,
+            std::vector<uint64_t>{ 1, 2, 3 },
+            std::vector<S3ChunkInfoList>{
+                GenS3ChunkInfoList(1, 1),
+                GenS3ChunkInfoList(2, 2),
+                GenS3ChunkInfoList(3, 3),
+            });
     }
 
-    // CASE 2: idempotent request
+    // CASE 2: GetOrModifyS3ChunkInfo() with delete
     {
+        LOG(INFO) << "CASE 2: GetOrModifyS3ChunkInfo() with delete";
+        google::protobuf::Map<uint64_t, S3ChunkInfoList> map2add;
+        google::protobuf::Map<uint64_t, S3ChunkInfoList> map2del;
+
+        map2del[1] = GenS3ChunkInfoList(1, 1);
+        map2del[2] = GenS3ChunkInfoList(2, 2);
+        map2del[3] = GenS3ChunkInfoList(3, 3);
+
         std::shared_ptr<Iterator> iterator;
         MetaStatusCode rc = manager->GetOrModifyS3ChunkInfo(
-            fsId, inodeId, map4add, &iterator, true, false);
+            fsId, inodeId, map2add, map2del, true, &iterator);
         ASSERT_EQ(rc, MetaStatusCode::OK);
 
-        size_t size = 0;
-        Key4S3ChunkInfoList key;
-        S3ChunkInfoList list4get;
-        ASSERT_EQ(iterator->Status(), 0);
-        for (iterator->SeekToFirst(); iterator->Valid(); iterator->Next()) {
-            ASSERT_TRUE(conv_->ParseFromString(iterator->Key(), &key));
-            ASSERT_TRUE(conv_->ParseFromString(iterator->Value(), &list4get));
-            ASSERT_EQ(key.chunkIndex, size);
-            ASSERT_TRUE(EqualS3ChunkInfoList(list4add, list4get));
-            size++;
-        }
-        ASSERT_EQ(size, 10);
+        CHECK_ITERATOR_S3CHUNKINFOLIST(iterator,
+            std::vector<uint64_t>{},
+            std::vector<S3ChunkInfoList>{});
     }
 
-    // CASE 3: compaction
+    // CASE 3: GetOrModifyS3ChunkInfo() with add and delete
     {
-        map4add.clear();
-        map4add[0] = GenS3ChunkInfoList(100, 100);
-        map4add[1] = GenS3ChunkInfoList(100, 100);
-        map4add[2] = GenS3ChunkInfoList(100, 100);
-        map4add[7] = GenS3ChunkInfoList(100, 100);
-        map4add[8] = GenS3ChunkInfoList(100, 100);
-        map4add[9] = GenS3ChunkInfoList(100, 100);
+        LOG(INFO) << "CASE 3: GetOrModifyS3ChunkInfo() with add and delete";
+        google::protobuf::Map<uint64_t, S3ChunkInfoList> map2add;
+        google::protobuf::Map<uint64_t, S3ChunkInfoList> map2del;
+
+        map2add[0] = GenS3ChunkInfoList(1, 100);
+        map2add[1] = GenS3ChunkInfoList(1, 100);
+        map2add[2] = GenS3ChunkInfoList(1, 100);
+        map2add[7] = GenS3ChunkInfoList(1, 100);
+        map2add[8] = GenS3ChunkInfoList(1, 100);
+        map2add[9] = GenS3ChunkInfoList(1, 100);
+
+        map2del[0] = GenS3ChunkInfoList(1, 100);
+        map2del[2] = GenS3ChunkInfoList(51, 100);
+        map2del[7] = GenS3ChunkInfoList(1, 100);
+        map2del[8] = GenS3ChunkInfoList(1, 100);
+        map2del[9] = GenS3ChunkInfoList(1, 100);
 
         std::shared_ptr<Iterator> iterator;
         MetaStatusCode rc = manager->GetOrModifyS3ChunkInfo(
-            fsId, inodeId, map4add, &iterator, true, true);
+            fsId, inodeId, map2add, map2del, true, &iterator);
         ASSERT_EQ(rc, MetaStatusCode::OK);
         ASSERT_EQ(iterator->Status(), 0);
 
-        size_t size = 0;
-        Key4S3ChunkInfoList key;
-        S3ChunkInfoList list4get;
-        std::vector<S3ChunkInfoList> lists{
-            GenS3ChunkInfoList(100, 100),
-            GenS3ChunkInfoList(100, 100),
-            GenS3ChunkInfoList(100, 100),
-            GenS3ChunkInfoList(1, 100),
-            GenS3ChunkInfoList(1, 100),
-            GenS3ChunkInfoList(1, 100),
-            GenS3ChunkInfoList(1, 100),
-            GenS3ChunkInfoList(100, 100),
-            GenS3ChunkInfoList(100, 100),
-            GenS3ChunkInfoList(100, 100),
-        };
-        for (iterator->SeekToFirst(); iterator->Valid(); iterator->Next()) {
-            LOG(INFO) << "check chunkIndex(" << size << ")"
-                      << ", key=" << iterator->Key();
-            ASSERT_TRUE(conv_->ParseFromString(iterator->Key(), &key));
-            ASSERT_TRUE(conv_->ParseFromString(iterator->Value(), &list4get));
-            ASSERT_EQ(key.chunkIndex, size);
-            ASSERT_TRUE(EqualS3ChunkInfoList(lists[size], list4get));
-            size++;
-        }
-        ASSERT_EQ(size, 10);
+        CHECK_ITERATOR_S3CHUNKINFOLIST(iterator,
+            std::vector<uint64_t>{ 1, 2 },
+            std::vector<S3ChunkInfoList>{
+                GenS3ChunkInfoList(1, 100),
+                GenS3ChunkInfoList(1, 50),
+            });
+
+        LOG(INFO) << "CASE 3.1: GetOrModifyS3ChunkInfo() with only delete";
+        map2add.clear();
+        map2del.clear();
+        map2del[1] = GenS3ChunkInfoList(1, 100);
+        map2del[2] = GenS3ChunkInfoList(11, 50);
+
+        rc = manager->GetOrModifyS3ChunkInfo(
+            fsId, inodeId, map2add, map2del, true, &iterator);
+        ASSERT_EQ(rc, MetaStatusCode::OK);
+        ASSERT_EQ(iterator->Status(), 0);
+
+        CHECK_ITERATOR_S3CHUNKINFOLIST(iterator,
+            std::vector<uint64_t>{ 2 },
+            std::vector<S3ChunkInfoList>{
+                GenS3ChunkInfoList(1, 10),
+            });
     }
 }
 
@@ -394,9 +429,8 @@ TEST_F(InodeManagerTest, testGetXAttr) {
 
     Inode inode2;
     param_.type = FsFileType::TYPE_DIRECTORY;
-    ASSERT_EQ(
-        manager->CreateInode(3, param_, &inode2),
-        MetaStatusCode::OK);
+    ASSERT_EQ(manager->CreateInode(3, param_, &inode2),
+              MetaStatusCode::OK);
     ASSERT_FALSE(inode2.xattr().empty());
     ASSERT_EQ(inode2.xattr().find(XATTRFILES)->second, "0");
     ASSERT_EQ(inode2.xattr().find(XATTRSUBDIRS)->second, "0");

--- a/curvefs/test/metaserver/inode_storage_test.cpp
+++ b/curvefs/test/metaserver/inode_storage_test.cpp
@@ -315,16 +315,17 @@ TEST_F(InodeStorageTest, testGetXAttr) {
     ASSERT_EQ(xattr.xattrinfos().find(XATTRRFBYTES)->second, "1000");
 }
 
-TEST_F(InodeStorageTest, GetOrModifyS3ChunkInfo) {
+TEST_F(InodeStorageTest, ModifyInodeS3ChunkInfoList) {
     uint32_t fsId = 1;
     uint64_t inodeId = 1;
     InodeStorage storage(kvStorage_, tablename_);
 
-    // CASE 1: empty s3chunkinfo
+    // CASE 1: get empty s3chunkinfo
     {
-        LOG(INFO) << "CASE 1:";
+        LOG(INFO) << "CASE 1: get empty s3chukninfo";
         Inode inode = GenInode(fsId, inodeId);
         ASSERT_EQ(storage.Insert(inode), MetaStatusCode::OK);
+        S3ChunkInfoList list2del;
 
         size_t size = 0;
         auto iterator = storage.GetInodeS3ChunkInfoList(fsId, inodeId);
@@ -337,56 +338,59 @@ TEST_F(InodeStorageTest, GetOrModifyS3ChunkInfo) {
 
     // CASE 2: append one s3chunkinfo
     {
-        LOG(INFO) << "CASE 2:";
+        LOG(INFO) << "CASE 2: append one s3chunkinfo";
         ASSERT_EQ(storage.Clear(), MetaStatusCode::OK);
         std::vector<uint64_t> chunkIndexs{ 1 };
-        std::vector<S3ChunkInfoList> lists{ GenS3ChunkInfoList(1, 1) };
+        std::vector<S3ChunkInfoList> lists2add{ GenS3ChunkInfoList(1, 1) };
+        S3ChunkInfoList list2del;
 
-        for (size_t size = 0; size < chunkIndexs.size(); size++) {
-            MetaStatusCode rc = storage.AppendS3ChunkInfoList(
-                fsId, inodeId, chunkIndexs[size], lists[size], false);
+        for (size_t i = 0; i < chunkIndexs.size(); i++) {
+            MetaStatusCode rc = storage.ModifyInodeS3ChunkInfoList(
+                fsId, inodeId, chunkIndexs[i], lists2add[i], list2del);
             ASSERT_EQ(rc, MetaStatusCode::OK);
         }
 
-        CHECK_INODE_S3CHUNKINFOLIST(
-            &storage, fsId, inodeId, chunkIndexs, lists);
+        CHECK_INODE_S3CHUNKINFOLIST(&storage, fsId, inodeId,
+                                    chunkIndexs, lists2add);
     }
 
     // CASE 3: append multi s3chunkinfos
     {
-        LOG(INFO) << "CASE 3:";
+        LOG(INFO) << "CASE 3: append multi s3chunkinfos";
         ASSERT_EQ(storage.Clear(), MetaStatusCode::OK);
         std::vector<uint64_t> chunkIndexs{ 1, 2, 3 };
-        std::vector<S3ChunkInfoList> lists{
+        std::vector<S3ChunkInfoList> lists2add{
             GenS3ChunkInfoList(1, 1),
             GenS3ChunkInfoList(2, 2),
             GenS3ChunkInfoList(3, 3),
         };
+        S3ChunkInfoList list2del;
 
-        for (size_t size = 0; size < chunkIndexs.size(); size++) {
-            MetaStatusCode rc = storage.AppendS3ChunkInfoList(
-                fsId, inodeId, chunkIndexs[size], lists[size], false);
+        for (size_t i = 0; i < chunkIndexs.size(); i++) {
+            MetaStatusCode rc = storage.ModifyInodeS3ChunkInfoList(
+                fsId, inodeId, chunkIndexs[i], lists2add[i], list2del);
             ASSERT_EQ(rc, MetaStatusCode::OK);
         }
 
-        CHECK_INODE_S3CHUNKINFOLIST(
-            &storage, fsId, inodeId, chunkIndexs, lists);
+        CHECK_INODE_S3CHUNKINFOLIST(&storage, fsId, inodeId,
+                                    chunkIndexs, lists2add);
     }
 
     // CASE 4: check order for s3chunkinfo's chunk index
     {
-        LOG(INFO) << "CASE 4:";
+        LOG(INFO) << "CASE 4: check order for s3chunkinfo's chunk index";
         ASSERT_EQ(storage.Clear(), MetaStatusCode::OK);
         std::vector<uint64_t> chunkIndexs{ 2, 1, 3 };
-        std::vector<S3ChunkInfoList> lists{
+        std::vector<S3ChunkInfoList> lists2add{
             GenS3ChunkInfoList(2, 2),
             GenS3ChunkInfoList(1, 1),
             GenS3ChunkInfoList(3, 3),
         };
+        S3ChunkInfoList list2del;
 
-        for (size_t size = 0; size < chunkIndexs.size(); size++) {
-            MetaStatusCode rc = storage.AppendS3ChunkInfoList(
-                fsId, inodeId, chunkIndexs[size], lists[size], false);
+        for (size_t i = 0; i < chunkIndexs.size(); i++) {
+            MetaStatusCode rc = storage.ModifyInodeS3ChunkInfoList(
+                fsId, inodeId, chunkIndexs[i], lists2add[i], list2del);
             ASSERT_EQ(rc, MetaStatusCode::OK);
         }
 
@@ -401,20 +405,21 @@ TEST_F(InodeStorageTest, GetOrModifyS3ChunkInfo) {
 
     // CASE 5: check order for s3chunkinfo's chunk id
     {
-        LOG(INFO) << "CASE 5:";
+        LOG(INFO) << "CASE 5: check order for s3chunkinfo's chunk id";
         ASSERT_EQ(storage.Clear(), MetaStatusCode::OK);
         std::vector<uint64_t> chunkIndexs{ 2, 1, 3, 1, 2 };
-        std::vector<S3ChunkInfoList> lists{
+        std::vector<S3ChunkInfoList> lists2add{
             GenS3ChunkInfoList(200, 210),
             GenS3ChunkInfoList(120, 130),
             GenS3ChunkInfoList(300, 310),
             GenS3ChunkInfoList(100, 110),
             GenS3ChunkInfoList(220, 230),
         };
+        S3ChunkInfoList list2del;
 
-        for (size_t size = 0; size < chunkIndexs.size(); size++) {
-            MetaStatusCode rc = storage.AppendS3ChunkInfoList(
-                fsId, inodeId, chunkIndexs[size], lists[size], false);
+        for (size_t i = 0; i < chunkIndexs.size(); i++) {
+            MetaStatusCode rc = storage.ModifyInodeS3ChunkInfoList(
+                fsId, inodeId, chunkIndexs[i], lists2add[i], list2del);
             ASSERT_EQ(rc, MetaStatusCode::OK);
         }
 
@@ -427,6 +432,91 @@ TEST_F(InodeStorageTest, GetOrModifyS3ChunkInfo) {
                 GenS3ChunkInfoList(220, 230),
                 GenS3ChunkInfoList(300, 310),
             });
+    }
+
+    // CASE 6: delete s3chunkinfo list
+    {
+        LOG(INFO) << "CASE 6: delete s3chukninfo list";
+        ASSERT_EQ(storage.Clear(), MetaStatusCode::OK);
+        std::vector<uint64_t> chunkIndexs{ 1, 2, 3 };
+        std::vector<S3ChunkInfoList> lists2add{
+            GenS3ChunkInfoList(100, 199),
+            GenS3ChunkInfoList(200, 299),
+            GenS3ChunkInfoList(300, 399),
+        };
+        std::vector<S3ChunkInfoList> lists2del{
+            GenS3ChunkInfoList(100, 199),
+            GenS3ChunkInfoList(250, 299),
+            GenS3ChunkInfoList(400, 499),
+        };
+
+        for (size_t i = 0; i < chunkIndexs.size(); i++) {
+            MetaStatusCode rc = storage.ModifyInodeS3ChunkInfoList(
+                fsId, inodeId, chunkIndexs[i], lists2add[i], lists2del[i]);
+            ASSERT_EQ(rc, MetaStatusCode::OK);
+        }
+
+        CHECK_INODE_S3CHUNKINFOLIST(&storage, fsId, inodeId,
+            std::vector<uint64_t>{ 2, 3 },
+            std::vector<S3ChunkInfoList>{
+                GenS3ChunkInfoList(200, 249),
+                GenS3ChunkInfoList(300, 399),
+            });
+    }
+
+    // CASE 7: delete s3chunkinfo list with wrong range
+    {
+        LOG(INFO) << "CASE 6: delete s3chunkinfo list with wrong range";
+        ASSERT_EQ(storage.Clear(), MetaStatusCode::OK);
+        std::vector<uint64_t> chunkIndexs{ 1, 2, 3 };
+        std::vector<S3ChunkInfoList> lists2add{
+            GenS3ChunkInfoList(100, 199),
+            GenS3ChunkInfoList(200, 299),
+            GenS3ChunkInfoList(300, 399),
+        };
+        std::vector<S3ChunkInfoList> lists2del{
+            GenS3ChunkInfoList(100, 199),
+            GenS3ChunkInfoList(250, 299),
+            GenS3ChunkInfoList(300, 301),
+        };
+
+        size_t size = chunkIndexs.size();
+        for (size_t i = 0; i < size; i++) {
+            MetaStatusCode rc = storage.ModifyInodeS3ChunkInfoList(
+                fsId, inodeId, chunkIndexs[i], lists2add[i], lists2del[i]);
+            if (i == size - 1) {
+                ASSERT_EQ(rc, MetaStatusCode::STORAGE_INTERNAL_ERROR);
+            } else {
+                ASSERT_EQ(rc, MetaStatusCode::OK);
+            }
+        }
+    }
+
+    // CASE 8: delete all s3chunkinfo list
+    {
+        LOG(INFO) << "CASE 8: delete all s3chukninfo list";
+        ASSERT_EQ(storage.Clear(), MetaStatusCode::OK);
+        std::vector<uint64_t> chunkIndexs{ 1, 2, 3 };
+        std::vector<S3ChunkInfoList> lists2add{
+            GenS3ChunkInfoList(100, 199),
+            GenS3ChunkInfoList(200, 299),
+            GenS3ChunkInfoList(300, 399),
+        };
+        std::vector<S3ChunkInfoList> lists2del{
+            GenS3ChunkInfoList(100, 199),
+            GenS3ChunkInfoList(200, 299),
+            GenS3ChunkInfoList(300, 399),
+        };
+
+        for (size_t i = 0; i < chunkIndexs.size(); i++) {
+            MetaStatusCode rc = storage.ModifyInodeS3ChunkInfoList(
+                fsId, inodeId, chunkIndexs[i], lists2add[i], lists2del[i]);
+            ASSERT_EQ(rc, MetaStatusCode::OK);
+        }
+
+        CHECK_INODE_S3CHUNKINFOLIST(&storage, fsId, inodeId,
+            std::vector<uint64_t>{},
+            std::vector<S3ChunkInfoList>{});
     }
 }
 
@@ -451,8 +541,8 @@ TEST_F(InodeStorageTest, PaddingInodeS3ChunkInfo) {
     };
 
     for (size_t i = 0; i < chunkIndexs.size(); i++) {
-        MetaStatusCode rc = storage.AppendS3ChunkInfoList(
-            fsId, inodeId, chunkIndexs[i], lists2add[i], false);
+        MetaStatusCode rc = storage.ModifyInodeS3ChunkInfoList(
+            fsId, inodeId, chunkIndexs[i], lists2add[i], list2del);
         ASSERT_EQ(rc, MetaStatusCode::OK);
     }
     ASSERT_EQ(inode.mutable_s3chunkinfomap()->size(), 0);
@@ -503,15 +593,16 @@ TEST_F(InodeStorageTest, PaddingInodeS3ChunkInfo) {
 TEST_F(InodeStorageTest, GetAllS3ChunkInfoList) {
     InodeStorage storage(kvStorage_, tablename_);
     uint64_t chunkIndex = 1;
-    S3ChunkInfoList list4add = GenS3ChunkInfoList(1, 10);
+    S3ChunkInfoList list2add = GenS3ChunkInfoList(1, 10);
+    S3ChunkInfoList list2del;
 
     // step1: prepare inode and its s3chunkinfo
     auto prepareInode = [&](uint32_t fsId, uint64_t inodeId) {
         Inode inode = GenInode(fsId, inodeId);
         ASSERT_EQ(storage.Insert(inode), MetaStatusCode::OK);
 
-        MetaStatusCode rc = storage.AppendS3ChunkInfoList(
-            fsId, inodeId, chunkIndex, list4add, false);
+        MetaStatusCode rc = storage.ModifyInodeS3ChunkInfoList(
+            fsId, inodeId, chunkIndex, list2add, list2del);
         ASSERT_EQ(rc, MetaStatusCode::OK);
     };
 
@@ -531,7 +622,7 @@ TEST_F(InodeStorageTest, GetAllS3ChunkInfoList) {
         ASSERT_EQ(key.chunkIndex, chunkIndex);
         ASSERT_EQ(key.fsId, fsIds[size]);
         ASSERT_EQ(key.inodeId, inodeIds[size]);
-        ASSERT_TRUE(EqualS3ChunkInfoList(list4add, list4get));
+        ASSERT_TRUE(EqualS3ChunkInfoList(list2add, list4get));
         size++;
     }
     ASSERT_EQ(size, 2);

--- a/curvefs/test/metaserver/s3compactwq_test.cpp
+++ b/curvefs/test/metaserver/s3compactwq_test.cpp
@@ -656,8 +656,9 @@ TEST_F(S3CompactWorkQueueImplTest, test_CompactChunks) {
         ref->set_size(5);
         ref->set_zero(false);
     }
-    auto rc = inodeStorage_->AppendS3ChunkInfoList(
-        inode1.fsid(), inode1.inodeid(), 0, l0, false);
+    S3ChunkInfoList dummy;
+    auto rc = inodeStorage_->ModifyInodeS3ChunkInfoList(
+        inode1.fsid(), inode1.inodeid(), 0, l0, dummy);
     ASSERT_EQ(rc, MetaStatusCode::OK);
     ASSERT_EQ(inodeStorage_->Update(inode1), MetaStatusCode::OK);
     mockImpl_->CompactChunks(t);


### PR DESCRIPTION
…GetOrModifyS3ChunkInfo` PRC request.

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #xxx <!-- replace xxx with issue number -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
