### PR TITLE
fix clear copyset creating flag when create copyset success

### DIFF
--- a/curvefs/src/mds/topology/topology_manager.cpp
+++ b/curvefs/src/mds/topology/topology_manager.cpp
@@ -853,7 +853,7 @@ TopoStatusCode TopologyManager::CreateCopyset(
         return TopoStatusCode::TOPO_CREATE_COPYSET_ON_METASERVER_FAIL;
     }
 
-    // add copyset record to topogy
+    // add copyset record to topology
     CopySetInfo copysetInfo(copyset.poolId, copyset.copysetId);
     copysetInfo.SetCopySetMembers(copyset.metaServerIds);
     auto ret = topology_->AddCopySet(copysetInfo);
@@ -866,6 +866,7 @@ TopoStatusCode TopologyManager::CreateCopyset(
         return ret;
     }
 
+    ClearCopysetCreating(copyset.poolId, copyset.copysetId);
     return TopoStatusCode::TOPO_OK;
 }
 

--- a/curvefs/test/mds/topology/test_topology_manager.cpp
+++ b/curvefs/test/mds/topology/test_topology_manager.cpp
@@ -1822,6 +1822,7 @@ TEST_F(TestTopologyManager,
     ASSERT_TRUE(topology_->GetCopySet(key, &info));
     ASSERT_EQ(copysetId, info.GetId());
     ASSERT_EQ(1, info.GetPartitionNum());
+    ASSERT_FALSE(topology_->IsCopysetCreating(key));
 }
 
 TEST_F(TestTopologyManager,
@@ -1965,6 +1966,7 @@ TEST_F(TestTopologyManager,
     ASSERT_TRUE(topology_->GetCopySet(key, &info));
     ASSERT_EQ(copysetId, info.GetId());
     ASSERT_EQ(1, info.GetPartitionNum());
+    ASSERT_FALSE(topology_->IsCopysetCreating(key));
 }
 
 TEST_F(TestTopologyManager,
@@ -2097,6 +2099,7 @@ TEST_F(TestTopologyManager,
     ASSERT_TRUE(topology_->GetCopySet(key, &info));
     ASSERT_EQ(copysetId, info.GetId());
     ASSERT_EQ(1, info.GetPartitionNum());
+    ASSERT_FALSE(topology_->IsCopysetCreating(key));
 }
 
 TEST_F(TestTopologyManager,
@@ -2182,6 +2185,7 @@ TEST_F(TestTopologyManager,
     ASSERT_TRUE(topology_->GetCopySet(key, &info));
     ASSERT_EQ(copysetId, info.GetId());
     ASSERT_EQ(1, info.GetPartitionNum());
+    ASSERT_FALSE(topology_->IsCopysetCreating(key));
 }
 
 TEST_F(TestTopologyManager, test_CommitTx_Success) {


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #1382

Problem Summary: Copyset is not automatically migrated after stopping metaserver

### What is changed and how it works?

What's Changed: fix clear copyset creating flag when create copyset success

When copyset created success, it should clear the copyset creating flag. But the code miss this in code.
