### PR TITLE
curvefs_tool/fix create fs fail and build error

### DIFF
--- a/curvefs/conf/tools.conf
+++ b/curvefs/conf/tools.conf
@@ -2,8 +2,8 @@
 mdsAddr=127.0.0.1:6700  # __CURVEADM_TEMPLATE__ ${cluster_mds_addr} __CURVEADM_TEMPLATE__  __ANSIBLE_TEMPLATE__ {{ groups.mds | join_peer(hostvars, "mds_listen_port") }} __ANSIBLE_TEMPLATE__
 mdsDummyAddr=127.0.0.1:7700  # __CURVEADM_TEMPLATE__ ${cluster_mds_dummy_addr} __CURVEADM_TEMPLATE__  __ANSIBLE_TEMPLATE__ {{ groups.mds | join_peer(hostvars, "mds_listen_dummy_port") }} __ANSIBLE_TEMPLATE__
 # rpc timeout
-rpcTimeoutMs=10000
-rpcRetryTimes=5
+rpcTimeoutMs=30000
+rpcRetryTimes=3
 # rpc stream idle timeout
 rpcStreamIdleTimeoutMs=10000
 # topo file path

--- a/curvefs/src/tools/list/curvefs_partition_list.cpp
+++ b/curvefs/src/tools/list/curvefs_partition_list.cpp
@@ -71,7 +71,7 @@ int PartitionListTool::Init() {
 
     curvefs::mds::topology::ListPartitionRequest request;
     for (const auto& i : fsIds) {
-        uint32_t fsId;
+        uint32_t fsId = 0;
         curve::common::StringToUl(i, &fsId);
         request.set_fsid(fsId);
         AddRequest(request);

--- a/curvefs/src/tools/query/curvefs_inode_query.cpp
+++ b/curvefs/src/tools/query/curvefs_inode_query.cpp
@@ -65,11 +65,11 @@ int InodeQueryTool::Init() {
     }
     for (size_t i = 0; i < fsIds.size(); ++i) {
         InodeBase tmp;
-        uint64_t tmpFsId;
+        uint64_t tmpFsId = 0;
         curve::common::StringToUll(fsIds[i], &tmpFsId);
         tmp.set_fsid(tmpFsId);
 
-        uint64_t tmpInodeId;
+        uint64_t tmpInodeId = 0;
         curve::common::StringToUll(inodeIds[i], &tmpInodeId);
         tmp.set_inodeid(tmpInodeId);
 

--- a/mk-deb.sh
+++ b/mk-deb.sh
@@ -129,12 +129,12 @@ function build_curvefs_python() {
 bazel_version=`bazel version | grep "Build label" | awk '{print $3}'`
 if [ -z ${bazel_version} ]
 then
-    echo "please install bazel 0.17.2 first"
+    echo "please install bazel 4.2.2 first"
     exit
 fi
-if [ ${bazel_version} != "0.17.2" ]
+if [ ${bazel_version} != "4.2.2" ]
 then
-    echo "bazel version must 0.17.2"
+    echo "bazel version must 4.2.2"
     echo "now version is ${bazel_version}"
     exit
 fi

--- a/mk-tar.sh
+++ b/mk-tar.sh
@@ -129,12 +129,12 @@ function build_curvefs_python() {
 bazel_version=`bazel version | grep "Build label" | awk '{print $3}'`
 if [ -z ${bazel_version} ]
 then
-    echo "please install bazel 0.17.2 first"
+    echo "please install bazel 4.2.2 first"
     exit
 fi
-if [ ${bazel_version} != "0.17.2" ]
+if [ ${bazel_version} != "4.2.2" ]
 then
-    echo "bazel version must 0.17.2"
+    echo "bazel version must 4.2.2"
     echo "now version is ${bazel_version}"
     exit
 fi


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #1386 <!-- replace xxx with issue number -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

1. fix the bug that always prompted the creation of fs failed due to
rpctimeout.
Since topology.yaml does not save s3 information, the default related
parameters of curvefs_tool running in it are not available, and the mds
check will cause a timeout.

2. fix make release error due to uninitialized variables

3. fix bazel version check erorr in mk-deb.sh and mk-tar.sh

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
