### PR TITLE
curvefs:fix_mountpoint

### DIFF
--- a/curvefs/src/mds/metric/metric.h
+++ b/curvefs/src/mds/metric/metric.h
@@ -52,13 +52,14 @@ class FsMountMetric {
     struct MountPoint {
         bool valid;
         std::string hostname;
+        std::string port;
         std::string mountdir;
     };
 
     MountPoint ParseMountPoint(const std::string& mountpoint) const;
 
     // mountpoint metric key
-    // format is fs_mount_${fsname}_${host}_${mountdir}
+    // format is fs_mount_${fsname}_${host}_${port}_${mountdir}
     std::string Key(const MountPoint& mp);
 
  private:

--- a/curvefs/src/tools/curvefs_tool_define.cpp
+++ b/curvefs/src/tools/curvefs_tool_define.cpp
@@ -33,7 +33,7 @@ DEFINE_bool(example, false, "print the example of usage");
 DEFINE_string(confPath, "/etc/curvefs/tools.conf", "config file path of tools");
 DEFINE_string(fsName, "curvefs", "fs name");
 DEFINE_string(fsId, "1,2,3", "fs id");
-DEFINE_string(mountpoint, "127.0.0.1:/mnt/curvefs-umount-test",
+DEFINE_string(mountpoint, "127.0.0.1:9000:/mnt/curvefs-umount-test",
               "curvefs mount in local path");
 DEFINE_uint32(rpcRetryTimes, 0, "rpc retry times");
 DEFINE_uint32(rpcTimeoutMs, 10000u, "rpc time out");


### PR DESCRIPTION
add port in mountpoint(like: {host}:{port}:{path}),
but mds metric only identify {host}:{path}.
add port in struct MoutPoint, fix key and ParseMountPoint func

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #xxx <!-- replace xxx with issue number -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
