### PR TITLE
Fix clear copyset creating flag to v2.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,8 +97,10 @@ curvefs/BUILD_MODE
 *.pyc
 .facts/
 *retry
+# monitor
+curvefs/monitor/prometheus/target.json
 
-curvefs/docker/curvefs
+curvefs/docker/*/curvefs
 curvefs/docker/base/*
 !curvefs/docker/base/Dockerfile
 !curvefs/docker/base/Makefile

--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,15 @@ __not_found__
 thirdparties/rocksdb/lib/
 thirdparties/rocksdb/include/
 thirdparties/rocksdb/rocksdb/
+thirdparties/rocksdb/*.tar.gz
+
+/external
+/bazel-*
+/compile_commands.json
+/.cache/
+
+docker/curvebs
+docker/*/curvebs
+
+curvefs/docker/curvefs
+curvefs/docker/*/curvefs

--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,4 @@ docker/*/curvebs
 
 curvefs/docker/curvefs
 curvefs/docker/*/curvefs
+storage_*

--- a/conf/client.conf
+++ b/conf/client.conf
@@ -129,6 +129,9 @@ global.fileIOSplitMaxSizeKB=64
 #
 ################# log相关配置 ###############
 #
+# enable logging or not
+global.logging.enable=True
+#
 # log等级 INFO=0/WARNING=1/ERROR=2/FATAL=3
 global.logLevel=0
 # 设置log的路径

--- a/conf/s3.conf
+++ b/conf/s3.conf
@@ -27,3 +27,4 @@ s3.throttle.iopsWriteLimit=5000
 s3.throttle.bpsTotalMB=1280
 s3.throttle.bpsReadMB=1280
 s3.throttle.bpsWriteMB=1280
+s3.useVirtualAddressing=false

--- a/curvefs/Makefile
+++ b/curvefs/Makefile
@@ -1,100 +1,23 @@
 # Copyright (C) 2021 Jingli Chen (Wine93), NetEase Inc.
 
-.PHONY: build install deploy core config topo start stop reload status clean mount umount
+.PHONY: build dep install image
 
 prefix?= "$(PWD)/devops/projects"
-release?= 0
-build_rocksdb?= 0
 only?= "*"
-hosts?= "*"
-tag?= "curvefs:unknown"
+dep?= 0
+release?= 0
 os?= "debian9"
-
-define deploy_begin
-	@bash util/deploy.sh begin
-endef
-
-define deploy_end
-	@bash util/deploy.sh end
-endef
-
-define only_service
-	$(call deploy_begin)
-	@bash util/deploy.sh --hosts=$(hosts) --only="etcd" --tags=$(1)
-	@bash util/deploy.sh --hosts=$(hosts) --only="mds" --tags=$(1)
-	@bash util/deploy.sh --hosts=$(hosts) --only="metaserver" --tags=$(1)
-	$(call deploy_end)
-endef
-
-define only_specify
-	$(call deploy_begin)
-	@bash util/deploy.sh --hosts=$(hosts) --only=$(1) --tags=$(2)
-	$(call deploy_end)
-endef
+build_rocksdb?= 0
+tag?= "curvefs:unknown"
 
 build:
-	@bash util/build.sh --only=$(only) --release=$(release) --os=$(os) --build_rocksdb=$(build_rocksdb)
+	@bash util/build.sh --only=$(only) --dep=$(dep) --release=$(release) --os=$(os) --build_rocksdb=$(build_rocksdb)
+
+dep:
+	@bash util/build.sh --only="" --dep=1 --build_rocksdb=$(build_rocksdb)
 
 install:
 	@bash util/install.sh --prefix=$(prefix) --only=$(only)
 
 image:
 	@bash util/image.sh $(tag) $(os)
-
-deploy:
-	$(call deploy_begin)
-	@bash util/deploy.sh --hosts="etcd" --only="etcd" --tags="core,config,start"
-	@bash util/deploy.sh --hosts="mds" --only="mds" --tags="core,config,start"
-	@bash util/deploy.sh --hosts="metaserver" --only="metaserver" --tags="core,config,start"
-	@bash util/deploy.sh --hosts="tools" --only="tools" --tags="core,config,topo"
-	@bash util/deploy.sh --hosts="client" --only="client" --tags="core,config"
-	$(call deploy_end)
-
-core:
-	$(call only_specify,$(only),core)
-
-config:
-	$(call only_specify,$(only),config)
-
-topo:
-	$(call only_specify,tools,topo)
-
-debug:
-	$(call only_specify,$(only),debug)
-
-start:
-ifeq ($(only), "*")
-	$(call only_service,start)
-else
-	$(call only_specify,$(only),start)
-endif
-
-stop:
-ifeq ($(only), "*")
-	$(call only_service,stop)
-else
-	$(call only_specify,$(only),stop)
-endif
-
-reload:
-ifeq ($(only), "*")
-	$(call only_service,restart)
-else
-	$(call only_specify,$(only),restart)
-endif
-
-status:
-ifeq ($(only), "*")
-	$(call only_service,status)
-else
-	$(call only_specify,$(only),status)
-endif
-
-clean:
-	$(call only_specify,$(only),clean)
-
-mount:
-	$(call only_specify,client,mount)
-
-umount:
-	$(call only_specify,client,umount)

--- a/curvefs/README.md
+++ b/curvefs/README.md
@@ -3,127 +3,16 @@ CURVEFS
 
 Curve FileSystem
 
-Table of Contents
-===
-* [Requirement](#requirement)
-* [Quick Start](#quick-start)
-* [Devops](#devops)
-* [Hint](#hint)
-
-Requirement
-===
-
-* bazel
-* ansible
-* linux*
-
-[Back to Toc](#table-of-contents)
-
 Quick Start
 ===
 
-NOTE: If you are using CentOS-8, you can refer to this issue to compile CurveFS: https://github.com/opencurve/curve/issues/807
+```
+$ make build dep=1
+```
 
-step 1: clone repository, run build and install:
+OR
 
 ```
-$ git clone https://github.com/opencurve/curve.git
-$ cd curve/curvefs
+$ make dep
 $ make build
-$ make install
-$ make install only=etcd
 ```
-
-step 2: edit ansible config file, inventory file and client config file:
-
-* devops/ansible.cfg:
-    * `remoter_user`: we use this user to log in to the remote machine, create file and start service
-    * `private_key_file`: paste `remote_user`'s private key to `devops/ssh/pub_rsa` (you can also save the private key anywhere locally and point the `private_key_file` to it)
-    * Please make sure that the mode of private key file which `private_key_file` specfied is `600` (`-rw-------`)
-    * Please make sure that the public key already exists in `remote_user`'s ssh file (`~/.ssh/authorized_keys`)
-* inventory/server.ini:
-    * You can specify which hosts to deploy which services
-    * Please specify the client mount path (`client_mount_path`), the path will create automatic if it not exist
-    * Please specify the filesystem name which client mount (`client_mount_fsname`), the filesystem will create automatic if it not exist
-    * The `tools` only used to create topology, you can select one of `mds` hosts
-* conf/{client.conf, metaserver.conf}
-    * `s3.ak`
-    * `s3.sk`
-    * `s3.endpoint`
-    * `s3.bucket_name`
-
-step 3: deploy all and mount curve filesystem:
-
-```
-$ make deploy
-$ make mount
-```
-
-once this is done, you can enter the mount path and do anything like local filesystem.
-
-[Back to Toc](#table-of-contents)
-
-Devops
-===
-
-| command                                  | description                                   |
-| :---                                     | :---                                          |
-| make build [only=ONLY] [release=1]       | compile                                       |
-| make install [only=ONLY] [prefix=PREFIX] | install                                       |
-| [sudo] make image tag=TAG                | make docker image (maybe need sudo privilege) |
-| make deploy                              | deploy all                                    |
-| make core [only=ONLY] [hosts=HOSTS]      | sync binary file                              |
-| make config [only=ONLY] [hosts=HOSTS]    | sync config file                              |
-| make start [only=ONLY] [hosts=HOSTS]     | start service                                 |
-| make stop [only=ONLY] [hosts=HOSTS]      | stop service                                  |
-| make reload [only=ONLY] [hosts=HOSTS]    | restart service                               |
-| make status [only=ONLY] [hosts=HOSTS]    | show service status                           |
-| make clean [only=ONLY] [hosts=HOSTS]     | clean environment (include all created files) |
-| make topo                                | create topology                               |
-| make mount                               | mount curve filesystem                        |
-| make umount                              | umount curve filesystem                       |
-
-
-* If you want to execute action for specfied service, you can use `only` option, e.g: `make start only=mds`
-* If you want to execute action in specfied host, you can use `hosts` option, e.g: `make start hosts=machine1`
-* You can also specify both `only` and `hosts` option, e.g: `make start only=mds hosts=machine1:machine2`
-* The `only` option can be one of the following values: `etcd`、`mds`、`metaserver`、`space`、`client`、 `tools`
-
-[Back to Toc](#table-of-contents)
-
-HINT
-===
-
-* The default install prefix of projects is `devops/projects`
-* If you want to modify the service's config, you can modify the config under `conf` directory, then run `make config`
-* You can use `make status` to show service status, include active status, listen address, memory usage and etc:
-
-```
-$ make status only=mds
-
-curve-vm1:
-mds.service - CurveFS Mds
-    Active: [RUNNING] since 2021-09-26 19:27:39; 52:35 ago
-  Main PID: 326373 (curvefs_mds)
-    Daemon: True
-    Listen: 0.0.0.0:26700, 0.0.0.0:27700
-       Mem: 51688 KB
-
-curve-vm2:
-mds.service - CurveFS Mds
-    Active: [RUNNING] since 2021-09-26 19:27:39; 52:35 ago
-  Main PID: 326381 (curvefs_mds)
-    Daemon: True
-    Listen: 0.0.0.0:37700
-       Mem: 40688 KB
-
-curve-vm3:
-mds.service - CurveFS Mds
-    Active: [RUNNING] since 2021-09-26 19:27:39; 52:35 ago
-  Main PID: 326401 (curvefs_mds)
-    Daemon: True
-    Listen: 0.0.0.0:17700
-       Mem: 55520 KB
-```
-
-[Back to Toc](#table-of-contents)

--- a/curvefs/conf/client.conf
+++ b/curvefs/conf/client.conf
@@ -139,6 +139,7 @@ s3.logPrefix=/data/logs/curvefs/aws_ # __CURVEADM_TEMPLATE__ /curvefs/client/log
 s3.async_thread_num=30
 # limit all inflight async requests' bytes, |0| means not limited
 s3.max_async_request_inflight_bytes=104857600
+s3.chunkFlushThreads=5
 # throttle
 s3.throttle.iopsTotalLimit=0
 s3.throttle.iopsReadLimit=0
@@ -162,6 +163,7 @@ diskCache.asyncLoadPeriodMs=5
 # util less than safeRatio
 diskCache.fullRatio=90
 diskCache.safeRatio=70
+diskCache.threads=5
 # the max size disk cache can use
 diskCache.maxUsableSpaceBytes=107374182400
 # the max time system command can run

--- a/curvefs/conf/client.conf
+++ b/curvefs/conf/client.conf
@@ -171,16 +171,16 @@ diskCache.cmdTimeoutSec=300
 # directory of disk cache
 diskCache.cacheDir=/mnt/curvefs_cache  # __CURVEADM_TEMPLATE__ /curvefs/client/data/cache __CURVEADM_TEMPLATE__  __ANSIBLE_TEMPLATE__ /mnt/curvefs_disk_cache/{{ 99999999 | random | to_uuid | upper }} __ANSIBLE_TEMPLATE__
 
-# the write throttle bps of disk cache, default 80MB/s
-diskCache.avgFlushBytes=83886080
-# the write burst bps of disk cache, default 100MB/s
-diskCache.burstFlushBytes=104857600
+# the write throttle bps of disk cache, default no limit
+diskCache.avgFlushBytes=0
+# the write burst bps of disk cache, default no limit
+diskCache.burstFlushBytes=0
 # the times that write burst bps can continue, default 180s
 diskCache.burstSecs=180
 # the write throttle iops of disk cache, default no limit
 diskCache.avgFlushIops=0
-# the read throttle bps of disk cache, default 80MB/s
-diskCache.avgReadFileBytes=83886080
+# the read throttle bps of disk cache, default no limit
+diskCache.avgReadFileBytes=0
 # the read throttle iops of disk cache, default no limit
 diskCache.avgReadFileIops=0
 

--- a/curvefs/conf/client.conf
+++ b/curvefs/conf/client.conf
@@ -35,9 +35,9 @@ metaCacheOpt.metacacheGetLeaderRPCTimeOutMS=1000
 #### excutorOpt
 # excutorOpt rpc with metaserver
 # rpc retry times with metaserver
-excutorOpt.maxRetry=1000000
+excutorOpt.maxRetry=4294967295
 # Retry sleep time between failed RPCs
-excutorOpt.retryIntervalUS=500
+excutorOpt.retryIntervalUS=100000
 # RPC timeout for communicating with metaserver
 excutorOpt.rpcTimeoutMS=1000
 # RPC stream idle timeout

--- a/curvefs/conf/client.conf
+++ b/curvefs/conf/client.conf
@@ -146,6 +146,7 @@ s3.throttle.iopsWriteLimit=0
 s3.throttle.bpsTotalMB=0
 s3.throttle.bpsReadMB=0
 s3.throttle.bpsWriteMB=0
+s3.useVirtualAddressing=false
 
 # TODO(hongsong): limit bytes、iops/bps
 #### disk cache options

--- a/curvefs/conf/client.conf
+++ b/curvefs/conf/client.conf
@@ -88,6 +88,11 @@ fuseClient.dCacheLruSize=65536
 fuseClient.enableICacheMetrics=true
 fuseClient.enableDCacheMetrics=true
 fuseClient.cto=true
+# splice will bring higher performance in some cases
+# but there're might be a kernel issue that will cause kernel panic when enabling it
+# see https://lore.kernel.org/all/CAAmZXrsGg2xsP1CK+cbuEMumtrqdvD-NKnWzhNcvn71RV3c1yw@mail.gmail.com/
+# until this issue has been fixed, splice should be disabled
+fuseClient.enableSplice=false
 
 #### volume
 volume.bigFileSize=1048576

--- a/curvefs/conf/mds.conf
+++ b/curvefs/conf/mds.conf
@@ -128,3 +128,4 @@ s3.throttle.iopsWriteLimit=0
 s3.throttle.bpsTotalMB=0
 s3.throttle.bpsReadMB=0
 s3.throttle.bpsWriteMB=0
+s3.useVirtualAddressing=false

--- a/curvefs/conf/mds.conf
+++ b/curvefs/conf/mds.conf
@@ -106,6 +106,8 @@ mds.scheduler.metaserver.cooling.timeSec=1800
 # the backend thread check whether fs is able to delete,
 # check partition of deleting fs is deleting
 mds.fsmanager.backEndThreadRunInterSec=10
+# number of threads that load space info of volume
+mds.fsmanager.reloadSpaceConcurrency=10
 
 #### s3
 # TODO(huyao): use more meaningfull name

--- a/curvefs/conf/metaserver.conf
+++ b/curvefs/conf/metaserver.conf
@@ -229,8 +229,10 @@ storage.rocksdb.ordered_write_buffer_size=134217728
 # rocksdb column family's max_write_buffer_number
 # for store dentry and inode's s3chunkinfo list (default: 15)
 storage.rocksdb.ordered_max_write_buffer_number=15
-# rocksdb block cache(LRU) capacity (default: 128MB)
-storage.rocksdb.block_cache_capacity=134217728
+# rocksdb block cache(LRU) capacity (default: 512MB)
+storage.rocksdb.block_cache_capacity=536870912
+# rocksdb memtable prefix bloom size ratio (size=write_buffer_size*memtable_prefix_bloom_size_ratio)
+storage.rocksdb.memtable_prefix_bloom_size_ratio=0.1
 # if the number of inode's s3chunkinfo exceed the limit_size,
 # we will sending its with rpc streaming instead of
 # padding its into inode (default: 25000, about 25000 * 41 (byte) = 1MB)

--- a/curvefs/conf/metaserver.conf
+++ b/curvefs/conf/metaserver.conf
@@ -231,3 +231,7 @@ storage.rocksdb.ordered_write_buffer_size=134217728
 storage.rocksdb.ordered_max_write_buffer_number=15
 # rocksdb block cache(LRU) capacity (default: 128MB)
 storage.rocksdb.block_cache_capacity=134217728
+# if the number of inode's s3chunkinfo exceed the limit_size,
+# we will sending its with rpc streaming instead of
+# padding its into inode (default: 25000, about 25000 * 41 (byte) = 1MB)
+storage.s3_meta_inside_inode.limit_size=25000

--- a/curvefs/conf/metaserver.conf
+++ b/curvefs/conf/metaserver.conf
@@ -26,6 +26,7 @@ s3.throttle.iopsWriteLimit=0
 s3.throttle.bpsTotalMB=0
 s3.throttle.bpsReadMB=0
 s3.throttle.bpsWriteMB=0
+s3.useVirtualAddressing=false
 # s3 workqueue
 s3compactwq.enable=True
 s3compactwq.thread_num=2

--- a/curvefs/conf/tools.conf
+++ b/curvefs/conf/tools.conf
@@ -29,5 +29,6 @@ s3.endpoint=endpoint
 s3.bucket_name=bucket
 s3.blocksize=4194304
 s3.chunksize=67108864
+s3.useVirtualAddressing=false
 # statistic info in xattr, hardlink will not be supported when enable
 enableSumInDir=true

--- a/curvefs/docker/debian10/Dockerfile
+++ b/curvefs/docker/debian10/Dockerfile
@@ -1,6 +1,6 @@
 FROM opencurvedocker/curve-base:debian10
 ENV TZ=Asia/Shanghai
-RUN mkdir -p /curvefs /etc/curvefs /core
+RUN mkdir -p /curvefs /etc/curvefs /core /etc/curve
 COPY curvefs /curvefs
 COPY entrypoint.sh /
 COPY curvefs/tools/sbin/curvefs_tool /usr/bin

--- a/curvefs/docker/debian11/Dockerfile
+++ b/curvefs/docker/debian11/Dockerfile
@@ -1,6 +1,6 @@
 FROM opencurvedocker/curve-base:debian11
 ENV TZ=Asia/Shanghai
-RUN mkdir -p /curvefs /etc/curvefs /core
+RUN mkdir -p /curvefs /etc/curvefs /core /etc/curve
 COPY curvefs /curvefs
 COPY entrypoint.sh /
 COPY curvefs/tools/sbin/curvefs_tool /usr/bin

--- a/curvefs/docker/debian9/Dockerfile
+++ b/curvefs/docker/debian9/Dockerfile
@@ -1,6 +1,6 @@
 FROM opencurvedocker/curve-base:debian9
 ENV TZ=Asia/Shanghai
-RUN mkdir -p /curvefs /etc/curvefs /core
+RUN mkdir -p /curvefs /etc/curvefs /core /etc/curve
 COPY curvefs /curvefs
 COPY entrypoint.sh /
 COPY curvefs/tools/sbin/curvefs_tool /usr/bin

--- a/curvefs/monitor/README.md
+++ b/curvefs/monitor/README.md
@@ -1,0 +1,131 @@
+# 目录结构介绍
+
+```
+monitor
+├── curve-monitor.sh        # curve集群监控的控制脚本，用于启动、停止、重启监控功能。
+├── docker-compose.yml      # 编排监控系统相关容器的配置文件，包括prometheus容器、grafana容器。
+|                           # 修改该文件来配置各组件的配置参数。
+├── grafana                 # grafana相关目录
+│   ├── dashboards          # grafana所有dashboards的json文件存放目录，grafana将从该目录加载文件来创建dashboards；
+|   |   |                   # 通过update_dashboard.sh脚本来更新最新的dashboards。
+│   │   ├── etcd.json
+│   │   ├── mds.json
+│   │   ├── metaserver.json
+│   │   └── clinet.json
+│   ├── grafana.ini         # grafana的启动配置文件，将映射到容器的 `/etc/grafana/grafana.ini` 上
+│   ├── provisioning        # grafana预配置相关目录，将映射到容器的`/etc/grafana/provisioning`上
+│   │   ├── dashboards
+│   │   │   └── all.yml
+│   │   └── datasources     # grafana的datasources的json文件存放目录，grafana将从该目录加载文件来创建datasources。
+│   │       └── all.yml
+│   └── report              # grafana日报临时目录，将映射到reporter容器的`/tmp/report`目录上
+│       └── README
+├── grafana-report.py
+├── prometheus              # prometheus相关目录
+│   ├── prometheus.yml      # prometheus的配置文件
+│   └── target.json
+├── README.md
+├── target.ini              # target_json.py脚本依赖的一些配置
+├── target_json.py          # 用于生成prometheus监控对象的python脚本，每隔一段时间用curvefs_tool拉取监控目标并更新。
+└── update_dashboard.sh     # 从grafana界面配置环境当中拉取最新的dashboard，用于更新该环境上grafana的界面。
+```
+
+## 使用说明
+
+以下步骤为不使用puppet进行部署的过程。
+
+### 环境初始化
+
+1.部署监控系统的机器需要安装如下组件：
+
+node_exporter、docker、docker-compose、jq
+
+* docker安装
+
+```
+$ curl -fsSL get.docker.com -o get-docker.sh
+$ sudo sh get-docker.sh --mirror Aliyun
+```
+
+或者直接安装
+
+```
+apt-get install docker-ce
+apt-get install docker-ce-cli
+```
+
+* docker-compose
+
+* ```
+  curl -L https://github.com/docker/compose/releases/download/1.18.0/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
+  chmod +x /usr/local/bin/docker-compose
+  ```
+
+  或者直接安装
+
+  ```
+  apt-get install docker-compose
+  ```
+
+* node_exporter
+
+  可能很多节点都要安装，可以用脚本来一起装，如下面的方式：
+
+  ```
+  for i in {1..4};
+  do
+  scp -P 1046 ~/Downloads/node_exporter-0.18.1.linux-amd64.tar.gz yangyaokai@pubt1-curve$i.yq.163.org:~/
+  ssh -p 1046 yangyaokai@pubt1-curve$i.yq.163.org "tar zxvf node_exporter-0.18.1.linux-amd64.tar.gz ; cd node_exporter-0.18.1.linux-amd64 ; nohup ./node_exporter >/dev/null 2>log &"
+  echo $i
+  done
+  ```
+
+* jq
+
+  update_dashboard.sh脚本需要依赖jq命令，这个一般机器上都没装
+
+  ```
+  apt-get install jq
+  ```
+
+2.chunkserver上安装node_exporter（机器监控可以依赖哨兵，可以不装）
+
+
+### 部署监控系统
+
+* 修改相关配置
+
+1.修改target_json.py文件中相应的配置
+
+2.修改update_dashboard.sh，将 URL 和 LOGIN 改为对应的地址和用户名密码
+
+3.修改docker-compose.yml文件，主要是映射的目录路径
+
+* 启动docker-compose
+
+在当前目录下执行如下命令即可
+
+```curve-monitor.sh start ```
+
+* 部署grafana每日报表
+
+crontab配置定时任务，添加如下任务：
+30 8 * * * python /etc/curve/monitor/grafana-report.py >> /etc/curve/monitor/cron.log 2>&1
+如果机器上没有配置其他的定时任务，可直接用下面命令
+echo "30 8 * * * python /etc/curve/monitor/grafana-report.py >> /etc/curve/monitor/cron.log 2>&1" >> conf && crontab conf && rm -f conf
+
+#### 对接puppet
+
+如果对接puppet，配置相关文件都会放到puppet上，配置的变更都要上传到puppet上。
+
+puppet上管理的配置包括：docker-compose.yml、target.ini、grafana.ini、prometheus.yml
+
+通过安装包安装完curve-monitor以后，会将curve-monitor.sh拷贝到/usr/bin目录下，可以通过以下命令管理监控系统：
+
+启动：```curve-monitor.sh start```
+
+停止：```curve-monitor.sh stop```
+
+重启：```curve-monitor.sh restart```
+
+上面环境初始化中的依赖的包puppet基本都会帮忙安装，除了node_exporter需要自己安装。

--- a/curvefs/monitor/curve-monitor.sh
+++ b/curvefs/monitor/curve-monitor.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+
+#
+#     Copyright (c) 2022 NetEase Inc.
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+#sh update_dashboard.sh
+#echo "update dashboards success!"
+
+WORKDIR=/etc/curvefs/monitor
+
+if [ ! -d $WORKDIR ]; then
+  echo "${WORKDIR} not exists"
+  exit 1
+fi
+
+cd $WORKDIR
+chmod -R 777 prometheus
+chmod -R 777 grafana
+
+start() {
+    echo "==========start==========="
+
+    echo "" > monitor.log
+
+    stdbuf -oL python3 target_json.py >> monitor.log 2>&1 &
+    echo "start prometheus targets service success!"
+
+    docker-compose up >> monitor.log 2>&1 &
+    echo "start metric system success!"
+}
+
+stop() {
+    echo "===========stop============"
+
+    docker-compose down
+
+    ID=`(ps -ef | grep "target_json.py"| grep -v "grep") | awk '{print $2}'`
+    for id in $ID
+    do
+        kill -9 $id
+	echo "killed $id"
+    done
+}
+
+restart() {
+    stop
+    echo "sleeping........."
+    sleep 3
+    start
+}
+
+case "$1" in
+    'start')
+        start
+        ;;
+    'stop')
+        stop
+        ;;
+    'status')
+        status
+        ;;
+    'restart')
+        restart
+        ;;
+    *)
+    echo "usage: $0 {start|stop|restart}"
+    exit 1
+        ;;
+    esac

--- a/curvefs/monitor/docker-compose.yml
+++ b/curvefs/monitor/docker-compose.yml
@@ -1,0 +1,57 @@
+#
+#     Copyright (c) 2022 NetEase Inc.
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+version: '2.0'
+
+services:
+
+  prometheus:
+    image: prom/prometheus:latest
+    volumes:
+      - ./prometheus/:/etc/prometheus/:rw
+      - ./prometheus/data:/prometheus:rw
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--storage.tsdb.retention.time=7d'
+      - '--storage.tsdb.retention.size=256GB'
+      - '--web.console.libraries=/usr/share/prometheus/console_libraries'
+      - '--web.console.templates=/usr/share/prometheus/consoles'
+      - '--web.listen-address=:9090'
+    network_mode: host
+
+  grafana:
+    image: grafana/grafana
+    depends_on:
+      - prometheus
+    network_mode: host
+    volumes:
+      - ./grafana/data:/var/lib/grafana:rw
+      - ./grafana/grafana.ini:/etc/grafana/grafana.ini:rw
+    environment:
+      - GF_INSTALL_PLUGINS=grafana-piechart-panel
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=curve
+
+  reporter:
+    image: promoon/reporter:latest
+    volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
+      - ./grafana/report:/tmp/report:rw
+    network_mode: host

--- a/curvefs/monitor/grafana-report.py
+++ b/curvefs/monitor/grafana-report.py
@@ -1,0 +1,135 @@
+#
+#     Copyright (c) 2022 NetEase Inc.
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+# coding: utf8
+
+import smtplib
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from email.mime.image import MIMEImage
+from email.utils import parseaddr, formataddr
+import time as Time
+import re
+import shutil
+import os
+
+sender = 'Grafana<xxxxxxxxx@163.com>'
+to_address = ['xxxxxxxxx@163.com']
+username = 'xxxxxxxxx@163.com'
+password = 'xxxxxxxxx' # SMTP授权码
+smtpserver = 'xxxx.163.com:1234'
+sourcefile= '/etc/curve/monitor/grafana/report/report.tex'
+imagedir= '/etc/curve/monitor/grafana/report/images/'
+pdfpath= '/etc/curve/monitor/grafana/report/report.pdf'
+clustername = '【CURVE】xxxxxxxxx'
+grafanauri = '127.0.0.1:3000'
+reporteruri = '127.0.0.1:8686'
+dashboardid = 'xxxxxxxxx'
+apitoken = 'xxxxxxxxx'
+
+def get_images():
+    image_name_list = []
+    file = open(sourcefile, 'r')
+    line = file.readline()
+    while line:
+        # print (line)
+        prefix_image_name = re.findall(r'image\d+', line)
+        if prefix_image_name:
+            print (prefix_image_name)
+            image_name_list.append(prefix_image_name[0])
+        line = file.readline()
+    file.close()
+
+    return image_name_list
+
+def getMsgImage(image_name):
+    file_name = imagedir+image_name+'.png'
+    print (file_name)
+    fp = open(file_name, 'rb')
+    msgImage = MIMEImage(fp.read())
+    fp.close()
+    msgImage.add_header('Content-ID', image_name)
+    msgImage.add_header("Content-Disposition", "inline", filename=file_name)
+    return msgImage
+
+def attach_body(msgRoot):
+    image_list = get_images()
+
+    image_body = ""
+    for image in image_list:
+        image_body += ('<img src="cid:%s" alt="%s">' % (image, image))
+        msgRoot.attach(getMsgImage(image))
+
+    html_str = '<html><head><style>#string{text-align:center;font-size:25px;}</style></head><body>%s</body></html>' % (image_body)
+
+    mailMsg = """
+    <p>可点击如下链接在grafana面板中查看（若显示混乱，请在附件pdf中查看）</p>
+    <p><a href="http://%s">grafana链接</a></p>
+    """ % (grafanauri)
+    mailMsg += html_str
+    print(mailMsg)
+    content = MIMEText(mailMsg,'html','utf-8')
+    msgRoot.attach(content)
+
+# 发送dashboard日报邮件
+def send_mail():
+    time_now = int(Time.time())
+    time_local = Time.localtime(time_now)
+    dt = Time.strftime("%Y%m%d",time_local)
+
+    msgRoot = MIMEMultipart('related')
+    msgRoot['Subject'] = '%s集群监控日报-%s' % (clustername, dt)
+    msgRoot['From'] = sender
+    msgRoot['To'] = ",".join( to_address ) # 发给多人
+
+    # 添加pdf附件
+    pdf_attach = MIMEText(open(pdfpath, 'rb').read(), 'base64', 'utf-8')
+    pdf_attach["Content-Type"] = 'application/octet-stream'
+    # 这里的filename可以任意写，写什么名字，邮件中显示什么名字
+    pdf_attach["Content-Disposition"] = 'attachment; filename="reporter-{}.pdf"'.format(dt)
+    msgRoot.attach(pdf_attach)
+
+    # 添加正文
+    attach_body(msgRoot)
+
+    smtp = smtplib.SMTP_SSL(smtpserver)
+    smtp.login(username, password)
+    smtp.sendmail(sender, to_address, msgRoot.as_string())
+    smtp.quit()
+
+def clear():
+    shutil.rmtree(imagedir)
+    os.mkdir(imagedir)
+    os.chmod(imagedir, 0777)
+
+def generate_report():
+    downloadcmd = (
+        "wget -O %s "
+        "http://%s/api/v5/report/%s?apitoken=%s"
+        "\&from=now-24h\&to=now"
+    ) % (pdfpath, reporteruri, dashboardid, apitoken)
+    print(downloadcmd)
+    os.system(downloadcmd)
+
+def main():
+    generate_report()
+    send_mail()
+    clear()
+
+if __name__ == '__main__':
+    main()

--- a/curvefs/monitor/grafana/dashboards/client.json
+++ b/curvefs/monitor/grafana/dashboards/client.json
@@ -1,0 +1,2046 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Curvefs client",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 4,
+  "iteration": 1649851130043,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 6,
+      "panels": [],
+      "title": "process usage",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "hiddenSeries": false,
+      "id": 4,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": false,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.4.4",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "tJLDJxsnz"
+          },
+          "exemplar": true,
+          "expr": "process_memory_resident{instance=~\"$instance\"}",
+          "interval": "",
+          "legendFormat": "process_memory_resident {{instance}}",
+          "refId": "process_memory_resident"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "tJLDJxsnz"
+          },
+          "exemplar": true,
+          "expr": "process_memory_virtual{instance=~\"$instance\"}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "process_memory_virtual {{instance}}",
+          "refId": "process_memory_virtual"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "tJLDJxsnz"
+          },
+          "exemplar": true,
+          "expr": "process_memory_shared{instance=~\"$instance\"}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "process_memory_shared {{instance}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "process memory usage",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:63",
+          "format": "decbytes",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:64",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "hiddenSeries": false,
+      "id": 2,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": false,
+        "max": true,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.4.4",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "tJLDJxsnz"
+          },
+          "exemplar": true,
+          "expr": "process_cpu_usage{instance=~\"$instance\"}",
+          "interval": "",
+          "legendFormat": "process_cpu_usage {{instance}}",
+          "refId": "process_cpu_usage"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "tJLDJxsnz"
+          },
+          "exemplar": true,
+          "expr": "process_cpu_usage_system{instance=~\"$instance\"}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "process_cpu_usage_system {{instance}}",
+          "refId": "process_cpu_usage_system"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "tJLDJxsnz"
+          },
+          "exemplar": true,
+          "expr": "process_cpu_usage_user{instance=~\"$instance\"}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "process_cpu_usage_user {{instance}}",
+          "refId": "process_cpu_usage_user"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "process cpu usage",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:495",
+          "format": "percentunit",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:496",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 8,
+      "panels": [],
+      "title": " r/w performance",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 10
+      },
+      "hiddenSeries": false,
+      "id": 10,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.4.4",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "tJLDJxsnz"
+          },
+          "exemplar": true,
+          "expr": "{__name__=~\"curvefs.*[[fs:regex]].*read_qps.*\"}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "read_qps",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:212",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:213",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 10
+      },
+      "hiddenSeries": false,
+      "id": 11,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.4.4",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "tJLDJxsnz"
+          },
+          "exemplar": true,
+          "expr": "{__name__=~\"curvefs.*[[fs:regex]].*write_qps.*\"}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "write_qps",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:212",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:213",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 18
+      },
+      "hiddenSeries": false,
+      "id": 12,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.4.4",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "tJLDJxsnz"
+          },
+          "exemplar": true,
+          "expr": "{__name__=~\"curvefs.*[[fs:regex]].*read_bps.*\"}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "read_bps",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:212",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:213",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 18
+      },
+      "hiddenSeries": false,
+      "id": 13,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.4.4",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "tJLDJxsnz"
+          },
+          "exemplar": true,
+          "expr": "{__name__=~\"curvefs.*[[fs:regex]].*write_bps.*\"}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "write_bps",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:212",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:213",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 26
+      },
+      "hiddenSeries": false,
+      "id": 14,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.4.4",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "tJLDJxsnz"
+          },
+          "exemplar": true,
+          "expr": "{__name__=~\"curvefs.*[[fs:regex]].*read_eps.*\"}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "read_eps",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:212",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:213",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 26
+      },
+      "hiddenSeries": false,
+      "id": 15,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.4.4",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "tJLDJxsnz"
+          },
+          "exemplar": true,
+          "expr": "{__name__=~\"curvefs.*[[fs:regex]].*write_eps.*\"}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "write_eps",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:212",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:213",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 34
+      },
+      "hiddenSeries": false,
+      "id": 42,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.4.4",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "tJLDJxsnz"
+          },
+          "exemplar": true,
+          "expr": "{__name__=~\"curvefs.*[[fs:regex]].*read_rps.*\"}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "read_rps",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:212",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:213",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 34
+      },
+      "hiddenSeries": false,
+      "id": 43,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.4.4",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "tJLDJxsnz"
+          },
+          "exemplar": true,
+          "expr": "{__name__=~\"curvefs.*[[fs:regex]].*write_rps.*\"}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "write_rps",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:212",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:213",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 42
+      },
+      "hiddenSeries": false,
+      "id": 26,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.4.4",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "tJLDJxsnz"
+          },
+          "exemplar": true,
+          "expr": "{__name__=~\"curvefs.*[[fs:regex]].*read.*latency.*\"}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "read_latency",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:212",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:213",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 42
+      },
+      "hiddenSeries": false,
+      "id": 27,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.4.4",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "tJLDJxsnz"
+          },
+          "exemplar": true,
+          "expr": "{__name__=~\"curvefs.*[[fs:regex]].*write.*latency.*\"}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "write_latency",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:212",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:213",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 50
+      },
+      "id": 32,
+      "panels": [],
+      "title": "mds client latency",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 51
+      },
+      "hiddenSeries": false,
+      "id": 36,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.4.4",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "tJLDJxsnz"
+          },
+          "exemplar": true,
+          "expr": "{__name__=~\"curvefs_mds_client.*bps.*\"}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "mds_clinet_bps",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:212",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:213",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 51
+      },
+      "hiddenSeries": false,
+      "id": 38,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.4.4",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "tJLDJxsnz"
+          },
+          "exemplar": true,
+          "expr": "{__name__=~\"curvefs_mds_client.*eps.*\"}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "mds_clinet_eps",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:212",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:213",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 57
+      },
+      "hiddenSeries": false,
+      "id": 39,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.4.4",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "tJLDJxsnz"
+          },
+          "exemplar": true,
+          "expr": "{__name__=~\"curvefs_mds_client.*qps.*\"}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "mds_clinet_qps",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:212",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:213",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 57
+      },
+      "hiddenSeries": false,
+      "id": 44,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.4.4",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "tJLDJxsnz"
+          },
+          "exemplar": true,
+          "expr": "{__name__=~\"curvefs_mds_client.*rps.*\"}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "mds_clinet_rps",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:212",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:213",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 63
+      },
+      "hiddenSeries": false,
+      "id": 28,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.4.4",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "tJLDJxsnz"
+          },
+          "exemplar": true,
+          "expr": "{__name__=~\"curvefs_mds_client.*latency.*\"}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "mds_clinet_latency",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:212",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:213",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 69
+      },
+      "id": 34,
+      "panels": [],
+      "title": "metaserver client latency",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 70
+      },
+      "hiddenSeries": false,
+      "id": 37,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.4.4",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "tJLDJxsnz"
+          },
+          "exemplar": true,
+          "expr": "{__name__=~\"curvefs_metaserver_client.*bps.*\"}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "metaserver_clinet_bps",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:212",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:213",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 70
+      },
+      "hiddenSeries": false,
+      "id": 40,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.4.4",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "tJLDJxsnz"
+          },
+          "exemplar": true,
+          "expr": "{__name__=~\"curvefs_metaserver_client.*eps.*\"}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "metaserver_clinet_eps",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:212",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:213",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 76
+      },
+      "hiddenSeries": false,
+      "id": 41,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.4.4",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "tJLDJxsnz"
+          },
+          "exemplar": true,
+          "expr": "{__name__=~\"curvefs_metaserver_client.*qps.*\"}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "metaserver_clinet_qps",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:212",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:213",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 76
+      },
+      "hiddenSeries": false,
+      "id": 45,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.4.4",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "tJLDJxsnz"
+          },
+          "exemplar": true,
+          "expr": "{__name__=~\"curvefs_metaserver_client.*rps.*\"}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "metaserver_clinet_rps",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:212",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:213",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 82
+      },
+      "hiddenSeries": false,
+      "id": 35,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.4.4",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "tJLDJxsnz"
+          },
+          "exemplar": true,
+          "expr": "{__name__=~\"curvefs_metaserver_client.*latency.*\"}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "metaserver_client_latency",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:212",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:213",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 35,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "definition": "{__name__=~\"bthread_count\", job=\"client\"}",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Addr",
+        "multi": false,
+        "name": "instance",
+        "options": [],
+        "query": {
+          "query": "{__name__=~\"bthread_count\", job=\"client\"}",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "/.*instance=\"([^\"]*).*/",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "definition": "{__name__=~\"curvefs_s3_.*_adaptor_write_bps\", job=\"client\"}",
+        "hide": 0,
+        "includeAll": true,
+        "label": "fsname",
+        "multi": false,
+        "name": "fs",
+        "options": [],
+        "query": {
+          "query": "{__name__=~\"curvefs_s3_.*_adaptor_write_bps\", job=\"client\"}",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "/curvefs_s3_(.*)_adaptor_write_bps.*/",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "client",
+  "uid": "QPevOxsnk",
+  "version": 45,
+  "weekStart": ""
+}

--- a/curvefs/monitor/grafana/dashboards/etcd.json
+++ b/curvefs/monitor/grafana/dashboards/etcd.json
@@ -1,0 +1,2419 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "etcd",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "gnetId": 3070,
+  "graphTooltip": 0,
+  "id": 6,
+  "iteration": 1648715604389,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 58,
+      "panels": [],
+      "title": "Server",
+      "type": "row"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "text": "NO"
+                },
+                "1": {
+                  "text": "YES"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "rgba(245, 54, 54, 0.9)"
+              },
+              {
+                "color": "rgba(237, 129, 40, 0.89)",
+                "value": 0
+              },
+              {
+                "color": "rgba(50, 172, 45, 0.97)",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 0,
+        "y": 1
+      },
+      "id": 44,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.4.4",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "WADmvby7z"
+          },
+          "exemplar": true,
+          "expr": "max(etcd_server_has_leader)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "",
+          "refId": "A",
+          "step": 600
+        }
+      ],
+      "title": "etcd has a leader?",
+      "type": "stat"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 8,
+        "y": 1
+      },
+      "id": 42,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.4.4",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "WADmvby7z"
+          },
+          "exemplar": true,
+          "expr": "max(etcd_server_leader_changes_seen_total)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "",
+          "refId": "A",
+          "step": 600
+        }
+      ],
+      "title": "The number of leader changes seen",
+      "type": "stat"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 16,
+        "y": 1
+      },
+      "id": 43,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.4.4",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "WADmvby7z"
+          },
+          "exemplar": true,
+          "expr": "max(etcd_server_leader_changes_seen_total)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "",
+          "refId": "A",
+          "step": 600
+        }
+      ],
+      "title": "The total number of failed proposals seen",
+      "type": "stat"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "WADmvby7z"
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 6
+      },
+      "hiddenSeries": false,
+      "id": 48,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.4.4",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "etcd_server_proposals_committed_total{instance=~\"$instance\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "etcd_server_proposals_committed_total",
+          "refId": "A"
+        },
+        {
+          "expr": "etcd_server_proposals_applied_total{instance=~\"$instance\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "etcd_server_proposals_applied_total",
+          "refId": "B"
+        },
+        {
+          "expr": "etcd_server_proposals_pending{instance=~\"$instance\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "etcd_server_proposals_pending",
+          "refId": "C"
+        },
+        {
+          "expr": "etcd_server_proposals_failed_total{instance=~\"$instance\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "etcd_server_proposals_failed_total",
+          "refId": "D"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Proposals Committed",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "WADmvby7z"
+      },
+      "editable": true,
+      "error": false,
+      "fill": 0,
+      "fillGradient": 0,
+      "grid": {},
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 6
+      },
+      "hiddenSeries": false,
+      "id": 1,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "connected",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.4.4",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "etcd_debugging_mvcc_db_total_size_in_bytes{instance=~\"$instance\"}",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{instance}} DB Size",
+          "metric": "",
+          "refId": "A",
+          "step": 120
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "DB Size",
+      "tooltip": {
+        "msResolution": false,
+        "shared": true,
+        "sort": 0,
+        "value_type": "cumulative"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "bytes",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "WADmvby7z"
+      },
+      "description": "Abnormally high snapshot duration (snapshot_save_total_duration_seconds) indicates disk issues and might cause the cluster to be unstable.",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 6
+      },
+      "hiddenSeries": false,
+      "id": 67,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.4.4",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(etcd_debugging_snap_save_total_duration_seconds_sum[1m]))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "The total latency distributions of save called by snapshot",
+          "refId": "A",
+          "step": 30
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Snapshot Duration",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "logBase": 1,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      },
+      "id": 56,
+      "panels": [],
+      "title": "Disk",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "WADmvby7z"
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 14
+      },
+      "hiddenSeries": false,
+      "id": 60,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "show": true,
+        "sort": "current",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": true,
+      "pluginVersion": "8.4.4",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "\nhistogram_quantile(1, \n  sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket{instance=~\"$instance\"}[5m])) by (le)\n)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "quantile=1",
+          "refId": "B"
+        },
+        {
+          "expr": "\nhistogram_quantile(0.99, \n  sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket{instance=~\"$instance\"}[5m])) by (le)\n)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "quantile=0.99",
+          "refId": "A"
+        },
+        {
+          "expr": "\nhistogram_quantile(0.75, \n  sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket{instance=~\"$instance\"}[5m])) by (le)\n)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "quantile=0.75",
+          "refId": "E"
+        },
+        {
+          "expr": "\nhistogram_quantile(0.50, \n  sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket{instance=~\"$instance\"}[5m])) by (le)\n)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "quantile=0.50",
+          "refId": "C"
+        },
+        {
+          "expr": "\nhistogram_quantile(0.25, \n  sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket{instance=~\"$instance\"}[5m])) by (le)\n)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "quantile=0.25",
+          "refId": "D"
+        },
+        {
+          "expr": "rate(etcd_disk_wal_fsync_duration_seconds_sum{instance=~\"$instance\"}[5m]) / rate(etcd_disk_wal_fsync_duration_seconds_count{instance=~\"$instance\"}[5m])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "avg",
+          "refId": "F"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "WAL Fsync Duration Sec Quantile",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "s",
+          "label": "",
+          "logBase": 1,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 14
+      },
+      "hiddenSeries": false,
+      "id": 62,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.4.4",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "histogram_quantile(1,\n  sum(rate(etcd_disk_backend_commit_duration_seconds_bucket{instance=~\"$instance\"}[5m])) by (le)\n)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "quantile=1",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99,\n  sum(rate(etcd_disk_backend_commit_duration_seconds_bucket{instance=~\"$instance\"}[5m])) by (instance,le)\n)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "quantile=0.99",
+          "refId": "C"
+        },
+        {
+          "expr": "histogram_quantile(0.75,\n  sum(rate(etcd_disk_backend_commit_duration_seconds_bucket{instance=~\"$instance\"}[5m])) by (instance,le)\n)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "quantile=0.75",
+          "refId": "D"
+        },
+        {
+          "expr": "histogram_quantile(0.50,\n  sum(rate(etcd_disk_backend_commit_duration_seconds_bucket{instance=~\"$instance\"}[5m])) by (instance,le)\n)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "quantile=0.50",
+          "refId": "F"
+        },
+        {
+          "expr": "histogram_quantile(0.25,\n  sum(rate(etcd_disk_backend_commit_duration_seconds_bucket{instance=~\"$instance\"}[5m])) by (instance,le)\n)",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "quantile=0.25",
+          "refId": "E"
+        },
+        {
+          "expr": "rate(etcd_disk_backend_commit_duration_seconds_sum{instance=~\"$instance\"}[5m]) / rate(etcd_disk_backend_commit_duration_seconds_count{instance=\"$instance\"}[5m])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "avg",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Increamental Snapshot Commit Duration Sec Quantile",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "s",
+          "logBase": 1,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 22
+      },
+      "id": 64,
+      "panels": [],
+      "title": "NetWork",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "WADmvby7z"
+      },
+      "editable": true,
+      "error": false,
+      "fill": 0,
+      "fillGradient": 0,
+      "grid": {},
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 23
+      },
+      "hiddenSeries": false,
+      "id": 16,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "connected",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.4.4",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(etcd_network_peer_sent_bytes_total{instance=~\"$instance\"}[1m])) by (To)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "E"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Peer Traffic Out",
+      "tooltip": {
+        "msResolution": false,
+        "shared": true,
+        "sort": 0,
+        "value_type": "cumulative"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "Bps",
+          "logBase": 1,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "WADmvby7z"
+      },
+      "editable": true,
+      "error": false,
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 23
+      },
+      "hiddenSeries": false,
+      "id": 20,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "connected",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.4.4",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(etcd_network_peer_received_bytes_total{instance=~\"$instance\"}[1m])) by (From)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance}} receive from {{From}}",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Peer Traffic In",
+      "tooltip": {
+        "msResolution": false,
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "Bps",
+          "logBase": 1,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 32
+      },
+      "hiddenSeries": false,
+      "id": 69,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.4.4",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "etcd_network_peer_sent_bytes_total{instance=~\"$instance\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Sent Bytes",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "bytes",
+          "logBase": 1,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 32
+      },
+      "hiddenSeries": false,
+      "id": 73,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.4.4",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "etcd_network_peer_sent_failures_total{instance=~\"$instance\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Sent Failures",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "locale",
+          "logBase": 1,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 40
+      },
+      "hiddenSeries": false,
+      "id": 71,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.4.4",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "etcd_network_peer_received_bytes_total{instance=~\"$instance\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Received Bytes",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "bytes",
+          "logBase": 1,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 40
+      },
+      "hiddenSeries": false,
+      "id": 75,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.4.4",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "etcd_network_peer_received_failures_total{instance=~\"$instance\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Receive Failures",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "locale",
+          "logBase": 1,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 48
+      },
+      "hiddenSeries": false,
+      "id": 77,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": true,
+        "min": true,
+        "rightSide": false,
+        "show": true,
+        "sort": "max",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.4.4",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "histogram_quantile(1,\n  sum(rate(etcd_network_peer_round_trip_time_seconds_bucket{instance=~\"$instance\"}[1m])) by (To,le)\n)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "to={{To}}, quantile=1",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.99,\n  sum(rate(etcd_network_peer_round_trip_time_seconds_bucket{instance=~\"$instance\"}[1m])) by (To,le)\n)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "to={{To}}, quantile=0.99",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.75,\n  sum(rate(etcd_network_peer_round_trip_time_seconds_bucket{instance=~\"$instance\"}[1m])) by (To,le)\n)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "to={{To}}, quantile=0.75",
+          "refId": "C"
+        },
+        {
+          "expr": "histogram_quantile(0.50,\n  sum(rate(etcd_network_peer_round_trip_time_seconds_bucket{instance=~\"$instance\"}[1m])) by (To,le)\n)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "to={{To}}, quantile=0.50",
+          "refId": "D"
+        },
+        {
+          "expr": "histogram_quantile(0.25,\n  sum(rate(etcd_network_peer_round_trip_time_seconds_bucket{instance=~\"$instance\"}[1m])) by (To,le)\n)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "to={{To}}, quantile=0.25",
+          "refId": "E"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Round Trip Time Quantile",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "s",
+          "label": "",
+          "logBase": 1,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 56
+      },
+      "id": 66,
+      "panels": [],
+      "title": "gRPC Requests",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "WADmvby7z"
+      },
+      "editable": true,
+      "error": false,
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 57
+      },
+      "hiddenSeries": false,
+      "id": 23,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "connected",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.4.4",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(grpc_server_started_total{grpc_type=\"unary\"}[1m]))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "RPC Rate",
+          "metric": "grpc_server_started_total",
+          "refId": "A",
+          "step": 60
+        },
+        {
+          "expr": "sum(rate(grpc_server_handled_total{grpc_type=\"unary\",grpc_code!=\"OK\"}[1m]))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "RPC Failed Rate",
+          "metric": "grpc_server_handled_total",
+          "refId": "B",
+          "step": 60
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "RPC Rate",
+      "tooltip": {
+        "msResolution": false,
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ops",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "WADmvby7z"
+      },
+      "editable": true,
+      "error": false,
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 57
+      },
+      "hiddenSeries": false,
+      "id": 41,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "connected",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.4.4",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(grpc_server_started_total{grpc_service=\"etcdserverpb.Lease\",grpc_type=\"bidi_stream\"}) - sum(grpc_server_handled_total{grpc_service=\"etcdserverpb.Lease\",grpc_type=\"bidi_stream\"})",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "Lease Streams",
+          "metric": "grpc_server_handled_total",
+          "refId": "B",
+          "step": 60
+        },
+        {
+          "expr": "sum(grpc_server_started_total{grpc_service=\"etcdserverpb.Watch\",grpc_type=\"bidi_stream\"}) - sum(grpc_server_handled_total{grpc_service=\"etcdserverpb.Watch\",grpc_type=\"bidi_stream\"})",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "intervalFactor": 1,
+          "legendFormat": "Watch Streams",
+          "metric": "grpc_server_handled_total",
+          "refId": "A",
+          "step": 60
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Active Streams",
+      "tooltip": {
+        "msResolution": false,
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "WADmvby7z"
+      },
+      "editable": true,
+      "error": false,
+      "fill": 5,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 64
+      },
+      "hiddenSeries": false,
+      "id": 22,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "connected",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.4.4",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(etcd_network_client_grpc_received_bytes_total{instance=~\"$instance\"}[1m])",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{instance}} Client Traffic In",
+          "metric": "etcd_network_client_grpc_received_bytes_total",
+          "refId": "A",
+          "step": 120
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Client Traffic In",
+      "tooltip": {
+        "msResolution": false,
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "Bps",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "WADmvby7z"
+      },
+      "editable": true,
+      "error": false,
+      "fill": 5,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 64
+      },
+      "hiddenSeries": false,
+      "id": 21,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "connected",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.4.4",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(etcd_network_client_grpc_sent_bytes_total{instance=~\"$instance\"}[1m])",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{instance}} Client Traffic Out",
+          "metric": "etcd_network_client_grpc_sent_bytes_total",
+          "refId": "A",
+          "step": 120
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Client Traffic Out",
+      "tooltip": {
+        "msResolution": false,
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "Bps",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "WADmvby7z"
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 70
+      },
+      "hiddenSeries": false,
+      "id": 46,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "show": true,
+        "sort": "current",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.4.4",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "grpc_server_handled_total{instance=~\"$instance\"}",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "intervalFactor": 1,
+          "legendFormat": "method={{grpc_method}}, service={{grpc_service}}, type={{grpc_type}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "RPC Total",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 70
+      },
+      "hiddenSeries": false,
+      "id": 81,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "show": true,
+        "sort": "current",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.4.4",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(grpc_server_handled_total{instance=~\"$instance\",grpc_code!=\"OK\"}) by (grpc_service)",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Error RPC Requst",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "logBase": 1,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 78
+      },
+      "hiddenSeries": false,
+      "id": 79,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": true,
+        "show": true,
+        "sort": "current",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.4.4",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(grpc_server_handled_total{instance=~\"$instance\"}[10s])) by (grpc_service)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Different RPC Rate",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ops",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 78
+      },
+      "hiddenSeries": false,
+      "id": 83,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.4.4",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(grpc_server_msg_sent_total{instance=~\"$instance\",grpc_type=\"server_stream\"}[1m])) by (grpc_service)\n /\nsum(rate(grpc_server_started_total{instance=~\"$instance\",grpc_type=\"server_stream\"}[1m])) by (grpc_service)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Avg Rep-Stream Size",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "logBase": 1,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 86
+      },
+      "id": 85,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": true,
+        "show": true,
+        "sort": "max",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pluginVersion": "8.4.4",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "histogram_quantile(1, \n  sum(rate(grpc_server_handling_seconds_bucket{instance=~\"$instance\"}[5m])) by (grpc_service,le)\n)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "grpc_service={{grpc_service}}, quantile=1",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.99, \n  sum(rate(grpc_server_handling_seconds_bucket{instance=~\"$instance\"}[5m])) by (grpc_service,le)\n)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "grpc_service={{grpc_service}}, quantile=0.99",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.75, \n  sum(rate(grpc_server_handling_seconds_bucket{instance=~\"$instance\"}[5m])) by (grpc_service,le)\n)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "grpc_service={{grpc_service}}, quantile=0.75",
+          "refId": "C"
+        },
+        {
+          "expr": "histogram_quantile(0.50, \n  sum(rate(grpc_server_handling_seconds_bucket{instance=~\"$instance\"}[5m])) by (grpc_service,le)\n)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "grpc_service={{grpc_service}}, quantile=0.50",
+          "refId": "D"
+        },
+        {
+          "expr": "histogram_quantile(0.25, \n  sum(rate(grpc_server_handling_seconds_bucket{instance=~\"$instance\"}[5m])) by (grpc_service,le)\n)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "grpc_service={{grpc_service}}, quantile=0.25",
+          "refId": "E"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "RPC Lantency Quantile",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "s",
+          "logBase": 1,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 86
+      },
+      "id": 87,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pluginVersion": "8.4.4",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "100.0 - (\nsum(rate(grpc_server_handling_seconds_bucket{instance=~\"$instance\",grpc_type=\"unary\",le=\"0.25\"}[5m])) by (grpc_service)\n / \nsum(rate(grpc_server_handling_seconds_count{instance=~\"$instance\",grpc_type=\"unary\"}[5m])) by (grpc_service)\n) * 100.0",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Slow Unary Queries (>250ms)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "percent",
+          "logBase": 1,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 35,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "WADmvby7z"
+        },
+        "definition": "etcd_server_has_leader",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Addr",
+        "multi": true,
+        "name": "instance",
+        "options": [],
+        "query": {
+          "query": "etcd_server_has_leader",
+          "refId": "Prometheus-instance-Variable-Query"
+        },
+        "refresh": 2,
+        "regex": "/.*instance=\"([^\"]*).*/",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "etcd",
+  "uid": "EuLA2DVZz",
+  "version": 5,
+  "weekStart": ""
+}

--- a/curvefs/monitor/grafana/dashboards/mds.json
+++ b/curvefs/monitor/grafana/dashboards/mds.json
@@ -1,0 +1,443 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Curvefs mds server",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 7,
+  "iteration": 1649851028366,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 6,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 2
+          },
+          "hiddenSeries": false,
+          "id": 4,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": false,
+            "max": true,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "8.4.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "tJLDJxsnz"
+              },
+              "exemplar": true,
+              "expr": "process_memory_resident{instance=~\"$instance\"}",
+              "interval": "",
+              "legendFormat": "process_memory_resident {{instance}}",
+              "refId": "process_memory_resident"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "tJLDJxsnz"
+              },
+              "exemplar": true,
+              "expr": "process_memory_virtual{instance=~\"$instance\"}",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "process_memory_virtual {{instance}}",
+              "refId": "process_memory_virtual"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "tJLDJxsnz"
+              },
+              "exemplar": true,
+              "expr": "process_memory_shared{instance=~\"$instance\"}",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "process_memory_shared {{instance}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "process memory usage",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:63",
+              "format": "decbytes",
+              "logBase": 1,
+              "show": true
+            },
+            {
+              "$$hashKey": "object:64",
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 2
+          },
+          "hiddenSeries": false,
+          "id": 2,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": false,
+            "max": true,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "8.4.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "tJLDJxsnz"
+              },
+              "exemplar": true,
+              "expr": "process_cpu_usage{instance=~\"$instance\"}",
+              "interval": "",
+              "legendFormat": "process_cpu_usage {{instance}}",
+              "refId": "process_cpu_usage"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "tJLDJxsnz"
+              },
+              "exemplar": true,
+              "expr": "process_cpu_usage_system{instance=~\"$instance\"}",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "process_cpu_usage_system {{instance}}",
+              "refId": "process_cpu_usage_system"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "tJLDJxsnz"
+              },
+              "exemplar": true,
+              "expr": "process_cpu_usage_user{instance=~\"$instance\"}",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "process_cpu_usage_user {{instance}}",
+              "refId": "process_cpu_usage_user"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "process cpu usage",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:495",
+              "format": "percentunit",
+              "logBase": 1,
+              "show": true
+            },
+            {
+              "$$hashKey": "object:496",
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        }
+      ],
+      "title": "process usage",
+      "type": "row"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 8,
+      "panels": [],
+      "title": "metaserver",
+      "type": "row"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto",
+            "filterable": true
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 10,
+        "x": 0,
+        "y": 2
+      },
+      "id": 10,
+      "options": {
+        "footer": {
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "8.4.4",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "tJLDJxsnz"
+          },
+          "exemplar": true,
+          "expr": "{__name__=~\"topology_metric_metaserver_id_[[metaserver:regex]].*\",job=\"mds\"}",
+          "format": "table",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "topology",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "instance": false,
+              "job": true
+            },
+            "indexByName": {
+              "Time": 1,
+              "Value": 4,
+              "__name__": 0,
+              "instance": 2,
+              "job": 3
+            },
+            "renameByName": {
+              "__name__": "name"
+            }
+          }
+        },
+        {
+          "id": "groupBy",
+          "options": {
+            "fields": {
+              "Value": {
+                "aggregations": [
+                  "last"
+                ],
+                "operation": "aggregate"
+              },
+              "name": {
+                "aggregations": [],
+                "operation": "groupby"
+              }
+            }
+          }
+        }
+      ],
+      "type": "table"
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 35,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "definition": "{__name__=~\"bthread_count\", job=\"mds\"}",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Addr",
+        "multi": false,
+        "name": "instance",
+        "options": [],
+        "query": {
+          "query": "{__name__=~\"bthread_count\", job=\"mds\"}",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "/.*instance=\"([^\"]*).*/",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "definition": "{__name__=~\"topology_metric_metaserver_id_.*_copyset_num\",job=\"mds\"}",
+        "hide": 0,
+        "includeAll": true,
+        "label": "metaserverId",
+        "multi": false,
+        "name": "metaserver",
+        "options": [],
+        "query": {
+          "query": "{__name__=~\"topology_metric_metaserver_id_.*_copyset_num\",job=\"mds\"}",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "/topology_metric_metaserver_id_(.*)_copyset_num.*/",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "mds",
+  "uid": "dsgsdfg",
+  "version": 16,
+  "weekStart": ""
+}

--- a/curvefs/monitor/grafana/dashboards/metaserver.json
+++ b/curvefs/monitor/grafana/dashboards/metaserver.json
@@ -1,0 +1,423 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "Prometheus",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Curvefs mds server",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 5,
+  "iteration": 1649851101054,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 6,
+      "panels": [],
+      "title": "process usage",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "hiddenSeries": false,
+      "id": 4,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": false,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.4.4",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "tJLDJxsnz"
+          },
+          "exemplar": true,
+          "expr": "process_memory_resident{instance=~\"$instance\"}",
+          "interval": "",
+          "legendFormat": "process_memory_resident {{hostname}}",
+          "refId": "process_memory_resident"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "tJLDJxsnz"
+          },
+          "exemplar": true,
+          "expr": "process_memory_virtual{instance=~\"$instance\"}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "process_memory_virtual {{hostname}}",
+          "refId": "process_memory_virtual"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "tJLDJxsnz"
+          },
+          "exemplar": true,
+          "expr": "process_memory_shared{instance=~\"$instance\"}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "process_memory_shared {{hostname}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "process memory usage",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:63",
+          "format": "decbytes",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:64",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "hiddenSeries": false,
+      "id": 2,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": false,
+        "max": true,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.4.4",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "tJLDJxsnz"
+          },
+          "exemplar": true,
+          "expr": "process_cpu_usage{instance=~\"$instance\"}",
+          "interval": "",
+          "legendFormat": "process_cpu_usage {{hostname}}",
+          "refId": "process_cpu_usage"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "tJLDJxsnz"
+          },
+          "exemplar": true,
+          "expr": "process_cpu_usage_system{instance=~\"$instance\"}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "process_cpu_usage_system {{hostname}}",
+          "refId": "process_cpu_usage_system"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "tJLDJxsnz"
+          },
+          "exemplar": true,
+          "expr": "process_cpu_usage_user{instance=~\"$instance\"}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "process_cpu_usage_user {{hostname}}",
+          "refId": "process_cpu_usage_user"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "process cpu usage",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:495",
+          "format": "percentunit",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:496",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 8,
+      "panels": [],
+      "title": "latency",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "hiddenSeries": false,
+      "id": 10,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.4.4",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "tJLDJxsnz"
+          },
+          "exemplar": true,
+          "expr": "{__name__=~\".*latency.*\",job=\"metaserver\"}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "latency",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:12821",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:12822",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    }
+  ],
+  "schemaVersion": 35,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "10.219.192.50:6800",
+          "value": "10.219.192.50:6800"
+        },
+        "definition": "{__name__=~\"bthread_count\", job=\"metaserver\"}",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Addr",
+        "multi": false,
+        "name": "instance",
+        "options": [],
+        "query": {
+          "query": "{__name__=~\"bthread_count\", job=\"metaserver\"}",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "/.*instance=\"([^\"]*).*/",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "definition": "{__name__=~\"bthread_count\", job=\"metaserver\"}",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Hostname",
+        "multi": false,
+        "name": "hostname",
+        "options": [],
+        "query": {
+          "query": "{__name__=~\"bthread_count\", job=\"metaserver\"}",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "/.*hostname=\"([^\"]*).*/",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "metaserver",
+  "uid": "t-YkFxy7z",
+  "version": 9,
+  "weekStart": ""
+}

--- a/curvefs/monitor/grafana/grafana.ini
+++ b/curvefs/monitor/grafana/grafana.ini
@@ -1,0 +1,597 @@
+#
+#     Copyright (c) 2022 NetEase Inc.
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+##################### Grafana Configuration Example #####################
+#
+# Everything has defaults so you only need to uncomment things you want to
+# change
+
+# possible values : production, development
+;app_mode = production
+
+# instance name, defaults to HOSTNAME environment variable value or hostname if HOSTNAME var is empty
+;instance_name = ${HOSTNAME}
+
+#################################### Paths ####################################
+[paths]
+# Path to where grafana can store temp files, sessions, and the sqlite3 db (if that is used)
+;data = /var/lib/grafana
+
+# Temporary files in `data` directory older than given duration will be removed
+;temp_data_lifetime = 24h
+
+# Directory where grafana can store logs
+;logs = /var/log/grafana
+
+# Directory where grafana will automatically scan and look for plugins
+;plugins = /var/lib/grafana/plugins
+
+# folder that contains provisioning config files that grafana will apply on startup and while running.
+;provisioning = conf/provisioning
+
+#################################### Server ####################################
+[server]
+# Protocol (http, https, socket)
+;protocol = http
+
+# The ip address to bind to, empty will bind to all interfaces
+;http_addr =
+
+# The http port  to use
+;http_port = 3000
+
+# The public facing domain name used to access grafana from a browser
+;domain = localhost
+
+# Redirect to correct domain if host header does not match domain
+# Prevents DNS rebinding attacks
+;enforce_domain = false
+
+# The full public facing url you use in browser, used for redirects and emails
+# If you use reverse proxy and sub path specify full url (with sub path)
+;root_url = http://localhost:3000
+
+# Serve Grafana from subpath specified in `root_url` setting. By default it is set to `false` for compatibility reasons.
+;serve_from_sub_path = false
+
+# Log web requests
+;router_logging = false
+
+# the path relative working path
+;static_root_path = public
+
+# enable gzip
+;enable_gzip = false
+
+# https certs & key file
+;cert_file =
+;cert_key =
+
+# Unix socket path
+;socket =
+
+#################################### Database ####################################
+[database]
+# You can configure the database connection by specifying type, host, name, user and password
+# as separate properties or as on string using the url properties.
+
+# Either "mysql", "postgres" or "sqlite3", it's your choice
+;type = sqlite3
+;host = 127.0.0.1:3306
+;name = grafana
+;user = root
+# If the password contains # or ; you have to wrap it with triple quotes. Ex """#password;"""
+;password =
+
+# Use either URL or the previous fields to configure the database
+# Example: mysql://user:secret@host:port/database
+;url =
+
+# For "postgres" only, either "disable", "require" or "verify-full"
+;ssl_mode = disable
+
+# For "sqlite3" only, path relative to data_path setting
+;path = grafana.db
+
+# Max idle conn setting default is 2
+;max_idle_conn = 2
+
+# Max conn setting default is 0 (mean not set)
+;max_open_conn =
+
+# Connection Max Lifetime default is 14400 (means 14400 seconds or 4 hours)
+;conn_max_lifetime = 14400
+
+# Set to true to log the sql calls and execution times.
+;log_queries =
+
+# For "sqlite3" only. cache mode setting used for connecting to the database. (private, shared)
+;cache_mode = private
+
+#################################### Cache server #############################
+[remote_cache]
+# Either "redis", "memcached" or "database" default is "database"
+;type = database
+
+# cache connectionstring options
+# database: will use Grafana primary database.
+# redis: config like redis server e.g. `addr=127.0.0.1:6379,pool_size=100,db=0`. Only addr is required.
+# memcache: 127.0.0.1:11211
+;connstr =
+
+#################################### Data proxy ###########################
+[dataproxy]
+
+# This enables data proxy logging, default is false
+;logging = false
+
+# How long the data proxy should wait before timing out default is 30 (seconds)
+;timeout = 30
+
+# If enabled and user is not anonymous, data proxy will add X-Grafana-User header with username into the request, default is false.
+;send_user_header = false
+
+#################################### Analytics ####################################
+[analytics]
+# Server reporting, sends usage counters to stats.grafana.org every 24 hours.
+# No ip addresses are being tracked, only simple counters to track
+# running instances, dashboard and error counts. It is very helpful to us.
+# Change this option to false to disable reporting.
+;reporting_enabled = true
+
+# Set to false to disable all checks to https://grafana.net
+# for new vesions (grafana itself and plugins), check is used
+# in some UI views to notify that grafana or plugin update exists
+# This option does not cause any auto updates, nor send any information
+# only a GET request to http://grafana.com to get latest versions
+;check_for_updates = true
+
+# Google Analytics universal tracking code, only enabled if you specify an id here
+;google_analytics_ua_id =
+
+# Google Tag Manager ID, only enabled if you specify an id here
+;google_tag_manager_id =
+
+#################################### Security ####################################
+[security]
+# default admin user, created on startup
+;admin_user = admin
+
+# default admin password, can be changed before first start of grafana,  or in profile settings
+;admin_password = admin
+
+# used for signing
+;secret_key = SW2YcwTIb9zpOOhoPsMm
+
+# disable gravatar profile images
+;disable_gravatar = false
+
+# data source proxy whitelist (ip_or_domain:port separated by spaces)
+;data_source_proxy_whitelist =
+
+# disable protection against brute force login attempts
+;disable_brute_force_login_protection = false
+
+# set to true if you host Grafana behind HTTPS. default is false.
+;cookie_secure = false
+
+# set cookie SameSite attribute. defaults to `lax`. can be set to "lax", "strict" and "none"
+;cookie_samesite = lax
+
+# set to true if you want to allow browsers to render Grafana in a <frame>, <iframe>, <embed> or <object>. default is false.
+;allow_embedding = false
+
+# Set to true if you want to enable http strict transport security (HSTS) response header.
+# This is only sent when HTTPS is enabled in this configuration.
+# HSTS tells browsers that the site should only be accessed using HTTPS.
+# The default version will change to true in the next minor release, 6.3.
+;strict_transport_security = false
+
+# Sets how long a browser should cache HSTS. Only applied if strict_transport_security is enabled.
+;strict_transport_security_max_age_seconds = 86400
+
+# Set to true if to enable HSTS preloading option. Only applied if strict_transport_security is enabled.
+;strict_transport_security_preload = false
+
+# Set to true if to enable the HSTS includeSubDomains option. Only applied if strict_transport_security is enabled.
+;strict_transport_security_subdomains = false
+
+# Set to true to enable the X-Content-Type-Options response header.
+# The X-Content-Type-Options response HTTP header is a marker used by the server to indicate that the MIME types advertised
+# in the Content-Type headers should not be changed and be followed. The default will change to true in the next minor release, 6.3.
+;x_content_type_options = false
+
+# Set to true to enable the X-XSS-Protection header, which tells browsers to stop pages from loading
+# when they detect reflected cross-site scripting (XSS) attacks. The default will change to true in the next minor release, 6.3.
+;x_xss_protection = false
+
+#################################### Snapshots ###########################
+[snapshots]
+# snapshot sharing options
+;external_enabled = true
+;external_snapshot_url = https://snapshots-origin.raintank.io
+;external_snapshot_name = Publish to snapshot.raintank.io
+
+# remove expired snapshot
+;snapshot_remove_expired = true
+
+#################################### Dashboards History ##################
+[dashboards]
+# Number dashboard versions to keep (per dashboard). Default: 20, Minimum: 1
+;versions_to_keep = 20
+
+#################################### Users ###############################
+[users]
+# disable user signup / registration
+;allow_sign_up = true
+
+# Allow non admin users to create organizations
+;allow_org_create = true
+
+# Set to true to automatically assign new users to the default organization (id 1)
+;auto_assign_org = true
+
+# Default role new users will be automatically assigned (if disabled above is set to true)
+;auto_assign_org_role = Viewer
+
+# Background text for the user field on the login page
+;login_hint = email or username
+;password_hint = password
+
+# Default UI theme ("dark" or "light")
+;default_theme = dark
+
+# External user management, these options affect the organization users view
+;external_manage_link_url =
+;external_manage_link_name =
+;external_manage_info =
+
+# Viewers can edit/inspect dashboard settings in the browser. But not save the dashboard.
+;viewers_can_edit = false
+
+# Editors can administrate dashboard, folders and teams they create
+;editors_can_admin = false
+
+[auth]
+# Login cookie name
+;login_cookie_name = grafana_session
+
+# The lifetime (days) an authenticated user can be inactive before being required to login at next visit. Default is 7 days,
+;login_maximum_inactive_lifetime_days = 7
+
+# The maximum lifetime (days) an authenticated user can be logged in since login time before being required to login. Default is 30 days.
+;login_maximum_lifetime_days = 30
+
+# How often should auth tokens be rotated for authenticated users when being active. The default is each 10 minutes.
+;token_rotation_interval_minutes = 10
+
+# Set to true to disable (hide) the login form, useful if you use OAuth, defaults to false
+;disable_login_form = false
+
+# Set to true to disable the signout link in the side menu. useful if you use auth.proxy, defaults to false
+;disable_signout_menu = false
+
+# URL to redirect the user to after sign out
+;signout_redirect_url =
+
+# Set to true to attempt login with OAuth automatically, skipping the login screen.
+# This setting is ignored if multiple OAuth providers are configured.
+;oauth_auto_login = false
+
+#################################### Anonymous Auth ######################
+[auth.anonymous]
+# enable anonymous access
+;enabled = false
+
+# specify organization name that should be used for unauthenticated users
+;org_name = Main Org.
+
+# specify role for unauthenticated users
+;org_role = Viewer
+
+#################################### Github Auth ##########################
+[auth.github]
+;enabled = false
+;allow_sign_up = true
+;client_id = some_id
+;client_secret = some_secret
+;scopes = user:email,read:org
+;auth_url = https://github.com/login/oauth/authorize
+;token_url = https://github.com/login/oauth/access_token
+;api_url = https://api.github.com/user
+;team_ids =
+;allowed_organizations =
+
+#################################### Google Auth ##########################
+[auth.google]
+;enabled = false
+;allow_sign_up = true
+;client_id = some_client_id
+;client_secret = some_client_secret
+;scopes = https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email
+;auth_url = https://accounts.google.com/o/oauth2/auth
+;token_url = https://accounts.google.com/o/oauth2/token
+;api_url = https://www.googleapis.com/oauth2/v1/userinfo
+;allowed_domains =
+
+#################################### Generic OAuth ##########################
+[auth.generic_oauth]
+;enabled = false
+;name = OAuth
+;allow_sign_up = true
+;client_id = some_id
+;client_secret = some_secret
+;scopes = user:email,read:org
+;auth_url = https://foo.bar/login/oauth/authorize
+;token_url = https://foo.bar/login/oauth/access_token
+;api_url = https://foo.bar/user
+;team_ids =
+;allowed_organizations =
+;tls_skip_verify_insecure = false
+;tls_client_cert =
+;tls_client_key =
+;tls_client_ca =
+
+; Set to true to enable sending client_id and client_secret via POST body instead of Basic authentication HTTP header
+; This might be required if the OAuth provider is not RFC6749 compliant, only supporting credentials passed via POST payload
+;send_client_credentials_via_post = false
+
+#################################### SAML Auth ###########################
+;[auth.saml] # Enterprise only
+;enabled = false
+;private_key =
+;private_key_path =
+;certificate =
+;certificate_path =
+;idp_metadata =
+;idp_metadata_path =
+;idp_metadata_url =
+;max_issue_delay = 90s
+;metadata_valid_duration = 48h
+
+#################################### Grafana.com Auth ####################
+[auth.grafana_com]
+;enabled = false
+;allow_sign_up = true
+;client_id = some_id
+;client_secret = some_secret
+;scopes = user:email
+;allowed_organizations =
+
+#################################### Auth Proxy ##########################
+[auth.proxy]
+;enabled = false
+;header_name = X-WEBAUTH-USER
+;header_property = username
+;auto_sign_up = true
+;ldap_sync_ttl = 60
+;whitelist = 192.168.1.1, 192.168.2.1
+;headers = Email:X-User-Email, Name:X-User-Name
+
+#################################### Basic Auth ##########################
+[auth.basic]
+;enabled = true
+
+#################################### Auth LDAP ##########################
+[auth.ldap]
+;enabled = false
+;config_file = /etc/grafana/ldap.toml
+;allow_sign_up = true
+
+# LDAP backround sync (Enterprise only)
+# At 1 am every day
+;sync_cron = "0 0 1 * * *"
+;active_sync_enabled = true
+
+#################################### SMTP / Emailing ##########################
+[smtp]
+;enabled = false
+;host = localhost:25
+;user =
+# If the password contains # or ; you have to wrap it with trippel quotes. Ex """#password;"""
+;password =
+;cert_file =
+;key_file =
+;skip_verify = false
+;from_address = admin@grafana.localhost
+;from_name = Grafana
+# EHLO identity in SMTP dialog (defaults to instance_name)
+;ehlo_identity = dashboard.example.com
+
+[emails]
+;welcome_email_on_sign_up = false
+
+#################################### Logging ##########################
+[log]
+# Either "console", "file", "syslog". Default is console and  file
+# Use space to separate multiple modes, e.g. "console file"
+;mode = console file
+
+# Either "debug", "info", "warn", "error", "critical", default is "info"
+;level = info
+
+# optional settings to set different levels for specific loggers. Ex filters = sqlstore:debug
+;filters =
+
+# For "console" mode only
+[log.console]
+;level =
+
+# log line format, valid options are text, console and json
+;format = console
+
+# For "file" mode only
+[log.file]
+;level =
+
+# log line format, valid options are text, console and json
+;format = text
+
+# This enables automated log rotate(switch of following options), default is true
+;log_rotate = true
+
+# Max line number of single file, default is 1000000
+;max_lines = 1000000
+
+# Max size shift of single file, default is 28 means 1 << 28, 256MB
+;max_size_shift = 28
+
+# Segment log daily, default is true
+;daily_rotate = true
+
+# Expired days of log file(delete after max days), default is 7
+;max_days = 7
+
+[log.syslog]
+;level =
+
+# log line format, valid options are text, console and json
+;format = text
+
+# Syslog network type and address. This can be udp, tcp, or unix. If left blank, the default unix endpoints will be used.
+;network =
+;address =
+
+# Syslog facility. user, daemon and local0 through local7 are valid.
+;facility =
+
+# Syslog tag. By default, the process' argv[0] is used.
+;tag =
+
+#################################### Alerting ############################
+[alerting]
+# Disable alerting engine & UI features
+;enabled = true
+# Makes it possible to turn off alert rule execution but alerting UI is visible
+;execute_alerts = true
+
+# Default setting for new alert rules. Defaults to categorize error and timeouts as alerting. (alerting, keep_state)
+;error_or_timeout = alerting
+
+# Default setting for how Grafana handles nodata or null values in alerting. (alerting, no_data, keep_state, ok)
+;nodata_or_nullvalues = no_data
+
+# Alert notifications can include images, but rendering many images at the same time can overload the server
+# This limit will protect the server from render overloading and make sure notifications are sent out quickly
+;concurrent_render_limit = 5
+
+
+# Default setting for alert calculation timeout. Default value is 30
+;evaluation_timeout_seconds = 30
+
+# Default setting for alert notification timeout. Default value is 30
+;notification_timeout_seconds = 30
+
+# Default setting for max attempts to sending alert notifications. Default value is 3
+;max_attempts = 3
+
+#################################### Explore #############################
+[explore]
+# Enable the Explore section
+;enabled = true
+
+#################################### Internal Grafana Metrics ##########################
+# Metrics available at HTTP API Url /metrics
+[metrics]
+# Disable / Enable internal metrics
+;enabled           = true
+
+# Publish interval
+;interval_seconds  = 10
+
+# Send internal metrics to Graphite
+[metrics.graphite]
+# Enable by setting the address setting (ex localhost:2003)
+;address =
+;prefix = prod.grafana.%(instance_name)s.
+
+#################################### Distributed tracing ############
+[tracing.jaeger]
+# Enable by setting the address sending traces to jaeger (ex localhost:6831)
+;address = localhost:6831
+# Tag that will always be included in when creating new spans. ex (tag1:value1,tag2:value2)
+;always_included_tag = tag1:value1
+# Type specifies the type of the sampler: const, probabilistic, rateLimiting, or remote
+;sampler_type = const
+# jaeger samplerconfig param
+# for "const" sampler, 0 or 1 for always false/true respectively
+# for "probabilistic" sampler, a probability between 0 and 1
+# for "rateLimiting" sampler, the number of spans per second
+# for "remote" sampler, param is the same as for "probabilistic"
+# and indicates the initial sampling rate before the actual one
+# is received from the mothership
+;sampler_param = 1
+# Whether or not to use Zipkin propagation (x-b3- HTTP headers).
+;zipkin_propagation = false
+# Setting this to true disables shared RPC spans.
+# Not disabling is the most common setting when using Zipkin elsewhere in your infrastructure.
+;disable_shared_zipkin_spans = false
+
+#################################### Grafana.com integration  ##########################
+# Url used to import dashboards directly from Grafana.com
+[grafana_com]
+;url = https://grafana.com
+
+#################################### External image storage ##########################
+[external_image_storage]
+# Used for uploading images to public servers so they can be included in slack/email messages.
+# you can choose between (s3, webdav, gcs, azure_blob, local)
+;provider =
+
+[external_image_storage.s3]
+;bucket =
+;region =
+;path =
+;access_key =
+;secret_key =
+
+[external_image_storage.webdav]
+;url =
+;public_url =
+;username =
+;password =
+
+[external_image_storage.gcs]
+;key_file =
+;bucket =
+;path =
+
+[external_image_storage.azure_blob]
+;account_name =
+;account_key =
+;container_name =
+
+[external_image_storage.local]
+# does not require any configuration
+
+[rendering]
+# Options to configure external image rendering server like https://github.com/grafana/grafana-image-renderer
+;server_url =
+;callback_url =
+
+[enterprise]
+# Path to a valid Grafana Enterprise license.jwt file
+;license_path =
+
+[panels]
+# If set to true Grafana will allow script tags in text panels. Not recommended as it enable XSS vulnerabilities.
+;disable_sanitize_html = false
+
+[plugins]
+;enable_alpha = false
+;app_tls_skip_verify_insecure = false

--- a/curvefs/monitor/grafana/provisioning/dashboards/all.yml
+++ b/curvefs/monitor/grafana/provisioning/dashboards/all.yml
@@ -1,0 +1,24 @@
+#
+#     Copyright (c) 2022 NetEase Inc.
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+- name: 'default'
+  org_id: 1
+  folder: ''
+  type: 'file'
+  options:
+    folder: '/etc/grafana/provisioning/dashboards'

--- a/curvefs/monitor/grafana/provisioning/datasources/all.yml
+++ b/curvefs/monitor/grafana/provisioning/datasources/all.yml
@@ -1,0 +1,27 @@
+#
+#     Copyright (c) 2022 NetEase Inc.
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+datasources:
+- name: 'Prometheus'
+  type: 'prometheus'
+  access: 'proxy'
+  org_id: 1
+  url: 'http://localhost:9090'
+  is_default: true
+  version: 1
+  editable: true

--- a/curvefs/monitor/prometheus/prometheus.yml
+++ b/curvefs/monitor/prometheus/prometheus.yml
@@ -1,0 +1,53 @@
+#
+#     Copyright (c) 2022 NetEase Inc.
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+# my global config
+global:
+  scrape_interval:     3s # Set the scrape interval to every 15 seconds. Default is every 1 minute.
+  evaluation_interval: 15s # Evaluate rules every 15 seconds. The default is every 1 minute.
+  # scrape_timeout is set to the global default (10s).
+
+# Alertmanager configuration
+alerting:
+  alertmanagers:
+  - static_configs:
+    - targets:
+      # - alertmanager:9093
+
+# Load rules once and periodically evaluate them according to the global 'evaluation_interval'.
+rule_files:
+  # - "first_rules.yml"
+  # - "second_rules.yml"
+
+# A scrape configuration containing exactly one endpoint to scrape:
+# Here it's Prometheus itself.
+scrape_configs:
+  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+  - job_name: 'prometheus'
+
+    # metrics_path defaults to '/metrics'
+    # scheme defaults to 'http'.
+
+    static_configs:
+    - targets: ['localhost:9090']
+
+  - job_name: 'curve_metrics'
+
+    file_sd_configs:
+    - files: ['*.json']
+

--- a/curvefs/monitor/target.ini
+++ b/curvefs/monitor/target.ini
@@ -1,0 +1,20 @@
+#
+#     Copyright (c) 2022 NetEase Inc.
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+[path]
+target_path=prometheus/target.json

--- a/curvefs/monitor/target_json.py
+++ b/curvefs/monitor/target_json.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+# coding=utf-8
+
+#
+#     Copyright (c) 2022 NetEase Inc.
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+from cProfile import label
+import os
+import time
+import json
+import configparser
+import subprocess
+import re
+
+CURVEFS_TOOL = "curvefs_tool"
+JSON_PATH = "/tmp/topology.json"
+HOSTNAME_PORT_REGEX = r"[^\"\ ]\S*:\d+"
+IP_PORT_REGEX = r"[0-9]+(?:\.[0-9]+){3}:\d+"
+
+targetPath=None
+
+def loadConf():
+    global targetPath
+    conf=configparser.ConfigParser()
+    conf.read("target.ini")
+    targetPath=conf.get("path", "target_path")
+
+def runCurvefsToolCommand(command):
+    cmd = [CURVEFS_TOOL]+command
+    try:
+        output = subprocess.check_output(cmd, stderr=subprocess.STDOUT, timeout=5)
+    except subprocess.TimeoutExpired as e:
+        return -1, str(output)
+    except subprocess.CalledProcessError as e:
+        return 0, str(e.output)
+    return 0, str(output)
+    
+
+def loadServer():
+    ret, _ = runCurvefsToolCommand(["list-topology", "-jsonType=tree", "-jsonPath=%s"%JSON_PATH])
+    data = None
+    if ret == 0:
+        with open(JSON_PATH) as load_f:
+            data = json.load(load_f)
+    servers = []
+    if data is not None:
+        for pool in data["poollist"]:
+            for zone in pool["zonelist"]:
+                for server in zone["serverlist"]:
+                    servers.append(server)
+    return servers
+
+def loadClient():
+    ret, output = runCurvefsToolCommand(["list-fs"])
+    clients = []
+    if ret == 0 :
+        for line in output.split('\\n'):
+            if line.startswith("mountpoints:"):
+                targets = re.findall(HOSTNAME_PORT_REGEX, line)
+                clients.extend(targets)
+    label = lablesValue(None, "client")
+    return unitValue(label, clients)
+
+def loadType(hostType):
+    ret, output = runCurvefsToolCommand(["status-%s"%hostType])
+    targets = []
+    if ret == 0:
+        targets = re.findall(IP_PORT_REGEX, output)
+    labels = lablesValue(None, hostType)
+    return unitValue(labels, targets)
+
+def ipPort2Addr(ip, port):
+    return str(ip) + ":" + str(port)
+
+def server2Target(server):
+    labels = lablesValue(server["hostname"], "metaserver")
+    serverAddr = []
+    serverAddr.append(ipPort2Addr(server["internalip"], server["internalport"]))
+    targets = list(set(serverAddr))
+    return unitValue(labels, targets)
+
+def lablesValue(hostname, job):
+    labels = {}
+    if hostname is not None:
+        labels["hostname"] = hostname
+    if job is not None:
+        labels["job"] = job
+    return labels
+
+def unitValue(lables, targets):
+    unit = {}
+    if lables is not None:
+        unit["labels"] = lables
+    if targets is not None:
+        unit["targets"] = targets
+    return unit
+
+
+def refresh():
+    targets = []
+    # load metaserver
+    servers = loadServer()
+    for server in servers:
+        targets.append(server2Target(server))
+    # load etcd
+    etcd = loadType("etcd")
+    targets.append(etcd)
+    # load mds
+    mds = loadType("mds")
+    targets.append(mds)
+    # load client 
+    client = loadClient()
+    targets.append(client)
+    
+    with open(targetPath+'.new', 'w', 0o777) as fd:
+        json.dump(targets, fd, indent=4)
+        fd.flush()
+        os.fsync(fd.fileno())
+
+    os.rename(targetPath+'.new', targetPath)
+    os.chmod(targetPath, 0o777)
+
+
+if __name__ == '__main__':
+    while True:
+        loadConf()
+        refresh()
+        # refresh every 30s
+        time.sleep(30)

--- a/curvefs/monitor/update_dashboard.sh
+++ b/curvefs/monitor/update_dashboard.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+
+#
+#     Copyright (c) 2022 NetEase Inc.
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+# Updates local dashboard configurations by retrieving
+# the new version from a Grafana instance.
+#
+# The script assumes that basic authentication is configured
+# (change the login credentials with `LOGIN`).
+#
+# DASHBOARD_DIRECTORY represents the path to the directory
+# where the JSON files corresponding to the dashboards exist.
+# The default location is relative to the execution of the
+# script.
+#
+# URL specifies the URL of the Grafana instance.
+#
+
+set -o errexit
+
+readonly URL=${URL:-"http://127.0.0.1:3000"}
+readonly LOGIN=${LOGIN:-"admin:curve"}
+readonly DASHBOARDS_DIRECTORY=${DASHBOARDS_DIRECTORY:-"./grafana/provisioning/dashboards"}
+
+
+main() {
+  local dashboards=$(list_dashboards)
+  local dashboard_json
+
+  show_config
+
+  for dashboard in $dashboards; do
+    dashboard_json=$(get_dashboard "$dashboard")
+
+    if [[ -z "$dashboard_json" ]]; then
+      echo "ERROR:
+  Couldn't retrieve dashboard $dashboard.
+      "
+      exit 1
+    fi
+
+    echo "$dashboard_json" >$DASHBOARDS_DIRECTORY/$dashboard.json
+  done
+}
+
+
+# Shows the global environment variables that have been configured
+# for this run.
+show_config() {
+  echo "INFO:
+  Starting dashboard extraction.
+
+  URL:                  $URL
+  LOGIN:                $LOGIN
+  DASHBOARDS_DIRECTORY: $DASHBOARDS_DIRECTORY
+  "
+}
+
+
+# Retrieves a dashboard ($1) from the database of dashboards.
+#
+# As we're getting it right from the database, it'll contain an `id`.
+#
+# Given that the ID is potentially different when we import it
+# later, to be make this dashboard importable we make the `id`
+# field NULL.
+get_dashboard() {
+  local dashboard=$1
+
+  if [[ -z "$dashboard" ]]; then
+    echo "ERROR:
+  A dashboard must be specified.
+  "
+    exit 1
+  fi
+
+  curl \
+    --silent \
+    --user "$LOGIN" \
+    $URL/api/dashboards/db/$dashboard |
+    jq '.dashboard | .id = null'
+}
+
+
+# lists all the dashboards available.
+#
+# `/api/search` lists all the dashboards and folders
+# that exist under our organization.
+#
+# Here we filter the response (that also contain folders)
+# to gather only the name of the dashboards.
+list_dashboards() {
+  curl \
+    --silent \
+    --user "$LOGIN" \
+    $URL/api/search |
+    jq -r '.[] | select(.type == "dash-db") | .uri' |
+    cut -d '/' -f2
+}
+
+main "$@"

--- a/curvefs/proto/metaserver.proto
+++ b/curvefs/proto/metaserver.proto
@@ -46,6 +46,7 @@ enum MetaStatusCode {
     PARSE_FROM_STRING_FAILED = 23;
     STORAGE_INTERNAL_ERROR = 24;
     RPC_STREAM_ERROR = 25;
+    INODE_S3_META_TOO_LARGE = 26;
 }
 
 // dentry interface
@@ -147,6 +148,7 @@ message GetInodeRequest {
     required uint32 fsId = 4;
     required uint64 inodeId = 5;
     optional uint64 appliedIndex = 6;
+    optional bool supportStreaming = 7;  // for backward compatibility
 }
 
 enum FsFileType {
@@ -211,6 +213,7 @@ message GetInodeResponse {
     required MetaStatusCode statusCode = 1;
     optional Inode inode = 2;
     optional uint64 appliedIndex = 3;
+    optional bool streaming = 4;
 }
 
 message CreateInodeRequest {
@@ -334,6 +337,7 @@ message GetOrModifyS3ChunkInfoRequest {
     required bool returnS3ChunkInfoMap = 8;
     optional bool fromS3Compaction = 9;
     // todo: we only need a bit flag to indicate a lot of bool
+    optional bool supportStreaming = 10;  // for backward compatibility
 }
 
 message GetOrModifyS3ChunkInfoResponse {

--- a/curvefs/proto/metaserver.proto
+++ b/curvefs/proto/metaserver.proto
@@ -152,11 +152,10 @@ message GetInodeRequest {
 }
 
 enum FsFileType {
-    TYPE_DIRECTORY = 1;   // 1 << 0
-    TYPE_FILE = 2;        // 1 << 1
-    TYPE_SYM_LINK = 4;    // 1 << 2
-    TYPE_S3 = 18;         // (1 << 4) | TYPE_FILE
-    TYPE_VOLUME = 34;     // (1 << 5) | TYPE_FILE
+    TYPE_DIRECTORY = 1;
+    TYPE_FILE = 2;
+    TYPE_SYM_LINK = 3;
+    TYPE_S3 = 4;
 };
 
 message VolumeExtent {

--- a/curvefs/src/client/BUILD
+++ b/curvefs/src/client/BUILD
@@ -28,6 +28,7 @@ cc_binary(
     ],
     deps = [
         ":fuse_client_lib",
+        "@com_google_absl//absl/memory",
     ],
 )
 

--- a/curvefs/src/client/common/config.cpp
+++ b/curvefs/src/client/common/config.cpp
@@ -118,6 +118,8 @@ void InitDiskCacheOption(Configuration *conf,
                               &diskCacheOption->maxUsableSpaceBytes);
     conf->GetValueFatalIfFail("diskCache.cmdTimeoutSec",
                               &diskCacheOption->cmdTimeoutSec);
+    conf->GetValueFatalIfFail("diskCache.threads",
+                              &diskCacheOption->threads);
     conf->GetValueFatalIfFail("diskCache.avgFlushBytes",
                               &diskCacheOption->avgFlushBytes);
     conf->GetValueFatalIfFail("diskCache.burstFlushBytes",
@@ -145,6 +147,8 @@ void InitS3Option(Configuration *conf, S3Option *s3Opt) {
                               &s3Opt->s3ClientAdaptorOpt.intervalSec);
     conf->GetValueFatalIfFail("s3.flushIntervalSec",
                               &s3Opt->s3ClientAdaptorOpt.flushIntervalSec);
+    conf->GetValueFatalIfFail("s3.chunkFlushThreads",
+                              &s3Opt->s3ClientAdaptorOpt.chunkFlushThreads);
     conf->GetValueFatalIfFail("s3.writeCacheMaxByte",
                               &s3Opt->s3ClientAdaptorOpt.writeCacheMaxByte);
     conf->GetValueFatalIfFail("s3.readCacheMaxByte",

--- a/curvefs/src/client/common/config.cpp
+++ b/curvefs/src/client/common/config.cpp
@@ -238,6 +238,11 @@ void InitFuseClientOption(Configuration *conf, FuseClientOption *clientOption) {
     conf->GetValueFatalIfFail("client.dummyserver.startport",
                               &clientOption->dummyServerStartPort);
 
+    LOG_IF(WARNING, conf->GetBoolValue("fuseClient.enableSplice",
+                                       &clientOption->enableFuseSplice))
+        << "Not found `fuseClient.enableSplice` in conf, use default value `"
+        << std::boolalpha << clientOption->enableFuseSplice << '`';
+
     SetBrpcOpt(conf);
 }
 

--- a/curvefs/src/client/common/config.h
+++ b/curvefs/src/client/common/config.h
@@ -97,6 +97,8 @@ struct DiskCacheOption {
     uint64_t maxUsableSpaceBytes;
     // the max time system command can run
     uint32_t cmdTimeoutSec;
+    // threads for disk cache
+    uint32_t threads;
     // the write throttle bps of disk cache
     uint64_t avgFlushBytes;
     // the write burst bps of disk cache
@@ -119,6 +121,7 @@ struct S3ClientAdaptorOption {
     uint32_t prefetchBlocks;
     uint32_t prefetchExecQueueNum;
     uint32_t intervalSec;
+    uint32_t chunkFlushThreads;
     uint32_t flushIntervalSec;
     uint64_t writeCacheMaxByte;
     uint64_t readCacheMaxByte;

--- a/curvefs/src/client/common/config.h
+++ b/curvefs/src/client/common/config.h
@@ -183,6 +183,8 @@ struct FuseClientOption {
     bool enableDCacheMetrics;
 
     uint32_t dummyServerStartPort;
+
+    bool enableFuseSplice = false;
 };
 
 void InitFuseClientOption(Configuration *conf, FuseClientOption *clientOption);

--- a/curvefs/src/client/curve_fuse_op.cpp
+++ b/curvefs/src/client/curve_fuse_op.cpp
@@ -70,6 +70,11 @@ DEFINE_validator(vlog_level, CheckVLogLevel);
 namespace {
 
 void EnableSplice(struct fuse_conn_info* conn) {
+    if (!g_fuseClientOption->enableFuseSplice) {
+        LOG(INFO) << "Fuse splice is disabled";
+        return;
+    }
+
     if (conn->capable & FUSE_CAP_SPLICE_MOVE) {
         conn->want |= FUSE_CAP_SPLICE_MOVE;
         LOG(INFO) << "FUSE_CAP_SPLICE_MOVE enabled";

--- a/curvefs/src/client/curve_fuse_op.cpp
+++ b/curvefs/src/client/curve_fuse_op.cpp
@@ -478,3 +478,13 @@ void FuseOpBmap(fuse_req_t req,
     // TODO(wuhanqing): implement for volume storage
     FuseReplyErrByErrCode(req, CURVEFS_ERROR::NOTSUPPORT);
 }
+
+void FuseOpStatFs(fuse_req_t req, fuse_ino_t ino) {
+    struct statvfs stbuf;
+    CURVEFS_ERROR ret = g_ClientInstance->FuseOpStatFs(req, ino, &stbuf);
+    if (ret != CURVEFS_ERROR::OK) {
+        FuseReplyErrByErrCode(req, ret);
+        return;
+    }
+    fuse_reply_statfs(req, &stbuf);
+}

--- a/curvefs/src/client/curve_fuse_op.cpp
+++ b/curvefs/src/client/curve_fuse_op.cpp
@@ -52,6 +52,21 @@ static FuseClientOption *g_fuseClientOption = nullptr;
 
 DECLARE_int32(v);
 
+/**
+ * use vlog_level to set vlog level on the fly
+ * When vlog_level is set, CheckVLogLevel is called to check the validity of the
+ * value. Dynamically modify the vlog level by setting FLAG_v in CheckVLogLevel.
+ *
+ * You can modify the vlog level to 0 using:
+ * curl -s http://127.0.0.1:9000/flags/vlog_level?setvalue=0
+ */
+DEFINE_int32(vlog_level, 0, "set vlog level");
+static bool CheckVLogLevel(const char*, int32_t value) {
+    FLAGS_v = value;
+    return true;
+}
+DEFINE_validator(vlog_level, CheckVLogLevel);
+
 namespace {
 
 void EnableSplice(struct fuse_conn_info* conn) {
@@ -110,6 +125,7 @@ int InitGlog(const char *confPath, const char *argv0) {
 
     curve::common::GflagsLoadValueFromConfIfCmdNotSet dummy;
     dummy.Load(&conf, "v", "client.loglevel", &FLAGS_v);
+    FLAGS_vlog_level = FLAGS_v;
 
     // initialize logging module
     google::InitGoogleLogging(argv0);

--- a/curvefs/src/client/fuse_client.cpp
+++ b/curvefs/src/client/fuse_client.cpp
@@ -35,7 +35,7 @@
 #include "curvefs/proto/mds.pb.h"
 #include "curvefs/src/client/fuse_common.h"
 #include "curvefs/src/client/client_operator.h"
-#include "src/common/timeutility.h"
+#include "src/common/net_common.h"
 #include "src/common/dummyserver.h"
 #include "src/client/client_common.h"
 #include "src/common/string_util.h"

--- a/curvefs/src/client/fuse_client.cpp
+++ b/curvefs/src/client/fuse_client.cpp
@@ -1115,8 +1115,8 @@ CURVEFS_ERROR FuseClient::FastCalAllLayerSumInfo(Inode *inode) {
 CURVEFS_ERROR FuseClient::FuseOpGetXattr(fuse_req_t req, fuse_ino_t ino,
                                          const char* name, void* value,
                                          size_t size) {
-    LOG(INFO) << "FuseOpGetXattr, ino: " << ino
-              << ", name: " << name << ", size = " << size;
+    VLOG(6) << "FuseOpGetXattr, ino: " << ino
+            << ", name: " << name << ", size = " << size;
     std::shared_ptr<InodeWrapper> inodeWrapper;
     CURVEFS_ERROR ret = inodeManager_->GetInode(ino, inodeWrapper);
     if (ret != CURVEFS_ERROR::OK) {

--- a/curvefs/src/client/fuse_client.cpp
+++ b/curvefs/src/client/fuse_client.cpp
@@ -167,9 +167,9 @@ CURVEFS_ERROR FuseClient::FuseOpInit(void *userdata,
         (mOpts->mountPoint == nullptr) ? "" : mOpts->mountPoint;
     std::string fsName = (mOpts->fsName == nullptr) ? "" : mOpts->fsName;
 
-    int retVal = AddHostNameToMountPointStr(mountPointStr, &mountpoint_);
+    int retVal = AddHostPortToMountPointStr(mountPointStr, &mountpoint_);
     if (retVal < 0) {
-        LOG(ERROR) << "AddHostNameToMountPointStr failed, ret = " << retVal;
+        LOG(ERROR) << "AddHostPortToMountPointStr failed, ret = " << retVal;
         return CURVEFS_ERROR::INTERNAL;
     }
 
@@ -217,7 +217,7 @@ void FuseClient::FuseOpDestroy(void *userdata) {
         (mOpts->mountPoint == nullptr) ? "" : mOpts->mountPoint;
 
     std::string mountPointWithHost;
-    int retVal = AddHostNameToMountPointStr(mountPointStr, &mountPointWithHost);
+    int retVal = AddHostPortToMountPointStr(mountPointStr, &mountPointWithHost);
     if (retVal < 0) {
         return;
     }

--- a/curvefs/src/client/fuse_client.h
+++ b/curvefs/src/client/fuse_client.h
@@ -204,6 +204,23 @@ class FuseClient {
         return CURVEFS_ERROR::OK;
     }
 
+    virtual CURVEFS_ERROR FuseOpStatFs(fuse_req_t req, fuse_ino_t ino,
+                                       struct statvfs* stbuf) {
+        // TODO(chengyi01,wuhanqing): implement in s3 and volume client
+        stbuf->f_frsize = stbuf->f_bsize = fsInfo_->blocksize();
+        stbuf->f_blocks = 10UL << 30;
+        stbuf->f_bavail = stbuf->f_bfree = stbuf->f_blocks - 1;
+
+        stbuf->f_files = 1UL << 30;
+        stbuf->f_ffree = stbuf->f_favail = stbuf->f_files - 1;
+
+        stbuf->f_fsid = fsInfo_->fsid();
+
+        stbuf->f_flag = 0;
+        stbuf->f_namemax = option_.maxNameLength;
+        return CURVEFS_ERROR::OK;
+    }
+
     void SetFsInfo(const std::shared_ptr<FsInfo>& fsInfo) {
         fsInfo_ = fsInfo;
         init_ = true;
@@ -236,7 +253,7 @@ class FuseClient {
         const std::shared_ptr<InodeWrapper> &inodeWrapper_,
         fuse_entry_param *param);
 
-    int AddHostNameToMountPointStr(const std::string& mountPointStr,
+    int AddHostPortToMountPointStr(const std::string& mountPointStr,
                                    std::string* out) {
         char hostname[kMaxHostNameLength];
         int ret = gethostname(hostname, kMaxHostNameLength);
@@ -244,7 +261,11 @@ class FuseClient {
             LOG(ERROR) << "GetHostName failed, ret = " << ret;
             return ret;
         }
-        *out = std::string(hostname) + ":" + mountPointStr;
+        *out =
+            std::string(hostname) + ":" +
+            std::to_string(
+                curve::client::ClientDummyServerInfo::GetInstance().GetPort()) +
+            ":" + mountPointStr;
         return 0;
     }
 

--- a/curvefs/src/client/fuse_volume_client.cpp
+++ b/curvefs/src/client/fuse_volume_client.cpp
@@ -224,7 +224,7 @@ CURVEFS_ERROR FuseVolumeClient::FuseOpCreate(fuse_req_t req, fuse_ino_t parent,
               << ", name: " << name
               << ", mode: " << mode;
     CURVEFS_ERROR ret =
-        MakeNode(req, parent, name, mode, FsFileType::TYPE_VOLUME, 0, e);
+        MakeNode(req, parent, name, mode, FsFileType::TYPE_FILE, 0, e);
     if (ret != CURVEFS_ERROR::OK) {
         return ret;
     }
@@ -236,7 +236,7 @@ CURVEFS_ERROR FuseVolumeClient::FuseOpMkNod(fuse_req_t req, fuse_ino_t parent,
                                             dev_t rdev, fuse_entry_param *e) {
     VLOG(3) << "FuseOpMkNod, parent: " << parent << ", name: " << name
             << ", mode: " << mode << ", rdev: " << rdev;
-    return MakeNode(req, parent, name, mode, FsFileType::TYPE_VOLUME, rdev, e);
+    return MakeNode(req, parent, name, mode, FsFileType::TYPE_FILE, rdev, e);
 }
 
 CURVEFS_ERROR FuseVolumeClient::FuseOpFsync(fuse_req_t req, fuse_ino_t ino,

--- a/curvefs/src/client/inode_cache_manager.cpp
+++ b/curvefs/src/client/inode_cache_manager.cpp
@@ -86,6 +86,8 @@ CURVEFS_ERROR InodeCacheManagerImpl::GetInode(uint64_t inodeid,
     std::shared_ptr<InodeWrapper> eliminatedOne;
     bool eliminated = iCache_->Put(inodeid, out, &eliminatedOne);
     if (eliminated) {
+        VLOG(3) << "GetInode eliminate one inode, ino: "
+                << eliminatedOne->GetInodeId();
         eliminatedOne->FlushAsync();
     }
     return CURVEFS_ERROR::OK;

--- a/curvefs/src/client/inode_wrapper.cpp
+++ b/curvefs/src/client/inode_wrapper.cpp
@@ -197,7 +197,7 @@ void InodeWrapper::FlushAttrAsync() {
     if (dirty_) {
         LockSyncingInode();
 
-        if (inode_.type() == FsFileType::TYPE_VOLUME) {
+        if (inode_.type() == FsFileType::TYPE_FILE) {
             auto tmp = extentCache_.ToInodePb();
             inode_.mutable_volumeextentmap()->swap(tmp);
         }
@@ -455,7 +455,7 @@ static std::ostream &operator<<(
 }
 
 void InodeWrapper::BuildExtentCache() {
-    if (inode_.type() != FsFileType::TYPE_VOLUME) {
+    if (inode_.type() != FsFileType::TYPE_FILE) {
         return;
     }
 
@@ -465,7 +465,7 @@ void InodeWrapper::BuildExtentCache() {
 }
 
 void InodeWrapper::AddVolumeExtentMapToInode() {
-    if (inode_.type() != FsFileType::TYPE_VOLUME) {
+    if (inode_.type() != FsFileType::TYPE_FILE) {
         return;
     }
 

--- a/curvefs/src/client/inode_wrapper.h
+++ b/curvefs/src/client/inode_wrapper.h
@@ -271,7 +271,7 @@ class InodeWrapper : public std::enable_shared_from_this<InodeWrapper> {
                 return SyncS3ChunkInfo();
             }
 
-            case FsFileType::TYPE_VOLUME: {
+            case FsFileType::TYPE_FILE: {
                 return SyncFullInode();
             }
 

--- a/curvefs/src/client/inode_wrapper.h
+++ b/curvefs/src/client/inode_wrapper.h
@@ -373,6 +373,9 @@ class InodeWrapper : public std::enable_shared_from_this<InodeWrapper> {
 
     void BuildExtentCache();
 
+    // TODO(wuhanqing): separate `volumeextentmap` from `Inode`
+    void AddVolumeExtentMapToInode();
+
  private:
     Inode inode_;
     uint32_t openCount_;

--- a/curvefs/src/client/main.c
+++ b/curvefs/src/client/main.c
@@ -51,6 +51,7 @@ static const struct fuse_lowlevel_ops curve_ll_oper = {
     .releasedir = FuseOpReleaseDir,
     .flush      = FuseOpFlush,
     .bmap       = FuseOpBmap,
+    .statfs     = FuseOpStatFs,
 };
 
 int main(int argc, char *argv[]) {

--- a/curvefs/src/client/metric/client_metric.h
+++ b/curvefs/src/client/metric/client_metric.h
@@ -128,6 +128,8 @@ struct S3Metric {
     InterfaceMetric adaptorWriteDiskCache;
     InterfaceMetric adaptorReadS3;
     InterfaceMetric adaptorReadDiskCache;
+    bvar::LatencyRecorder readSize;
+    bvar::LatencyRecorder writeSize;
 
     explicit S3Metric(const std::string &name = "")
         : fsName(!name.empty() ? name
@@ -137,7 +139,9 @@ struct S3Metric {
           adaptorWriteS3(prefix, fsName + "_adaptor_write_s3"),
           adaptorWriteDiskCache(prefix, fsName + "_adaptor_write_disk_cache"),
           adaptorReadS3(prefix, fsName + "_adaptor_read_s3"),
-          adaptorReadDiskCache(prefix, fsName + "_adaptor_read_disk_cache") {}
+          adaptorReadDiskCache(prefix, fsName + "_adaptor_read_disk_cache"),
+          readSize(prefix, fsName + "_adaptor_read_size"),
+          writeSize(prefix, fsName + "_adaptor_write_size") {}
 };
 
 struct DiskCacheMetric {

--- a/curvefs/src/client/rpcclient/metacache.cpp
+++ b/curvefs/src/client/rpcclient/metacache.cpp
@@ -75,9 +75,6 @@ bool MetaCache::GetTxId(uint32_t fsId, uint64_t inodeId, uint32_t *partitionId,
 bool MetaCache::GetTarget(uint32_t fsID, uint64_t inodeID,
                           CopysetTarget *target, uint64_t *applyIndex,
                           bool refresh) {
-    VLOG(3) << "Get target, fsid: " << fsID << ", inode id " << inodeID
-            << ", target: " << *target;
-
     // list infos from mds
     if (!ListPartitions(fsID)) {
         LOG(ERROR) << "get target for {fsid:" << fsID

--- a/curvefs/src/client/rpcclient/metaserver_client.h
+++ b/curvefs/src/client/rpcclient/metaserver_client.h
@@ -88,7 +88,7 @@ class MetaServerClient {
     PrepareRenameTx(const std::vector<Dentry> &dentrys) = 0;
 
     virtual MetaStatusCode GetInode(uint32_t fsId, uint64_t inodeid,
-                                    Inode *out) = 0;
+                                    Inode *out, bool* streaming) = 0;
 
     virtual MetaStatusCode BatchGetInodeAttr(uint32_t fsId,
         std::set<uint64_t> *inodeIds,
@@ -161,7 +161,7 @@ class MetaServerClientImpl : public MetaServerClient {
     MetaStatusCode PrepareRenameTx(const std::vector<Dentry> &dentrys) override;
 
     MetaStatusCode GetInode(uint32_t fsId, uint64_t inodeid,
-                            Inode *out) override;
+                            Inode *out, bool* streaming) override;
 
     MetaStatusCode BatchGetInodeAttr(uint32_t fsId,
         std::set<uint64_t> *inodeIds,

--- a/curvefs/src/client/s3/client_s3_adaptor.cpp
+++ b/curvefs/src/client/s3/client_s3_adaptor.cpp
@@ -145,6 +145,7 @@ int S3ClientAdaptorImpl::Write(uint64_t inodeId, uint64_t offset,
     fsCacheManager_->DataCacheByteDec(length);
     if (s3Metric_.get() != nullptr) {
         CollectMetrics(&s3Metric_->adaptorWrite, ret, start);
+        s3Metric_->writeSize << length;
     }
     VLOG(6) << "write end inodeId:" << inodeId << ",ret:" << ret
             << ", pendingReq_ is: " << pendingReq_;
@@ -166,6 +167,7 @@ int S3ClientAdaptorImpl::Read(uint64_t inodeId, uint64_t offset,
     }
     if (s3Metric_.get() != nullptr) {
         CollectMetrics(&s3Metric_->adaptorRead, ret, start);
+        s3Metric_->readSize << length;
     }
     VLOG(6) << "read end offset:" << offset << ", len:" << length
             << ", fsId:" << fsId_ << ", inodeId:" << inodeId;

--- a/curvefs/src/client/s3/client_s3_adaptor.cpp
+++ b/curvefs/src/client/s3/client_s3_adaptor.cpp
@@ -20,12 +20,12 @@
  * Author: huyao
  */
 
-
-
 #include <brpc/channel.h>
 #include <brpc/controller.h>
 #include <algorithm>
 #include <list>
+
+#include "absl/memory/memory.h"
 #include "curvefs/src/client/s3/client_s3_adaptor.h"
 #include "curvefs/src/common/s3util.h"
 
@@ -57,6 +57,7 @@ S3ClientAdaptorImpl::Init(
     memCacheNearfullRatio_ = option.nearfullRatio;
     throttleBaseSleepUs_ = option.baseSleepUs;
     flushIntervalSec_ = option.flushIntervalSec;
+    chunkFlushThreads_ = option.chunkFlushThreads;
     client_ = client;
     inodeManager_ = inodeManager;
     mdsClient_ = mdsClient;
@@ -95,6 +96,8 @@ S3ClientAdaptorImpl::Init(
               << ", readCacheMaxByte: " << option.readCacheMaxByte
               << ", nearfullRatio: " << option.nearfullRatio
               << ", baseSleepUs: " << option.baseSleepUs;
+    // start chunk flush threads
+    taskPool_.Start(chunkFlushThreads_);
     return CURVEFS_ERROR::OK;
 }
 
@@ -116,12 +119,16 @@ int S3ClientAdaptorImpl::Write(uint64_t inodeId, uint64_t offset,
         if ((size + pendingReq * fuseMaxSize_) >= maxSize) {
             LOG(INFO) << "write cache is full, wait flush. size:" << size
                       << ", maxSize:" << maxSize;
+            // offer to do flush
+            waitInterval_.StopWait();
             fsCacheManager_->WaitFlush();
         }
     }
     uint64_t memCacheRatio = fsCacheManager_->MemCacheRatio();
     int64_t exceedRatio = memCacheRatio - memCacheNearfullRatio_;
     if (exceedRatio > 0) {
+        // offer to do flush
+        waitInterval_.StopWait();
         // upload to s3 derectly or cache disk full
         bool needSleep =
             (DisableDiskCache() || IsReadCache()) ||
@@ -160,7 +167,8 @@ int S3ClientAdaptorImpl::Read(uint64_t inodeId, uint64_t offset,
     if (s3Metric_.get() != nullptr) {
         CollectMetrics(&s3Metric_->adaptorRead, ret, start);
     }
-
+    VLOG(6) << "read end offset:" << offset << ", len:" << length
+            << ", fsId:" << fsId_ << ", inodeId:" << inodeId;
     return ret;
 }
 
@@ -300,8 +308,8 @@ int S3ClientAdaptorImpl::Stop() {
         }
         diskCacheManagerImpl_->UmountDiskCache();
     }
+    taskPool_.Stop();
     client_->Deinit();
-    LOG(INFO) << "Stopping S3ClientAdaptor success";
     return 0;
 }
 
@@ -367,6 +375,27 @@ int S3ClientAdaptorImpl::ClearDiskCache(int64_t inodeId) {
     LOG_IF(ERROR, ret < 0) << "FlushAllCache, inode:" << inodeId
                            << ", upload write cache fail";
     return ret;
+}
+
+void S3ClientAdaptorImpl::Enqueue(
+  std::shared_ptr<FlushChunkCacheContext> context) {
+    auto task = [this, context]() {
+        this->FlushChunkClosure(context);
+    };
+    taskPool_.Enqueue(task);
+}
+
+int S3ClientAdaptorImpl::FlushChunkClosure(
+  std::shared_ptr<FlushChunkCacheContext> context) {
+    VLOG(9) << "FlushChunkCacheClosure start: " << context->inode;
+    CURVEFS_ERROR ret = context->chunkCacheManptr->Flush(
+      context->inode, context->force);
+    // set the returned value
+    // it is need in FlushChunkCacheCallBack
+    context->retCode = ret;
+    context->cb(context);
+    VLOG(9) << "FlushChunkCacheClosure end: " << context->inode;
+    return 0;
 }
 
 }  // namespace client

--- a/curvefs/src/client/s3/client_s3_cache_manager.cpp
+++ b/curvefs/src/client/s3/client_s3_cache_manager.cpp
@@ -999,13 +999,12 @@ CURVEFS_ERROR FileCacheManager::Flush(bool force, bool toS3) {
             flushTasks.emplace_back(context);
         }
         pendingReq.fetch_add(flushTasks.size(), std::memory_order_seq_cst);
-        for (auto iter = flushTasks.begin();
-          iter != flushTasks.end(); ++iter) {
-            s3ClientAdaptor_->Enqueue(*iter);
-        }
-
         if (pendingReq.load(std::memory_order_seq_cst)) {
             VLOG(6) << "wait for pendingReq";
+            for (auto iter = flushTasks.begin();
+              iter != flushTasks.end(); ++iter) {
+                s3ClientAdaptor_->Enqueue(*iter);
+            }
             cond.Wait();
         }
         VLOG(6) << "file cache flush over";

--- a/curvefs/src/client/s3/client_s3_cache_manager.cpp
+++ b/curvefs/src/client/s3/client_s3_cache_manager.cpp
@@ -155,7 +155,6 @@ CURVEFS_ERROR FsCacheManager::FsSync(bool force) {
     }
 
     auto iter = tmp.begin();
-    VLOG(3) << "FsSync force: " << force;
     for (; iter != tmp.end(); iter++) {
         ret = iter->second->Flush(force);
         if (ret == CURVEFS_ERROR::OK) {

--- a/curvefs/src/client/s3/disk_cache_manager.cpp
+++ b/curvefs/src/client/s3/disk_cache_manager.cpp
@@ -155,8 +155,9 @@ int DiskCacheManager::ClearReadCache(const std::list<std::string> &files) {
     return cacheRead_->ClearReadCache(files);
 }
 
-void DiskCacheManager::AddCache(const std::string name) {
-    cachedObjName_->Put(name, true);
+void DiskCacheManager::AddCache(const std::string name,
+  bool cacheWriteExist) {
+    cachedObjName_->Put(name, cacheWriteExist);
     VLOG(9) << "cache size is: " << cachedObjName_->Size();
 }
 
@@ -349,7 +350,7 @@ void DiskCacheManager::TrimCache() {
         SetDiskFsUsedRatio();
             while (!IsDiskCacheSafe()) {
                 if (!cachedObjName_->GetLast(false, &cacheKey)) {
-                    VLOG(3) << "obj is empty";
+                    VLOG(9) << "obj is empty";
                     break;
                 }
 

--- a/curvefs/src/client/s3/disk_cache_manager.cpp
+++ b/curvefs/src/client/s3/disk_cache_manager.cpp
@@ -292,7 +292,7 @@ void DiskCacheManager::SetDiskInitUsedBytes() {
         return;
     }
     usedBytes_.fetch_add(usedBytes, std::memory_order_seq_cst);
-    VLOG(3) << "cache disk used size is: " << result;
+    VLOG(9) << "cache disk used size is: " << result;
     return;
 }
 
@@ -393,7 +393,6 @@ void DiskCacheManager::TrimCache() {
                 DecDiskUsedBytes(statReadFile.st_size);
                 VLOG(6) << "remove disk file success, file is: " << cacheKey;
             }
-            VLOG(6) << "trim over.";
     }
     LOG(INFO) << "trim function end.";
 }

--- a/curvefs/src/client/s3/disk_cache_manager.cpp
+++ b/curvefs/src/client/s3/disk_cache_manager.cpp
@@ -271,8 +271,6 @@ int64_t DiskCacheManager::SetDiskFsUsedRatio() {
     int64_t usedBytes = totalBytes - freeBytes;
     int64_t usedPercent = 100 * usedBytes / (usedBytes + availableBytes) + 1;
 
-    VLOG(3) << "cache disk usage = " << usedPercent;
-
     diskFsUsedRatio_.store(usedPercent, std::memory_order_seq_cst);
     return usedPercent;
 }

--- a/curvefs/src/client/s3/disk_cache_manager.h
+++ b/curvefs/src/client/s3/disk_cache_manager.h
@@ -34,6 +34,7 @@
 #include "src/common/interruptible_sleeper.h"
 #include "src/common/lru_cache.h"
 #include "src/common/throttle.h"
+#include "src/common/wait_interval.h"
 #include "curvefs/src/common/wrap_posix.h"
 #include "curvefs/src/common/utils.h"
 #include "curvefs/src/client/s3/client_s3.h"
@@ -111,8 +112,8 @@ class DiskCacheManager {
      */
     void AddDiskUsedBytes(uint64_t length) {
         usedBytes_.fetch_add(length, std::memory_order_seq_cst);
-        VLOG(9) << "add disk used size is: "
-                << usedBytes_.load(std::memory_order_seq_cst);
+        VLOG(9) << "add disk used size is: " << length
+                << ", now is: " << usedBytes_.load(std::memory_order_seq_cst);
         return;
     }
     /**
@@ -125,8 +126,8 @@ class DiskCacheManager {
         usedBytes = usedBytes_.fetch_sub(length, std::memory_order_seq_cst);
         assert(usedBytes >= 0);
         (void)usedBytes;
-        VLOG(9) << "dec disk used size is: "
-                << usedBytes_.load(std::memory_order_seq_cst);
+        VLOG(9) << "dec disk used size is: " << length
+                << ", now is: " << usedBytes_.load(std::memory_order_seq_cst);
         return;
     }
     void SetDiskInitUsedBytes();
@@ -143,6 +144,7 @@ class DiskCacheManager {
     curve::common::Thread backEndThread_;
     curve::common::Atomic<bool> isRunning_;
     curve::common::InterruptibleSleeper sleeper_;
+    curve::common::WaitInterval waitIntervalSec_;
     uint32_t trimCheckIntervalSec_;
     uint32_t fullRatio_;
     uint32_t safeRatio_;
@@ -155,7 +157,8 @@ class DiskCacheManager {
     std::string cacheDir_;
     std::shared_ptr<DiskCacheWrite> cacheWrite_;
     std::shared_ptr<DiskCacheRead> cacheRead_;
-    std::shared_ptr<SglLRUCache<std::string>> cachedObjName_;
+
+    std::shared_ptr<LRUCache<std::string, bool>> cachedObjName_;
 
     S3Client *client_;
     std::shared_ptr<PosixWrapper> posixWrapper_;

--- a/curvefs/src/client/s3/disk_cache_manager.h
+++ b/curvefs/src/client/s3/disk_cache_manager.h
@@ -69,8 +69,11 @@ class DiskCacheManager {
     /**
      * @brief add obj to cachedObjName
      * @param[in] name obj name
+     * @param[in] cacheWriteExist whether the obj is
+     *                            exist in cache write
      */
-    void AddCache(const std::string name);
+    void AddCache(const std::string name,
+      bool cacheWriteExist = true);
 
     int CreateDir();
     std::string GetCacheReadFullDir();

--- a/curvefs/src/client/s3/disk_cache_manager_impl.cpp
+++ b/curvefs/src/client/s3/disk_cache_manager_impl.cpp
@@ -135,7 +135,7 @@ int DiskCacheManagerImpl::WriteReadDirect(const std::string fileName,
         return ret;
     }
     // add cache.
-    diskCacheManager_->AddCache(fileName);
+    diskCacheManager_->AddCache(fileName, false);
     return ret;
 }
 

--- a/curvefs/src/client/s3/disk_cache_manager_impl.cpp
+++ b/curvefs/src/client/s3/disk_cache_manager_impl.cpp
@@ -48,7 +48,29 @@ int DiskCacheManagerImpl::Init(const S3ClientAdaptorOption option) {
     }
 
     forceFlush_ = option.diskCacheOpt.forceFlush;
+    threads_ = option.diskCacheOpt.threads;
+    taskPool_.Start(threads_);
     LOG(INFO) << "DiskCacheManagerImpl init end.";
+    return 0;
+}
+
+void DiskCacheManagerImpl::Enqueue(
+  std::shared_ptr<PutObjectAsyncContext> context) {
+    auto task = [this, context]() {
+        this->WriteClosure(context);
+    };
+    taskPool_.Enqueue(task);
+}
+
+int DiskCacheManagerImpl::WriteClosure(
+  std::shared_ptr<PutObjectAsyncContext> context) {
+    VLOG(9) << "WriteClosure start, name: " << context->key;
+    int ret = Write(context->key, context->buffer, context->bufferSize);
+     // set the returned value
+    // it is need in CallBack
+    context->retCode = ret;
+    context->cb(context);
+    VLOG(9) << "WriteClosure end, name: " << context->key;
     return 0;
 }
 
@@ -154,6 +176,7 @@ int DiskCacheManagerImpl::UmountDiskCache() {
         LOG(ERROR) << "umount disk cache error.";
         return -1;
     }
+    taskPool_.Stop();
     return 0;
 }
 

--- a/curvefs/src/client/s3/disk_cache_manager_impl.h
+++ b/curvefs/src/client/s3/disk_cache_manager_impl.h
@@ -43,6 +43,7 @@ namespace curvefs {
 namespace client {
 
 using curvefs::common::PosixWrapper;
+using curve::common::TaskThreadPool;
 
 struct DiskCacheOption {
     DiskCacheType diskCacheType;
@@ -54,6 +55,7 @@ struct DiskCacheOption {
     bool forceFlush;
     uint64_t maxUsableSpaceBytes;
     uint32_t cmdTimeoutSec;
+    uint32_t threads;
     uint64_t avgFlushBytes;
     uint64_t burstFlushBytes;
     uint64_t burstSecs;
@@ -114,12 +116,21 @@ class DiskCacheManagerImpl {
 
     virtual int ClearReadCache(const std::list<std::string> &files);
 
+    void Enqueue(std::shared_ptr<PutObjectAsyncContext> context);
+
  private:
     int WriteDiskFile(const std::string name, const char *buf, uint64_t length);
 
     std::shared_ptr<DiskCacheManager> diskCacheManager_;
+
     bool forceFlush_;
     S3Client *client_;
+
+    int WriteClosure(std::shared_ptr<PutObjectAsyncContext> context);
+    // threads for disk cache
+    uint32_t threads_;
+    TaskThreadPool<bthread::Mutex, bthread::ConditionVariable>
+        taskPool_;
 };
 
 }  // namespace client

--- a/curvefs/src/client/s3/disk_cache_read.cpp
+++ b/curvefs/src/client/s3/disk_cache_read.cpp
@@ -20,11 +20,11 @@
  * Author: hzwuhongsong
  */
 
-#include <sys/stat.h>
-#include <unistd.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <sys/stat.h>
 #include <sys/types.h>
+#include <unistd.h>
 #include <dirent.h>
 #include <memory>
 #include <utility>
@@ -106,7 +106,7 @@ int DiskCacheRead::LinkWriteToRead(const std::string fileName,
 }
 
 int DiskCacheRead::LoadAllCacheReadFile(
-    std::shared_ptr<SglLRUCache<std::string>> cachedObj) {
+    std::shared_ptr<LRUCache<std::string, bool>> cachedObj) {
     std::set<std::string> tmp;
     int ret = LoadAllCacheFile(&tmp);
     if (ret < 0) {
@@ -117,7 +117,7 @@ int DiskCacheRead::LoadAllCacheReadFile(
     }
 
     for (auto iter = tmp.begin(); iter != tmp.end(); iter++) {
-        cachedObj->Put(std::move(*iter));
+        cachedObj->Put(std::move(*iter), false);
     }
 
     return ret;

--- a/curvefs/src/client/s3/disk_cache_read.cpp
+++ b/curvefs/src/client/s3/disk_cache_read.cpp
@@ -95,7 +95,8 @@ int DiskCacheRead::LinkWriteToRead(const std::string fileName,
         return -1;
     }
     ret = posixWrapper_->link(fullWritePath.c_str(), fullReadPath.c_str());
-    if (ret < 0) {
+    if (ret < 0 &&
+      errno != EEXIST ) {
         LOG(ERROR) << "link error. ret = " << ret << ", errno = " << errno
                    << ", write path = " << fullWritePath
                    << ", read path = " << fullReadPath;

--- a/curvefs/src/client/s3/disk_cache_read.h
+++ b/curvefs/src/client/s3/disk_cache_read.h
@@ -37,7 +37,7 @@
 namespace curvefs {
 namespace client {
 
-using curve::common::SglLRUCache;
+using curve::common::LRUCache;
 using curvefs::common::PosixWrapper;
 
 class DiskCacheRead : public DiskCacheBase {
@@ -58,7 +58,8 @@ class DiskCacheRead : public DiskCacheBase {
      * @brief after reboot，load all files that store in read cache.
      */
     virtual int
-    LoadAllCacheReadFile(std::shared_ptr<SglLRUCache<std::string>> cachedObj);
+    LoadAllCacheReadFile(std::shared_ptr<LRUCache<
+      std::string, bool>> cachedObj);
     virtual int ClearReadCache(const std::list<std::string> &files);
     virtual void InitMetrics(std::shared_ptr<DiskCacheMetric> metric) {
         metric_ = metric;

--- a/curvefs/src/client/s3/disk_cache_write.h
+++ b/curvefs/src/client/s3/disk_cache_write.h
@@ -33,15 +33,23 @@
 
 #include "src/common/concurrent/concurrent.h"
 #include "src/common/interruptible_sleeper.h"
+#include "src/common/lru_cache.h"
+#include "src/common/throttle.h"
+#include "src/common/wait_interval.h"
 #include "curvefs/src/common/wrap_posix.h"
-#include "curvefs/src/client/s3/disk_cache_base.h"
+#include "curvefs/src/common/utils.h"
 #include "curvefs/src/client/s3/client_s3.h"
+#include "curvefs/src/client/s3/disk_cache_write.h"
+#include "curvefs/src/client/s3/disk_cache_read.h"
+#include "curvefs/src/client/common/config.h"
+#include "curvefs/src/client/s3/disk_cache_base.h"
 
 namespace curvefs {
 namespace client {
 
 using curvefs::common::PosixWrapper;
 using curve::common::InterruptibleSleeper;
+using ::curve::common::LRUCache;
 using curve::common::PutObjectAsyncCallBack;
 
 class DiskCacheWrite : public DiskCacheBase {
@@ -74,7 +82,8 @@ class DiskCacheWrite : public DiskCacheBase {
        AsyncUploadStop();
     }
     void Init(S3Client *client, std::shared_ptr<PosixWrapper> posixWrapper,
-              const std::string cacheDir, uint64_t asyncLoadPeriodMs);
+              const std::string cacheDir, uint64_t asyncLoadPeriodMs,
+              std::shared_ptr<LRUCache<std::string, bool>> cachedObjName);
     /**
      * @brief write obj to write cahce disk
      * @param[in] client S3Client
@@ -143,6 +152,8 @@ class DiskCacheWrite : public DiskCacheBase {
     // file system operation encapsulation
     std::shared_ptr<PosixWrapper> posixWrapper_;
     std::shared_ptr<DiskCacheMetric> metric_;
+
+    std::shared_ptr<LRUCache<std::string, bool>> cachedObjName_;
 };
 
 }  // namespace client

--- a/curvefs/src/mds/fs_manager.h
+++ b/curvefs/src/mds/fs_manager.h
@@ -65,7 +65,7 @@ using ::curvefs::mds::topology::TopologyManager;
 
 struct FsManagerOption {
     uint32_t backEndThreadRunInterSec;
-    uint32_t spaceReloadConcurrency;
+    uint32_t spaceReloadConcurrency = 10;
     curve::common::S3AdapterOption s3AdapterOption;
 };
 

--- a/curvefs/src/mds/mds.cpp
+++ b/curvefs/src/mds/mds.cpp
@@ -133,6 +133,14 @@ void MDS::InitScheduleOption(ScheduleOption* scheduleOption) {
 void MDS::InitFsManagerOptions(FsManagerOption* fsManagerOption) {
     conf_->GetValueFatalIfFail("mds.fsmanager.backEndThreadRunInterSec",
                                &fsManagerOption->backEndThreadRunInterSec);
+
+    LOG_IF(ERROR,
+           conf_->GetUInt32Value("mds.fsmanager.reloadSpaceConcurrency",
+                                 &fsManagerOption->spaceReloadConcurrency))
+        << "Get `mds.fsmanager.reloadSpaceConcurrency` from conf error, use "
+           "default value: "
+        << fsManagerOption->spaceReloadConcurrency;
+
     ::curve::common::InitS3AdaptorOptionExceptS3InfoOption(
         conf_.get(), &fsManagerOption->s3AdapterOption);
 }

--- a/curvefs/src/mds/topology/topology_manager.cpp
+++ b/curvefs/src/mds/topology/topology_manager.cpp
@@ -853,7 +853,7 @@ TopoStatusCode TopologyManager::CreateCopyset(
         return TopoStatusCode::TOPO_CREATE_COPYSET_ON_METASERVER_FAIL;
     }
 
-    // add copyset record to topogy
+    // add copyset record to topology
     CopySetInfo copysetInfo(copyset.poolId, copyset.copysetId);
     copysetInfo.SetCopySetMembers(copyset.metaServerIds);
     auto ret = topology_->AddCopySet(copysetInfo);
@@ -866,6 +866,7 @@ TopoStatusCode TopologyManager::CreateCopyset(
         return ret;
     }
 
+    ClearCopysetCreating(copyset.poolId, copyset.copysetId);
     return TopoStatusCode::TOPO_OK;
 }
 

--- a/curvefs/src/metaserver/copyset/meta_operator.cpp
+++ b/curvefs/src/metaserver/copyset/meta_operator.cpp
@@ -176,7 +176,6 @@ void GetOrModifyS3ChunkInfoOperator::OnApply(int64_t index,
     MetaStatusCode rc;
     auto request = static_cast<const GetOrModifyS3ChunkInfoRequest*>(request_);
     auto response = static_cast<GetOrModifyS3ChunkInfoResponse*>(response_);
-    bool streaming = request->returns3chunkinfomap();
     auto metastore = node_->GetMetaStore();
     std::shared_ptr<StreamConnection> connection;
     std::shared_ptr<Iterator> iterator;
@@ -199,7 +198,9 @@ void GetOrModifyS3ChunkInfoOperator::OnApply(int64_t index,
         }
 
         brpc::Controller* cntl = static_cast<brpc::Controller*>(cntl_);
-        if (rc != MetaStatusCode::OK || !streaming) {
+        if (rc != MetaStatusCode::OK ||
+            !request->returns3chunkinfomap() ||
+            !request->supportstreaming()) {
             return;
         }
 

--- a/curvefs/src/metaserver/inode_manager.cpp
+++ b/curvefs/src/metaserver/inode_manager.cpp
@@ -343,10 +343,11 @@ MetaStatusCode InodeManager::GetOrModifyS3ChunkInfo(
 
 MetaStatusCode InodeManager::PaddingInodeS3ChunkInfo(int32_t fsId,
                                                      uint64_t inodeId,
-                                                     Inode* inode) {
+                                                     S3ChunkInfoMap* m,
+                                                     uint64_t limit) {
     VLOG(1) << "PaddingInodeS3ChunkInfo, fsId: " << fsId
             << ", inodeId: " << inodeId;
-    return inodeStorage_->PaddingInodeS3ChunkInfo(fsId, inodeId, inode);
+    return inodeStorage_->PaddingInodeS3ChunkInfo(fsId, inodeId, m, limit);
 }
 
 MetaStatusCode InodeManager::UpdateInodeWhenCreateOrRemoveSubNode(

--- a/curvefs/src/metaserver/inode_manager.h
+++ b/curvefs/src/metaserver/inode_manager.h
@@ -34,7 +34,6 @@
 
 using ::curve::common::NameLock;
 using ::curvefs::metaserver::S3ChunkInfoList;
-using S3ChunkInfoMap = google::protobuf::Map<uint64_t, S3ChunkInfoList>;
 
 namespace curvefs {
 namespace metaserver {
@@ -81,7 +80,8 @@ class InodeManager {
 
     MetaStatusCode PaddingInodeS3ChunkInfo(int32_t fsId,
                                            uint64_t inodeId,
-                                           Inode* inode);
+                                           S3ChunkInfoMap* m,
+                                           uint64_t limit = 0);
 
     MetaStatusCode UpdateInodeWhenCreateOrRemoveSubNode(uint32_t fsId,
         uint64_t inodeId, bool isCreate);

--- a/curvefs/src/metaserver/metaserver.cpp
+++ b/curvefs/src/metaserver/metaserver.cpp
@@ -500,6 +500,9 @@ void Metaserver::InitStorage() {
     LOG_IF(FATAL, !conf_->GetUInt64Value(
         "storage.rocksdb.block_cache_capacity",
         &storageOptions_.blockCacheCapacity));
+    LOG_IF(FATAL, !conf_->GetUInt64Value(
+        "storage.s3_meta_inside_inode.limit_size",
+        &storageOptions_.s3MetaLimitSizeInsideInode));
 
     bool succ = ::curvefs::metaserver::storage::InitStorage(storageOptions_);
     LOG_IF(FATAL, !succ) << "Init storage failed";

--- a/curvefs/src/metaserver/metaserver.cpp
+++ b/curvefs/src/metaserver/metaserver.cpp
@@ -500,6 +500,9 @@ void Metaserver::InitStorage() {
     LOG_IF(FATAL, !conf_->GetUInt64Value(
         "storage.rocksdb.block_cache_capacity",
         &storageOptions_.blockCacheCapacity));
+    LOG_IF(FATAL, !conf_->GetDoubleValue(
+        "storage.rocksdb.memtable_prefix_bloom_size_ratio",
+        &storageOptions_.memtablePrefixBloomSizeRatio));
     LOG_IF(FATAL, !conf_->GetUInt64Value(
         "storage.s3_meta_inside_inode.limit_size",
         &storageOptions_.s3MetaLimitSizeInsideInode));

--- a/curvefs/src/metaserver/metastore.cpp
+++ b/curvefs/src/metaserver/metastore.cpp
@@ -397,13 +397,29 @@ MetaStatusCode MetaStoreImpl::GetInode(const GetInodeRequest* request,
         return status;
     }
 
-    MetaStatusCode status =
-        partition->GetInode(fsId, inodeId, response->mutable_inode());
-    if (status != MetaStatusCode::OK) {
+    Inode* inode = response->mutable_inode();
+    MetaStatusCode rc = partition->GetInode(fsId, inodeId, inode);
+    // NOTE: the following two cases we should padding inode's s3chunkinfo:
+    // (1): for RPC requests which unsupport streaming
+    // (2): inode's s3chunkinfo is small enough
+    if (rc == MetaStatusCode::OK) {
+        uint64_t limit = 0;
+        if (request->supportstreaming()) {
+            limit = kvStorage_->GetStorageOptions().s3MetaLimitSizeInsideInode;
+        }
+        rc = partition->PaddingInodeS3ChunkInfo(
+            fsId, inodeId, inode->mutable_s3chunkinfomap(), limit);
+        if (rc == MetaStatusCode::INODE_S3_META_TOO_LARGE) {
+            response->set_streaming(true);
+            rc = MetaStatusCode::OK;
+        }
+    }
+
+    if (rc != MetaStatusCode::OK) {
         response->clear_inode();
     }
-    response->set_statuscode(status);
-    return status;
+    response->set_statuscode(rc);
+    return rc;
 }
 
 MetaStatusCode MetaStoreImpl::BatchGetInodeAttr(
@@ -517,6 +533,13 @@ MetaStatusCode MetaStoreImpl::GetOrModifyS3ChunkInfo(
                                                request->returns3chunkinfomap(),
                                                request->froms3compaction());
     }
+
+    if (rc == MetaStatusCode::OK && !request->supportstreaming()) {
+        rc = partition->PaddingInodeS3ChunkInfo(
+            request->fsid(), request->inodeid(),
+            response->mutable_s3chunkinfomap(), 0);
+    }
+
     response->set_statuscode(rc);
     return rc;
 }

--- a/curvefs/src/metaserver/partition.cpp
+++ b/curvefs/src/metaserver/partition.cpp
@@ -278,6 +278,18 @@ MetaStatusCode Partition::GetOrModifyS3ChunkInfo(
         fsId, inodeId, list2add, iterator, returnS3ChunkInfoMap, compaction);
 }
 
+MetaStatusCode Partition::PaddingInodeS3ChunkInfo(int32_t fsId,
+                                                  uint64_t inodeId,
+                                                  S3ChunkInfoMap* m,
+                                                  uint64_t limit) {
+    if (!IsInodeBelongs(fsId, inodeId)) {
+        return MetaStatusCode::PARTITION_ID_MISSMATCH;
+    } else if (GetStatus() == PartitionStatus::DELETING) {
+        return MetaStatusCode::PARTITION_DELETING;
+    }
+    return inodeManager_->PaddingInodeS3ChunkInfo(fsId, inodeId, m, limit);
+}
+
 MetaStatusCode Partition::InsertInode(const Inode& inode) {
     if (!IsInodeBelongs(inode.fsid(), inode.inodeid())) {
         return MetaStatusCode::PARTITION_ID_MISSMATCH;

--- a/curvefs/src/metaserver/partition.h
+++ b/curvefs/src/metaserver/partition.h
@@ -97,6 +97,11 @@ class Partition {
                                           bool returnS3ChunkInfoMap,
                                           bool compaction);
 
+    MetaStatusCode PaddingInodeS3ChunkInfo(int32_t fsId,
+                                           uint64_t inodeId,
+                                           S3ChunkInfoMap* m,
+                                           uint64_t limit = 0);
+
     MetaStatusCode InsertInode(const Inode& inode);
 
     bool GetInodeIdList(std::list<uint64_t>* InodeIdList);

--- a/curvefs/src/metaserver/s3compact_wq_impl.cpp
+++ b/curvefs/src/metaserver/s3compact_wq_impl.cpp
@@ -477,7 +477,7 @@ bool S3CompactWorkQueueImpl::CompactPrecheck(
         auto inodeKey = task.inodeKey;
         auto inodeManager = task.inodeManager;
         MetaStatusCode rc = inodeManager->PaddingInodeS3ChunkInfo(
-            inodeKey.fsId, inodeKey.inodeId, inode);
+            inodeKey.fsId, inodeKey.inodeId, inode->mutable_s3chunkinfomap());
         if (rc != MetaStatusCode::OK) {
             LOG(ERROR) << "Padding inode s3chunkinfo failed, "
                        << "retCode = " << MetaStatusCode_Name(ret);

--- a/curvefs/src/metaserver/storage/config.h
+++ b/curvefs/src/metaserver/storage/config.h
@@ -53,6 +53,9 @@ struct StorageOptions {
     uint64_t orderedMaxWriteBufferNumber;
 
     uint64_t blockCacheCapacity;
+
+    // misc config item
+    uint64_t s3MetaLimitSizeInsideInode;
 };
 
 }  // namespace storage

--- a/curvefs/src/metaserver/storage/config.h
+++ b/curvefs/src/metaserver/storage/config.h
@@ -54,6 +54,8 @@ struct StorageOptions {
 
     uint64_t blockCacheCapacity;
 
+    double memtablePrefixBloomSizeRatio;
+
     // misc config item
     uint64_t s3MetaLimitSizeInsideInode;
 };

--- a/curvefs/src/metaserver/storage/converter.cpp
+++ b/curvefs/src/metaserver/storage/converter.cpp
@@ -90,18 +90,21 @@ Key4S3ChunkInfoList::Key4S3ChunkInfoList()
       inodeId(0),
       chunkIndex(0),
       firstChunkId(0),
-      lastChunkId(0) {}
+      lastChunkId(0),
+      size(0) {}
 
 Key4S3ChunkInfoList::Key4S3ChunkInfoList(uint32_t fsId,
                                          uint64_t inodeId,
                                          uint64_t chunkIndex,
                                          uint64_t firstChunkId,
-                                         uint64_t lastChunkId)
+                                         uint64_t lastChunkId,
+                                         uint64_t size)
     : fsId(fsId),
       inodeId(inodeId),
       chunkIndex(chunkIndex),
       firstChunkId(firstChunkId),
-      lastChunkId(lastChunkId) {}
+      lastChunkId(lastChunkId),
+      size(size) {}
 
 std::string Key4S3ChunkInfoList::SerializeToString() const {
     std::ostringstream oss;
@@ -109,18 +112,20 @@ std::string Key4S3ChunkInfoList::SerializeToString() const {
         << inodeId << ":" << chunkIndex << ":"
         << std::setw(kMaxUint64Length_) << std::setfill('0') << firstChunkId
         << ":"
-        << std::setw(kMaxUint64Length_) << std::setfill('0') << lastChunkId;
+        << std::setw(kMaxUint64Length_) << std::setfill('0') << lastChunkId
+        << ":" << size;
     return oss.str();
 }
 
 bool Key4S3ChunkInfoList::ParseFromString(const std::string& value) {
     std::vector<std::string> items;
     SplitString(value, ":", &items);
-    return items.size() == 6 && CompareType(items[0], keyType_) &&
+    return items.size() == 7 && CompareType(items[0], keyType_) &&
         StringToUl(items[1], &fsId) && StringToUll(items[2], &inodeId) &&
         StringToUll(items[3], &chunkIndex) &&
         StringToUll(items[4], &firstChunkId) &&
-        StringToUll(items[5], &lastChunkId);
+        StringToUll(items[5], &lastChunkId) &&
+        StringToUll(items[6], &size);
 }
 
 Prefix4ChunkIndexS3ChunkInfoList::Prefix4ChunkIndexS3ChunkInfoList()

--- a/curvefs/src/metaserver/storage/converter.h
+++ b/curvefs/src/metaserver/storage/converter.h
@@ -94,7 +94,8 @@ class Key4S3ChunkInfoList : public StorageKey {
                         uint64_t inodeId,
                         uint64_t chunkIndex,
                         uint64_t firstChunkId,
-                        uint64_t lastChunkId);
+                        uint64_t lastChunkId,
+                        uint64_t size);
 
     std::string SerializeToString() const override;
 
@@ -109,6 +110,7 @@ class Key4S3ChunkInfoList : public StorageKey {
      uint64_t chunkIndex;
      uint64_t firstChunkId;
      uint64_t lastChunkId;
+     uint64_t size;
 };
 
 class Prefix4ChunkIndexS3ChunkInfoList : public StorageKey {

--- a/curvefs/src/metaserver/storage/memory_storage.cpp
+++ b/curvefs/src/metaserver/storage/memory_storage.cpp
@@ -321,6 +321,10 @@ bool MemoryStorage::GetStatistics(StorageStatistics* statistics) {
     return true;
 }
 
+StorageOptions MemoryStorage::GetStorageOptions() const {
+    return options_;
+}
+
 }  // namespace storage
 }  // namespace metaserver
 }  // namespace curvefs

--- a/curvefs/src/metaserver/storage/memory_storage.h
+++ b/curvefs/src/metaserver/storage/memory_storage.h
@@ -97,6 +97,8 @@ class MemoryStorage : public KVStorage, public StorageTransaction {
 
     bool GetStatistics(StorageStatistics* Statistics) override;
 
+    StorageOptions GetStorageOptions() const override;
+
     Status HGet(const std::string& name,
                 const std::string& key,
                 ValueType* value) override;

--- a/curvefs/src/metaserver/storage/rocksdb_storage.cpp
+++ b/curvefs/src/metaserver/storage/rocksdb_storage.cpp
@@ -282,7 +282,7 @@ Status RocksDBStorage::Get(const std::string& name,
 
     std::string iname = ToInternalName(name, ordered);
     std::string ikey = ToInternalKey(iname, key);
-    if (!FindKey(iname, ikey)) {
+    if (!InTransaction_ && !FindKey(iname, ikey)) {
         return Status::NotFound();
     }
 
@@ -333,7 +333,7 @@ Status RocksDBStorage::Del(const std::string& name,
 
     std::string iname = ToInternalName(name, ordered);
     std::string ikey = ToInternalKey(iname, key);
-    if (!counter_->Find(iname, ikey)) {
+    if (!InTransaction_ && !counter_->Find(iname, ikey)) {
         return Status::NotFound();
     }
 
@@ -441,6 +441,10 @@ bool RocksDBStorage::GetStatistics(StorageStatistics* statistics) {
     statistics->diskUsageBytes = total - available;
 
     return true;
+}
+
+StorageOptions RocksDBStorage::GetStorageOptions() const {
+    return options_;
 }
 
 }  // namespace storage

--- a/curvefs/src/metaserver/storage/rocksdb_storage.h
+++ b/curvefs/src/metaserver/storage/rocksdb_storage.h
@@ -33,6 +33,7 @@
 #include "rocksdb/slice.h"
 #include "rocksdb/table.h"
 #include "rocksdb/options.h"
+#include "rocksdb/filter_policy.h"
 #include "rocksdb/slice_transform.h"
 #include "rocksdb/utilities/transaction.h"
 #include "rocksdb/utilities/transaction_db.h"
@@ -56,7 +57,8 @@ using ROCKSDB_NAMESPACE::BlockBasedTableOptions;
 using ROCKSDB_NAMESPACE::Transaction;
 using ROCKSDB_NAMESPACE::TransactionDB;
 using ROCKSDB_NAMESPACE::NewLRUCache;
-using ROCKSDB_NAMESPACE::NewFixedPrefixTransform;
+using ROCKSDB_NAMESPACE::NewBloomFilterPolicy;
+using ROCKSDB_NAMESPACE::NewCappedPrefixTransform;
 using ROCKSDB_NAMESPACE::NewBlockBasedTableFactory;
 using STORAGE_TYPE = KVStorage::STORAGE_TYPE;
 

--- a/curvefs/src/metaserver/storage/rocksdb_storage.h
+++ b/curvefs/src/metaserver/storage/rocksdb_storage.h
@@ -135,6 +135,8 @@ class RocksDBStorage : public KVStorage, public StorageTransaction {
 
     bool GetStatistics(StorageStatistics* Statistics) override;
 
+    StorageOptions GetStorageOptions() const override;
+
     // unordered
     Status HGet(const std::string& name,
                 const std::string& key,
@@ -337,13 +339,21 @@ class RocksDBStorageIterator : public Iterator {
           ordered_(ordered) {
         if (status_ == 0) {
             readOptions_ = storage_->ReadOptions();
-            readOptions_.snapshot = storage_->db_->GetSnapshot();
+            if (storage_->InTransaction_) {
+                readOptions_.snapshot = storage_->txn_->GetSnapshot();
+            } else {
+                readOptions_.snapshot = storage_->db_->GetSnapshot();
+            }
         }
     }
 
     ~RocksDBStorageIterator() {
         if (status_ == 0) {
-            storage_->db_->ReleaseSnapshot(readOptions_.snapshot);
+            if (storage_->InTransaction_) {
+                storage_->txn_->ClearSnapshot();
+            } else {
+                storage_->db_->ReleaseSnapshot(readOptions_.snapshot);
+            }
         }
     }
 
@@ -364,7 +374,11 @@ class RocksDBStorageIterator : public Iterator {
 
     void SeekToFirst() {
         auto handler = storage_->GetColumnFamilyHandle(ordered_);
-        iter_ = storage_->db_->NewIterator(readOptions_, handler);
+        if (storage_->InTransaction_) {
+            iter_ = storage_->txn_->GetIterator(readOptions_, handler);
+        } else {
+            iter_ = storage_->db_->NewIterator(readOptions_, handler);
+        }
         iter_->Seek(prefix_);
     }
 

--- a/curvefs/src/metaserver/storage/storage.h
+++ b/curvefs/src/metaserver/storage/storage.h
@@ -110,6 +110,8 @@ class KVStorage : public BaseStorage {
 
     virtual bool GetStatistics(StorageStatistics* Statistics) = 0;
 
+    virtual StorageOptions GetStorageOptions() const = 0;
+
     virtual std::shared_ptr<StorageTransaction> BeginTransaction() = 0;
 };
 

--- a/curvefs/src/metaserver/storage/storage_fstream.h
+++ b/curvefs/src/metaserver/storage/storage_fstream.h
@@ -92,11 +92,17 @@ static std::pair<std::string, std::string> UserKey(const std::string& ikey) {
     if (items.size() >= 2) {
         prefix = items[0];
         ukey = ikey.substr(prefix.size() + 1);
+    } else if (items.size() == 1) {  // e.g: t3:
+        prefix = items[0];
     }
     return std::make_pair(prefix, ukey);
 }
 
 static std::pair<ENTRY_TYPE, uint32_t> Extract(const std::string& prefix) {
+    if (prefix.size() == 0) {
+        return std::make_pair(ENTRY_TYPE::UNKNOWN, 0);
+    }
+
     std::vector<std::string> items{
         prefix.substr(0, 1),  // eg: i
         prefix.substr(1),  // eg: 100

--- a/curvefs/src/metaserver/storage/utils.cpp
+++ b/curvefs/src/metaserver/storage/utils.cpp
@@ -56,6 +56,8 @@ std::string Number2BinaryString(size_t num) {
 
 size_t BinrayString2Number(const std::string& str) {
     if (str.size() < sizeof(size_t)) {
+        LOG(ERROR) << "The length of binray string must equal or greater than "
+                   << sizeof(size_t) << ", but now is " << str.size();
         return 0;
     }
     return *reinterpret_cast<const size_t*>(str.c_str());

--- a/curvefs/src/tools/status/curvefs_mds_status.cpp
+++ b/curvefs/src/tools/status/curvefs_mds_status.cpp
@@ -76,7 +76,7 @@ void MdsStatusTool::AfterGetMetric(const std::string hostAddr,
                                    const std::string& subUri,
                                    const std::string& value,
                                    const MetricStatusCode& statusCode) {
-    auto mainAddr = dummy2MainAddr_[hostAddr];
+    auto mainAddr = hostAddr;
     if (statusCode == MetricStatusCode::kOK) {
         onlineHosts_.insert(mainAddr);
         if (subUri == statusSubUri_) {
@@ -88,6 +88,7 @@ void MdsStatusTool::AfterGetMetric(const std::string hostAddr,
                     standbyHost_.insert(mainAddr);
                 } else if (keyValue == hostLeaderValue_) {
                     // leader host
+                    mainAddr = dummy2MainAddr_[hostAddr];
                     leaderHosts_.insert(mainAddr);
                 } else {
                     // error host

--- a/curvefs/src/tools/status/curvefs_status_base_tool.cpp
+++ b/curvefs/src/tools/status/curvefs_status_base_tool.cpp
@@ -125,7 +125,7 @@ int StatusBaseTool::ProcessMetrics() {
     if (show_) {
         std::cout << "standby " << hostType_ << ": [ ";
         for (auto const& i : standbyHost_) {
-            std::cerr << i << " ";
+            std::cout << i << " ";
         }
         std::cout << "]." << std::endl;
     }

--- a/curvefs/test/client/client_s3_adaptor_test.cpp
+++ b/curvefs/test/client/client_s3_adaptor_test.cpp
@@ -67,6 +67,7 @@ class ClientS3AdaptorTest : public testing::Test {
         option.readCacheMaxByte = 104857600;
         option.writeCacheMaxByte = 10485760000;
         option.fuseMaxSize = 131072;
+        option.chunkFlushThreads = 5;
         option.diskCacheOpt.diskCacheType = (DiskCacheType)0;
         s3ClientAdaptor_->Init(option, mockS3Client_, mockInodeManager_,
                                mockMdsClient_, mockFsCacheManager_,
@@ -266,3 +267,4 @@ TEST_F(ClientS3AdaptorTest, FlushAllCache_with_cache) {
 
 }  // namespace client
 }  // namespace curvefs
+

--- a/curvefs/test/client/mock_metaserver_client.h
+++ b/curvefs/test/client/mock_metaserver_client.h
@@ -72,8 +72,8 @@ class MockMetaServerClient : public MetaServerClient {
     MOCK_METHOD1(PrepareRenameTx,
                  MetaStatusCode(const std::vector<Dentry>& dentrys));
 
-    MOCK_METHOD3(GetInode, MetaStatusCode(
-            uint32_t fsId, uint64_t inodeid, Inode *out));
+    MOCK_METHOD4(GetInode, MetaStatusCode(
+            uint32_t fsId, uint64_t inodeid, Inode *out, bool* streaming));
 
     MOCK_METHOD3(BatchGetInodeAttr, MetaStatusCode(
         uint32_t fsId, std::set<uint64_t> *inodeIds,

--- a/curvefs/test/client/test_disk_cache_manager.cpp
+++ b/curvefs/test/client/test_disk_cache_manager.cpp
@@ -64,7 +64,10 @@ class TestDiskCacheManager : public ::testing::Test {
         diskCacheManager_ = std::make_shared<DiskCacheManager>(
             wrapper, diskCacheWrite_, diskCacheRead_);
         diskCacheRead_->Init(wrapper, "/mnt/test");
-        diskCacheWrite_->Init(client, wrapper, "/mnt/test", 1);
+         std::shared_ptr<LRUCache<std::string, bool>> cachedObjName
+          = std::make_shared<LRUCache<std::string, bool>>
+              (0, std::make_shared<CacheMetrics>("diskcache"));
+        diskCacheWrite_->Init(client, wrapper, "/mnt/test", 1, cachedObjName);
     }
 
     virtual void TearDown() {
@@ -105,52 +108,6 @@ TEST_F(TestDiskCacheManager, Init) {
     EXPECT_CALL(*diskCacheRead_, CreateIoDir(_)).WillOnce(Return(-1));
     ret = diskCacheManager_->Init(client, s3AdaptorOption);
     ASSERT_EQ(-1, ret);
-    /*
-        EXPECT_CALL(*wrapper, stat(NotNull(), NotNull()))
-              .WillOnce(Return(0));
-        EXPECT_CALL(*diskCacheWrite_, CreateIoDir(_))
-              .WillOnce(Return(0));
-        EXPECT_CALL(*diskCacheRead_, CreateIoDir(_))
-              .WillOnce(Return(0));
-        EXPECT_CALL(*diskCacheWrite_, AsyncUploadRun())
-              .WillOnce(Return(0));
-        EXPECT_CALL(*diskCacheWrite_, UploadAllCacheWriteFile())
-              .WillOnce(Return(-1));
-        EXPECT_CALL(*diskCacheRead_, LoadAllCacheReadFile(_))
-              .WillOnce(Return(0));
-        ret = diskCacheManager_->Init(client, s3AdaptorOption);
-        ASSERT_EQ(0, ret);
-
-        EXPECT_CALL(*wrapper, stat(NotNull(), NotNull()))
-              .WillOnce(Return(0));
-        EXPECT_CALL(*diskCacheWrite_, CreateIoDir(_))
-              .WillOnce(Return(0));
-        EXPECT_CALL(*diskCacheRead_, CreateIoDir(_))
-              .WillOnce(Return(0));
-        EXPECT_CALL(*diskCacheWrite_, AsyncUploadRun())
-              .WillOnce(Return(0));
-        EXPECT_CALL(*diskCacheWrite_, UploadAllCacheWriteFile())
-              .WillOnce(Return(0));
-        EXPECT_CALL(*diskCacheRead_, LoadAllCacheReadFile(_))
-              .WillOnce(Return(-1));
-        ret = diskCacheManager_->Init(client, s3AdaptorOption);
-        ASSERT_EQ(-1, ret);
-
-        EXPECT_CALL(*wrapper, stat(NotNull(), NotNull()))
-              .WillOnce(Return(0));
-        EXPECT_CALL(*diskCacheWrite_, CreateIoDir(_))
-              .WillOnce(Return(0));
-        EXPECT_CALL(*diskCacheRead_, CreateIoDir(_))
-              .WillOnce(Return(0));
-        EXPECT_CALL(*diskCacheWrite_, AsyncUploadRun())
-              .WillOnce(Return(0));
-        EXPECT_CALL(*diskCacheWrite_, UploadAllCacheWriteFile())
-              .WillOnce(Return(0));
-        EXPECT_CALL(*diskCacheRead_, LoadAllCacheReadFile(_))
-              .WillOnce(Return(0));
-        ret = diskCacheManager_->Init(client, s3AdaptorOption);
-        ASSERT_EQ(0, ret);
-    */
 }
 
 TEST_F(TestDiskCacheManager, CreateDir) {

--- a/curvefs/test/client/test_disk_cache_manager.cpp
+++ b/curvefs/test/client/test_disk_cache_manager.cpp
@@ -194,12 +194,12 @@ TEST_F(TestDiskCacheManager, IsCached) {
     bool ret = diskCacheManager_->IsCached(fileName);
     ASSERT_EQ(false, ret);
 
-    diskCacheManager_->AddCache(fileName);
+    diskCacheManager_->AddCache(fileName, false);
     diskCacheManager_->AddCache(fileName2);
     ret = diskCacheManager_->IsCached(fileName2);
     ASSERT_EQ(true, ret);
 
-    diskCacheManager_->AddCache(fileName);
+    diskCacheManager_->AddCache(fileName, false);
     diskCacheManager_->AddCache(fileName2);
     ret = diskCacheManager_->IsCached(fileName);
     ASSERT_EQ(true, ret);

--- a/curvefs/test/client/test_disk_cache_read.cpp
+++ b/curvefs/test/client/test_disk_cache_read.cpp
@@ -130,9 +130,9 @@ TEST_F(TestDiskCacheRead, LinkWriteToRead) {
 
 TEST_F(TestDiskCacheRead, LoadAllCacheFile) {
     EXPECT_CALL(*wrapper_, stat(NotNull(), NotNull())).WillOnce(Return(-1));
-    std::shared_ptr<SglLRUCache<std::string>> cachedObj;
-    cachedObj = std::make_shared<SglLRUCache<std::string>>(
-        0, std::make_shared<CacheMetrics>("diskcache"));
+    std::shared_ptr<LRUCache<std::string, bool>> cachedObj;
+    cachedObj =  std::make_shared<LRUCache<std::string, bool>>
+        (0, std::make_shared<CacheMetrics>("diskcache"));;
     int ret = diskCacheRead_->LoadAllCacheReadFile(cachedObj);
     ASSERT_EQ(-1, ret);
 
@@ -226,3 +226,4 @@ TEST_F(TestDiskCacheRead, ClearReadCache) {
 
 }  // namespace client
 }  // namespace curvefs
+

--- a/curvefs/test/client/test_disk_cache_write.cpp
+++ b/curvefs/test/client/test_disk_cache_write.cpp
@@ -63,7 +63,10 @@ class TestDiskCacheWrite : public ::testing::Test {
 
         std::shared_ptr<PosixWrapper> wrapper =
             std::make_shared<PosixWrapper>();
-        diskCacheWrite_->Init(client_, wrapper_, "test", 1);
+         std::shared_ptr<LRUCache<std::string, bool>> cachedObjName
+          = std::make_shared<LRUCache<std::string, bool>>
+              (0, std::make_shared<CacheMetrics>("diskcache"));
+        diskCacheWrite_->Init(client_, wrapper_, "test", 1, cachedObjName);
     }
 
     virtual void TearDown() {
@@ -535,4 +538,3 @@ TEST_F(TestDiskCacheWrite, test_SynchronizationTask) {
 
 }  // namespace client
 }  // namespace curvefs
-

--- a/curvefs/test/client/test_fuse_client.cpp
+++ b/curvefs/test/client/test_fuse_client.cpp
@@ -1166,7 +1166,7 @@ TEST_F(TestFuseVolumeClient, FuseOpSetAttr) {
     Inode inode;
     inode.set_inodeid(ino);
     inode.set_length(0);
-    inode.set_type(FsFileType::TYPE_VOLUME);
+    inode.set_type(FsFileType::TYPE_FILE);
     auto inodeWrapper = std::make_shared<InodeWrapper>(inode, metaClient_);
 
     EXPECT_CALL(*inodeManager_, GetInode(ino, _))
@@ -1212,7 +1212,7 @@ TEST_F(TestFuseVolumeClient, FuseOpSetAttrFailed) {
     Inode inode;
     inode.set_inodeid(ino);
     inode.set_length(0);
-    inode.set_type(FsFileType::TYPE_VOLUME);
+    inode.set_type(FsFileType::TYPE_FILE);
     auto inodeWrapper = std::make_shared<InodeWrapper>(inode, metaClient_);
 
     EXPECT_CALL(*inodeManager_, GetInode(ino, _))

--- a/curvefs/test/client/test_inodeWrapper.cpp
+++ b/curvefs/test/client/test_inodeWrapper.cpp
@@ -183,7 +183,7 @@ MATCHER(HasVolumeExtentMap, "") {
 }
 
 TEST_F(TestInodeWrapper, TestAllUpdateInodeMustHasVolumeExtentMap) {
-    inodeWrapper_->SetType(FsFileType::TYPE_VOLUME);
+    inodeWrapper_->SetType(FsFileType::TYPE_FILE);
 
     // Sync
     {

--- a/curvefs/test/client/test_inode_cache_manager.cpp
+++ b/curvefs/test/client/test_inode_cache_manager.cpp
@@ -83,7 +83,7 @@ TEST_F(TestInodeCacheManager, GetInode) {
     inode.set_fsid(fsId_);
     inode.set_length(fileLength);
 
-    EXPECT_CALL(*metaClient_, GetInode(fsId_, inodeId, _))
+    EXPECT_CALL(*metaClient_, GetInode(fsId_, inodeId, _, _))
         .WillOnce(Return(MetaStatusCode::NOT_FOUND))
         .WillOnce(DoAll(SetArgPointee<2>(inode), Return(MetaStatusCode::OK)));
 
@@ -109,7 +109,7 @@ TEST_F(TestInodeCacheManager, GetInode) {
 
     curvefs::client::common::FLAGS_enableCto = true;
     inodeWrapper->SetOpenCount(0);
-    EXPECT_CALL(*metaClient_, GetInode(fsId_, inodeId, _))
+    EXPECT_CALL(*metaClient_, GetInode(fsId_, inodeId, _, _))
         .WillOnce(Return(MetaStatusCode::NOT_FOUND));
     ret = iCacheManager_->GetInode(inodeId, inodeWrapper);
     ASSERT_EQ(CURVEFS_ERROR::NOTEXIST, ret);
@@ -118,7 +118,7 @@ TEST_F(TestInodeCacheManager, GetInode) {
     ASSERT_EQ(fileLength, out.length());
 
     inodeWrapper->SetOpenCount(1);
-    EXPECT_CALL(*metaClient_, GetInode(fsId_, inodeId, _))
+    EXPECT_CALL(*metaClient_, GetInode(fsId_, inodeId, _, _))
         .WillOnce(Return(MetaStatusCode::NOT_FOUND));
     ret = iCacheManager_->GetInode(inodeId, inodeWrapper);
     ASSERT_EQ(CURVEFS_ERROR::NOTEXIST, ret);

--- a/curvefs/test/client/volume/default_volume_storage_test.cpp
+++ b/curvefs/test/client/volume/default_volume_storage_test.cpp
@@ -76,7 +76,7 @@ TEST_F(DefaultVolumeStorageTest, WriteAndReadTest_InodeNotFound) {
 
 TEST_F(DefaultVolumeStorageTest, ReadTest_BlockDevReadError) {
     Inode inode;
-    inode.set_type(FsFileType::TYPE_VOLUME);
+    inode.set_type(FsFileType::TYPE_FILE);
 
     VolumeExtentList exts;
     auto* ext = exts.add_volumeextents();
@@ -109,7 +109,7 @@ TEST_F(DefaultVolumeStorageTest, ReadTest_BlockDevReadError) {
 TEST_F(DefaultVolumeStorageTest, ReadTest_BlockDevReadSuccess) {
     Inode inode;
     VolumeExtentList exts;
-    inode.set_type(FsFileType::TYPE_VOLUME);
+    inode.set_type(FsFileType::TYPE_FILE);
 
     auto* ext = exts.add_volumeextents();
     ext->set_fsoffset(0);
@@ -144,7 +144,7 @@ TEST_F(DefaultVolumeStorageTest, ReadTest_BlockDevReadSuccess) {
 TEST_F(DefaultVolumeStorageTest, ReadTest_BlockDevReadHoleSuccess) {
     Inode inode;
     VolumeExtentList exts;
-    inode.set_type(FsFileType::TYPE_VOLUME);
+    inode.set_type(FsFileType::TYPE_FILE);
 
     auto* ext = exts.add_volumeextents();
     ext->set_fsoffset(0);
@@ -184,7 +184,7 @@ TEST_F(DefaultVolumeStorageTest, ReadTest_BlockDevReadHoleSuccess) {
 
 TEST_F(DefaultVolumeStorageTest, WriteTest_PrepareError) {
     Inode inode;
-    inode.set_type(FsFileType::TYPE_VOLUME);
+    inode.set_type(FsFileType::TYPE_FILE);
 
     auto inodeWrapper = std::make_shared<InodeWrapper>(inode, metaServerCli_);
 
@@ -207,7 +207,7 @@ TEST_F(DefaultVolumeStorageTest, WriteTest_PrepareError) {
 
 TEST_F(DefaultVolumeStorageTest, WriteTest_BlockDevWriteError) {
     Inode inode;
-    inode.set_type(FsFileType::TYPE_VOLUME);
+    inode.set_type(FsFileType::TYPE_FILE);
 
     auto inodeWrapper = std::make_shared<InodeWrapper>(inode, metaServerCli_);
 
@@ -241,7 +241,7 @@ TEST_F(DefaultVolumeStorageTest, WriteTest_BlockDevWriteError) {
 
 TEST_F(DefaultVolumeStorageTest, WriteTest_BlockDevWriteSuccess) {
     Inode inode;
-    inode.set_type(FsFileType::TYPE_VOLUME);
+    inode.set_type(FsFileType::TYPE_FILE);
 
     auto inodeWrapper = std::make_shared<InodeWrapper>(inode, metaServerCli_);
 

--- a/curvefs/test/mds/topology/test_topology_manager.cpp
+++ b/curvefs/test/mds/topology/test_topology_manager.cpp
@@ -1822,6 +1822,7 @@ TEST_F(TestTopologyManager,
     ASSERT_TRUE(topology_->GetCopySet(key, &info));
     ASSERT_EQ(copysetId, info.GetId());
     ASSERT_EQ(1, info.GetPartitionNum());
+    ASSERT_FALSE(topology_->IsCopysetCreating(key));
 }
 
 TEST_F(TestTopologyManager,
@@ -1965,6 +1966,7 @@ TEST_F(TestTopologyManager,
     ASSERT_TRUE(topology_->GetCopySet(key, &info));
     ASSERT_EQ(copysetId, info.GetId());
     ASSERT_EQ(1, info.GetPartitionNum());
+    ASSERT_FALSE(topology_->IsCopysetCreating(key));
 }
 
 TEST_F(TestTopologyManager,
@@ -2097,6 +2099,7 @@ TEST_F(TestTopologyManager,
     ASSERT_TRUE(topology_->GetCopySet(key, &info));
     ASSERT_EQ(copysetId, info.GetId());
     ASSERT_EQ(1, info.GetPartitionNum());
+    ASSERT_FALSE(topology_->IsCopysetCreating(key));
 }
 
 TEST_F(TestTopologyManager,
@@ -2182,6 +2185,7 @@ TEST_F(TestTopologyManager,
     ASSERT_TRUE(topology_->GetCopySet(key, &info));
     ASSERT_EQ(copysetId, info.GetId());
     ASSERT_EQ(1, info.GetPartitionNum());
+    ASSERT_FALSE(topology_->IsCopysetCreating(key));
 }
 
 TEST_F(TestTopologyManager, test_CommitTx_Success) {

--- a/curvefs/test/metaserver/metastore_test.cpp
+++ b/curvefs/test/metaserver/metastore_test.cpp
@@ -58,6 +58,7 @@ class MetastoreTest : public ::testing::Test {
         dataDir_ = RandomStoragePath();;
         StorageOptions options;
         options.dataDir = dataDir_;
+        options.s3MetaLimitSizeInsideInode = 100;
         kvStorage_ = std::make_shared<RocksDBStorage>(options);
         ASSERT_TRUE(kvStorage_->Open());
 
@@ -186,6 +187,24 @@ class MetastoreTest : public ::testing::Test {
             info->set_zero(false);
         }
         return list;
+    }
+
+    void CHECK_ITERATOR_S3CHUNKINFOLIST(
+        std::shared_ptr<Iterator> iterator,
+        const std::vector<uint64_t> chunkIndexs,
+        const std::vector<S3ChunkInfoList> lists) {
+        size_t size = 0;
+        Key4S3ChunkInfoList key;
+        S3ChunkInfoList list4get;
+        ASSERT_EQ(iterator->Status(), 0);
+        for (iterator->SeekToFirst(); iterator->Valid(); iterator->Next()) {
+            ASSERT_TRUE(conv_->ParseFromString(iterator->Key(), &key));
+            ASSERT_TRUE(conv_->ParseFromString(iterator->Value(), &list4get));
+            ASSERT_EQ(key.chunkIndex, chunkIndexs[size]);
+            ASSERT_TRUE(EqualS3ChunkInfoList(list4get, lists[size]));
+            size++;
+        }
+        ASSERT_EQ(size, chunkIndexs.size());
     }
 
     class OnSnapshotSaveDoneImpl : public OnSnapshotSaveDoneClosure {
@@ -1397,6 +1416,7 @@ TEST_F(MetastoreTest, GetOrModifyS3ChunkInfo) {
 
     // CASE 1: partition not found -> failed
     {
+        LOG(INFO) << "CASE 1: partition not found -> failed";
         GetOrModifyS3ChunkInfoRequest request;
         GetOrModifyS3ChunkInfoResponse response;
         request.set_partitionid(100);
@@ -1409,18 +1429,127 @@ TEST_F(MetastoreTest, GetOrModifyS3ChunkInfo) {
 
     // CASE 2: GetOrModifyS3ChunkInfo success
     {
+        LOG(INFO) << "CASE 2: GetOrModifyS3ChunkInfo success";
+        GetOrModifyS3ChunkInfoRequest request;
+        GetOrModifyS3ChunkInfoResponse response;
         std::vector<uint64_t> chunkIndexs{ 1, 2 };
-        std::vector<S3ChunkInfoList> list2add{
+        std::vector<S3ChunkInfoList> lists2add{
             GenS3ChunkInfoList(100, 200),
             GenS3ChunkInfoList(300, 400),
         };
 
-        GetOrModifyS3ChunkInfoRequest request;
-        GetOrModifyS3ChunkInfoResponse response;
         request.set_partitionid(partitionId);
         request.set_fsid(fsId);
         request.set_inodeid(inodeId);
+        request.set_supportstreaming(true);
         request.set_returns3chunkinfomap(true);
+        for (size_t i = 0; i < chunkIndexs.size(); i++) {
+            request.mutable_s3chunkinfoadd()->insert(
+                { chunkIndexs[i], lists2add[i] });
+        }
+
+        std::shared_ptr<Iterator> iterator;
+        MetaStatusCode rc = metastore.GetOrModifyS3ChunkInfo(
+            &request, &response, &iterator);
+        ASSERT_EQ(rc, MetaStatusCode::OK);
+        ASSERT_EQ(response.statuscode(), rc);
+        ASSERT_EQ(response.mutable_s3chunkinfomap()->size(), 0);
+
+        CHECK_ITERATOR_S3CHUNKINFOLIST(iterator, chunkIndexs, lists2add);
+    }
+
+    // CASE 3: GetOrModifyS3ChunkInfo success with unsupport streaming
+    {
+        LOG(INFO) << "CASE 3: GetOrModifyS3ChunkInfo success"
+                  << " with unsupport streaming";
+        GetOrModifyS3ChunkInfoRequest request;
+        GetOrModifyS3ChunkInfoResponse response;
+        std::vector<uint64_t> chunkIndexs{ 1, 2 };
+        std::vector<S3ChunkInfoList> lists2add{
+            GenS3ChunkInfoList(100, 200),
+            GenS3ChunkInfoList(300, 400),
+        };
+
+        request.set_partitionid(partitionId);
+        request.set_fsid(fsId);
+        request.set_inodeid(inodeId);
+        request.set_supportstreaming(false);
+        request.set_returns3chunkinfomap(true);
+        for (size_t i = 0; i < chunkIndexs.size(); i++) {
+            request.mutable_s3chunkinfoadd()->insert(
+                { chunkIndexs[i], lists2add[i] });
+        }
+
+        std::shared_ptr<Iterator> iterator;
+        MetaStatusCode rc = metastore.GetOrModifyS3ChunkInfo(
+            &request, &response, &iterator);
+        ASSERT_EQ(rc, MetaStatusCode::OK);
+        ASSERT_EQ(response.statuscode(), rc);
+        ASSERT_EQ(response.mutable_s3chunkinfomap()->size(), 2);
+    }
+}
+
+TEST_F(MetastoreTest, GetInodeWithPaddingS3Meta) {
+    MetaStoreImpl metastore(nullptr, kvStorage_);
+    uint32_t poolId = 1;
+    uint32_t copysetId = 1;
+    uint32_t partitionId = 1;
+    uint32_t fsId = 1;
+    uint64_t inodeId = 1;
+
+    // init: create partition
+    {
+        CreatePartitionRequest request;
+        CreatePartitionResponse response;
+
+        PartitionInfo partitionInfo;
+        partitionInfo.set_poolid(poolId);
+        partitionInfo.set_copysetid(copysetId);
+        partitionInfo.set_partitionid(partitionId);
+        partitionInfo.set_fsid(fsId);
+        partitionInfo.set_start(1);
+        partitionInfo.set_end(100);
+        request.mutable_partition()->CopyFrom(partitionInfo);
+        MetaStatusCode rc = metastore.CreatePartition(&request, &response);
+        ASSERT_EQ(rc, MetaStatusCode::OK);
+        ASSERT_EQ(response.statuscode(), rc);
+    }
+
+    // step1: create inode
+    {
+        CreateInodeRequest request;
+        CreateInodeResponse response;
+
+        request.set_poolid(poolId);
+        request.set_copysetid(copysetId);
+        request.set_partitionid(partitionId);
+        request.set_fsid(fsId);
+        request.set_length(1);
+        request.set_uid(1);
+        request.set_gid(1);
+        request.set_mode(777);
+        request.set_type(FsFileType::TYPE_FILE);
+
+        auto rc = metastore.CreateInode(&request, &response);
+        ASSERT_EQ(response.statuscode(), MetaStatusCode::OK);
+        inodeId = response.inode().inodeid();
+    }
+
+    // step2: append s3chunkinfo within limit
+    {
+        GetOrModifyS3ChunkInfoRequest request;
+        GetOrModifyS3ChunkInfoResponse response;
+
+        std::vector<uint64_t> chunkIndexs{ 1, 2 };
+        std::vector<S3ChunkInfoList> list2add{
+            GenS3ChunkInfoList(100, 149),
+            GenS3ChunkInfoList(200, 249),
+        };
+
+        request.set_partitionid(partitionId);
+        request.set_fsid(fsId);
+        request.set_inodeid(inodeId);
+        request.set_returns3chunkinfomap(false);
         for (size_t i = 0; i < chunkIndexs.size(); i++) {
             request.mutable_s3chunkinfoadd()->insert(
                 { chunkIndexs[i], list2add[i] });
@@ -1432,20 +1561,93 @@ TEST_F(MetastoreTest, GetOrModifyS3ChunkInfo) {
             &request, &response, &iterator);
         ASSERT_EQ(rc, MetaStatusCode::OK);
         ASSERT_EQ(response.statuscode(), rc);
+    }
 
-        size_t size = 0;
-        Key4S3ChunkInfoList key;
-        S3ChunkInfoList list4get;
-        for (iterator->SeekToFirst(); iterator->Valid(); iterator->Next()) {
-            LOG(INFO) << "check chunkIndex(" << size << ")"
-                      << ", key=" << iterator->Key();
-            ASSERT_TRUE(conv_->ParseFromString(iterator->Key(), &key));
-            ASSERT_TRUE(conv_->ParseFromString(iterator->Value(), &list4get));
-            ASSERT_EQ(key.chunkIndex, chunkIndexs[size]);
-            ASSERT_TRUE(EqualS3ChunkInfoList(list2add[size], list4get));
-            size++;
+    // step3: get inode with support streaming
+    {
+        GetInodeRequest request;
+        GetInodeResponse response;
+
+        request.set_poolid(poolId);
+        request.set_copysetid(copysetId);
+        request.set_partitionid(partitionId);
+        request.set_fsid(fsId);
+        request.set_inodeid(inodeId);
+        request.set_supportstreaming(true);
+
+        auto rc = metastore.GetInode(&request, &response);
+        ASSERT_EQ(response.statuscode(), MetaStatusCode::OK);
+        ASSERT_EQ(rc, MetaStatusCode::OK);
+        auto inode = response.mutable_inode();
+        ASSERT_EQ(response.streaming(), false);
+        ASSERT_EQ(inode->mutable_s3chunkinfomap()->size(), 2);
+    }
+
+    // step4: append s3chunkinfo exceed limit
+    {
+        GetOrModifyS3ChunkInfoRequest request;
+        GetOrModifyS3ChunkInfoResponse response;
+
+        std::vector<uint64_t> chunkIndexs{ 3 };
+        std::vector<S3ChunkInfoList> list2add{
+            GenS3ChunkInfoList(1, 1),
+        };
+
+        request.set_partitionid(partitionId);
+        request.set_fsid(fsId);
+        request.set_inodeid(inodeId);
+        request.set_returns3chunkinfomap(false);
+        for (size_t i = 0; i < chunkIndexs.size(); i++) {
+            request.mutable_s3chunkinfoadd()->insert(
+                { chunkIndexs[i], list2add[i] });
         }
-        ASSERT_EQ(size, 2);
+
+        // ModifyS3ChunkInfo()
+        std::shared_ptr<Iterator> iterator;
+        MetaStatusCode rc = metastore.GetOrModifyS3ChunkInfo(
+            &request, &response, &iterator);
+        ASSERT_EQ(rc, MetaStatusCode::OK);
+        ASSERT_EQ(response.statuscode(), rc);
+    }
+
+    // step5: get inode with support straming
+    {
+        GetInodeRequest request;
+        GetInodeResponse response;
+
+        request.set_poolid(poolId);
+        request.set_copysetid(copysetId);
+        request.set_partitionid(partitionId);
+        request.set_fsid(fsId);
+        request.set_inodeid(inodeId);
+        request.set_supportstreaming(true);
+
+        auto rc = metastore.GetInode(&request, &response);
+        ASSERT_EQ(response.statuscode(), MetaStatusCode::OK);
+        ASSERT_EQ(rc, MetaStatusCode::OK);
+        auto inode = response.mutable_inode();
+        ASSERT_EQ(response.streaming(), true);
+        ASSERT_EQ(inode->mutable_s3chunkinfomap()->size(), 0);
+    }
+
+    // step6: get inode without unsupport streaming
+    {
+        GetInodeRequest request;
+        GetInodeResponse response;
+
+        request.set_poolid(poolId);
+        request.set_copysetid(copysetId);
+        request.set_partitionid(partitionId);
+        request.set_fsid(fsId);
+        request.set_inodeid(inodeId);
+        request.set_supportstreaming(false);
+
+        auto rc = metastore.GetInode(&request, &response);
+        ASSERT_EQ(response.statuscode(), MetaStatusCode::OK);
+        ASSERT_EQ(rc, MetaStatusCode::OK);
+        auto inode = response.mutable_inode();
+        ASSERT_EQ(response.streaming(), false);
+        ASSERT_EQ(inode->mutable_s3chunkinfomap()->size(), 3);
     }
 }
 

--- a/curvefs/test/metaserver/storage/rocksdb_storage_test.cpp
+++ b/curvefs/test/metaserver/storage/rocksdb_storage_test.cpp
@@ -54,9 +54,17 @@ class RocksDBStorageTest : public testing::Test {
         std::string ret;
         ASSERT_TRUE(ExecShell("mkdir -p " + dirname_, &ret));
 
+        options_.maxMemoryQuotaBytes = 32212254720;
+        options_.maxDiskQuotaBytes = 2199023255552;
         options_.dataDir = dbpath_;
-        options_.maxMemoryQuotaBytes = 1024;
-        options_.maxDiskQuotaBytes = 1024;
+        options_.compression = false;
+        options_.unorderedWriteBufferSize = 134217728;
+        options_.unorderedMaxWriteBufferNumber = 5;
+        options_.orderedWriteBufferSize = 134217728;
+        options_.orderedMaxWriteBufferNumber = 15;
+        options_.blockCacheCapacity = 134217728;
+        options_.memtablePrefixBloomSizeRatio = 0.1;
+
         kvStorage_ = std::make_shared<RocksDBStorage>(options_);
         ASSERT_TRUE(kvStorage_->Open());
     }

--- a/curvefs/test/metaserver/storage/storage_fstream_test.cpp
+++ b/curvefs/test/metaserver/storage/storage_fstream_test.cpp
@@ -180,9 +180,33 @@ TEST_F(StorageFstreamTest, MiscTest) {
     ASSERT_EQ(Str2Type("x"), ENTRY_TYPE::UNKNOWN);
     ASSERT_EQ(Str2Type("y"), ENTRY_TYPE::UNKNOWN);
 
-    auto ret = Extract("i:-1");
-    ASSERT_EQ(ret.first, ENTRY_TYPE::INODE);
-    ASSERT_EQ(ret.second, 0);
+    {
+        auto ret = Extract("d100");
+        ASSERT_EQ(ret.first, ENTRY_TYPE::DENTRY);
+        ASSERT_EQ(ret.second, 100);
+
+        ret = Extract("i0");
+        ASSERT_EQ(ret.first, ENTRY_TYPE::INODE);
+        ASSERT_EQ(ret.second, 0);
+
+        ret = Extract("");
+        ASSERT_EQ(ret.first, ENTRY_TYPE::UNKNOWN);
+        ASSERT_EQ(ret.second, 0);
+    }
+
+    {
+        auto ret = UserKey("t3:");
+        ASSERT_EQ(ret.first, "t3");
+        ASSERT_EQ(ret.second, "");
+
+        ret = UserKey("i100:000");
+        ASSERT_EQ(ret.first, "i100");
+        ASSERT_EQ(ret.second, "000");
+
+        ret = UserKey("");
+        ASSERT_EQ(ret.first, "");
+        ASSERT_EQ(ret.second, "");
+    }
 
     // CASE 2: open file failed when save
     ASSERT_FALSE(SaveToFile("/__not_found__/dumpfile", nullptr, false));

--- a/curvefs/test/metaserver/storage/storage_test.cpp
+++ b/curvefs/test/metaserver/storage/storage_test.cpp
@@ -290,7 +290,7 @@ void TestHClear(std::shared_ptr<KVStorage> kvStorage) {
     s = kvStorage->HGet("partition:1", "key1", &value);
     ASSERT_TRUE(s.IsNotFound());
 
-    // CASE 2: iterator after clear
+    // CASE 2: get all after clear table
     iterator = kvStorage->HGetAll("partition:1");
     ASSERT_EQ(iterator->Status(), 0);
     size = 0;
@@ -300,7 +300,7 @@ void TestHClear(std::shared_ptr<KVStorage> kvStorage) {
     ASSERT_EQ(size, 0);
     ASSERT_EQ(iterator->Size(), 0);
 
-    // CASE 3: invoke set after clear
+    // CASE 3: set key-value after clear table
     s = kvStorage->HSet("partition:1", "key1", Value("value1"));
     ASSERT_TRUE(s.ok());
     s = kvStorage->HGet("partition:1", "key1", &value);
@@ -315,6 +315,45 @@ void TestHClear(std::shared_ptr<KVStorage> kvStorage) {
     }
     ASSERT_EQ(size, 1);
     ASSERT_EQ(iterator->Size(), 1);
+
+    s = kvStorage->HClear("partition:1");
+    ASSERT_TRUE(s.ok());
+
+    // CASE 4: clear different table
+    std::string tablename1 = "partition:1";
+    std::string tablename2 = "partition:2";
+    std::string tablename3 = "partition:3";
+
+    s = kvStorage->HSet(tablename1, "key1", Value("value1"));
+    ASSERT_TRUE(s.ok());
+    s = kvStorage->HSet(tablename2, "key1", Value("value1"));
+    ASSERT_TRUE(s.ok());
+    s = kvStorage->HSet(tablename3, "key1", Value("value1"));
+    ASSERT_TRUE(s.ok());
+
+    // clear table1
+    s = kvStorage->HClear(tablename1);
+    ASSERT_TRUE(s.ok());
+
+    ASSERT_EQ(kvStorage->HSize(tablename1), 0);
+    ASSERT_EQ(kvStorage->HSize(tablename2), 1);
+    ASSERT_EQ(kvStorage->HSize(tablename3), 1);
+
+    // clear table2
+    s = kvStorage->HClear(tablename2);
+    ASSERT_TRUE(s.ok());
+
+    ASSERT_EQ(kvStorage->HSize(tablename1), 0);
+    ASSERT_EQ(kvStorage->HSize(tablename2), 0);
+    ASSERT_EQ(kvStorage->HSize(tablename3), 1);
+
+    // clear table3
+    s = kvStorage->HClear(tablename3);
+    ASSERT_TRUE(s.ok());
+
+    ASSERT_EQ(kvStorage->HSize(tablename1), 0);
+    ASSERT_EQ(kvStorage->HSize(tablename2), 0);
+    ASSERT_EQ(kvStorage->HSize(tablename3), 0);
 }
 
 void TestSGet(std::shared_ptr<KVStorage> kvStorage) {
@@ -645,7 +684,7 @@ void TestSClear(std::shared_ptr<KVStorage> kvStorage) {
     s = kvStorage->SGet("partition:1", "key1", &value);
     ASSERT_TRUE(s.IsNotFound());
 
-    // CASE 2: iterator after clear
+    // CASE 2: get all after clear table
     iterator = kvStorage->SGetAll("partition:1");
     ASSERT_EQ(iterator->Status(), 0);
     size = 0;
@@ -655,7 +694,7 @@ void TestSClear(std::shared_ptr<KVStorage> kvStorage) {
     ASSERT_EQ(size, 0);
     ASSERT_EQ(iterator->Size(), 0);
 
-    // CASE 3: invoke set after clear
+    // CASE 3: set key-value after clear table
     s = kvStorage->SSet("partition:1", "key1", Value("value1"));
     ASSERT_TRUE(s.ok());
     s = kvStorage->SGet("partition:1", "key1", &value);
@@ -670,6 +709,42 @@ void TestSClear(std::shared_ptr<KVStorage> kvStorage) {
     }
     ASSERT_EQ(size, 1);
     ASSERT_EQ(iterator->Size(), 1);
+
+    // CASE 4: clear different table
+    std::string tablename1 = "partition:1";
+    std::string tablename2 = "partition:2";
+    std::string tablename3 = "partition:3";
+
+    s = kvStorage->SSet(tablename1, "key1", Value("value1"));
+    ASSERT_TRUE(s.ok());
+    s = kvStorage->SSet(tablename2, "key1", Value("value1"));
+    ASSERT_TRUE(s.ok());
+    s = kvStorage->SSet(tablename3, "key1", Value("value1"));
+    ASSERT_TRUE(s.ok());
+
+    // clear table1
+    s = kvStorage->SClear(tablename1);
+    ASSERT_TRUE(s.ok());
+
+    ASSERT_EQ(kvStorage->SSize(tablename1), 0);
+    ASSERT_EQ(kvStorage->SSize(tablename2), 1);
+    ASSERT_EQ(kvStorage->SSize(tablename3), 1);
+
+    // clear table2
+    s = kvStorage->SClear(tablename2);
+    ASSERT_TRUE(s.ok());
+
+    ASSERT_EQ(kvStorage->SSize(tablename1), 0);
+    ASSERT_EQ(kvStorage->SSize(tablename2), 0);
+    ASSERT_EQ(kvStorage->SSize(tablename3), 1);
+
+    // clear table3
+    s = kvStorage->SClear(tablename3);
+    ASSERT_TRUE(s.ok());
+
+    ASSERT_EQ(kvStorage->SSize(tablename1), 0);
+    ASSERT_EQ(kvStorage->SSize(tablename2), 0);
+    ASSERT_EQ(kvStorage->SSize(tablename3), 0);
 }
 
 void TestMixOperator(std::shared_ptr<KVStorage> kvStorage) {

--- a/curvefs/test/volume/bitmap_allocator_test.cpp
+++ b/curvefs/test/volume/bitmap_allocator_test.cpp
@@ -230,6 +230,10 @@ TEST_F(BitmapAllocatorTest, TestMarkUsedRandom) {
         auto off = rand_r(&seed) * 4096 % opt_.sizePerBit;
         auto len = rand_r(&seed) * 4096 % opt_.sizePerBit;
 
+        if (len == 0) {
+            len = 4096;
+        }
+
         if (off + len > opt_.sizePerBit) {
             len = opt_.sizePerBit - off;
         }

--- a/curvefs/util/build.sh
+++ b/curvefs/util/build.sh
@@ -5,6 +5,7 @@
 ############################  GLOBAL VARIABLES
 
 g_list=0
+g_depend=0
 g_target=""
 g_release=0
 g_build_rocksdb=0
@@ -84,7 +85,7 @@ _EOC_
 }
 
 get_options() {
-    local args=`getopt -o lorh --long list,only:,os:,release:,build_rocksdb: -n "$0" -- "$@"`
+    local args=`getopt -o ldorh --long list,dep:,only:,os:,release:,build_rocksdb: -n "$0" -- "$@"`
     eval set -- "${args}"
     while true
     do
@@ -92,6 +93,10 @@ get_options() {
             -l|--list)
                 g_list=1
                 shift 1
+                ;;
+            -d|--dep)
+                g_depend=$2
+                shift 2
                 ;;
             -o|--only)
                 g_target=$2
@@ -136,6 +141,10 @@ get_target() {
 }
 
 build_target() {
+    if [ -z "$g_target" ]; then
+        exit 0
+    fi
+
     local targets
     declare -A pass
     if [ $g_release -eq 1 ]; then
@@ -190,11 +199,13 @@ main() {
 
     if [ "$g_list" -eq 1 ]; then
         list_target
-    elif [ "$g_target" == "" ]; then
+    elif [[ "$g_target" == "" && "$g_depend" -ne 1 ]]; then
         usage
         exit 1
     else
-        build_requirements
+        if [ "$g_depend" -eq 1 ]; then
+            build_requirements
+        fi
         build_target
     fi
 }

--- a/curvefs/util/image.sh
+++ b/curvefs/util/image.sh
@@ -30,5 +30,7 @@ do
     tmpl $dsv "conf/$file" "$prefix/conf/$file"
 done
 
+cp ../conf/client.conf "$prefix/conf/curvebs-client.conf"
+
 docker pull opencurvedocker/curve-base:$2
 docker build -t "$1" "$(pwd)/docker/$2"

--- a/docker/debian10/Dockerfile
+++ b/docker/debian10/Dockerfile
@@ -2,7 +2,7 @@ FROM opencurvedocker/curve-base:debian10
 ENV TZ=Asia/Shanghai
 RUN mkdir -p /curvebs /etc/curve /etc/nebd /core
 COPY curvebs /curvebs
-COPY entrypoint.sh exec.sh /
+COPY entrypoint.sh /
 COPY curvebs/tools/sbin/curve_ops_tool curvebs/nbd/sbin/curve-nbd /usr/bin/
-RUN chmod a+x /entrypoint.sh /exec.sh
+RUN chmod a+x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/debian11/Dockerfile
+++ b/docker/debian11/Dockerfile
@@ -1,8 +1,8 @@
 FROM opencurvedocker/curve-base:debian11
 ENV TZ=Asia/Shanghai
-RUN mkdir -p /curvefs /etc/curvefs /core
-COPY curvefs /curvefs
+RUN mkdir -p /curvebs /etc/curve /etc/nebd /core
+COPY curvebs /curvebs
 COPY entrypoint.sh /
-COPY curvefs/tools/sbin/curvefs_tool /usr/bin
+COPY curvebs/tools/sbin/curve_ops_tool curvebs/nbd/sbin/curve-nbd /usr/bin/
 RUN chmod a+x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/debian9/Dockerfile
+++ b/docker/debian9/Dockerfile
@@ -2,7 +2,7 @@ FROM opencurvedocker/curve-base:debian9
 ENV TZ=Asia/Shanghai
 RUN mkdir -p /curvebs /etc/curve /etc/nebd /core
 COPY curvebs /curvebs
-COPY entrypoint.sh exec.sh /
+COPY entrypoint.sh /
 COPY curvebs/tools/sbin/curve_ops_tool curvebs/nbd/sbin/curve-nbd /usr/bin/
-RUN chmod a+x /entrypoint.sh /exec.sh
+RUN chmod a+x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/src/client/client_common.h
+++ b/src/client/client_common.h
@@ -32,7 +32,6 @@
 #include <unordered_set>
 
 #include "include/client/libcurve.h"
-#include "src/common/net_common.h"
 #include "src/common/throttle.h"
 
 namespace curve {

--- a/src/client/client_config.cpp
+++ b/src/client/client_config.cpp
@@ -41,7 +41,9 @@ namespace client {
 
 extern uint32_t kMinIOAlignment;
 
-int ClientConfig::Init(const char* configpath) {
+static constexpr int kDefaultDummyServerPort = 9000;
+
+int ClientConfig::Init(const std::string& configpath) {
     conf_.SetConfigPath(configpath);
 
     LOG(INFO) << "Init config from " << configpath;
@@ -299,8 +301,9 @@ int ClientConfig::Init(const char* configpath) {
     return 0;
 }
 
-uint16_t ClientConfig::GetDummyserverStartPort() {
-    return conf_.GetIntValue("global.metricDummyServerStartPort", 9000);
+int ClientConfig::GetDummyserverStartPort() {
+    return conf_.GetIntValue("global.metricDummyServerStartPort",
+                             kDefaultDummyServerPort);
 }
 
 }   // namespace client

--- a/src/client/client_config.h
+++ b/src/client/client_config.h
@@ -23,6 +23,8 @@
 #ifndef SRC_CLIENT_CLIENT_CONFIG_H_
 #define SRC_CLIENT_CLIENT_CONFIG_H_
 
+#include <string>
+
 #include "src/client/config_info.h"
 #include "src/common/configuration.h"
 
@@ -31,20 +33,13 @@ namespace client {
 
 class ClientConfig {
  public:
-    int Init(const char* configpath);
+    int Init(const std::string& configpath);
 
     FileServiceOption GetFileServiceOption() const {
         return fileServiceOption_;
     }
 
-    /**
-     * test use, set the fileServiceOption_
-     */
-    void SetFileServiceOption(FileServiceOption opt) {
-        fileServiceOption_ = opt;
-    }
-
-    uint16_t GetDummyserverStartPort();
+    int GetDummyserverStartPort();
 
  private:
     FileServiceOption fileServiceOption_;

--- a/src/client/libcurve_file.h
+++ b/src/client/libcurve_file.h
@@ -32,10 +32,8 @@
 
 #include "include/client/libcurve.h"
 #include "src/client/client_common.h"
-#include "src/client/config_info.h"
 #include "src/client/file_instance.h"
 #include "src/common/concurrent/rw_lock.h"
-#include "src/common/uuid.h"
 
 // TODO(tongguangxun) :添加关键函数trace功能
 namespace curve {
@@ -43,19 +41,6 @@ namespace client {
 
 using curve::common::BthreadRWLock;
 
-class LoggerGuard {
- public:
-    explicit LoggerGuard(const std::string& confpath) {
-        InitInternal(confpath);
-    }
-
-    ~LoggerGuard() { google::ShutdownGoogleLogging(); }
-
- private:
-    static void InitInternal(const std::string& confpath);
-};
-
-// FileClient是vdisk的管理类，一个QEMU对应多个vdisk
 class FileClient {
  public:
     FileClient();

--- a/src/common/lru_cache.h
+++ b/src/common/lru_cache.h
@@ -127,6 +127,10 @@ class LRUCacheInterface {
     * @param[in] key
     */
     virtual void Remove(const K &key) = 0;
+    /*
+    * @brief Get the size of the lru
+    */
+    virtual uint64_t Size() = 0;
 };
 
 
@@ -186,6 +190,19 @@ class LRUCache : public LRUCacheInterface<K, V> {
     * @param[in] key
     */
     void Remove(const K &key) override;
+    /*
+    * @brief Get the first key that $value = value
+    *
+    * @param[in] value
+    * @param[out] key
+    *
+    * @return false if not find the value, true if succeeded
+    */
+    bool GetLast(const V value, K *key);
+    /*
+    * @brief Get the size of the lru
+    */
+    uint64_t Size() override;
 
     std::shared_ptr<CacheMetrics> GetCacheMetrics() const;
 
@@ -244,6 +261,12 @@ class LRUCache : public LRUCacheInterface<K, V> {
 };
 
 template <typename K,  typename V, typename KeyTraits, typename ValueTraits>
+uint64_t LRUCache<K, V, KeyTraits, ValueTraits>::Size() {
+    ::curve::common::WriteLockGuard guard(lock_);
+    return ll_.size();
+}
+
+template <typename K,  typename V, typename KeyTraits, typename ValueTraits>
 void LRUCache<K, V, KeyTraits, ValueTraits>::Put(
     const K &key, const V &value) {
     V eliminated;
@@ -276,6 +299,24 @@ bool LRUCache<K, V, KeyTraits, ValueTraits>::Get(const K &key, V *value) {
     // update the position of the target item in the list
     MoveToFront(iter->second);
     *value = cache_[key]->value;
+    return true;
+}
+
+template <typename K,  typename V, typename KeyTraits, typename ValueTraits>
+bool LRUCache<K, V, KeyTraits, ValueTraits>::GetLast(const V value, K *key) {
+    ::curve::common::WriteLockGuard guard(lock_);
+    if (ll_.empty()) {
+        return false;
+    }
+    auto it = ll_.rbegin();
+    for (; it != ll_.rend(); ++it) {
+        if ((*it).value == value) {
+            break;
+        }
+    }
+    if (it == ll_.rend())
+        return false;
+    *key = (*it).key;
     return true;
 }
 

--- a/src/common/s3_adapter.h
+++ b/src/common/s3_adapter.h
@@ -85,6 +85,7 @@ struct S3AdapterOption {
     uint64_t bpsTotalMB;
     uint64_t bpsReadMB;
     uint64_t bpsWriteMB;
+    bool useVirtualAddressing;
 };
 
 struct S3InfoOption {

--- a/test/common/lru_cache_test.cpp
+++ b/test/common/lru_cache_test.cpp
@@ -148,13 +148,30 @@ TEST(CaCheTest, TestCacheHitAndMissMetric) {
 
     ASSERT_EQ(10, cache->GetCacheMetrics()->cacheHit.get_value());
     ASSERT_EQ(10, cache->GetCacheMetrics()->cacheMiss.get_value());
-
     for (int i = 0; i < 5; ++i) {
         ASSERT_TRUE(cache->Get(existKey, &out));
     }
 
     ASSERT_EQ(15, cache->GetCacheMetrics()->cacheHit.get_value());
     ASSERT_EQ(10, cache->GetCacheMetrics()->cacheMiss.get_value());
+}
+
+TEST(CaCheTest, TestCacheGetLast) {
+    auto cache = std::make_shared<LRUCache<int, bool>>(
+        std::make_shared<CacheMetrics>("LruCache"));
+
+    for (int i = 0; i < 3; ++i) {
+        cache->Put(i, true);
+    }
+    cache->Put(3, false);
+    for (int i = 4; i < 6; ++i) {
+        cache->Put(i, true);
+    }
+    int out;
+    cache->GetLast(false, &out);
+    ASSERT_EQ(3, out);
+    cache->GetLast(true, &out);
+    ASSERT_EQ(0, out);
 }
 
 TEST(SglCaCheTest, TestGetBefore) {

--- a/test/mds/mock/mock_etcdclient.h
+++ b/test/mds/mock/mock_etcdclient.h
@@ -73,6 +73,7 @@ class MockLRUCache : public Cache {
     MOCK_METHOD3(Put, bool(
         const std::string&, const std::string&, std::string*));
     MOCK_METHOD2(Get, bool(const std::string&, std::string*));
+    MOCK_METHOD0(Size, uint64_t());
     MOCK_METHOD1(Remove, void(const std::string&));
 };
 }  // namespace mds


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #1382

Problem Summary: Copyset is not automatically migrated after stopping metaserver

### What is changed and how it works?

What's Changed: fix clear copyset creating flag when create copyset success

When copyset created success, it should clear the copyset creating flag. But the code miss this in code.
