### PR TITLE
update thread_pool.cpp

### DIFF
--- a/src/common/concurrent/thread_pool.cpp
+++ b/src/common/concurrent/thread_pool.cpp
@@ -49,7 +49,7 @@ void ThreadPool::Start() {
     if (!starting_.exchange(true, std::memory_order_acq_rel)) {
         threads_.reserve(numThreads_);
         for (int i = 0; i < numThreads_; ++i) {
-            threads_.emplace_back(new std::thread(threadFunc_));
+            threads_.emplace_back(std::make_unique<std::thread>(threadFunc_));
         }
     }
 }


### PR DESCRIPTION
use std::make_unique<> is better than new, 
 1. std::make_unique<> exception safe
 2. use std::make_unique<>, The compiler can optimize the code.