### PR TITLE
curvefs/fuse: fix generate identical inodeid sequences

### DIFF
--- a/curvefs/src/client/rpcclient/metacache.cpp
+++ b/curvefs/src/client/rpcclient/metacache.cpp
@@ -20,6 +20,7 @@
  * Author: lixiaocui
  */
 
+#include <butil/fast_rand.h>
 #include <algorithm>
 #include <iterator>
 #include <vector>
@@ -492,7 +493,7 @@ bool MetaCache::SelectPartition(CopysetTarget *target) {
         target->txId = newPartitions[0].txid();
     } else {
         // random select a partition
-        int index = rand() % candidate.size();  // NOLINT
+        const auto index = butil::fast_rand() % candidate.size();
         auto iter = candidate.begin();
         std::advance(iter, index);
         target->groupID =

--- a/curvefs/src/client/rpcclient/task_excutor.cpp
+++ b/curvefs/src/client/rpcclient/task_excutor.cpp
@@ -21,6 +21,7 @@
  * Author: lixiaocui
  */
 
+#include <butil/fast_rand.h>
 #include <algorithm>
 #include <utility>
 
@@ -255,7 +256,7 @@ uint64_t TaskExecutor::OverLoadBackOff() {
     uint64_t nextsleeptime = opt_.retryIntervalUS * (1 << curpowTime);
 
     // -10% ~ 10% jitter
-    uint64_t random_time = std::rand() % (nextsleeptime / 5 + 1);
+    uint64_t random_time = butil::fast_rand() % (nextsleeptime / 5 + 1);
     random_time -= nextsleeptime / 10;
     nextsleeptime += random_time;
 


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #1398 

Problem Summary: previous policy use `rand` without `srand()`, so each filesystem will generate same random number sequences

### What is changed and how it works?

What's Changed: replace `rand` with `butil::fast_rand()`

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [x] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license
