### PR TITLE
curvefs/client: list dentry concurrently when get summary xattr

### DIFF
--- a/curvefs/conf/client.conf
+++ b/curvefs/conf/client.conf
@@ -93,6 +93,8 @@ fuseClient.cto=true
 # see https://lore.kernel.org/all/CAAmZXrsGg2xsP1CK+cbuEMumtrqdvD-NKnWzhNcvn71RV3c1yw@mail.gmail.com/
 # until this issue has been fixed, splice should be disabled
 fuseClient.enableSplice=false
+# thread number of listDentry when get summary xattr
+fuseClient.listDentryThreads=10
 
 #### volume
 volume.bigFileSize=1048576

--- a/curvefs/src/client/common/common.cpp
+++ b/curvefs/src/client/common/common.cpp
@@ -40,8 +40,17 @@ std::ostream &operator<<(std::ostream &os, MetaServerOpType optype) {
     case MetaServerOpType::DeleteDentry:
         os << "DeleteDentry";
         break;
+    case MetaServerOpType::PrepareRenameTx:
+        os << "PrepareRenameTx";
+        break;
     case MetaServerOpType::GetInode:
         os << "GetInode";
+        break;
+    case MetaServerOpType::BatchGetInodeAttr:
+        os << "BatchGetInodeAttr";
+        break;
+    case MetaServerOpType::BatchGetXAttr:
+        os << "BatchGetXAttr";
         break;
     case MetaServerOpType::UpdateInode:
         os << "UpdateInode";

--- a/curvefs/src/client/common/config.cpp
+++ b/curvefs/src/client/common/config.cpp
@@ -222,6 +222,8 @@ void InitFuseClientOption(Configuration *conf, FuseClientOption *clientOption) {
                               &clientOption->entryTimeOut);
     conf->GetValueFatalIfFail("fuseClient.listDentryLimit",
                               &clientOption->listDentryLimit);
+    conf->GetValueFatalIfFail("fuseClient.listDentryThreads",
+                              &clientOption->listDentryThreads);
     conf->GetValueFatalIfFail("fuseClient.flushPeriodSec",
                               &clientOption->flushPeriodSec);
     conf->GetValueFatalIfFail("fuseClient.maxNameLength",

--- a/curvefs/src/client/common/config.h
+++ b/curvefs/src/client/common/config.h
@@ -23,6 +23,7 @@
 #ifndef CURVEFS_SRC_CLIENT_COMMON_CONFIG_H_
 #define CURVEFS_SRC_CLIENT_COMMON_CONFIG_H_
 
+#include <cstdint>
 #include <string>
 
 #include "curvefs/src/client/common/common.h"
@@ -175,6 +176,7 @@ struct FuseClientOption {
     double attrTimeOut;
     double entryTimeOut;
     uint32_t listDentryLimit;
+    uint32_t listDentryThreads;
     uint32_t flushPeriodSec;
     uint32_t maxNameLength;
     uint64_t iCacheLruSize;

--- a/curvefs/src/client/fuse_client.cpp
+++ b/curvefs/src/client/fuse_client.cpp
@@ -28,21 +28,19 @@
 #include <cstring>
 #include <string>
 #include <vector>
-#include <stack>
 #include <set>
 #include <unordered_map>
 
 #include "curvefs/proto/mds.pb.h"
 #include "curvefs/src/client/fuse_common.h"
 #include "curvefs/src/client/client_operator.h"
+#include "curvefs/src/client/xattr_manager.h"
 #include "src/common/net_common.h"
 #include "src/common/dummyserver.h"
 #include "src/client/client_common.h"
-#include "src/common/string_util.h"
 
 #define PORT_LIMIT 65535
 
-using ::curve::common::StringToUll;
 using ::curvefs::common::S3Info;
 using ::curvefs::common::Volume;
 using ::curvefs::mds::topology::PartitionTxId;
@@ -91,6 +89,9 @@ CURVEFS_ERROR FuseClient::Init(const FuseClientOption &option) {
 
     leaseExecutor_ =
         std::make_shared<LeaseExecutor>(option.leaseOpt, metaCache, mdsClient_);
+
+    xattrManager_ = std::make_shared<XattrManager>(inodeManager_,
+        dentryManager_, option_.listDentryLimit, option_.listDentryThreads);
 
     uint32_t listenPort = 0;
     if (!curve::common::StartBrpcDummyserver(option.dummyServerStartPort,
@@ -150,6 +151,7 @@ void FuseClient::Fini() {
         LOG(INFO) << "stop fuse client flush thread ...";
         sleeper_.interrupt();
         flushThread_.join();
+        xattrManager_->Stop();
     }
     LOG(INFO) << "stop fuse client flush thread ok.";
 }
@@ -326,7 +328,8 @@ CURVEFS_ERROR FuseClient::FuseOpOpen(fuse_req_t req, fuse_ino_t ino,
                 xattr.mutable_xattrinfos()->insert({XATTRFBYTES,
                     std::to_string(length)});
                 for (const auto &it : inode->parent()) {
-                    auto tret = UpdateParentInodeXattr(it, xattr, false);
+                    auto tret = xattrManager_->UpdateParentInodeXattr(
+                        it, xattr, false);
                     if (tret != CURVEFS_ERROR::OK) {
                         LOG(ERROR) << "UpdateParentInodeXattr failed,"
                                    << " inodeId = " << it
@@ -432,7 +435,7 @@ CURVEFS_ERROR FuseClient::MakeNode(fuse_req_t req, fuse_ino_t parent,
         }
         xattr.mutable_xattrinfos()->insert({XATTRFBYTES,
             std::to_string(inodeWrapper->GetLength())});
-        auto tret = UpdateParentInodeXattr(parent, xattr, true);
+        auto tret = xattrManager_->UpdateParentInodeXattr(parent, xattr, true);
         if (tret != CURVEFS_ERROR::OK) {
             LOG(ERROR) << "UpdateParentInodeXattr failed,"
                        << " inodeId = " << parent
@@ -544,7 +547,7 @@ CURVEFS_ERROR FuseClient::RemoveNode(fuse_req_t req, fuse_ino_t parent,
         }
         xattr.mutable_xattrinfos()->insert({XATTRFBYTES,
             std::to_string(inodeWrapper->GetLength())});
-        auto tret = UpdateParentInodeXattr(parent, xattr, false);
+        auto tret = xattrManager_->UpdateParentInodeXattr(parent, xattr, false);
         if (tret != CURVEFS_ERROR::OK) {
             LOG(ERROR) << "UpdateParentInodeXattr failed,"
                        << " inodeId = " << parent
@@ -665,87 +668,10 @@ CURVEFS_ERROR FuseClient::FuseOpRename(fuse_req_t req, fuse_ino_t parent,
     renameOp.UpdateCache();
 
     if (enableSumInDir_) {
-        UpdateParentXattrAfterRename(parent, newparent, newname, &renameOp);
+        xattrManager_->UpdateParentXattrAfterRename(
+            parent, newparent, newname, &renameOp);
     }
 
-    return rc;
-}
-
-CURVEFS_ERROR FuseClient::UpdateParentXattrAfterRename(fuse_ino_t parent,
-    fuse_ino_t newparent, const char *newname,
-    RenameOperator* renameOp) {
-    CURVEFS_ERROR rc = CURVEFS_ERROR::OK;
-    if (parent != newparent) {
-        Dentry dentry;
-        rc = dentryManager_->GetDentry(newparent, newname, &dentry);
-        if (rc != CURVEFS_ERROR::OK) {
-            LOG(ERROR) << "dentryManager_ GetDentry fail, ret = " << rc
-                       << ", parent = " << newparent
-                       << ", name = " << newname;
-            return rc;
-        }
-        uint64_t ino = dentry.inodeid();
-
-        std::shared_ptr<InodeWrapper> inodeWrapper;
-        rc = inodeManager_->GetInode(ino, inodeWrapper);
-        if (rc != CURVEFS_ERROR::OK) {
-            LOG(ERROR) << "inodeManager get inode fail, ret = " << rc
-                       << ", inodeid = " << ino;
-            return rc;
-        }
-        XAttr xattr;
-        xattr.mutable_xattrinfos()->insert({XATTRENTRIES, "1"});
-        if (dentry.type() == FsFileType::TYPE_DIRECTORY) {
-            xattr.mutable_xattrinfos()->insert({XATTRSUBDIRS, "1"});
-        } else {
-            xattr.mutable_xattrinfos()->insert({XATTRFILES, "1"});
-        }
-        xattr.mutable_xattrinfos()->insert({XATTRFBYTES,
-            std::to_string(inodeWrapper->GetLength())});
-
-        // update src parent
-        rc = UpdateParentInodeXattr(parent, xattr, false);
-        if (rc != CURVEFS_ERROR::OK) {
-            LOG(ERROR) << "UpdateParentInodeXattr failed, ret = " << rc
-                       << "parentId = " << parent
-                       << ", xattr = " << xattr.DebugString();
-            return rc;
-        }
-
-        // update dest parent
-        rc = UpdateParentInodeXattr(newparent, xattr, true);
-        if (rc != CURVEFS_ERROR::OK) {
-            LOG(ERROR) << "UpdateParentInodeXattr failed, ret = " << rc
-                       << "parentId = " << newparent
-                       << ", xattr = " << xattr.DebugString();
-            return rc;
-        }
-    }
-
-    // if rename dest exist and is file or empty dir, it will be overwirte
-    uint64_t oldInode;
-    int64_t oldInodeSize;
-    FsFileType oldInodeType;
-    renameOp->GetOldInode(&oldInode, &oldInodeSize, &oldInodeType);
-    if (oldInode != 0 && oldInodeSize >= 0) {
-        XAttr xattr;
-        xattr.mutable_xattrinfos()->insert({XATTRENTRIES, "1"});
-        if (oldInodeType == FsFileType::TYPE_DIRECTORY) {
-            xattr.mutable_xattrinfos()->insert({XATTRSUBDIRS, "1"});
-        } else {
-            xattr.mutable_xattrinfos()->insert({XATTRFILES, "1"});
-        }
-        xattr.mutable_xattrinfos()->insert({XATTRFBYTES,
-            std::to_string(oldInodeSize)});
-
-        rc = UpdateParentInodeXattr(newparent, xattr, false);
-        if (rc != CURVEFS_ERROR::OK) {
-            LOG(ERROR) << "UpdateParentInodeXattr failed, ret = " << rc
-                       << "parentId = " << newparent
-                       << ", xattr = " << xattr.DebugString();
-            return rc;
-        }
-    }
     return rc;
 }
 
@@ -838,7 +764,8 @@ CURVEFS_ERROR FuseClient::FuseOpSetAttr(fuse_req_t req, fuse_ino_t ino,
                 std::to_string(std::abs(changeSize))});
             bool direction = changeSize > 0;
             for (const auto &it : inode->parent()) {
-                auto tret = UpdateParentInodeXattr(it, xattr, direction);
+                auto tret = xattrManager_->UpdateParentInodeXattr(
+                    it, xattr, direction);
                 if (tret != CURVEFS_ERROR::OK) {
                     LOG(ERROR) << "UpdateParentInodeXattr failed,"
                                << " inodeId = " << it
@@ -870,248 +797,6 @@ bool IsOneLayer(const char *name) {
     return false;
 }
 
-bool AddUllStringToFirst(std::string *first, const std::string &second,
-    bool direction) {
-    uint64_t firstNum = 0;
-    uint64_t secondNum = 0;
-    if (StringToUll(*first, &firstNum) && StringToUll(second, &secondNum)) {
-        if (direction) {
-            *first = std::to_string(firstNum + secondNum);
-        } else {
-            if (firstNum < secondNum) {
-                *first = std::to_string(0);
-                LOG(ERROR) << "AddUllStringToFirst failed when minus, first = "
-                           << firstNum << ", second = " << secondNum;
-                return false;
-            } else {
-                *first = std::to_string(firstNum - secondNum);
-            }
-        }
-    } else {
-        LOG(ERROR) << "StringToUll failed, first = " << *first
-                   << ", second = " << second;
-        return false;
-    }
-    return true;
-}
-
-CURVEFS_ERROR FuseClient::CalOneLayerSumInfo(Inode *inode) {
-    std::stack<uint64_t> iStack;
-    // use set can deal with hard link
-    std::set<uint64_t> inodeIds;
-    std::list<InodeAttr> attrs;
-    auto limit = option_.listDentryLimit;
-    auto ino = inode->inodeid();
-
-    std::list<Dentry> dentryList;
-    auto ret = dentryManager_->ListDentry(ino, &dentryList, limit, false);
-    if (CURVEFS_ERROR::OK != ret) {
-        LOG(ERROR) << "ListDentry failed, inodeId = " << ino
-                    << ", limit = " << limit << ", onlyDir = false";
-        return ret;
-    }
-    for (const auto &it : dentryList) {
-        inodeIds.emplace(it.inodeid());
-    }
-    ret = inodeManager_->BatchGetInodeAttr(&inodeIds, &attrs);
-    if (ret == CURVEFS_ERROR::OK) {
-        uint64_t files = 0;
-        uint64_t subdirs = 0;
-        uint64_t entries = 0;
-        uint64_t fbytes = 0;
-        for (const auto &it : attrs) {
-            if (it.type() == FsFileType::TYPE_DIRECTORY) {
-                subdirs++;
-            } else {
-                files++;
-            }
-            entries++;
-            fbytes += it.length();
-        }
-        if (!(AddUllStringToFirst(
-                &(inode->mutable_xattr()->find(XATTRFILES)->second),
-                std::to_string(files), true) &&
-            AddUllStringToFirst(
-                &(inode->mutable_xattr()->find(XATTRSUBDIRS)->second),
-                std::to_string(subdirs), true) &&
-            AddUllStringToFirst(
-                &(inode->mutable_xattr()->find(XATTRENTRIES)->second),
-                std::to_string(entries), true) &&
-            AddUllStringToFirst(
-                &(inode->mutable_xattr()->find(XATTRFBYTES)->second),
-                std::to_string(fbytes + inode->length()), true))) {
-            ret = CURVEFS_ERROR::INTERNAL;
-        }
-    }
-    return ret;
-}
-
-CURVEFS_ERROR FuseClient::CalAllLayerSumInfo(Inode *inode) {
-    std::stack<uint64_t> iStack;
-    // record hard link, <inodeId, need2minus>
-    std::unordered_map<uint64_t, uint64_t> hardLinkMap;
-    std::set<uint64_t> inodeIds;
-    std::list<InodeAttr> attrs;
-    auto ino = inode->inodeid();
-    auto limit = option_.listDentryLimit;
-    // the attrsLimit is protect attrs and inodeIds at huge files,
-    // also can use a sigle config item, but not much sense.
-    auto attrsLimit = 10 * option_.excutorOpt.batchLimit;
-
-    iStack.emplace(ino);
-    uint64_t rfiles = 0;
-    uint64_t rsubdirs = 0;
-    uint64_t rentries = 0;
-    uint64_t rfbytes = 0;
-    while (!iStack.empty()) {
-        ino = iStack.top();
-        iStack.pop();
-        std::list<Dentry> dentryList;
-        auto ret = dentryManager_->ListDentry(ino, &dentryList, limit, false);
-        if (CURVEFS_ERROR::OK != ret) {
-            LOG(ERROR) << "ListDentry failed, inodeId = " << ino
-                       << ", limit = " << limit << ", onlyDir = false";
-            return ret;
-        }
-        for (const auto &it : dentryList) {
-            if (it.type() == FsFileType::TYPE_DIRECTORY) {
-                iStack.emplace(it.inodeid());
-            }
-            inodeIds.emplace(it.inodeid());
-        }
-        // check size
-        if (inodeIds.size() >= attrsLimit || iStack.empty()) {
-            ret = inodeManager_->BatchGetInodeAttr(&inodeIds, &attrs);
-            if (ret == CURVEFS_ERROR::OK) {
-                for (const auto &it : attrs) {
-                    if (it.type() == FsFileType::TYPE_DIRECTORY) {
-                        rsubdirs++;
-                    } else {
-                        rfiles++;
-                    }
-                    rentries++;
-                    rfbytes += it.length();
-                    // record hardlink
-                    if (it.type() != FsFileType::TYPE_DIRECTORY &&
-                        it.nlink() > 1) {
-                        if (hardLinkMap.count(it.inodeid())) {
-                            hardLinkMap[it.inodeid()] += it.length();
-                        } else {
-                            hardLinkMap.emplace(it.inodeid(), 0);
-                        }
-                    }
-                }
-                inodeIds.clear();
-                attrs.clear();
-            } else {
-                return ret;
-            }
-        }
-    }
-
-    // deal with hardlink
-    for (const auto &it : hardLinkMap) {
-        rfbytes -= it.second;
-    }
-
-    inode->mutable_xattr()->insert({XATTRRFILES,
-        std::to_string(rfiles)});
-    inode->mutable_xattr()->insert({XATTRRSUBDIRS,
-        std::to_string(rsubdirs)});
-    inode->mutable_xattr()->insert({XATTRRENTRIES,
-        std::to_string(rentries)});
-    inode->mutable_xattr()->insert({XATTRRFBYTES,
-        std::to_string(rfbytes + inode->length())});
-    return CURVEFS_ERROR::OK;
-}
-
-CURVEFS_ERROR FuseClient::FastCalAllLayerSumInfo(Inode *inode) {
-    std::stack<uint64_t> iStack;
-    std::set<uint64_t> inodeIds;
-    std::list<XAttr> xattrs;
-    auto ino = inode->inodeid();
-    auto limit = option_.listDentryLimit;
-    // the xattrsLimit is protect xattrs and inodeIds at huge files,
-    // also can use a sigle config item, but not much sense.
-    auto xattrsLimit = 10 * option_.excutorOpt.batchLimit;
-
-    iStack.emplace(ino);
-    if (!AddUllStringToFirst(
-            &(inode->mutable_xattr()->find(XATTRFBYTES)->second),
-            std::to_string(inode->length()),
-            true)) {
-        return CURVEFS_ERROR::INTERNAL;
-    }
-    inode->mutable_xattr()->insert({XATTRRFILES,
-        inode->mutable_xattr()->find(XATTRFILES)->second});
-    inode->mutable_xattr()->insert({XATTRRSUBDIRS,
-        inode->mutable_xattr()->find(XATTRSUBDIRS)->second});
-    inode->mutable_xattr()->insert({XATTRRENTRIES,
-        inode->mutable_xattr()->find(XATTRENTRIES)->second});
-    inode->mutable_xattr()->insert({XATTRRFBYTES,
-        inode->mutable_xattr()->find(XATTRFBYTES)->second});
-    while (!iStack.empty()) {
-        ino = iStack.top();
-        iStack.pop();
-        std::list<Dentry> dentryList;
-        auto ret = dentryManager_->ListDentry(ino, &dentryList, limit, true);
-        if (CURVEFS_ERROR::OK != ret) {
-            LOG(ERROR) << "ListDentry failed, inodeId = " << ino
-                       << ", limit = " << limit << ", onlyDir = true";
-            return ret;
-        }
-        for (const auto &it : dentryList) {
-            iStack.emplace(it.inodeid());
-            inodeIds.emplace(it.inodeid());
-        }
-        // check size
-        if (inodeIds.size() >= xattrsLimit || iStack.empty()) {
-            ret = inodeManager_->BatchGetXAttr(&inodeIds, &xattrs);
-            if (ret == CURVEFS_ERROR::OK) {
-                for (const auto &it : xattrs) {
-                    if (it.xattrinfos().count(XATTRFILES)) {
-                        if (!AddUllStringToFirst(
-                            &(inode->mutable_xattr()->find(XATTRRFILES)->second),    // NOLINT
-                            it.xattrinfos().find(XATTRFILES)->second,
-                            true)) {
-                            return CURVEFS_ERROR::INTERNAL;
-                        }
-                    }
-                    if (it.xattrinfos().count(XATTRSUBDIRS)) {
-                        if (!AddUllStringToFirst(
-                            &(inode->mutable_xattr()->find(XATTRRSUBDIRS)->second),    // NOLINT
-                            it.xattrinfos().find(XATTRSUBDIRS)->second,
-                            true)) {
-                            return CURVEFS_ERROR::INTERNAL;
-                        }
-                    }
-                    if (it.xattrinfos().count(XATTRENTRIES)) {
-                        if (!AddUllStringToFirst(
-                            &(inode->mutable_xattr()->find(XATTRRENTRIES)->second),    // NOLINT
-                            it.xattrinfos().find(XATTRENTRIES)->second,
-                            true)) {
-                            return CURVEFS_ERROR::INTERNAL;
-                        }
-                    }
-                    if (it.xattrinfos().count(XATTRFBYTES)) {
-                        if (!AddUllStringToFirst(
-                            &(inode->mutable_xattr()->find(XATTRRFBYTES)->second),    // NOLINT
-                            it.xattrinfos().find(XATTRFBYTES)->second,
-                            true)) {
-                            return CURVEFS_ERROR::INTERNAL;
-                        }
-                    }
-                }
-                inodeIds.clear();
-                xattrs.clear();
-            } else {
-                return ret;
-            }
-        }
-    }
-    return CURVEFS_ERROR::OK;
-}
-
 CURVEFS_ERROR FuseClient::FuseOpGetXattr(fuse_req_t req, fuse_ino_t ino,
                                          const char* name, void* value,
                                          size_t size) {
@@ -1136,20 +821,15 @@ CURVEFS_ERROR FuseClient::FuseOpGetXattr(fuse_req_t req, fuse_ino_t ino,
         // need recursive computation all files
         if (!enableSumInDir_) {
             if (IsOneLayer(name)) {
-                ret = CalOneLayerSumInfo(&inode);
+                ret = xattrManager_->CalOneLayerSumInfo(&inode);
             } else {
-                ret = CalAllLayerSumInfo(&inode);
+                ret = xattrManager_->CalAllLayerSumInfo(&inode);
             }
         } else {
             if (IsOneLayer(name)) {
-                if (!AddUllStringToFirst(
-                    &(inode.mutable_xattr()->find(XATTRFBYTES)->second),
-                    std::to_string(inode.length()),
-                    true)) {
-                    ret = CURVEFS_ERROR::INTERNAL;
-                }
+                ret = xattrManager_->FastCalOneLayerSumInfo(&inode);
             } else {
-                ret = FastCalAllLayerSumInfo(&inode);
+                ret = xattrManager_->FastCalAllLayerSumInfo(&inode);
             }
         }
 
@@ -1299,7 +979,7 @@ CURVEFS_ERROR FuseClient::FuseOpSymlink(fuse_req_t req, const char *link,
         xattr.mutable_xattrinfos()->insert({XATTRFILES, "1"});
         xattr.mutable_xattrinfos()->insert({XATTRFBYTES,
             std::to_string(inodeWrapper->GetLength())});
-        auto tret = UpdateParentInodeXattr(parent, xattr, true);
+        auto tret = xattrManager_->UpdateParentInodeXattr(parent, xattr, true);
         if (tret != CURVEFS_ERROR::OK) {
             LOG(ERROR) << "UpdateParentInodeXattr failed,"
                        << " inodeId = " << parent
@@ -1374,7 +1054,8 @@ CURVEFS_ERROR FuseClient::FuseOpLink(fuse_req_t req, fuse_ino_t ino,
         xattr.mutable_xattrinfos()->insert({XATTRFILES, "1"});
         xattr.mutable_xattrinfos()->insert({XATTRFBYTES,
             std::to_string(inodeWrapper->GetLength())});
-        auto tret = UpdateParentInodeXattr(newparent, xattr, true);
+        auto tret = xattrManager_->UpdateParentInodeXattr(
+            newparent, xattr, true);
         if (tret != CURVEFS_ERROR::OK) {
             LOG(ERROR) << "UpdateParentInodeXattr failed,"
                        << " inodeId = " << newparent
@@ -1433,34 +1114,6 @@ void FuseClient::FlushInodeAll() { inodeManager_->FlushAll(); }
 void FuseClient::FlushAll() {
     FlushData();
     FlushInodeAll();
-}
-
-CURVEFS_ERROR FuseClient::UpdateParentInodeXattr(uint64_t parentId,
-    const XAttr &xattr, bool direction) {
-    VLOG(9) << "UpdateParentInodeXattr inodeId = " << parentId
-            << ", direction = " << direction
-            << ", \nxattr = " << xattr.DebugString();
-    std::shared_ptr<InodeWrapper> pInodeWrapper;
-    CURVEFS_ERROR ret = inodeManager_->GetInode(parentId, pInodeWrapper);
-    if (ret != CURVEFS_ERROR::OK) {
-        LOG(ERROR) << "UpdateParentInodeXattr get parent inode fail, ret = "
-                << ret << ", inodeid = " << parentId;
-        return ret;
-    }
-
-    ::curve::common::UniqueLock lgGuard = pInodeWrapper->GetUniqueLock();
-    auto inode = pInodeWrapper->GetMutableInodeUnlocked();
-    for (const auto &it : xattr.xattrinfos()) {
-        auto iter = inode->mutable_xattr()->find(it.first);
-        if (iter != inode->mutable_xattr()->end()) {
-            if (!AddUllStringToFirst(&(iter->second), it.second,
-                                    direction)) {
-                return CURVEFS_ERROR::INTERNAL;
-            }
-        }
-    }
-    inodeManager_->ShipToFlush(pInodeWrapper);
-    return CURVEFS_ERROR::OK;
 }
 
 }  // namespace client

--- a/curvefs/src/client/fuse_client.h
+++ b/curvefs/src/client/fuse_client.h
@@ -48,6 +48,7 @@
 #include "curvefs/src/client/common/common.h"
 #include "curvefs/src/client/client_operator.h"
 #include "curvefs/src/client/lease/lease_excutor.h"
+#include "curvefs/src/client/xattr_manager.h"
 
 #define DirectIOAlignment 512
 
@@ -269,25 +270,12 @@ class FuseClient {
         return 0;
     }
 
-    CURVEFS_ERROR UpdateParentInodeXattr(uint64_t parentId,
-        const XAttr &xattr, bool direction);
-
  private:
     virtual CURVEFS_ERROR Truncate(Inode* inode, uint64_t length) = 0;
 
     virtual void FlushInodeLoop();
 
     virtual void FlushData() = 0;
-
-    CURVEFS_ERROR CalOneLayerSumInfo(Inode *inode);
-
-    CURVEFS_ERROR CalAllLayerSumInfo(Inode *inode);
-
-    CURVEFS_ERROR FastCalAllLayerSumInfo(Inode *inode);
-
-    CURVEFS_ERROR UpdateParentXattrAfterRename(fuse_ino_t parent,
-        fuse_ino_t newparent, const char *newname,
-        RenameOperator* renameOp);
 
  protected:
     // mds client
@@ -301,6 +289,9 @@ class FuseClient {
 
     // dentry cache manager
     std::shared_ptr<DentryCacheManager> dentryManager_;
+
+    // xattr manager
+    std::shared_ptr<XattrManager> xattrManager_;
 
     std::shared_ptr<LeaseExecutor> leaseExecutor_;
 

--- a/curvefs/src/client/fuse_s3_client.cpp
+++ b/curvefs/src/client/fuse_s3_client.cpp
@@ -152,7 +152,7 @@ CURVEFS_ERROR FuseS3Client::FuseOpWrite(fuse_req_t req, fuse_ino_t ino,
         xattr.mutable_xattrinfos()->insert({XATTRFBYTES,
             std::to_string(changeSize)});
         for (const auto &it : inode->parent()) {
-            auto tret = UpdateParentInodeXattr(it, xattr, true);
+            auto tret = xattrManager_->UpdateParentInodeXattr(it, xattr, true);
             if (tret != CURVEFS_ERROR::OK) {
                 LOG(ERROR) << "UpdateParentInodeXattr failed,"
                            << " inodeId = " << it

--- a/curvefs/src/client/inode_cache_manager.cpp
+++ b/curvefs/src/client/inode_cache_manager.cpp
@@ -115,6 +115,10 @@ CURVEFS_ERROR InodeCacheManagerImpl::BatchGetInodeAttr(
         }
     }
 
+    if (inodeIds->empty()) {
+        return CURVEFS_ERROR::OK;
+    }
+
     MetaStatusCode ret = metaClient_->BatchGetInodeAttr(fsId_, inodeIds, attr);
     if (MetaStatusCode::OK != ret) {
         LOG(ERROR) << "metaClient BatchGetInodeAttr failed, MetaStatusCode = "
@@ -140,6 +144,10 @@ CURVEFS_ERROR InodeCacheManagerImpl::BatchGetXAttr(
         } else {
             ++iter;
         }
+    }
+
+    if (inodeIds->empty()) {
+        return CURVEFS_ERROR::OK;
     }
 
     MetaStatusCode ret = metaClient_->BatchGetXAttr(fsId_, inodeIds, xattr);

--- a/curvefs/src/client/xattr_manager.cpp
+++ b/curvefs/src/client/xattr_manager.cpp
@@ -1,0 +1,539 @@
+/*
+ *  Copyright (c) 2022 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+
+/*
+ * Project: curve
+ * Created Date: Thur May 12 2022
+ * Author: wanghai01
+ */
+
+#include "curvefs/src/client/xattr_manager.h"
+#include "curvefs/src/client/common/common.h"
+#include "src/common/string_util.h"
+
+namespace curvefs {
+namespace client {
+
+using ::curve::common::StringToUll;
+using ::curve::common::Thread;
+
+// if direction is true means '+', false means '-'
+bool AddUllStringToFirst(std::string *first, uint64_t second, bool direction) {
+    uint64_t firstNum = 0;
+    uint64_t secondNum = second;
+    if (StringToUll(*first, &firstNum)) {
+        if (direction) {
+            *first = std::to_string(firstNum + secondNum);
+        } else {
+            if (firstNum < secondNum) {
+                *first = std::to_string(0);
+                LOG(ERROR) << "AddUllStringToFirst failed when minus, first = "
+                           << firstNum << ", second = " << secondNum;
+                return false;
+            }
+            *first = std::to_string(firstNum - secondNum);
+        }
+    } else {
+        LOG(ERROR) << "StringToUll failed, first = " << *first
+                   << ", second = " << second;
+        return false;
+    }
+    return true;
+}
+
+bool AddUllStringToFirst(uint64_t *first, const std::string &second) {
+    uint64_t secondNum = 0;
+    if (StringToUll(second, &secondNum)) {
+        *first += secondNum;
+        return true;
+    }
+
+    LOG(ERROR) << "StringToUll failed, second = " << second;
+    return false;
+}
+
+CURVEFS_ERROR XattrManager::CalOneLayerSumInfo(Inode *inode) {
+    std::stack<uint64_t> iStack;
+    // use set can deal with hard link
+    std::set<uint64_t> inodeIds;
+    std::list<InodeAttr> attrs;
+    auto ino = inode->inodeid();
+
+    std::list<Dentry> dentryList;
+    auto ret = dentryManager_->ListDentry(ino, &dentryList,
+                                          listDentryLimit_, false);
+    if (CURVEFS_ERROR::OK != ret) {
+        LOG(ERROR) << "ListDentry failed, inodeId = " << ino
+                   << ", limit = " << listDentryLimit_ << ", onlyDir = false";
+        return ret;
+    }
+
+    for (const auto &it : dentryList) {
+        inodeIds.emplace(it.inodeid());
+    }
+
+    ret = inodeManager_->BatchGetInodeAttr(&inodeIds, &attrs);
+    if (ret == CURVEFS_ERROR::OK) {
+        SummaryInfo summaryInfo;
+        for (const auto &it : attrs) {
+            if (it.type() == FsFileType::TYPE_DIRECTORY) {
+                summaryInfo.subdirs++;
+            } else {
+                summaryInfo.files++;
+            }
+            summaryInfo.entries++;
+            summaryInfo.fbytes += it.length();
+        }
+        if (!(AddUllStringToFirst(
+                &(inode->mutable_xattr()->find(XATTRFILES)->second),
+                summaryInfo.files, true) &&
+            AddUllStringToFirst(
+                &(inode->mutable_xattr()->find(XATTRSUBDIRS)->second),
+                summaryInfo.subdirs, true) &&
+            AddUllStringToFirst(
+                &(inode->mutable_xattr()->find(XATTRENTRIES)->second),
+                summaryInfo.entries, true) &&
+            AddUllStringToFirst(
+                &(inode->mutable_xattr()->find(XATTRFBYTES)->second),
+                summaryInfo.fbytes + inode->length(), true))) {
+            ret = CURVEFS_ERROR::INTERNAL;
+        }
+    }
+    return ret;
+}
+
+CURVEFS_ERROR XattrManager::FastCalOneLayerSumInfo(Inode *inode) {
+    if (!AddUllStringToFirst(
+        &(inode->mutable_xattr()->find(XATTRFBYTES)->second),
+        inode->length(), true)) {
+        return CURVEFS_ERROR::INTERNAL;
+    }
+    return CURVEFS_ERROR::OK;
+}
+
+bool XattrManager::ConcurrentListDentry(
+    std::list<Dentry> *dentrys,
+    std::stack<uint64_t> *iStack,
+    std::mutex *stackMutex,
+    bool dirOnly,
+    Atomic<uint32_t> *inflightNum,
+    Atomic<bool> *ret) {
+    InterruptibleSleeper sleeper;
+    uint64_t sleepIntervalMs = 5;
+    while (1) {
+        uint64_t ino = 0;
+        stackMutex->lock();
+        // 1. fuse client stop
+        // 2. if any of request failed, the upper request failed.
+        // 3. iStack is empty && inflightNum = 0 means finished.
+        if (isStop_.load() || !ret->load() ||
+            (iStack->empty() && inflightNum->load() == 0)) {
+            stackMutex->unlock();
+            return false;
+        }
+
+        if (!iStack->empty()) {
+            ino = iStack->top();
+            iStack->pop();
+            inflightNum->fetch_add(1);
+            stackMutex->unlock();
+        } else {
+            stackMutex->unlock();
+            sleeper.wait_for(std::chrono::milliseconds(sleepIntervalMs));
+            continue;
+        }
+
+        auto tret = dentryManager_->ListDentry(ino, dentrys,
+                                              listDentryLimit_, dirOnly);
+        if (CURVEFS_ERROR::OK != tret) {
+            LOG(ERROR) << "ListDentry failed, inodeId = " << ino
+                       << ", limit = " << listDentryLimit_ << ", onlyDir = "
+                       << dirOnly << ", ret = " << tret;
+            ret->store(false);
+            inflightNum->fetch_sub(1);
+            return false;
+        }
+        return true;
+    }
+}
+
+void XattrManager::ConcurrentGetInodeAttr(
+    std::stack<uint64_t> *iStack,
+    std::mutex *stackMutex,
+    std::unordered_map<uint64_t, uint64_t> *hardLinkMap,
+    std::mutex *mapMutex,
+    SummaryInfo *summaryInfo,
+    std::mutex *valueMutex,
+    Atomic<uint32_t> *inflightNum,
+    Atomic<bool> *ret) {
+    while (1) {
+        std::list<Dentry> dentryList;
+        std::set<uint64_t> inodeIds;
+        std::list<InodeAttr> attrs;
+        auto tret = ConcurrentListDentry(&dentryList, iStack, stackMutex,
+                                         false, inflightNum, ret);
+        if (!tret) {
+            return;
+        }
+        {
+            std::lock_guard<std::mutex> guard(*stackMutex);
+            for (const auto &it : dentryList) {
+                if (it.type() == FsFileType::TYPE_DIRECTORY) {
+                    iStack->emplace(it.inodeid());
+                }
+                inodeIds.emplace(it.inodeid());
+            }
+            inflightNum->fetch_sub(1);
+        }
+        if (!inodeIds.empty()) {
+            auto tret = inodeManager_->BatchGetInodeAttr(&inodeIds, &attrs);
+            if (tret == CURVEFS_ERROR::OK) {
+                std::lock_guard<std::mutex> guard(*valueMutex);
+                for (const auto &it : attrs) {
+                    if (it.type() == FsFileType::TYPE_DIRECTORY) {
+                        summaryInfo->subdirs++;
+                    } else {
+                        summaryInfo->files++;
+                    }
+                    summaryInfo->entries++;
+                    summaryInfo->fbytes += it.length();
+                    // record hardlink
+                    if (it.type() != FsFileType::TYPE_DIRECTORY &&
+                        it.nlink() > 1) {
+                        std::lock_guard<std::mutex> guard(*mapMutex);
+                        auto iter = hardLinkMap->find(it.inodeid());
+                        if (iter != hardLinkMap->end()) {
+                            iter->second += it.length();
+                        } else {
+                            hardLinkMap->emplace(it.inodeid(), 0);
+                        }
+                    }
+                }
+            } else {
+                ret->store(false);
+                return;
+            }
+        }
+    }
+}
+
+CURVEFS_ERROR XattrManager::CalAllLayerSumInfo(Inode *inode) {
+    std::stack<uint64_t> iStack;
+    std::mutex stackMutex;
+
+    // record hard link, <inodeId, need2minus>
+    std::unordered_map<uint64_t, uint64_t> hardLinkMap;
+    std::mutex mapMutex;
+
+    SummaryInfo summaryInfo;
+    std::mutex valueMutex;
+
+    auto ino = inode->inodeid();
+    iStack.emplace(ino);
+    std::vector<Thread> threadpool;
+    Atomic<uint32_t> inflightNum(0);
+    Atomic<bool> ret(true);
+
+    for (auto i = listDentryThreads_; i > 0; i--) {
+        try {
+            threadpool.emplace_back(Thread(
+                &XattrManager::ConcurrentGetInodeAttr,
+                this, &iStack, &stackMutex, &hardLinkMap, &mapMutex,
+                &summaryInfo, &valueMutex, &inflightNum, &ret));
+        } catch (const std::exception& e) {
+            LOG(WARNING) << "CalAllLayerSumInfo create thread failed,"
+                         << " err: " << e.what();
+        }
+    }
+
+    if (threadpool.empty()) {
+        return CURVEFS_ERROR::INTERNAL;
+    }
+
+    for (auto &thread : threadpool) {
+        thread.join();
+    }
+
+    if (!ret.load()) {
+        return CURVEFS_ERROR::INTERNAL;
+    }
+
+    // deal with hardlink
+    for (const auto &it : hardLinkMap) {
+        summaryInfo.fbytes -= it.second;
+    }
+
+    inode->mutable_xattr()->insert({XATTRRFILES,
+        std::to_string(summaryInfo.files)});
+    inode->mutable_xattr()->insert({XATTRRSUBDIRS,
+        std::to_string(summaryInfo.subdirs)});
+    inode->mutable_xattr()->insert({XATTRRENTRIES,
+        std::to_string(summaryInfo.entries)});
+    inode->mutable_xattr()->insert({XATTRRFBYTES,
+        std::to_string(summaryInfo.fbytes + inode->length())});
+    return CURVEFS_ERROR::OK;
+}
+
+void XattrManager::ConcurrentGetInodeXattr(
+    std::stack<uint64_t> *iStack,
+    std::mutex *stackMutex,
+    Inode *inode,
+    std::mutex *inodeMutex,
+    Atomic<uint32_t> *inflightNum,
+    Atomic<bool> *ret) {
+    while (1) {
+        std::list<Dentry> dentryList;
+        std::set<uint64_t> inodeIds;
+        std::list<XAttr> xattrs;
+        auto tret = ConcurrentListDentry(&dentryList, iStack, stackMutex,
+                                         true, inflightNum, ret);
+        if (!tret) {
+            return;
+        }
+        {
+            std::lock_guard<std::mutex> guard(*stackMutex);
+            for (const auto &it : dentryList) {
+                iStack->emplace(it.inodeid());
+                inodeIds.emplace(it.inodeid());
+            }
+            inflightNum->fetch_sub(1);
+        }
+        if (!inodeIds.empty()) {
+            auto tret = inodeManager_->BatchGetXAttr(&inodeIds, &xattrs);
+            if (tret == CURVEFS_ERROR::OK) {
+                SummaryInfo summaryInfo;
+                for (const auto &it : xattrs) {
+                    if (it.xattrinfos().count(XATTRFILES)) {
+                        if (!AddUllStringToFirst(&summaryInfo.files,
+                            it.xattrinfos().find(XATTRFILES)->second)) {
+                            ret->store(false);
+                            return;
+                        }
+                    }
+                    if (it.xattrinfos().count(XATTRSUBDIRS)) {
+                        if (!AddUllStringToFirst(&summaryInfo.subdirs,
+                            it.xattrinfos().find(XATTRSUBDIRS)->second)) {
+                            ret->store(false);
+                            return;
+                        }
+                    }
+                    if (it.xattrinfos().count(XATTRENTRIES)) {
+                        if (!AddUllStringToFirst(&summaryInfo.entries,
+                            it.xattrinfos().find(XATTRENTRIES)->second)) {
+                            ret->store(false);
+                            return;
+                        }
+                    }
+                    if (it.xattrinfos().count(XATTRFBYTES)) {
+                        if (!AddUllStringToFirst(&summaryInfo.fbytes,
+                            it.xattrinfos().find(XATTRFBYTES)->second)) {
+                            ret->store(false);
+                            return;
+                        }
+                    }
+                }
+                // record summary info to target inode
+                std::lock_guard<std::mutex> guard(*inodeMutex);
+                if (!(AddUllStringToFirst(
+                    &(inode->mutable_xattr()->find(XATTRRFILES)->second),
+                    summaryInfo.files, true) &&
+                    AddUllStringToFirst(
+                    &(inode->mutable_xattr()->find(XATTRRSUBDIRS)->second),
+                    summaryInfo.subdirs, true) &&
+                    AddUllStringToFirst(
+                    &(inode->mutable_xattr()->find(XATTRRENTRIES)->second),
+                    summaryInfo.entries, true) &&
+                    AddUllStringToFirst(
+                    &(inode->mutable_xattr()->find(XATTRRFBYTES)->second),
+                    summaryInfo.fbytes, true))) {
+                    ret->store(false);
+                    return;
+                }
+            } else {
+                ret->store(false);
+                return;
+            }
+        }
+    }
+}
+
+CURVEFS_ERROR XattrManager::FastCalAllLayerSumInfo(Inode *inode) {
+    std::stack<uint64_t> iStack;
+    std::mutex stackMutex;
+    std::mutex inodeMutex;
+
+    auto ino = inode->inodeid();
+    iStack.emplace(ino);
+    // add the size of itself first
+    if (!AddUllStringToFirst(
+            &(inode->mutable_xattr()->find(XATTRFBYTES)->second),
+            inode->length(), true)) {
+        return CURVEFS_ERROR::INTERNAL;
+    }
+
+    // add first layer summary to all layer summary info
+    inode->mutable_xattr()->insert({XATTRRFILES,
+        inode->xattr().find(XATTRFILES)->second});
+    inode->mutable_xattr()->insert({XATTRRSUBDIRS,
+        inode->xattr().find(XATTRSUBDIRS)->second});
+    inode->mutable_xattr()->insert({XATTRRENTRIES,
+        inode->xattr().find(XATTRENTRIES)->second});
+    inode->mutable_xattr()->insert({XATTRRFBYTES,
+        inode->xattr().find(XATTRFBYTES)->second});
+
+    std::vector<Thread> threadpool;
+    Atomic<uint32_t> inflightNum(0);
+    Atomic<bool> ret(true);
+    for (auto i = listDentryThreads_; i > 0; i--) {
+        try {
+            threadpool.emplace_back(Thread(
+                &XattrManager::ConcurrentGetInodeXattr,
+                this, &iStack, &stackMutex, inode,
+                &inodeMutex, &inflightNum, &ret));
+        } catch (const std::exception& e) {
+            LOG(WARNING) << "FastCalAllLayerSumInfo create thread failed,"
+                         << " err: " << e.what();
+        }
+    }
+
+    if (threadpool.empty()) {
+        return CURVEFS_ERROR::INTERNAL;
+    }
+
+    for (auto &thread : threadpool) {
+        thread.join();
+    }
+
+    if (!ret.load()) {
+        return CURVEFS_ERROR::INTERNAL;
+    }
+
+    return CURVEFS_ERROR::OK;
+}
+
+CURVEFS_ERROR XattrManager::UpdateParentInodeXattr(uint64_t parentId,
+    const XAttr &xattr, bool direction) {
+    VLOG(9) << "UpdateParentInodeXattr inodeId = " << parentId
+            << ", direction = " << direction
+            << ", \nxattr = " << xattr.DebugString();
+    std::shared_ptr<InodeWrapper> pInodeWrapper;
+    CURVEFS_ERROR ret = inodeManager_->GetInode(parentId, pInodeWrapper);
+    if (ret != CURVEFS_ERROR::OK) {
+        LOG(ERROR) << "UpdateParentInodeXattr get parent inode fail, ret = "
+                   << ret << ", inodeid = " << parentId;
+        return ret;
+    }
+
+    ::curve::common::UniqueLock lgGuard = pInodeWrapper->GetUniqueLock();
+    auto inode = pInodeWrapper->GetMutableInodeUnlocked();
+    for (const auto &it : xattr.xattrinfos()) {
+        auto iter = inode->mutable_xattr()->find(it.first);
+        if (iter != inode->mutable_xattr()->end()) {
+            uint64_t dat = 0;
+            if (StringToUll(it.second, &dat)) {
+                if (!AddUllStringToFirst(&(iter->second), dat, direction)) {
+                    return CURVEFS_ERROR::INTERNAL;
+                }
+            } else {
+                LOG(ERROR) << "StringToUll failed, first = " << it.second;
+                return CURVEFS_ERROR::INTERNAL;
+            }
+        }
+    }
+    inodeManager_->ShipToFlush(pInodeWrapper);
+    return CURVEFS_ERROR::OK;
+}
+
+CURVEFS_ERROR XattrManager::UpdateParentXattrAfterRename(uint64_t parent,
+    uint64_t newparent, const char *newname, RenameOperator* renameOp) {
+    CURVEFS_ERROR rc = CURVEFS_ERROR::OK;
+    if (parent != newparent) {
+        Dentry dentry;
+        rc = dentryManager_->GetDentry(newparent, newname, &dentry);
+        if (rc != CURVEFS_ERROR::OK) {
+            LOG(ERROR) << "dentryManager_ GetDentry fail, ret = " << rc
+                       << ", parent = " << newparent
+                       << ", name = " << newname;
+            return rc;
+        }
+        uint64_t ino = dentry.inodeid();
+
+        std::shared_ptr<InodeWrapper> inodeWrapper;
+        rc = inodeManager_->GetInode(ino, inodeWrapper);
+        if (rc != CURVEFS_ERROR::OK) {
+            LOG(ERROR) << "inodeManager get inode fail, ret = " << rc
+                       << ", inodeid = " << ino;
+            return rc;
+        }
+        XAttr xattr;
+        xattr.mutable_xattrinfos()->insert({XATTRENTRIES, "1"});
+        if (dentry.type() == FsFileType::TYPE_DIRECTORY) {
+            xattr.mutable_xattrinfos()->insert({XATTRSUBDIRS, "1"});
+        } else {
+            xattr.mutable_xattrinfos()->insert({XATTRFILES, "1"});
+        }
+        xattr.mutable_xattrinfos()->insert({XATTRFBYTES,
+            std::to_string(inodeWrapper->GetLength())});
+
+        // update src parent
+        rc = UpdateParentInodeXattr(parent, xattr, false);
+        if (rc != CURVEFS_ERROR::OK) {
+            LOG(ERROR) << "UpdateParentInodeXattr failed, ret = " << rc
+                       << "parentId = " << parent
+                       << ", xattr = " << xattr.DebugString();
+            return rc;
+        }
+
+        // update dest parent
+        rc = UpdateParentInodeXattr(newparent, xattr, true);
+        if (rc != CURVEFS_ERROR::OK) {
+            LOG(ERROR) << "UpdateParentInodeXattr failed, ret = " << rc
+                       << "parentId = " << newparent
+                       << ", xattr = " << xattr.DebugString();
+            return rc;
+        }
+    }
+
+    // if rename dest exist and is file or empty dir, it will be overwirte
+    uint64_t oldInode;
+    int64_t oldInodeSize;
+    FsFileType oldInodeType;
+    renameOp->GetOldInode(&oldInode, &oldInodeSize, &oldInodeType);
+    if (oldInode != 0 && oldInodeSize >= 0) {
+        XAttr xattr;
+        xattr.mutable_xattrinfos()->insert({XATTRENTRIES, "1"});
+        if (oldInodeType == FsFileType::TYPE_DIRECTORY) {
+            xattr.mutable_xattrinfos()->insert({XATTRSUBDIRS, "1"});
+        } else {
+            xattr.mutable_xattrinfos()->insert({XATTRFILES, "1"});
+        }
+        xattr.mutable_xattrinfos()->insert({XATTRFBYTES,
+            std::to_string(oldInodeSize)});
+
+        rc = UpdateParentInodeXattr(newparent, xattr, false);
+        if (rc != CURVEFS_ERROR::OK) {
+            LOG(ERROR) << "UpdateParentInodeXattr failed, ret = " << rc
+                       << "parentId = " << newparent
+                       << ", xattr = " << xattr.DebugString();
+            return rc;
+        }
+    }
+    return rc;
+}
+
+}  // namespace client
+}  // namespace curvefs

--- a/curvefs/src/client/xattr_manager.h
+++ b/curvefs/src/client/xattr_manager.h
@@ -1,0 +1,138 @@
+/*
+ *  Copyright (c) 2022 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * Project: curve
+ * Created Date: Thur May 12 2022
+ * Author: wanghai01
+ */
+
+#ifndef CURVEFS_SRC_CLIENT_XATTR_MANAGER_H_
+#define CURVEFS_SRC_CLIENT_XATTR_MANAGER_H_
+
+#include <cstdint>
+#include <map>
+#include <unordered_map>
+#include <memory>
+#include <string>
+#include <list>
+#include <stack>
+#include <mutex>
+#include <set>
+#include <vector>
+
+#include "curvefs/src/common/define.h"
+#include "curvefs/proto/metaserver.pb.h"
+#include "curvefs/src/client/error_code.h"
+#include "curvefs/src/client/client_operator.h"
+#include "src/common/interruptible_sleeper.h"
+
+#define DirectIOAlignment 512
+
+namespace curvefs {
+namespace client {
+
+using curvefs::metaserver::FsFileType;
+using ::curve::common::Atomic;
+using ::curve::common::InterruptibleSleeper;
+
+struct SummaryInfo {
+    uint64_t files = 0;
+    uint64_t subdirs = 0;
+    uint64_t entries = 0;
+    uint64_t fbytes = 0;
+};
+
+class XattrManager {
+ public:
+    XattrManager(const std::shared_ptr<InodeCacheManager> &inodeManager,
+        const std::shared_ptr<DentryCacheManager> &dentryManager,
+        uint32_t listDentryLimit,
+        uint32_t listDentryThreads)
+        : inodeManager_(inodeManager),
+        dentryManager_(dentryManager),
+        listDentryLimit_(listDentryLimit),
+        listDentryThreads_(listDentryThreads),
+        isStop_(false) {}
+
+    ~XattrManager() {}
+
+    void Stop() {
+        isStop_.store(true);
+    }
+
+    CURVEFS_ERROR CalOneLayerSumInfo(Inode *inode);
+
+    CURVEFS_ERROR CalAllLayerSumInfo(Inode *inode);
+
+    CURVEFS_ERROR FastCalOneLayerSumInfo(Inode *inode);
+
+    CURVEFS_ERROR FastCalAllLayerSumInfo(Inode *inode);
+
+    CURVEFS_ERROR UpdateParentInodeXattr(uint64_t parentId,
+        const XAttr &xattr, bool direction);
+
+    CURVEFS_ERROR UpdateParentXattrAfterRename(uint64_t parent,
+        uint64_t newparent, const char *newname,
+        RenameOperator* renameOp);
+
+ private:
+    bool ConcurrentListDentry(
+        std::list<Dentry> *dentrys,
+        std::stack<uint64_t> *iStack,
+        std::mutex *stackMutex,
+        bool dirOnly,
+        Atomic<uint32_t> *inflightNum,
+        Atomic<bool> *ret);
+
+    void ConcurrentGetInodeAttr(
+        std::stack<uint64_t> *iStack,
+        std::mutex *stackMutex,
+        std::unordered_map<uint64_t, uint64_t> *hardLinkMap,
+        std::mutex *mapMutex,
+        SummaryInfo *summaryInfo,
+        std::mutex *valueMutex,
+        Atomic<uint32_t> *inflightNum,
+        Atomic<bool> *ret);
+
+    void ConcurrentGetInodeXattr(
+        std::stack<uint64_t> *iStack,
+        std::mutex *stackMutex,
+        Inode *inode,
+        std::mutex *inodeMutex,
+        Atomic<uint32_t> *inflightNum,
+        Atomic<bool> *ret);
+
+ private:
+    // inode cache manager
+    std::shared_ptr<InodeCacheManager> inodeManager_;
+
+    // dentry cache manager
+    std::shared_ptr<DentryCacheManager> dentryManager_;
+
+    Atomic<bool> isStop_;
+
+    InterruptibleSleeper sleeper_;
+
+    uint32_t listDentryLimit_;
+
+    uint32_t listDentryThreads_;
+};
+
+}  // namespace client
+}  // namespace curvefs
+
+#endif  // CURVEFS_SRC_CLIENT_XATTR_MANAGER_H_

--- a/curvefs/src/metaserver/copyset/raft_log_codec.cpp
+++ b/curvefs/src/metaserver/copyset/raft_log_codec.cpp
@@ -124,6 +124,12 @@ std::unique_ptr<MetaOperator> RaftLogCodec::Decode(CopysetNode* node,
         case OperatorType::GetInode:
             return ParseFromRaftLog<GetInodeOperator, GetInodeRequest>(
                 node, type, meta);
+        case OperatorType::BatchGetInodeAttr:
+            return ParseFromRaftLog<BatchGetInodeAttrOperator,
+                BatchGetInodeAttrRequest>(node, type, meta);
+        case OperatorType::BatchGetXAttr:
+            return ParseFromRaftLog<BatchGetXAttrOperator,
+                BatchGetXAttrRequest>(node, type, meta);
         case OperatorType::CreateInode:
             return ParseFromRaftLog<CreateInodeOperator, CreateInodeRequest>(
                 node, type, meta);


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #xxx <!-- replace xxx with issue number -->

Problem Summary:
1. list dentry concurrently when get summary xattr to improve performance.
2. rebuild xattr code in client and use XattrManager to deal with.
example: du dir1
```
dir1
├── dir2
│   └── file2
├── dir3
├── dir4
├── dir5
└── file1
```
before: need 5 times listDentry synchronously one by one.
now: use 10 threads default to listDentry concurrently.

The test result:
<img width="798" alt="截屏2022-05-12 17 07 28" src="https://user-images.githubusercontent.com/13496900/168035165-81230e9e-f3a3-470d-8e77-70b7c638c71d.png">



### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
