### PR TITLE
curvefs/client: add -o mdsaddr=xxxx support

### DIFF
--- a/curvefs/src/client/curve_fuse_op.cpp
+++ b/curvefs/src/client/curve_fuse_op.cpp
@@ -145,7 +145,7 @@ int InitGlog(const char *confPath, const char *argv0) {
 }
 
 int InitFuseClient(const char *confPath, const char* fsName,
-    const char *fsType) {
+    const char *fsType, const char *mdsAddr) {
     g_clientOpMetric = new ClientOpMetric();
 
     Configuration conf;
@@ -154,6 +154,8 @@ int InitFuseClient(const char *confPath, const char* fsName,
         LOG(ERROR) << "LoadConfig failed, confPath = " << confPath;
         return -1;
     }
+    if (mdsAddr)
+        conf.SetStringValue("mdsOpt.rpcRetryOpt.addrs", mdsAddr);
 
     conf.PrintConfig();
 
@@ -199,8 +201,10 @@ int InitFuseClient(const char *confPath, const char* fsName,
 }
 
 void UnInitFuseClient() {
-    g_ClientInstance->Fini();
-    g_ClientInstance->UnInit();
+    if (g_ClientInstance) {
+        g_ClientInstance->Fini();
+        g_ClientInstance->UnInit();
+    }
     delete g_ClientInstance;
     delete g_fuseClientOption;
     delete g_clientOpMetric;

--- a/curvefs/src/client/curve_fuse_op.h
+++ b/curvefs/src/client/curve_fuse_op.h
@@ -40,7 +40,7 @@ extern "C" {
 int InitGlog(const char *confPath, const char *argv0);
 
 int InitFuseClient(const char *confPath, const char *fsName,
-        const char* fsType);
+        const char* fsType, const char* mdsAddr);
 
 void UnInitFuseClient();
 

--- a/curvefs/src/client/fuse_common.h
+++ b/curvefs/src/client/fuse_common.h
@@ -37,9 +37,8 @@ struct MountOption {
     const char* mountPoint;
     const char* fsName;
     const char* fsType;
-    const char* volume;
-    const char* user;
     const char* conf;
+    const char* mdsAddr;
 };
 
 static const struct fuse_opt mount_opts[] = {
@@ -49,14 +48,11 @@ static const struct fuse_opt mount_opts[] = {
     { "fstype=%s",
       offsetof(struct MountOption, fsType), 0},
 
-    { "volume=%s",
-      offsetof(struct MountOption, volume), 0},
-
-    { "user=%s",
-      offsetof(struct MountOption, user), 0},
-
     { "conf=%s",
       offsetof(struct MountOption, conf), 0},
+
+    { "mdsaddr=%s",
+      offsetof(struct MountOption, mdsAddr), 0},
 
     FUSE_OPT_END
 };

--- a/curvefs/test/client/test_fuse_client.cpp
+++ b/curvefs/test/client/test_fuse_client.cpp
@@ -162,14 +162,10 @@ TEST_F(TestFuseVolumeClient, FuseOpInit_when_fs_exist) {
     MountOption mOpts;
     memset(&mOpts, 0, sizeof(mOpts));
     mOpts.mountPoint = "host1:/test";
-    mOpts.volume = "xxx";
     mOpts.fsName = "xxx";
-    mOpts.user = "test";
     mOpts.fsType = "curve";
 
-    std::string volName = mOpts.volume;
-    std::string user = mOpts.user;
-    std::string fsName = mOpts.volume;
+    std::string fsName = mOpts.fsName;
 
     FsInfo fsInfoExp;
     fsInfoExp.set_fsid(200);
@@ -194,11 +190,10 @@ TEST_F(TestFuseVolumeClient, FuseOpDestroy) {
     MountOption mOpts;
     memset(&mOpts, 0, sizeof(mOpts));
     mOpts.mountPoint = "host1:/test";
-    mOpts.volume = "xxx";
     mOpts.fsName = "xxx";
     mOpts.fsType = "curve";
 
-    std::string fsName = mOpts.volume;
+    std::string fsName = mOpts.fsName;
 
     EXPECT_CALL(*mdsClient_, UmountFs(fsName, _))
         .WillOnce(Return(FSStatusCode::OK));
@@ -1561,7 +1556,6 @@ TEST_F(TestFuseS3Client, FuseOpInit_when_fs_exist) {
     memset(&mOpts, 0, sizeof(mOpts));
     mOpts.fsName = "s3fs";
     mOpts.mountPoint = "host1:/test";
-    mOpts.user = "test";
     mOpts.fsType = "s3";
 
     std::string fsName = mOpts.fsName;
@@ -1587,7 +1581,6 @@ TEST_F(TestFuseS3Client, FuseOpDestroy) {
     memset(&mOpts, 0, sizeof(mOpts));
     mOpts.fsName = "s3fs";
     mOpts.mountPoint = "host1:/test";
-    mOpts.user = "test";
     mOpts.fsType = "s3";
 
     std::string fsName = mOpts.fsName;


### PR DESCRIPTION
### What's Changed

1. remove option: user, volume
2. add option: mdsaddr
3. format help message
4. fix coredump issue

``` bash 
$ ../bazel-bin/curvefs/src/client/curve-fuse --help
usage: ../bazel-bin/curvefs/src/client/curve-fuse -o conf=/etc/curvefs/client.conf -o fsname=testfs \
       -o fstype=s3 [-o mdsAddr=1.1.1.1] [OPTIONS] <mountpoint>
Fuse Options:
    -h   --help            print help
    -V   --version         print version
    -d   -o debug          enable debug output (implies -f)
    -f                     foreground operation
    -s                     disable multi-threaded operation
    -o clone_fd            use separate fuse device fd for each thread
                           (may improve performance)
    -o max_idle_threads    the maximum number of idle worker threads
                           allowed (default: 10)
    -o allow_other         allow access by all users
    -o allow_root          allow access by root
    -o auto_unmount        auto unmount on process termination

Extra options:
    -o fsname              [required] name of filesystem to be mounted
    -o fstype              [required] type of filesystem to be mounted (s3/volume)
    -o conf                [required] path of config file
    -o mdsaddr             mdsAddr of curvefs cluster
```