### PR TITLE
curvefs/client: move fork to the front of InitGlog and InitFuseClient

### DIFF
--- a/curvefs/src/client/s3/client_s3_adaptor.cpp
+++ b/curvefs/src/client/s3/client_s3_adaptor.cpp
@@ -302,7 +302,9 @@ int S3ClientAdaptorImpl::Stop() {
     waitInterval_.StopWait();
     toStop_.store(true, std::memory_order_release);
     FsSyncSignal();
-    bgFlushThread_.join();
+    if (bgFlushThread_.joinable()) {
+        bgFlushThread_.join();
+    }
     if (HasDiskCache()) {
         for (auto &q : downloadTaskQueues_) {
             bthread::execution_queue_stop(q);


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #1414 

Problem Summary:

client deadlock after fork

### What is changed and how it works?

What's Changed:

How it Works:

move fork to the front of InitGlog and InitFuseClient

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
