### PR TITLE
curvefs/metaserver: recover s3ChunkInfoRemove field for GetOrModifyS3…

### DIFF
--- a/curvefs/src/metaserver/inode_manager.cpp
+++ b/curvefs/src/metaserver/inode_manager.cpp
@@ -25,6 +25,7 @@
 #include <glog/logging.h>
 #include <google/protobuf/util/message_differencer.h>
 #include <list>
+#include <unordered_set>
 
 #include "curvefs/src/common/define.h"
 #include "src/common/timeutility.h"
@@ -130,21 +131,27 @@ void InodeManager::GenerateInodeInternal(uint64_t inodeId,
     return;
 }
 
-MetaStatusCode InodeManager::GetInode(uint32_t fsId, uint64_t inodeId,
-                                      Inode *inode) {
+MetaStatusCode InodeManager::GetInode(uint32_t fsId,
+                                      uint64_t inodeId,
+                                      Inode *inode,
+                                      bool paddingS3ChunkInfo) {
     VLOG(1) << "GetInode, fsId = " << fsId << ", inodeId = " << inodeId;
     NameLockGuard lg(inodeLock_, GetInodeLockName(fsId, inodeId));
-    MetaStatusCode ret = inodeStorage_->Get(Key4Inode(fsId, inodeId), inode);
-    if (ret != MetaStatusCode::OK) {
+    MetaStatusCode rc = inodeStorage_->Get(Key4Inode(fsId, inodeId), inode);
+    if (rc == MetaStatusCode::OK && paddingS3ChunkInfo) {
+        rc = PaddingInodeS3ChunkInfo(fsId, inodeId,
+                                     inode->mutable_s3chunkinfomap());
+    }
+
+    if (rc != MetaStatusCode::OK) {
         LOG(ERROR) << "GetInode fail, fsId = " << fsId
                    << ", inodeId = " << inodeId
-                   << ", ret = " << MetaStatusCode_Name(ret);
-        return ret;
+                   << ", retCode = " << MetaStatusCode_Name(rc);
+        return rc;
     }
 
     VLOG(1) << "GetInode success, fsId = " << fsId << ", inodeId = " << inodeId
             << ", " << inode->ShortDebugString();
-
     return MetaStatusCode::OK;
 }
 
@@ -308,30 +315,59 @@ MetaStatusCode InodeManager::UpdateInode(const UpdateInodeRequest &request) {
 MetaStatusCode InodeManager::GetOrModifyS3ChunkInfo(
     uint32_t fsId, uint64_t inodeId,
     const S3ChunkInfoMap& map2add,
-    std::shared_ptr<Iterator>* iterator,
+    const S3ChunkInfoMap& map2del,
     bool returnS3ChunkInfoMap,
-    bool compaction) {
+    std::shared_ptr<Iterator>* iterator4InodeS3Meta) {
     VLOG(1) << "GetOrModifyS3ChunkInfo, fsId: " << fsId
             << ", inodeId: " << inodeId;
 
     NameLockGuard lg(inodeLock_, GetInodeLockName(fsId, inodeId));
 
-    if (!map2add.empty()) {
-        for (const auto& item : map2add) {
-            uint64_t chunkIndex = item.first;
-            auto list2add = item.second;
-            MetaStatusCode rc = inodeStorage_->AppendS3ChunkInfoList(
-                fsId, inodeId, chunkIndex, list2add, compaction);
-            if (rc != MetaStatusCode::OK) {
-                return rc;
-            }
+    const S3ChunkInfoList* list2add;
+    const S3ChunkInfoList* list2del;
+    std::unordered_set<uint64_t> deleted;
+    for (const auto& item : map2add) {
+        uint64_t chunkIndex = item.first;
+        list2add = &item.second;
+        auto iter = map2del.find(chunkIndex);
+        if (iter != map2del.end()) {
+            list2del = &iter->second;
+        } else {
+            list2del = nullptr;
+        }
+
+        MetaStatusCode rc = inodeStorage_->ModifyInodeS3ChunkInfoList(
+            fsId, inodeId, chunkIndex, list2add, list2del);
+        if (rc != MetaStatusCode::OK) {
+            LOG(ERROR) << "Modify inode s3chunkinfo list failed, fsId=" << fsId
+                       << ", inodeId=" << inodeId << ", retCode=" << rc;
+            return rc;
+        }
+        deleted.insert(chunkIndex);
+    }
+
+    for (const auto& item : map2del) {
+        uint64_t chunkIndex = item.first;
+        if (deleted.find(chunkIndex) != deleted.end()) {  // already deleted
+            continue;
+        }
+
+        list2add = nullptr;
+        list2del = &item.second;
+        MetaStatusCode rc = inodeStorage_->ModifyInodeS3ChunkInfoList(
+            fsId, inodeId, chunkIndex, list2add, list2del);
+        if (rc != MetaStatusCode::OK) {
+            LOG(ERROR) << "Modify inode s3chunkinfo list failed, fsId=" << fsId
+                       << ", inodeId=" << inodeId << ", retCode=" << rc;
+            return rc;
         }
     }
 
     // return if needed
     if (returnS3ChunkInfoMap) {
-        *iterator = inodeStorage_->GetInodeS3ChunkInfoList(fsId, inodeId);
-        if ((*iterator)->Status() != 0) {
+        *iterator4InodeS3Meta = inodeStorage_->GetInodeS3ChunkInfoList(
+            fsId, inodeId);
+        if ((*iterator4InodeS3Meta)->Status() != 0) {
             return MetaStatusCode::STORAGE_INTERNAL_ERROR;
         }
     }

--- a/curvefs/src/metaserver/inode_manager.h
+++ b/curvefs/src/metaserver/inode_manager.h
@@ -60,7 +60,11 @@ class InodeManager {
     MetaStatusCode CreateInode(uint64_t inodeId, const InodeParam &param,
                                Inode *inode);
     MetaStatusCode CreateRootInode(const InodeParam &param);
-    MetaStatusCode GetInode(uint32_t fsId, uint64_t inodeId, Inode *inode);
+
+    MetaStatusCode GetInode(uint32_t fsId,
+                            uint64_t inodeId,
+                            Inode *inode,
+                            bool paddingS3ChunkInfo = false);
 
     MetaStatusCode GetInodeAttr(uint32_t fsId, uint64_t inodeId,
                                 InodeAttr *attr);
@@ -71,12 +75,13 @@ class InodeManager {
 
     MetaStatusCode UpdateInode(const UpdateInodeRequest &request);
 
-    MetaStatusCode GetOrModifyS3ChunkInfo(uint32_t fsId,
-                                          uint64_t inodeId,
-                                          const S3ChunkInfoMap& map2add,
-                                          std::shared_ptr<Iterator>* iterator,
-                                          bool returnS3ChunkInfoMap,
-                                          bool compaction);
+    MetaStatusCode GetOrModifyS3ChunkInfo(
+        uint32_t fsId,
+        uint64_t inodeId,
+        const S3ChunkInfoMap& map2add,
+        const S3ChunkInfoMap& map2del,
+        bool returnS3ChunkInfoMap,
+        std::shared_ptr<Iterator>* iterator4InodeS3Meta);
 
     MetaStatusCode PaddingInodeS3ChunkInfo(int32_t fsId,
                                            uint64_t inodeId,

--- a/curvefs/src/metaserver/inode_storage.cpp
+++ b/curvefs/src/metaserver/inode_storage.cpp
@@ -180,37 +180,46 @@ MetaStatusCode InodeStorage::AddS3ChunkInfoList(
     uint32_t fsId,
     uint64_t inodeId,
     uint64_t chunkIndex,
-    const S3ChunkInfoList& list2add) {
-    // key
-    size_t size = list2add.s3chunks_size();
-    uint64_t firstChunkId = list2add.s3chunks(0).chunkid();
-    uint64_t lastChunkId = list2add.s3chunks(size - 1).chunkid();
+    const S3ChunkInfoList* list2add) {
+    if (nullptr == list2add || list2add->s3chunks_size() == 0) {
+        return MetaStatusCode::OK;
+    }
+
+    size_t size = list2add->s3chunks_size();
+    uint64_t firstChunkId = list2add->s3chunks(0).chunkid();
+    uint64_t lastChunkId = list2add->s3chunks(size - 1).chunkid();
     Key4S3ChunkInfoList key(fsId, inodeId, chunkIndex,
                             firstChunkId, lastChunkId, size);
     std::string skey = conv_->SerializeToString(key);
 
-    Status s = txn->SSet(table4s3chunkinfo_, skey, list2add);
+    Status s = txn->SSet(table4s3chunkinfo_, skey, *list2add);
     return s.ok() ? MetaStatusCode::OK :
                     MetaStatusCode::STORAGE_INTERNAL_ERROR;
 }
 
-// NOTE: s3chunkinfo which its chunkid equal or
-// less then min chunkid should be removed
-MetaStatusCode InodeStorage::RemoveS3ChunkInfoList(Transaction txn,
-                                                   uint32_t fsId,
-                                                   uint64_t inodeId,
-                                                   uint64_t chunkIndex,
-                                                   uint64_t minChunkId,
-                                                   uint64_t* size4del) {
+MetaStatusCode InodeStorage::DelS3ChunkInfoList(
+    Transaction txn,
+    uint32_t fsId,
+    uint64_t inodeId,
+    uint64_t chunkIndex,
+    const S3ChunkInfoList* list2del) {
+    if (nullptr == list2del || list2del->s3chunks_size() == 0) {
+        return MetaStatusCode::OK;
+    }
+
+    size_t size = list2del->s3chunks_size();
+    uint64_t delFirstChunkId = list2del->s3chunks(0).chunkid();
+    uint64_t delLastChunkId = list2del->s3chunks(size - 1).chunkid();
+
+    // prefix
     Prefix4ChunkIndexS3ChunkInfoList prefix(fsId, inodeId, chunkIndex);
     std::string sprefix = conv_->SerializeToString(prefix);
     auto iterator = txn->SSeek(table4s3chunkinfo_, sprefix);
     if (iterator->Status() != 0) {
+        LOG(ERROR) << "Get iterator failed, prefix=" << sprefix;
         return MetaStatusCode::STORAGE_INTERNAL_ERROR;
     }
 
-    *size4del = 0;
-    uint64_t lastChunkId;
     Key4S3ChunkInfoList key;
     std::vector<std::string> key2del;
     for (iterator->SeekToFirst(); iterator->Valid(); iterator->Next()) {
@@ -219,61 +228,70 @@ MetaStatusCode InodeStorage::RemoveS3ChunkInfoList(Transaction txn,
             break;
         } else if (!conv_->ParseFromString(skey, &key)) {
             return MetaStatusCode::PARSE_FROM_STRING_FAILED;
-        } else if (key.firstChunkId >= minChunkId) {
-            break;
         }
 
-        // firstChunkId < minChunkId
-        key2del.push_back(skey);
-        *size4del += key.size;
+        // current list range:    [  ]
+        // delete list range :  [      ]
+        if (delFirstChunkId <= key.firstChunkId &&
+            delLastChunkId >= key.lastChunkId) {
+            key2del.push_back(skey);
+        // current list range:       [  ]
+        // delete list range :  [  ]
+        } else if (delLastChunkId < key.firstChunkId) {
+            continue;
+        } else {
+            LOG(ERROR) << "wrong delete list range (" << delFirstChunkId
+                       << "," << delLastChunkId << "), skey=" << skey;
+            return MetaStatusCode::STORAGE_INTERNAL_ERROR;
+        }
     }
 
     for (const auto& skey : key2del) {
         if (!txn->SDel(table4s3chunkinfo_, skey).ok()) {
+            LOG(ERROR) << "Delete key failed, skey=" << skey;
             return MetaStatusCode::STORAGE_INTERNAL_ERROR;
         }
     }
     return MetaStatusCode::OK;
 }
 
-MetaStatusCode InodeStorage::AppendS3ChunkInfoList(
+MetaStatusCode InodeStorage::ModifyInodeS3ChunkInfoList(
     uint32_t fsId,
     uint64_t inodeId,
     uint64_t chunkIndex,
-    const S3ChunkInfoList& list2add,
-    bool compaction) {
+    const S3ChunkInfoList* list2add,
+    const S3ChunkInfoList* list2del) {
     WriteLockGuard writeLockGuard(rwLock_);
-    size_t size = list2add.s3chunks_size();
-    if (size == 0) {
-        return MetaStatusCode::OK;
-    }
-
     auto txn = kvStorage_->BeginTransaction();
     if (nullptr == txn) {
         return MetaStatusCode::STORAGE_INTERNAL_ERROR;
     }
 
-    MetaStatusCode rc;
-    uint64_t size4add = list2add.s3chunks_size();
-    uint64_t size4del = 0;
-    rc = AddS3ChunkInfoList(txn, fsId, inodeId, chunkIndex, list2add);
-    if (rc == MetaStatusCode::OK && compaction) {
-        uint64_t minChunkId = list2add.s3chunks(0).chunkid();
-        rc = RemoveS3ChunkInfoList(txn, fsId, inodeId, chunkIndex,
-                                   minChunkId, &size4del);
+    auto rc = DelS3ChunkInfoList(txn, fsId, inodeId, chunkIndex, list2del);
+    if (rc == MetaStatusCode::OK) {
+        rc = AddS3ChunkInfoList(txn, fsId, inodeId, chunkIndex, list2add);
     }
 
     if (rc != MetaStatusCode::OK) {
-        txn->Rollback();
+        if (!txn->Rollback().ok()) {
+            LOG(ERROR) << "Rollback transaction failed";
+            rc = MetaStatusCode::STORAGE_INTERNAL_ERROR;
+        }
     } else if (!txn->Commit().ok()) {
+        LOG(ERROR) << "Commit transaction failed";
         rc = MetaStatusCode::STORAGE_INTERNAL_ERROR;
     }
 
-    if (rc == MetaStatusCode::OK &&
-        !UpdateInodeS3MetaSize(fsId, inodeId, size4add, size4del)) {
-        rc = MetaStatusCode::STORAGE_INTERNAL_ERROR;
-        LOG(ERROR) << "UpdateInodeS3MetaSize() failed, size4add=" << size4add
-                   << ", size4del" << size4del;
+    if (rc != MetaStatusCode::OK) {
+        return rc;
+    }
+
+    // rc == MetaStatusCode::OK
+    uint64_t size4add = (nullptr == list2add) ? 0 : list2add->s3chunks_size();
+    uint64_t size4del = (nullptr == list2del) ? 0 : list2del->s3chunks_size();
+    if (!UpdateInodeS3MetaSize(fsId, inodeId, size4add, size4del)) {
+        LOG(ERROR) << "Update inode s3meta size failed";
+        return MetaStatusCode::STORAGE_INTERNAL_ERROR;
     }
     return rc;
 }

--- a/curvefs/src/metaserver/inode_storage.h
+++ b/curvefs/src/metaserver/inode_storage.h
@@ -24,14 +24,13 @@
 #define CURVEFS_SRC_METASERVER_INODE_STORAGE_H_
 
 #include <functional>
+#include <utility>
 #include <unordered_map>
 #include <unordered_set>
-#include <utility>
 #include <list>
 #include <string>
 #include <memory>
 
-#include "absl/container/btree_set.h"
 #include "src/common/concurrent/rw_lock.h"
 #include "curvefs/proto/metaserver.pb.h"
 #include "curvefs/src/metaserver/storage/converter.h"
@@ -45,6 +44,7 @@ using ::curvefs::metaserver::storage::Status;
 using ::curvefs::metaserver::storage::Iterator;
 using ::curvefs::metaserver::storage::KVStorage;
 using ::curvefs::metaserver::storage::StorageTransaction;
+using ::curvefs::metaserver::storage::Hash;
 
 namespace curvefs {
 namespace metaserver {
@@ -108,11 +108,11 @@ class InodeStorage {
      */
     MetaStatusCode Update(const Inode& inode);
 
-    MetaStatusCode AppendS3ChunkInfoList(uint32_t fsId,
-                                         uint64_t inodeId,
-                                         uint64_t chunkIndex,
-                                         const S3ChunkInfoList& list2add,
-                                         bool compaction);
+    MetaStatusCode ModifyInodeS3ChunkInfoList(uint32_t fsId,
+                                              uint64_t inodeId,
+                                              uint64_t chunkIndex,
+                                              const S3ChunkInfoList* list2add,
+                                              const S3ChunkInfoList* list2del);
 
     MetaStatusCode PaddingInodeS3ChunkInfo(int32_t fsId,
                                            uint64_t inodeId,
@@ -138,15 +138,14 @@ class InodeStorage {
         uint32_t fsId,
         uint64_t inodeId,
         uint64_t chunkIndex,
-        const S3ChunkInfoList& list2add);
+        const S3ChunkInfoList* list2add);
 
-    MetaStatusCode RemoveS3ChunkInfoList(
+    MetaStatusCode DelS3ChunkInfoList(
         std::shared_ptr<StorageTransaction> txn,
         uint32_t fsId,
         uint64_t inodeId,
         uint64_t chunkIndex,
-        uint64_t minChunkId,
-        uint64_t* size4del);
+        const S3ChunkInfoList* list2del);
 
     std::string RealTablename(TABLE_TYPE type, std::string tablename) {
         std::ostringstream oss;

--- a/curvefs/src/metaserver/metastore.h
+++ b/curvefs/src/metaserver/metastore.h
@@ -77,6 +77,7 @@ using ::curvefs::metaserver::copyset::OnSnapshotSaveDoneClosure;
 using ::curvefs::metaserver::storage::Iterator;
 using ::curvefs::common::StreamServer;
 using ::curvefs::common::StreamConnection;
+using S3ChunkInfoMap = google::protobuf::Map<uint64_t, S3ChunkInfoList>;
 
 class MetaStore {
  public:

--- a/curvefs/src/metaserver/metastore_fstream.cpp
+++ b/curvefs/src/metaserver/metastore_fstream.cpp
@@ -170,11 +170,12 @@ bool MetaStoreFStream::LoadInodeS3ChunkInfoList(uint32_t partitionId,
         return false;
     }
 
-    std::shared_ptr<Iterator> iterator;
     S3ChunkInfoMap map2add;
+    S3ChunkInfoMap map2del;
+    std::shared_ptr<Iterator> iterator;
     map2add.insert({key4list.chunkIndex, list});
     MetaStatusCode rc = partition->GetOrModifyS3ChunkInfo(
-        key4list.fsId, key4list.inodeId, map2add, &iterator, false, false);
+        key4list.fsId, key4list.inodeId, map2add, map2del, false, &iterator);
     if (rc != MetaStatusCode::OK) {
         LOG(ERROR) << "GetOrModifyS3ChunkInfo failed, retCode = "
                    << MetaStatusCode_Name(rc);

--- a/curvefs/src/metaserver/partition.cpp
+++ b/curvefs/src/metaserver/partition.cpp
@@ -262,20 +262,18 @@ MetaStatusCode Partition::UpdateInode(const UpdateInodeRequest& request) {
 MetaStatusCode Partition::GetOrModifyS3ChunkInfo(
     uint32_t fsId,
     uint64_t inodeId,
-    const S3ChunkInfoMap& list2add,
-    std::shared_ptr<Iterator>* iterator,
+    const S3ChunkInfoMap& map2add,
+    const S3ChunkInfoMap& map2del,
     bool returnS3ChunkInfoMap,
-    bool compaction) {
+    std::shared_ptr<Iterator>* iterator) {
     if (!IsInodeBelongs(fsId, inodeId)) {
         return MetaStatusCode::PARTITION_ID_MISSMATCH;
-    }
-
-    if (GetStatus() == PartitionStatus::DELETING) {
+    } else if (GetStatus() == PartitionStatus::DELETING) {
         return MetaStatusCode::PARTITION_DELETING;
     }
 
     return inodeManager_->GetOrModifyS3ChunkInfo(
-        fsId, inodeId, list2add, iterator, returnS3ChunkInfoMap, compaction);
+        fsId, inodeId, map2add, map2del, returnS3ChunkInfoMap, iterator);
 }
 
 MetaStatusCode Partition::PaddingInodeS3ChunkInfo(int32_t fsId,

--- a/curvefs/src/metaserver/partition.h
+++ b/curvefs/src/metaserver/partition.h
@@ -92,10 +92,10 @@ class Partition {
 
     MetaStatusCode GetOrModifyS3ChunkInfo(uint32_t fsId,
                                           uint64_t inodeId,
-                                          const S3ChunkInfoMap& list2add,
-                                          std::shared_ptr<Iterator>* iterator,
+                                          const S3ChunkInfoMap& map2add,
+                                          const S3ChunkInfoMap& map2del,
                                           bool returnS3ChunkInfoMap,
-                                          bool compaction);
+                                          std::shared_ptr<Iterator>* iterator);
 
     MetaStatusCode PaddingInodeS3ChunkInfo(int32_t fsId,
                                            uint64_t inodeId,

--- a/curvefs/src/metaserver/s3compact_wq_impl.cpp
+++ b/curvefs/src/metaserver/s3compact_wq_impl.cpp
@@ -442,7 +442,7 @@ bool S3CompactWorkQueueImpl::CompactPrecheck(const struct S3CompactTask& task,
 
     // inode exist?
     MetaStatusCode ret = task.inodeManager->GetInode(
-        task.inodeKey.fsId, task.inodeKey.inodeId, inode);
+        task.inodeKey.fsId, task.inodeKey.inodeId, inode, true);
     if (ret != MetaStatusCode::OK) {
         LOG(WARNING) << "s3compact: GetInode fail, inodeKey = "
                      << task.inodeKey.fsId << "," << task.inodeKey.inodeId
@@ -456,22 +456,9 @@ bool S3CompactWorkQueueImpl::CompactPrecheck(const struct S3CompactTask& task,
         return false;
     }
 
-    // pandding s3chunkinfomap for inode
-    {
-        auto inodeKey = task.inodeKey;
-        auto inodeManager = task.inodeManager;
-        MetaStatusCode rc = inodeManager->PaddingInodeS3ChunkInfo(
-            inodeKey.fsId, inodeKey.inodeId, inode->mutable_s3chunkinfomap());
-        if (rc != MetaStatusCode::OK) {
-            LOG(ERROR) << "Padding inode s3chunkinfo failed, "
-                       << "retCode = " << MetaStatusCode_Name(ret);
-            return false;
-        }
-
-        if (inode->s3chunkinfomap().size() == 0) {
-            VLOG(6) << "Inode s3chunkinfo is empty";
-            return false;
-        }
+    if (inode->s3chunkinfomap().size() == 0) {
+        VLOG(6) << "Inode s3chunkinfo is empty";
+        return false;
     }
 
     // pass

--- a/curvefs/src/metaserver/storage/rocksdb_storage.h
+++ b/curvefs/src/metaserver/storage/rocksdb_storage.h
@@ -223,6 +223,8 @@ class RocksDBStorage : public KVStorage, public StorageTransaction {
 
     void CommitKeys();
 
+    void RollbackKeys();
+
     Status Get(const std::string& name,
                const std::string& key,
                ValueType* value,
@@ -238,8 +240,11 @@ class RocksDBStorage : public KVStorage, public StorageTransaction {
                bool ordered);
 
     std::shared_ptr<Iterator> Seek(const std::string& name,
-                                    const std::string& prefix);
+                                   const std::string& prefix);
 
+    // TODO(@Wine93): We do not support transactions for the
+    // below 3 methods, maybe we should return Status::NotSupported
+    // when user invoke it in transaction.
     std::shared_ptr<Iterator> GetAll(const std::string& name, bool ordered);
 
     size_t Size(const std::string& name, bool ordered);

--- a/curvefs/test/metaserver/s3compactwq_test.cpp
+++ b/curvefs/test/metaserver/s3compactwq_test.cpp
@@ -656,8 +656,8 @@ TEST_F(S3CompactWorkQueueImplTest, test_CompactChunks) {
         ref->set_size(5);
         ref->set_zero(false);
     }
-    auto rc = inodeStorage_->AppendS3ChunkInfoList(
-        inode1.fsid(), inode1.inodeid(), 0, l0, false);
+    auto rc = inodeStorage_->ModifyInodeS3ChunkInfoList(
+        inode1.fsid(), inode1.inodeid(), 0, &l0, nullptr);
     ASSERT_EQ(rc, MetaStatusCode::OK);
     ASSERT_EQ(inodeStorage_->Update(inode1), MetaStatusCode::OK);
     mockImpl_->CompactChunks(t);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: #1304, #1308
Problem Summary:
* guarantee consistent of s3chunkinfo in inode
* recover s3ChunkInfoRemove field for GetOrModifyS3ChunkInfo PRC request

