### PR TITLE
nbd: use strsignal

### DIFF
--- a/nbd/src/main.cpp
+++ b/nbd/src/main.cpp
@@ -62,7 +62,7 @@ static void HandleSignal(int signum) {
         return;
     }
 
-    dout << "Got signal " << sys_siglist[signum] << "\n"
+    dout << "Got signal " << strsignal(signum) << "\n"
               << ", disconnect now" << std::endl;
 
     ret = nbdTool->Disconnect(nbdConfig.get());


### PR DESCRIPTION
variable sys_siglist disappeared on high version glibc, this is
verifyed on Ubuntu jammy.

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?
fix compiling problem

Issue Number: #1375

Problem Summary:

### What is changed and how it works?

What's Changed:
change nbd main.c 
How it Works:
use official function instead

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
