### PR TITLE
curvefs: support rename by parallel for multiple mountpoints, you MUST

### DIFF
--- a/curvefs/conf/client.conf
+++ b/curvefs/conf/client.conf
@@ -88,6 +88,10 @@ fuseClient.dCacheLruSize=65536
 fuseClient.enableICacheMetrics=true
 fuseClient.enableDCacheMetrics=true
 fuseClient.cto=true
+# you shoudle enable it when mount one filesystem to multi mountpoints,
+# it gurantee the consistent of file after rename, otherwise you should
+# disable it for performance.
+fuseClient.enableMultiMountPointRename=true
 # splice will bring higher performance in some cases
 # but there're might be a kernel issue that will cause kernel panic when enabling it
 # see https://lore.kernel.org/all/CAAmZXrsGg2xsP1CK+cbuEMumtrqdvD-NKnWzhNcvn71RV3c1yw@mail.gmail.com/

--- a/curvefs/conf/mds.conf
+++ b/curvefs/conf/mds.conf
@@ -133,3 +133,10 @@ s3.throttle.bpsTotalMB=0
 s3.throttle.bpsReadMB=0
 s3.throttle.bpsWriteMB=0
 s3.useVirtualAddressing=false
+
+# TTL(millisecond) for distributed lock
+dlock.ttl_ms=5000
+# lock try timeout(millisecond) for distributed lock
+dlock.try_timeout_ms=300
+# lock try interval(millisecond) for distributed lock
+dlock.try_interval_ms=30

--- a/curvefs/proto/mds.proto
+++ b/curvefs/proto/mds.proto
@@ -49,6 +49,9 @@ enum FSStatusCode {
     PARTITION_EXIST = 25;
     DELETE_PARTITION_ERROR = 26;
     S3_INFO_ERROR = 27;
+    LOCK_FAILED = 28;
+    LOCK_TIMEOUT = 29;
+    COMMIT_TX_SEQUENCE_MISMATCH = 30;
 }
 
 // fs interface
@@ -83,6 +86,8 @@ message FsInfo {
     required FsDetail detail = 10;
     required bool enableSumInDir = 11;
     required string owner = 12;
+    optional uint64 txSequence = 13;
+    optional string txOwner = 14;
 }
 
 message GetFsInfoResponse {
@@ -169,6 +174,36 @@ message RefreshSessionResponse {
     repeated topology.PartitionTxId latestTxIdList = 2;
 }
 
+message DLockValue {
+    required string owner = 1;
+    required uint64 expireTime = 2;
+}
+
+message GetLatestTxIdRequest {
+    optional bool lock = 1;
+    optional uint32 fsId = 2;
+    optional string fsName = 3;
+    optional string uuid = 4;
+}
+
+message GetLatestTxIdResponse {
+    required FSStatusCode statusCode = 1;
+    repeated topology.PartitionTxId txIds = 2;
+    optional uint64 txSequence = 3;
+}
+
+message CommitTxRequest {
+    repeated topology.PartitionTxId partitionTxIds = 1;
+    optional bool lock = 2;
+    optional string fsName = 3;
+    optional string uuid = 4;
+    optional uint64 txSequence = 5;
+}
+
+message CommitTxResponse {
+    required FSStatusCode statusCode = 1;
+}
+
 service MdsService {
     // fs interface
     rpc CreateFs(CreateFsRequest) returns (CreateFsResponse);
@@ -180,6 +215,9 @@ service MdsService {
     rpc DeleteFs(DeleteFsRequest) returns (DeleteFsResponse);
     rpc AllocateS3Chunk(AllocateS3ChunkRequest) returns (AllocateS3ChunkResponse);
     rpc ListClusterFsInfo (ListClusterFsInfoRequest) returns (ListClusterFsInfoResponse);
+
+    rpc GetLatestTxId(GetLatestTxIdRequest) returns (GetLatestTxIdResponse);
+    rpc CommitTx(CommitTxRequest) returns (CommitTxResponse);
 
     // client lease
     rpc RefreshSession(RefreshSessionRequest) returns (RefreshSessionResponse);

--- a/curvefs/proto/metaserver.proto
+++ b/curvefs/proto/metaserver.proto
@@ -75,6 +75,7 @@ message Dentry {
     required uint64 txId = 5;
     optional uint32 flag = 6;
     optional FsFileType type = 7;
+    optional uint64 txSequence = 8;
 }
 
 message GetDentryResponse {

--- a/curvefs/src/client/client_operator.h
+++ b/curvefs/src/client/client_operator.h
@@ -39,6 +39,7 @@ using rpcclient::MdsClient;
 class RenameOperator {
  public:
     RenameOperator(uint32_t fsId,
+                   const std::string& fsName,
                    uint64_t parentId,
                    std::string name,
                    uint64_t newParentId,
@@ -46,7 +47,8 @@ class RenameOperator {
                    std::shared_ptr<DentryCacheManager> dentryManager,
                    std::shared_ptr<InodeCacheManager> inodeManager,
                    std::shared_ptr<MetaServerClient> metaClient,
-                   std::shared_ptr<MdsClient> mdsClient);
+                   std::shared_ptr<MdsClient> mdsClient,
+                   bool enableParallel);
 
     CURVEFS_ERROR GetTxId();
     CURVEFS_ERROR Precheck();
@@ -71,6 +73,8 @@ class RenameOperator {
 
     CURVEFS_ERROR CheckOverwrite();
 
+    CURVEFS_ERROR GetLatestTxIdWithLock();
+
     CURVEFS_ERROR GetTxId(uint32_t fsId,
                           uint64_t inodeId,
                           uint32_t* partitionId,
@@ -86,6 +90,7 @@ class RenameOperator {
 
  private:
     uint32_t fsId_;
+    std::string fsName_;
     uint64_t parentId_;
     std::string name_;
     uint64_t newParentId_;
@@ -108,6 +113,11 @@ class RenameOperator {
     std::shared_ptr<InodeCacheManager> inodeManager_;
     std::shared_ptr<MetaServerClient> metaClient_;
     std::shared_ptr<MdsClient> mdsClient_;
+
+    // whether support execute rename with parallel
+    bool enableParallel_;
+    std::string uuid_;
+    uint64_t sequence_;
 };
 
 }  // namespace client

--- a/curvefs/src/client/common/config.cpp
+++ b/curvefs/src/client/common/config.cpp
@@ -89,6 +89,8 @@ void InitExcutorOption(Configuration *conf, ExcutorOpt *opts) {
     conf->GetValueFatalIfFail("excutorOpt.maxRetryTimesBeforeConsiderSuspend",
                               &opts->maxRetryTimesBeforeConsiderSuspend);
     conf->GetValueFatalIfFail("excutorOpt.batchLimit", &opts->batchLimit);
+    conf->GetValueFatalIfFail("fuseClient.enableMultiMountPointRename",
+                              &opts->enableRenameParallel);
 }
 
 void InitBlockDeviceOption(Configuration *conf,
@@ -237,6 +239,8 @@ void InitFuseClientOption(Configuration *conf, FuseClientOption *clientOption) {
     conf->GetValueFatalIfFail("fuseClient.cto", &FLAGS_enableCto);
     conf->GetValueFatalIfFail("client.dummyserver.startport",
                               &clientOption->dummyServerStartPort);
+    conf->GetValueFatalIfFail("fuseClient.enableMultiMountPointRename",
+                              &clientOption->enableMultiMountPointRename);
 
     LOG_IF(WARNING, conf->GetBoolValue("fuseClient.enableSplice",
                                        &clientOption->enableFuseSplice))

--- a/curvefs/src/client/common/config.h
+++ b/curvefs/src/client/common/config.h
@@ -66,6 +66,7 @@ struct ExcutorOpt {
     uint64_t minRetryTimesForceTimeoutBackoff = 5;
     uint64_t maxRetryTimesBeforeConsiderSuspend = 20;
     uint32_t batchLimit = 100;
+    bool enableRenameParallel = false;
 };
 
 struct LeaseOpt {
@@ -183,6 +184,8 @@ struct FuseClientOption {
     bool enableDCacheMetrics;
 
     uint32_t dummyServerStartPort;
+
+    bool enableMultiMountPointRename = false;
 
     bool enableFuseSplice = false;
 };

--- a/curvefs/src/client/fuse_client.cpp
+++ b/curvefs/src/client/fuse_client.cpp
@@ -648,8 +648,10 @@ CURVEFS_ERROR FuseClient::FuseOpRename(fuse_req_t req, fuse_ino_t parent,
     }
 
     auto renameOp =
-        RenameOperator(fsInfo_->fsid(), parent, name, newparent, newname,
-                       dentryManager_, inodeManager_, metaClient_, mdsClient_);
+        RenameOperator(fsInfo_->fsid(), fsInfo_->fsname(),
+                       parent, name, newparent, newname,
+                       dentryManager_, inodeManager_, metaClient_, mdsClient_,
+                       option_.enableMultiMountPointRename);
 
     curve::common::LockGuard lg(renameMutex_);
     CURVEFS_ERROR rc = CURVEFS_ERROR::OK;

--- a/curvefs/src/client/metric/client_metric.h
+++ b/curvefs/src/client/metric/client_metric.h
@@ -43,6 +43,7 @@ struct MDSClientMetric {
     InterfaceMetric getFsInfo;
     InterfaceMetric allocateS3Chunk;
 
+    InterfaceMetric getLatestTxId;
     InterfaceMetric commitTx;
 
     InterfaceMetric getMetaserverInfo;
@@ -54,6 +55,7 @@ struct MDSClientMetric {
           mountFs(prefix, "mountFs"), umountFs(prefix, "unmountFs"),
           getFsInfo(prefix, "getFsInfo"),
           allocateS3Chunk(prefix, "allocateS3Chunk"),
+          getLatestTxId(prefix, "getLatestTxId"),
           commitTx(prefix, "commitTx"),
           getMetaserverInfo(prefix, "getMetaserverInfo") {}
 };

--- a/curvefs/src/client/rpcclient/base_client.cpp
+++ b/curvefs/src/client/rpcclient/base_client.cpp
@@ -67,15 +67,6 @@ void MDSBaseClient::GetFsInfo(uint32_t fsId, GetFsInfoResponse* response,
     stub.GetFsInfo(cntl, &request, response, nullptr);
 }
 
-void MDSBaseClient::CommitTx(const std::vector<PartitionTxId>& txIds,
-                             CommitTxResponse* response, brpc::Controller* cntl,
-                             brpc::Channel* channel) {
-    CommitTxRequest request;
-    *request.mutable_partitiontxids() = {txIds.begin(), txIds.end()};
-    curvefs::mds::topology::TopologyService_Stub stub(channel);
-    stub.CommitTx(cntl, &request, response, nullptr);
-}
-
 void MDSBaseClient::GetMetaServerInfo(uint32_t port, std::string ip,
                                       GetMetaServerInfoResponse* response,
                                       brpc::Controller* cntl,
@@ -157,6 +148,22 @@ void MDSBaseClient::RefreshSession(const std::vector<PartitionTxId> &txIds,
     *request.mutable_txids() = {txIds.begin(), txIds.end()};
     curvefs::mds::MdsService_Stub stub(channel);
     stub.RefreshSession(cntl, &request, response, nullptr);
+}
+
+void MDSBaseClient::GetLatestTxId(const GetLatestTxIdRequest& request,
+                                  GetLatestTxIdResponse* response,
+                                  brpc::Controller* cntl,
+                                  brpc::Channel* channel) {
+    curvefs::mds::MdsService_Stub stub(channel);
+    stub.GetLatestTxId(cntl, &request, response, nullptr);
+}
+
+void MDSBaseClient::CommitTx(const CommitTxRequest& request,
+                             CommitTxResponse* response,
+                             brpc::Controller* cntl,
+                             brpc::Channel* channel) {
+    curvefs::mds::MdsService_Stub stub(channel);
+    stub.CommitTx(cntl, &request, response, nullptr);
 }
 
 // TODO(all): do we really need pass `fsId` all the time?

--- a/curvefs/src/client/rpcclient/base_client.h
+++ b/curvefs/src/client/rpcclient/base_client.h
@@ -75,6 +75,10 @@ using curvefs::mds::GetFsInfoRequest;
 using curvefs::mds::GetFsInfoResponse;
 using curvefs::mds::MountFsRequest;
 using curvefs::mds::MountFsResponse;
+using curvefs::mds::GetLatestTxIdRequest;
+using curvefs::mds::GetLatestTxIdResponse;
+using curvefs::mds::CommitTxRequest;
+using curvefs::mds::CommitTxResponse;
 using curvefs::mds::RefreshSessionRequest;
 using curvefs::mds::RefreshSessionResponse;
 using curvefs::mds::UmountFsRequest;
@@ -83,8 +87,6 @@ using curvefs::mds::UmountFsResponse;
 using ::curve::client::CopysetID;
 using ::curve::client::LogicPoolID;
 
-using curvefs::mds::topology::CommitTxRequest;
-using curvefs::mds::topology::CommitTxResponse;
 using curvefs::mds::topology::Copyset;
 using curvefs::mds::topology::CreatePartitionRequest;
 using curvefs::mds::topology::CreatePartitionResponse;
@@ -146,10 +148,6 @@ class MDSBaseClient {
     virtual void GetFsInfo(uint32_t fsId, GetFsInfoResponse* response,
                            brpc::Controller* cntl, brpc::Channel* channel);
 
-    virtual void CommitTx(const std::vector<PartitionTxId>& txIds,
-                          CommitTxResponse* response, brpc::Controller* cntl,
-                          brpc::Channel* channel);
-
     virtual void GetMetaServerInfo(uint32_t port, std::string ip,
                                    GetMetaServerInfoResponse* response,
                                    brpc::Controller* cntl,
@@ -180,6 +178,16 @@ class MDSBaseClient {
     virtual void RefreshSession(const std::vector<PartitionTxId> &txIds,
                                 RefreshSessionResponse *response,
                                 brpc::Controller *cntl, brpc::Channel *channel);
+
+    virtual void GetLatestTxId(const GetLatestTxIdRequest& request,
+                               GetLatestTxIdResponse* response,
+                               brpc::Controller* cntl,
+                               brpc::Channel* channel);
+
+    virtual void CommitTx(const CommitTxRequest& request,
+                          CommitTxResponse* response,
+                          brpc::Controller* cntl,
+                          brpc::Channel* channel);
 
     virtual void AllocateVolumeBlockGroup(uint32_t fsId,
                                           uint32_t count,

--- a/curvefs/src/client/rpcclient/mds_client.cpp
+++ b/curvefs/src/client/rpcclient/mds_client.cpp
@@ -163,33 +163,6 @@ FSStatusCode MdsClientImpl::GetFsInfo(uint32_t fsId, FsInfo *fsInfo) {
     return ReturnError(rpcexcutor_.DoRPCTask(task, mdsOpt_.mdsMaxRetryMS));
 }
 
-TopoStatusCode
-MdsClientImpl::CommitTx(const std::vector<PartitionTxId> &txIds) {
-    auto task = RPCTask {
-        mdsClientMetric_.commitTx.qps.count << 1;
-        CommitTxResponse response;
-        mdsbasecli_->CommitTx(txIds, &response, cntl, channel);
-
-        if (cntl->Failed()) {
-            mdsClientMetric_.commitTx.eps.count << 1;
-            LOG(WARNING) << "CommitTx failed, errorCode = " << cntl->ErrorCode()
-                         << ", errorText =" << cntl->ErrorText()
-                         << ", logId = " << cntl->log_id();
-            return -cntl->ErrorCode();
-        }
-
-        auto rc = response.statuscode();
-        if (rc != TopoStatusCode::TOPO_OK) {
-            LOG(WARNING) << "CommitTx: retCode = " << rc
-                         << ", message = " << TopoStatusCode_Name(rc);
-        }
-        return rc;
-    };
-    // NOTE: retry until success
-    auto rc = rpcexcutor_.DoRPCTask(task, 0);
-    return static_cast<TopoStatusCode>(rc);
-}
-
 template <typename T>
 void GetEndPoint(const T &info, butil::EndPoint *internal,
                  butil::EndPoint *external) {
@@ -472,6 +445,119 @@ MdsClientImpl::RefreshSession(const std::vector<PartitionTxId> &txIds,
     };
 
     return ReturnError(rpcexcutor_.DoRPCTask(task, mdsOpt_.mdsMaxRetryMS));
+}
+
+FSStatusCode MdsClientImpl::GetLatestTxId(const GetLatestTxIdRequest& request,
+                                          GetLatestTxIdResponse* response) {
+    auto task = RPCTask {
+        mdsClientMetric_.getLatestTxId.qps.count << 1;
+        mdsbasecli_->GetLatestTxId(request, response, cntl, channel);
+        if (cntl->Failed()) {
+            LOG(WARNING) << "GetLatestTxId fail, errCode = "
+                         << cntl->ErrorCode()
+                         << ", errorText = " << cntl->ErrorText()
+                         << ", logId = " << cntl->log_id();
+            return -cntl->ErrorCode();
+        }
+
+        FSStatusCode rc = response->statuscode();
+        if (rc == FSStatusCode::LOCK_FAILED) {
+            LOG(WARNING) << "GetLatestTxId fail for acquire dlock failed";
+            return -rc;
+        } else if (rc == FSStatusCode::LOCK_TIMEOUT) {
+            LOG(WARNING) << "GetLatestTxId fail for acquire dlock timeout";
+            return -rc;
+        } else if (rc != FSStatusCode::OK) {
+            LOG(WARNING) << "GetLatestTxId fail, errcode = " << rc
+                         << ", errmsg = " << FSStatusCode_Name(rc);
+        }
+        return rc;
+    };
+
+    // for rpc error or get lock failed/timeout, we will retry until success
+    return ReturnError(rpcexcutor_.DoRPCTask(task, 0));
+}
+
+FSStatusCode MdsClientImpl::CommitTx(const CommitTxRequest& request) {
+    auto task = RPCTask {
+        mdsClientMetric_.commitTx.qps.count << 1;
+        CommitTxResponse response;
+        mdsbasecli_->CommitTx(request, &response, cntl, channel);
+
+        if (cntl->Failed()) {
+            mdsClientMetric_.commitTx.eps.count << 1;
+            LOG(WARNING) << "CommitTx failed, errorCode = " << cntl->ErrorCode()
+                         << ", errorText =" << cntl->ErrorText()
+                         << ", logId = " << cntl->log_id();
+            return -cntl->ErrorCode();
+        }
+
+        FSStatusCode rc = response.statuscode();
+        if (rc == FSStatusCode::LOCK_FAILED) {
+            LOG(WARNING) << "CommitTx fail for acquire dlock failed";
+            return -rc;
+        } else if (rc == FSStatusCode::LOCK_TIMEOUT) {
+            LOG(WARNING) << "CommitTx fail for acquire dlock timeout";
+            return -rc;
+        } else if (rc != FSStatusCode::OK) {
+            LOG(WARNING) << "CommitTx: retCode = " << rc
+                         << ", message = " << FSStatusCode_Name(rc);
+        }
+        return rc;
+    };
+    // for rpc error or get lock failed/timeout, we will retry until success
+    return ReturnError(rpcexcutor_.DoRPCTask(task, 0));
+}
+
+FSStatusCode MdsClientImpl::GetLatestTxId(std::vector<PartitionTxId>* txIds) {
+    GetLatestTxIdRequest request;
+    GetLatestTxIdResponse response;
+    FSStatusCode rc = GetLatestTxId(request, &response);
+    if (rc == FSStatusCode::OK) {
+        *txIds = { response.txids().begin(), response.txids().end() };
+    }
+    return rc;
+}
+
+FSStatusCode MdsClientImpl::GetLatestTxIdWithLock(
+    uint32_t fsId,
+    const std::string& fsName,
+    const std::string& uuid,
+    std::vector<PartitionTxId>* txIds,
+    uint64_t* txSequence) {
+    GetLatestTxIdRequest request;
+    GetLatestTxIdResponse response;
+    request.set_lock(true);
+    request.set_fsid(fsId);
+    request.set_fsname(fsName);
+    request.set_uuid(uuid);
+    FSStatusCode rc = GetLatestTxId(request, &response);
+    if (rc == FSStatusCode::OK) {
+        *txIds = { response.txids().begin(), response.txids().end() };
+        *txSequence = response.txsequence();
+    }
+    return rc;
+}
+
+FSStatusCode MdsClientImpl::CommitTx(
+    const std::vector<PartitionTxId>& txIds) {
+    CommitTxRequest request;
+    *request.mutable_partitiontxids() = { txIds.begin(), txIds.end() };
+    return CommitTx(request);
+}
+
+FSStatusCode MdsClientImpl::CommitTxWithLock(
+    const std::vector<PartitionTxId>& txIds,
+    const std::string& fsName,
+    const std::string& uuid,
+    uint64_t sequence)  {
+    CommitTxRequest request;
+    request.set_lock(true);
+    request.set_fsname(fsName);
+    request.set_uuid(uuid);
+    request.set_txsequence(sequence);
+    *request.mutable_partitiontxids() = { txIds.begin(), txIds.end() };
+    return CommitTx(request);
 }
 
 FSStatusCode MdsClientImpl::ReturnError(int retcode) {

--- a/curvefs/src/client/rpcclient/mds_client.h
+++ b/curvefs/src/client/rpcclient/mds_client.h
@@ -58,6 +58,10 @@ namespace curvefs {
 namespace client {
 namespace rpcclient {
 
+using curvefs::mds::GetLatestTxIdRequest;
+using curvefs::mds::GetLatestTxIdResponse;
+using curvefs::mds::CommitTxRequest;
+using curvefs::mds::CommitTxResponse;
 class MdsClient {
  public:
     MdsClient() {}
@@ -77,9 +81,6 @@ class MdsClient {
                                    FsInfo *fsInfo) = 0;
 
     virtual FSStatusCode GetFsInfo(uint32_t fsId, FsInfo *fsInfo) = 0;
-
-    virtual TopoStatusCode
-    CommitTx(const std::vector<PartitionTxId> &txIds) = 0;
 
     virtual bool
     GetMetaServerInfo(const PeerAddr &addr,
@@ -105,6 +106,24 @@ class MdsClient {
     virtual FSStatusCode
     RefreshSession(const std::vector<PartitionTxId> &txIds,
                    std::vector<PartitionTxId> *latestTxIdList) = 0;
+
+    virtual FSStatusCode GetLatestTxId(std::vector<PartitionTxId>* txIds) = 0;
+
+    virtual FSStatusCode
+    GetLatestTxIdWithLock(uint32_t fsId,
+                          const std::string& fsName,
+                          const std::string& uuid,
+                          std::vector<PartitionTxId>* txIds,
+                          uint64_t* sequence) = 0;
+
+    virtual FSStatusCode
+    CommitTx(const std::vector<PartitionTxId>& txIds) = 0;
+
+    virtual FSStatusCode
+    CommitTxWithLock(const std::vector<PartitionTxId>& txIds,
+                     const std::string& fsName,
+                     const std::string& uuid,
+                     uint64_t sequence) = 0;
 
     // allocate block group
     virtual SpaceErrCode AllocateVolumeBlockGroup(
@@ -145,8 +164,6 @@ class MdsClientImpl : public MdsClient {
 
     FSStatusCode GetFsInfo(uint32_t fsId, FsInfo *fsInfo) override;
 
-    TopoStatusCode CommitTx(const std::vector<PartitionTxId> &txIds) override;
-
     bool
     GetMetaServerInfo(const PeerAddr &addr,
                       CopysetPeerInfo<MetaserverID> *metaserverInfo) override;
@@ -172,6 +189,23 @@ class MdsClientImpl : public MdsClient {
     RefreshSession(const std::vector<PartitionTxId> &txIds,
                    std::vector<PartitionTxId> *latestTxIdList) override;
 
+    FSStatusCode GetLatestTxId(std::vector<PartitionTxId>* txIds) override;
+
+    FSStatusCode
+    GetLatestTxIdWithLock(uint32_t fsId,
+                          const std::string& fsName,
+                          const std::string& uuid,
+                          std::vector<PartitionTxId>* txIds,
+                          uint64_t* sequence) override;
+
+    FSStatusCode CommitTx(const std::vector<PartitionTxId>& txIds) override;
+
+    FSStatusCode
+    CommitTxWithLock(const std::vector<PartitionTxId>& txIds,
+                     const std::string& fsName,
+                     const std::string& uuid,
+                     uint64_t sequence) override;
+
     // allocate block group
     SpaceErrCode AllocateVolumeBlockGroup(
         uint32_t fsId,
@@ -195,6 +229,11 @@ class MdsClientImpl : public MdsClient {
 
  private:
     FSStatusCode ReturnError(int retcode);
+
+    FSStatusCode GetLatestTxId(const GetLatestTxIdRequest& request,
+                               GetLatestTxIdResponse* response);
+
+    FSStatusCode CommitTx(const CommitTxRequest& request);
 
  private:
     MDSBaseClient *mdsbasecli_;

--- a/curvefs/src/client/rpcclient/metacache.h
+++ b/curvefs/src/client/rpcclient/metacache.h
@@ -147,6 +147,8 @@ class MetaCache {
     virtual bool GetPartitionIdByInodeId(uint32_t fsID, uint64_t inodeID,
                                          PartitionID *pid);
 
+    bool RefreshTxId();
+
  private:
     void GetTxId(uint32_t partitionId, uint64_t *txId);
 

--- a/curvefs/src/client/rpcclient/metaserver_client.cpp
+++ b/curvefs/src/client/rpcclient/metaserver_client.cpp
@@ -162,7 +162,8 @@ MetaStatusCode MetaServerClientImpl::GetDentry(uint32_t fsId, uint64_t inodeid,
     };
 
     auto taskCtx = std::make_shared<TaskContext>(MetaServerOpType::GetDentry,
-                                                 task, fsId, inodeid);
+                                                 task, fsId, inodeid, false,
+                                                 opt_.enableRenameParallel);
     GetDentryExcutor excutor(opt_, metaCache_, channelManager_, taskCtx);
     return ConvertToMetaStatusCode(excutor.DoRPCTask());
 }
@@ -232,7 +233,8 @@ MetaStatusCode MetaServerClientImpl::ListDentry(uint32_t fsId, uint64_t inodeid,
     };
 
     auto taskCtx = std::make_shared<TaskContext>(MetaServerOpType::ListDentry,
-                                                 task, fsId, inodeid);
+                                                 task, fsId, inodeid, false,
+                                                 opt_.enableRenameParallel);
     ListDentryExcutor excutor(opt_, metaCache_, channelManager_, taskCtx);
     return ConvertToMetaStatusCode(excutor.DoRPCTask());
 }
@@ -298,7 +300,7 @@ MetaStatusCode MetaServerClientImpl::CreateDentry(const Dentry &dentry) {
         MetaServerOpType::CreateDentry, task, dentry.fsid(),
         // TODO(@lixiaocui): may be taskContext need diffrent according to
         // different operatrion
-        dentry.parentinodeid());
+        dentry.parentinodeid(), false, opt_.enableRenameParallel);
     CreateDentryExcutor excutor(opt_, metaCache_, channelManager_, taskCtx);
     return ConvertToMetaStatusCode(excutor.DoRPCTask());
 }
@@ -354,7 +356,8 @@ MetaStatusCode MetaServerClientImpl::DeleteDentry(uint32_t fsId,
     };
 
     auto taskCtx = std::make_shared<TaskContext>(MetaServerOpType::DeleteDentry,
-                                                 task, fsId, inodeid);
+                                                 task, fsId, inodeid, false,
+                                                 opt_.enableRenameParallel);
     DeleteDentryExcutor excutor(opt_, metaCache_, channelManager_, taskCtx);
     return ConvertToMetaStatusCode(excutor.DoRPCTask());
 }

--- a/curvefs/src/client/rpcclient/task_excutor.cpp
+++ b/curvefs/src/client/rpcclient/task_excutor.cpp
@@ -70,6 +70,12 @@ int TaskExecutor::DoRPCTaskInner(TaskExecutorDone *done) {
             break;
         }
 
+        if (task_->refreshTxId && !metaCache_->RefreshTxId()) {
+            LOG(ERROR) << "Refresh partition txid failed.";
+            bthread_usleep(opt_.retryIntervalUS);
+            continue;
+        }
+
         if (!HasValidTarget() && !GetTarget()) {
             LOG(WARNING) << "get target fail for " << task_->TaskContextStr()
                          << ", sleep and retry";

--- a/curvefs/src/client/rpcclient/task_excutor.h
+++ b/curvefs/src/client/rpcclient/task_excutor.h
@@ -63,14 +63,16 @@ class TaskContext {
 
     TaskContext() = default;
     TaskContext(MetaServerOpType type, RpcFunc func, uint32_t fsid = 0,
-                uint32_t inodeid = 0, bool streaming = false)
+                uint32_t inodeid = 0, bool streaming = false,
+                bool refreshTxId = false)
         : optype(type), rpctask(func), fsID(fsid), inodeID(inodeid),
-          streaming(streaming) {}
+          streaming(streaming), refreshTxId(refreshTxId) {}
 
     std::string TaskContextStr() {
         std::ostringstream oss;
         oss << "{" << optype << ",fsid=" << fsID << ",inodeid=" << inodeID
-            << ",streaming=" << streaming << "}";
+            << ",streaming=" << streaming
+            << ",refreshTxId=" << refreshTxId << "}";
         return oss.str();
     }
 
@@ -92,6 +94,8 @@ class TaskContext {
 
     // whether need stream
     bool streaming = false;
+
+    bool refreshTxId = false;
 
     brpc::Controller cntl_;
 };

--- a/curvefs/src/mds/BUILD
+++ b/curvefs/src/mds/BUILD
@@ -35,6 +35,7 @@ cc_library(
         "//curvefs/src/mds/metric:fs_mds_metric",
         "//curvefs/src/mds/space:curvefs_mds_space",
         "//curvefs/src/mds/topology:curvefs_topology",
+        "//curvefs/src/mds/dlock:fs_mds_dlock",
         "//external:brpc",
         "//external:gflags",
         "//external:glog",

--- a/curvefs/src/mds/common/storage_key.h
+++ b/curvefs/src/mds/common/storage_key.h
@@ -62,6 +62,10 @@ const char PARTITIONKEYEND[] = "fs_1009";
 
 constexpr uint32_t TOPOLOGY_PREFIX_LENGTH = 7;
 
+const char DLOCK_KEY_PREFIX[] = "dlock_01";
+
+constexpr uint32_t DLOCK_PREFIX_LENGTH = 8;
+
 }  // namespace mds
 }  // namespace curvefs
 

--- a/curvefs/src/mds/dlock/BUILD
+++ b/curvefs/src/mds/dlock/BUILD
@@ -1,0 +1,33 @@
+#
+#  Copyright (c) 2022 NetEase Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+load("//:copts.bzl", "CURVE_DEFAULT_COPTS")
+
+cc_library(
+    name = "fs_mds_dlock",
+    srcs = ["dlock.cpp"],
+    hdrs = ["dlock.h"],
+    copts = CURVE_DEFAULT_COPTS,
+    visibility = ["//visibility:public"],
+    deps = [
+        "//external:protobuf",
+        "//src/common:curve_common",
+        "//src/common/concurrent:curve_concurrent",
+        "//src/kvstorageclient:kvstorage_client",
+        "//curvefs/proto:mds_cc_proto",
+        "//curvefs/src/mds/common:fs_mds_common",
+    ],
+)

--- a/curvefs/src/mds/dlock/dlock.cpp
+++ b/curvefs/src/mds/dlock/dlock.cpp
@@ -1,0 +1,215 @@
+/*
+ *  Copyright (c) 2022 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * Project: Curve
+ * Created Date: 2022-05-10
+ * Author: Jingli Chen (Wine93)
+ */
+
+#include <bthread/bthread.h>
+
+#include <memory>
+#include <thread>
+#include <ostream>
+#include <functional>
+
+#include "src/common/encode.h"
+#include "src/common/timeutility.h"
+#include "curvefs/proto/mds.pb.h"
+#include "curvefs/src/mds/dlock/dlock.h"
+#include "curvefs/src/mds/common/storage_key.h"
+
+namespace curvefs {
+namespace mds {
+namespace dlock {
+
+using ::curve::common::TimeUtility;
+using ::curve::common::NameLockGuard;
+using ::curve::common::EncodeBigEndian;
+using ::curvefs::mds::DLockValue;
+using ::curvefs::mds::DLOCK_KEY_PREFIX;
+using ::curvefs::mds::DLOCK_PREFIX_LENGTH;
+
+std::ostream& operator<<(std::ostream& os,  OWNER_STATUS status) {
+    switch (status) {
+        case OWNER_STATUS::OK:
+            os << "OK";
+            break;
+        case OWNER_STATUS::ERROR:
+            os << "ERROR";
+            break;
+        case OWNER_STATUS::NOT_EXIST:
+            os << "NOT_EXIST";
+            break;
+        case OWNER_STATUS::EXPIRED:
+            os << "EXPIRED";
+            break;
+        default:
+            os << "UNKNOWN";
+            break;
+    }
+    return os;
+}
+
+DLock::DLock(const DLockOptions& options,
+             std::shared_ptr<EtcdClientImp> etcdClient)
+    : options_(options),
+      etcdClient_(etcdClient) {}
+
+LOCK_STATUS DLock::Lock(const std::string& name,
+                        const std::string& owner) {
+    bool succ = false;
+    uint64_t total = options_.tryTimeoutMs;
+    uint64_t step = options_.tryIntervalMs;
+    std::string key = EncodeKey(name);
+    LOG(INFO) << "DLock try lock, name=" << name << ", owner=" << owner
+              << ", total=" << total << ", step=" << step << ", key=" << key;
+    for (uint64_t elapsed = 0; elapsed < total; elapsed += step) {
+        {
+            NameLockGuard lg(nameLock_, name);
+            if (ReplaceOwner(name, owner, options_.ttlMs)) {
+                succ = true;
+                break;
+            }
+        }
+        bthread_usleep(step * 1000);
+    }
+
+    if (!succ) {
+        LOG(ERROR) << "DLock lock failed, name=" << name
+                   << ", owner=" << owner;
+        return LOCK_STATUS::TIMEOUT;
+    }
+    LOG(INFO) << "DLock lock success, name=" << name << ", owner=" << owner;
+    return LOCK_STATUS::OK;
+}
+
+LOCK_STATUS DLock::UnLock(const std::string& name,
+                          const std::string& owner) {
+    NameLockGuard lg(nameLock_, name);
+    std::string oldOwner;
+    OWNER_STATUS status = GetOwner(name, &oldOwner);
+    if (status == OWNER_STATUS::EXPIRED ||
+        status == OWNER_STATUS::NOT_EXIST ||
+        (status == OWNER_STATUS::OK && oldOwner == owner)) {
+        return ClearOwner(name) ? LOCK_STATUS::OK :
+                                  LOCK_STATUS::FAILED;
+    }
+    return LOCK_STATUS::FAILED;
+}
+
+bool DLock::CheckOwner(const std::string& name,
+                       const std::string& owner) {
+    NameLockGuard lg(nameLock_, name);
+    std::string oldOwner;
+    OWNER_STATUS status = GetOwner(name, &oldOwner);
+    LOG(INFO) << "DLock check owner, retCode=" << status
+              << ", name=" << name << ", expect owner=" << owner
+              << ", actual owner=" << oldOwner;
+    return status == OWNER_STATUS::OK && oldOwner == owner;
+}
+
+size_t DLock::Hash(const std::string& key) {
+    return std::hash<std::string>{}(key);
+}
+
+std::string DLock::EncodeKey(const std::string& name) {
+    std::string key = DLOCK_KEY_PREFIX;
+    size_t prefixLen = DLOCK_PREFIX_LENGTH;
+    uint64_t num = static_cast<uint64_t>(Hash(name));
+    key.resize(prefixLen + sizeof(uint64_t));
+    EncodeBigEndian(&(key[prefixLen]), num);
+    return key;
+}
+
+OWNER_STATUS DLock::GetOwner(const std::string& name,
+                             std::string* owner) {
+    std::string skey = EncodeKey(name);
+    std::string svalue;
+    DLockValue value;
+    int rc = etcdClient_->Get(skey, &svalue);
+    if (rc == EtcdErrCode::EtcdKeyNotExist) {
+        return OWNER_STATUS::NOT_EXIST;
+    } else if (rc != EtcdErrCode::EtcdOK) {
+        LOG(ERROR) << "Get dlock value from etcd failed"
+                   << ", retCode=" << rc;
+        return OWNER_STATUS::ERROR;
+    } else if (!value.ParseFromString(svalue)) {
+        LOG(ERROR) << "Parase dlock value from string failed";
+        return OWNER_STATUS::ERROR;
+    }
+
+    uint64_t now = TimeUtility::GetTimeofDayMs();
+    if (now >= value.expiretime()) {
+        LOG(WARNING) << "DLock lock expired, expireTime=" << value.expiretime()
+                     << ", now=" << now;
+        return OWNER_STATUS::EXPIRED;
+    }
+    *owner = value.owner();
+    return OWNER_STATUS::OK;
+}
+
+bool DLock::SetOwner(const std::string& name,
+                     const std::string& owner,
+                     uint64_t ttlMs) {
+    std::string skey = EncodeKey(name);
+    std::string svalue;
+    DLockValue value;
+    value.set_owner(owner);
+    value.set_expiretime(TimeUtility::GetTimeofDayMs() + ttlMs);
+    if (!value.SerializeToString(&svalue)) {
+        LOG(ERROR) << "Serialize dlock value to string failed";
+        return false;
+    }
+
+    int rc = etcdClient_->Put(skey, svalue);
+    if (rc != EtcdErrCode::EtcdOK) {
+        LOG(ERROR) << "Put dlock value to etcd failed, retCode=" << rc;
+        return false;
+    }
+    return true;
+}
+
+bool DLock::ClearOwner(const std::string& name) {
+    std::string skey = EncodeKey(name);
+    int rc = etcdClient_->Delete(skey);
+    if (rc != EtcdErrCode::EtcdOK) {
+        LOG(ERROR) << "Delete dlock value from etcd failed"
+                    << ", retCode=" << rc;
+        return false;
+    }
+    return true;
+}
+
+bool DLock::ReplaceOwner(const std::string& name,
+                         const std::string& owner,
+                         uint64_t ttlMs) {
+    std::string oldOwner;
+    OWNER_STATUS status = GetOwner(name, &oldOwner);
+    LOG(INFO) << "DLock get owner, retCode=" << status
+              << ", name=" << name << ", owner=" << oldOwner;
+    if (status == OWNER_STATUS::NOT_EXIST ||
+        status == OWNER_STATUS::EXPIRED ||
+        oldOwner == owner) {
+        return SetOwner(name, owner, ttlMs);
+    }
+    return false;
+}
+
+}  // namespace dlock
+}  // namespace mds
+}  // namespace curvefs

--- a/curvefs/src/mds/dlock/dlock.h
+++ b/curvefs/src/mds/dlock/dlock.h
@@ -1,0 +1,128 @@
+/*
+ *  Copyright (c) 2022 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * Project: Curve
+ * Created Date: 2022-05-10
+ * Author: Jingli Chen (Wine93)
+ */
+
+#ifndef CURVEFS_SRC_MDS_DLOCK_DLOCK_H_
+#define CURVEFS_SRC_MDS_DLOCK_DLOCK_H_
+
+#include <string>
+#include <memory>
+
+#include "src/common/encode.h"
+#include "src/common/uncopyable.h"
+#include "src/common/concurrent/name_lock.h"
+#include "src/kvstorageclient/etcd_client.h"
+
+namespace curvefs {
+namespace mds {
+namespace dlock {
+
+using ::curve::common::NameLock;
+using ::curve::common::Uncopyable;
+using ::curve::kvstorage::EtcdClientImp;
+
+struct DLockOptions {
+    uint64_t ttlMs = 5000;
+
+    uint64_t tryTimeoutMs = 3000;
+
+    uint64_t tryIntervalMs = 50;
+};
+
+enum class LOCK_STATUS {
+    OK,
+    FAILED,
+    TIMEOUT,
+};
+
+enum class OWNER_STATUS {
+    OK,
+    ERROR,
+    NOT_EXIST,
+    EXPIRED,
+};
+
+class DLock : public Uncopyable {
+ public:
+    DLock(const DLockOptions& options,
+          std::shared_ptr<EtcdClientImp> etcdClient);
+
+    ~DLock() = default;
+
+    /**
+     * @brief: lock the specified namespace
+     * @param[in] name: namespace to lock
+     * @param[in] owner: owner for lock
+     * @return return LOCK_STATUS::OK if acquire lock success,
+     *         otherwise return LOCK_STATUS::TIMEOUT
+     */
+    LOCK_STATUS Lock(const std::string& name,
+                     const std::string& owner);
+
+    /**
+     * @brief: unlock the specified namespace
+     * @param[in] name: namespace to unlock
+     * @param[in] owner: owner for lock
+     * @return return LOCK_STATUS::OK if release lock success,
+     *         otherwise return LOCK_STATUS::TIMEOUT
+     */
+    LOCK_STATUS UnLock(const std::string& name,
+                       const std::string& owner);
+
+    /**
+     * @brief: check whether owner locked the namespace
+     * @param[in] name: namespace to check
+     * @param[in] owner: owner for lock
+     * @return return ture if owner locked the namespace,
+     *         otherwise return false
+     */
+    bool CheckOwner(const std::string& name,
+                    const std::string& owner);
+
+ private:
+    size_t Hash(const std::string& key);
+
+    std::string EncodeKey(const std::string& name);
+
+    OWNER_STATUS GetOwner(const std::string& name,
+                          std::string* owner);
+
+    bool SetOwner(const std::string& name,
+                  const std::string& owner,
+                  uint64_t ttlMs);
+
+    bool ClearOwner(const std::string& name);
+
+    bool ReplaceOwner(const std::string& name,
+                      const std::string& owner,
+                      uint64_t ttlMs);
+
+ private:
+    NameLock nameLock_;
+    DLockOptions options_;
+    std::shared_ptr<EtcdClientImp> etcdClient_;
+};
+
+}  // namespace dlock
+}  // namespace mds
+}  // namespace curvefs
+
+#endif  // CURVEFS_SRC_MDS_DLOCK_DLOCK_H_

--- a/curvefs/src/mds/fs_info_wrapper.h
+++ b/curvefs/src/mds/fs_info_wrapper.h
@@ -66,6 +66,8 @@ class FsInfoWrapper {
         fsInfo.set_blocksize(request->blocksize());
         fsInfo.set_mountnum(0);
         fsInfo.set_enablesumindir(request->enablesumindir());
+        fsInfo.set_txsequence(0);
+        fsInfo.set_txowner("");
 
         const auto& detail = request->fsdetail();
         fsInfo.set_allocated_detail(new FsDetail(detail));
@@ -161,6 +163,22 @@ class FsInfoWrapper {
 
     bool GetEnableSumInDir() const {
         return fsInfo_.enablesumindir();
+    }
+
+    uint64_t IncreaseFsTxSequence(const std::string& owner) {
+        if (!fsInfo_.has_txowner() || fsInfo_.txowner() != owner) {
+            uint64_t txSequence = 0;
+            if (fsInfo_.has_txsequence()) {
+                txSequence = fsInfo_.txsequence();
+            }
+            fsInfo_.set_txsequence(txSequence + 1);
+            fsInfo_.set_txowner(owner);
+        }
+        return fsInfo_.txsequence();
+    }
+
+    uint64_t GetFsTxSequence() {
+        return fsInfo_.has_txsequence() ? fsInfo_.txsequence() : 0;
     }
 
  private:

--- a/curvefs/src/mds/mds.h
+++ b/curvefs/src/mds/mds.h
@@ -39,6 +39,7 @@
 #include "curvefs/src/mds/topology/topology_service.h"
 #include "curvefs/src/mds/topology/topology_storge_etcd.h"
 #include "curvefs/src/mds/space/manager.h"
+#include "curvefs/src/mds/dlock/dlock.h"
 #include "src/common/configuration.h"
 #include "src/kvstorageclient/etcd_client.h"
 #include "src/leader_election/leader_election.h"
@@ -76,6 +77,7 @@ using ::curve::kvstorage::KVStorageClient;
 // TODO(split InitEtcdConf): split this InitEtcdConf to a single module
 
 using ::curvefs::mds::space::SpaceManager;
+using ::curvefs::mds::dlock::DLockOptions;
 
 struct MDSOptions {
     int dummyPort;
@@ -86,6 +88,8 @@ struct MDSOptions {
     TopologyOption topologyOptions;
     HeartbeatOption heartbeatOption;
     ScheduleOption scheduleOption;
+
+    DLockOptions dLockOptions;
 };
 
 class MDS {
@@ -117,6 +121,8 @@ class MDS {
 
     void InitHeartbeatOption(HeartbeatOption* heartbeatOption);
     void InitScheduleOption(ScheduleOption* scheduleOption);
+
+    void InitDLockOptions(DLockOptions* dLockOptions);
 
  private:
     void InitMetaServerOption(MetaserverOptions* metaserverOption);

--- a/curvefs/src/mds/mds_service.cpp
+++ b/curvefs/src/mds/mds_service.cpp
@@ -276,5 +276,22 @@ void MdsServiceImpl::RefreshSession(
     response->set_statuscode(FSStatusCode::OK);
 }
 
+void MdsServiceImpl::GetLatestTxId(
+    ::google::protobuf::RpcController* controller,
+    const GetLatestTxIdRequest* request,
+    GetLatestTxIdResponse* response,
+    ::google::protobuf::Closure* done) {
+    brpc::ClosureGuard guard(done);
+    fsManager_->GetLatestTxId(request, response);
+}
+
+void MdsServiceImpl::CommitTx(::google::protobuf::RpcController* controller,
+                              const CommitTxRequest* request,
+                              CommitTxResponse* response,
+                              ::google::protobuf::Closure* done) {
+    brpc::ClosureGuard guard(done);
+    fsManager_->CommitTx(request, response);
+}
+
 }  // namespace mds
 }  // namespace curvefs

--- a/curvefs/src/mds/mds_service.h
+++ b/curvefs/src/mds/mds_service.h
@@ -87,6 +87,16 @@ class MdsServiceImpl : public MdsService {
                         ::curvefs::mds::RefreshSessionResponse *response,
                         ::google::protobuf::Closure *done);
 
+    void GetLatestTxId(::google::protobuf::RpcController* controller,
+                       const GetLatestTxIdRequest* request,
+                       GetLatestTxIdResponse* response,
+                       ::google::protobuf::Closure* done);
+
+    void CommitTx(::google::protobuf::RpcController* controller,
+                  const CommitTxRequest* request,
+                  CommitTxResponse* response,
+                  ::google::protobuf::Closure* done);
+
  private:
     std::shared_ptr<FsManager> fsManager_;
     std::shared_ptr<ChunkIdAllocator> chunkIdAllocator_;

--- a/curvefs/src/mds/topology/topology_manager.cpp
+++ b/curvefs/src/mds/topology/topology_manager.cpp
@@ -869,18 +869,22 @@ TopoStatusCode TopologyManager::CreateCopyset(
     return TopoStatusCode::TOPO_OK;
 }
 
+TopoStatusCode TopologyManager::CommitTxId(
+    const std::vector<PartitionTxId>& txIds) {
+    if (txIds.size() == 0) {
+        return TopoStatusCode::TOPO_OK;
+    }
+    return topology_->UpdatePartitionTxIds(txIds);
+}
+
 void TopologyManager::CommitTx(const CommitTxRequest *request,
                                CommitTxResponse *response) {
-    if (request->partitiontxids_size() == 0) {
-        response->set_statuscode(TopoStatusCode::TOPO_OK);
-        return;
-    }
-
-    std::vector<PartitionTxId> partitionTxIds;
+    std::vector<PartitionTxId> txIds;
     for (int i = 0; i < request->partitiontxids_size(); i++) {
-        partitionTxIds.emplace_back(request->partitiontxids(i));
+        txIds.emplace_back(request->partitiontxids(i));
     }
-    response->set_statuscode(topology_->UpdatePartitionTxIds(partitionTxIds));
+    TopoStatusCode rc = CommitTxId(txIds);
+    response->set_statuscode(rc);
 }
 
 void TopologyManager::GetMetaServerListInCopysets(

--- a/curvefs/src/mds/topology/topology_manager.h
+++ b/curvefs/src/mds/topology/topology_manager.h
@@ -112,6 +112,8 @@ class TopologyManager {
     virtual TopoStatusCode CreatePartitionsAndGetMinPartition(
         FsIdType fsId, PartitionInfo *partition);
 
+    virtual TopoStatusCode CommitTxId(const std::vector<PartitionTxId>& txIds);
+
     virtual void CommitTx(const CommitTxRequest *request,
                           CommitTxResponse *response);
 

--- a/curvefs/src/metaserver/transaction.cpp
+++ b/curvefs/src/metaserver/transaction.cpp
@@ -41,7 +41,10 @@ do { \
 
 RenameTx::RenameTx(const std::vector<Dentry>& dentrys,
                    std::shared_ptr<DentryStorage> storage)
-    : txId_(dentrys[0].txid()) , dentrys_(dentrys), storage_(storage) {}
+    : txId_(dentrys[0].txid()) ,
+      txSequence_(dentrys[0].txsequence()),
+      dentrys_(dentrys),
+      storage_(storage) {}
 
 bool RenameTx::Prepare() {
     FOR_EACH_DENTRY(PREPARE);
@@ -60,6 +63,10 @@ bool RenameTx::Rollback() {
 
 uint64_t RenameTx::GetTxId() {
     return txId_;
+}
+
+uint64_t RenameTx::GetTxSequence() {
+    return txSequence_;
 }
 
 std::vector<Dentry>* RenameTx::GetDentrys() {
@@ -89,7 +96,8 @@ MetaStatusCode TxManager::PreCheck(const std::vector<Dentry>& dentrys) {
         return MetaStatusCode::PARAM_ERROR;
     } else if (size == 2) {
          if (dentrys[0].fsid() != dentrys[1].fsid() ||
-             dentrys[0].txid() != dentrys[1].txid()) {
+             dentrys[0].txid() != dentrys[1].txid() ||
+             dentrys[0].txsequence() != dentrys[1].txsequence()) {
             return MetaStatusCode::PARAM_ERROR;
         }
     }
@@ -107,7 +115,14 @@ MetaStatusCode TxManager::HandleRenameTx(const std::vector<Dentry>& dentrys) {
     RenameTx pendingTx;
     if (FindPendingTx(&pendingTx)) {
         auto txId = dentrys[0].txid();
-        if (!HandlePendingTx(txId, &pendingTx)) {
+        auto txSequence = dentrys[0].txsequence();
+        if (txSequence != 0 && txSequence <= pendingTx.GetTxSequence()) {
+            LOG(ERROR) << "HandlePendingTx failed, current transaction is stale"
+                       << ", we will discard it. current tx sequence = "
+                       << txSequence << ", pending tx sequence = "
+                       << pendingTx.GetTxSequence();
+            return MetaStatusCode::HANDLE_PENDING_TX_FAILED;
+        } else if (!HandlePendingTx(txId, &pendingTx)) {
             LOG(ERROR) << "HandlePendingTx failed, pendingTx: " << pendingTx;
             return MetaStatusCode::HANDLE_PENDING_TX_FAILED;
         }

--- a/curvefs/src/metaserver/transaction.h
+++ b/curvefs/src/metaserver/transaction.h
@@ -48,6 +48,8 @@ class RenameTx {
 
     uint64_t GetTxId();
 
+    uint64_t GetTxSequence();
+
     std::vector<Dentry>* GetDentrys();
 
     bool operator==(const RenameTx& rhs);
@@ -56,6 +58,9 @@ class RenameTx {
 
  private:
     uint64_t txId_;
+
+    // for prevent the stale transaction
+    uint64_t txSequence_;
 
     std::vector<Dentry> dentrys_;
 

--- a/curvefs/test/client/client_operator_test.cpp
+++ b/curvefs/test/client/client_operator_test.cpp
@@ -41,6 +41,7 @@ class ClientOperatorTest : public ::testing::Test {
  protected:
     ClientOperatorTest() {
         fsId_ = 1;
+        fsname_ = "/test";
         parentId_ = 10;
         name_ = "A";
         newParentId_ = 20;
@@ -49,12 +50,14 @@ class ClientOperatorTest : public ::testing::Test {
         inodeManager_ = std::make_shared<MockInodeCacheManager>();
         metaClient_ = std::make_shared<MockMetaServerClient>();
         mdsClient_ = std::make_shared<MockMdsClient>();
-        renameOp_ = std::make_shared<RenameOperator>(fsId_, parentId_, name_,
+        renameOp_ = std::make_shared<RenameOperator>(fsId_, fsname_,
+                                                     parentId_, name_,
                                                      newParentId_, newname_,
                                                      dentryManager_,
                                                      inodeManager_,
                                                      metaClient_,
-                                                     mdsClient_);
+                                                     mdsClient_,
+                                                     false);
     }
 
     ~ClientOperatorTest() {}
@@ -65,6 +68,7 @@ class ClientOperatorTest : public ::testing::Test {
 
  protected:
     uint32_t fsId_;
+    std::string fsname_;
     uint64_t parentId_;
     std::string name_;
     uint64_t newParentId_;
@@ -173,14 +177,14 @@ TEST_F(ClientOperatorTest, PrepareTx) {
 TEST_F(ClientOperatorTest, CommitTx) {
     // CASE 1: CommitTx fail
     EXPECT_CALL(*mdsClient_, CommitTx(_))
-        .WillOnce(Return(TopoStatusCode::TOPO_INTERNAL_ERROR));
+        .WillOnce(Return(FSStatusCode::UNKNOWN_ERROR));
 
     auto rc = renameOp_->CommitTx();
     ASSERT_EQ(rc, CURVEFS_ERROR::INTERNAL);
 
     // CASE 2: CommitTx success
     EXPECT_CALL(*mdsClient_, CommitTx(_))
-        .WillOnce(Return(TopoStatusCode::TOPO_OK));
+        .WillOnce(Return(FSStatusCode::OK));
 
     rc = renameOp_->CommitTx();
     ASSERT_EQ(rc, CURVEFS_ERROR::OK);

--- a/curvefs/test/client/rpcclient/base_client_test.cpp
+++ b/curvefs/test/client/rpcclient/base_client_test.cpp
@@ -149,6 +149,8 @@ TEST_F(BaseClientTest, test_GetFsInfo_by_fsName) {
     fsinfo->set_enablesumindir(false);
     fsinfo->set_fstype(::curvefs::common::FSType::TYPE_VOLUME);
     fsinfo->set_owner("test");
+    fsinfo->set_txsequence(0);
+    fsinfo->set_txowner("owner");
     auto vresp = new curvefs::common::Volume();
     vresp->set_volumesize(10 * 1024 * 1024L);
     vresp->set_blocksize(4 * 1024);
@@ -198,6 +200,8 @@ TEST_F(BaseClientTest, test_GetFsInfo_by_fsId) {
     fsinfo->set_enablesumindir(false);
     fsinfo->set_fstype(::curvefs::common::FSType::TYPE_VOLUME);
     fsinfo->set_owner("test");
+    fsinfo->set_txsequence(0);
+    fsinfo->set_txowner("owner");
     auto vresp = new curvefs::common::Volume();
     vresp->set_volumesize(10 * 1024 * 1024L);
     vresp->set_blocksize(4 * 1024);

--- a/curvefs/test/client/rpcclient/mds_client_test.cpp
+++ b/curvefs/test/client/rpcclient/mds_client_test.cpp
@@ -324,42 +324,196 @@ TEST_F(MdsClientImplTest, test_GetFsInfo_by_fsid) {
 }
 
 TEST_F(MdsClientImplTest, CommitTx) {
-    curvefs::mds::topology::CommitTxResponse response;
+    curvefs::mds::CommitTxResponse response;
 
     // CASE 1: CommitTx success
-    response.set_statuscode(TopoStatusCode::TOPO_OK);
+    response.set_statuscode(FSStatusCode::OK);
     EXPECT_CALL(mockmdsbasecli_, CommitTx(_, _, _, _))
         .WillOnce(SetArgPointee<1>(response));
 
     auto txIds = std::vector<PartitionTxId>();
     auto rc = mdsclient_.CommitTx(txIds);
-    ASSERT_EQ(rc, TopoStatusCode::TOPO_OK);
+    ASSERT_EQ(rc, FSStatusCode::OK);
 
     // CASE 2: CommitTx fail
-    response.set_statuscode(TopoStatusCode::TOPO_INTERNAL_ERROR);
+    response.set_statuscode(FSStatusCode::UNKNOWN_ERROR);
     EXPECT_CALL(mockmdsbasecli_, CommitTx(_, _, _, _))
         .WillOnce(SetArgPointee<1>(response));
 
     rc = mdsclient_.CommitTx(txIds);
-    ASSERT_EQ(rc, TopoStatusCode::TOPO_INTERNAL_ERROR);
+    ASSERT_EQ(rc, FSStatusCode::UNKNOWN_ERROR);
 
     // CASE 3: RPC error, retry until success
     int count = 0;
     EXPECT_CALL(mockmdsbasecli_, CommitTx(_, _, _, _))
         .Times(6)
         .WillRepeatedly(
-            Invoke([&](const std::vector<PartitionTxId> &txIds,
-                       CommitTxResponse *response, brpc::Controller *cntl,
+            Invoke([&](const CommitTxRequest& request,
+                       CommitTxResponse *response,
+                       brpc::Controller *cntl,
                        brpc::Channel *channel) {
                 if (++count <= 5) {
                     cntl->SetFailed(112, "Not connected to");
                 } else {
-                    response->set_statuscode(TopoStatusCode::TOPO_OK);
+                    response->set_statuscode(FSStatusCode::OK);
                 }
             }));
 
     rc = mdsclient_.CommitTx(txIds);
-    ASSERT_EQ(rc, TopoStatusCode::TOPO_OK);
+    ASSERT_EQ(rc, FSStatusCode::OK);
+}
+
+TEST_F(MdsClientImplTest, CommitTxWithLock) {
+    std::vector<PartitionTxId> txIds;
+    std::string fsName = "/test";
+    std::string uuid = "uuid";
+    uint64_t txSequence = 100;
+
+    // CASE 1: CommitTx success
+    CommitTxResponse response;
+    response.set_statuscode(FSStatusCode::OK);
+    EXPECT_CALL(mockmdsbasecli_, CommitTx(_, _, _, _))
+        .WillOnce(SetArgPointee<1>(response));
+
+    auto rc = mdsclient_.CommitTxWithLock(
+        txIds, fsName, uuid, txSequence);
+    ASSERT_EQ(rc, FSStatusCode::OK);
+
+    // CASE 2: CommitTx fail
+    response.set_statuscode(FSStatusCode::UNKNOWN_ERROR);
+    EXPECT_CALL(mockmdsbasecli_, CommitTx(_, _, _, _))
+        .WillOnce(SetArgPointee<1>(response));
+
+    rc = mdsclient_.CommitTxWithLock(
+        txIds, fsName, uuid, txSequence);
+    ASSERT_EQ(rc, FSStatusCode::UNKNOWN_ERROR);
+
+    // CASE 3: RPC error or acquire dlock fail/timeout, retry until success
+    int count = 0;
+    EXPECT_CALL(mockmdsbasecli_, CommitTx(_, _, _, _))
+        .Times(6)
+        .WillRepeatedly(
+            Invoke([&](const CommitTxRequest& request,
+                       CommitTxResponse* response,
+                       brpc::Controller *cntl,
+                       brpc::Channel *channel) {
+                ASSERT_EQ(request.lock(), true);
+                ASSERT_EQ(request.fsname(), fsName);
+                ASSERT_EQ(request.uuid(), uuid);
+                ASSERT_EQ(request.txsequence(), txSequence);
+                ++count;
+                if (count == 1) {
+                    response->set_statuscode(FSStatusCode::LOCK_TIMEOUT);
+                } else if (count == 2) {
+                    response->set_statuscode(FSStatusCode::LOCK_FAILED);
+                } else if (count <= 5) {
+                    cntl->SetFailed(112, "Not connected to");
+                } else {
+                    response->set_statuscode(FSStatusCode::OK);
+                }
+            }));
+
+    rc = mdsclient_.CommitTxWithLock(
+        txIds, fsName, uuid, txSequence);
+    ASSERT_EQ(rc, FSStatusCode::OK);
+}
+
+TEST_F(MdsClientImplTest, GetLatestTxId) {
+    std::vector<PartitionTxId> txIds;
+
+    // CASE 1: GetLatestTxId success
+    GetLatestTxIdResponse response;
+    response.set_statuscode(FSStatusCode::OK);
+    EXPECT_CALL(mockmdsbasecli_, GetLatestTxId(_, _, _, _))
+        .WillOnce(SetArgPointee<1>(response));
+
+    auto rc = mdsclient_.GetLatestTxId(&txIds);
+    ASSERT_EQ(rc, FSStatusCode::OK);
+
+    // CASE 2: GetLatestTxId fail
+    response.set_statuscode(FSStatusCode::UNKNOWN_ERROR);
+    EXPECT_CALL(mockmdsbasecli_, GetLatestTxId(_, _, _, _))
+        .WillOnce(SetArgPointee<1>(response));
+
+    rc = mdsclient_.GetLatestTxId(&txIds);
+    ASSERT_EQ(rc, FSStatusCode::UNKNOWN_ERROR);
+
+    // CASE 3: RPC error, retry until success
+    int count = 0;
+    EXPECT_CALL(mockmdsbasecli_, GetLatestTxId(_, _, _, _))
+        .Times(6)
+        .WillRepeatedly(
+            Invoke([&](const GetLatestTxIdRequest& request,
+                       GetLatestTxIdResponse* response,
+                       brpc::Controller *cntl,
+                       brpc::Channel *channel) {
+                if (++count <= 5) {
+                    cntl->SetFailed(112, "Not connected to");
+                } else {
+                    response->set_statuscode(FSStatusCode::OK);
+                }
+            }));
+
+    rc = mdsclient_.GetLatestTxId(&txIds);
+    ASSERT_EQ(rc, FSStatusCode::OK);
+}
+
+TEST_F(MdsClientImplTest, GetLatestTxIdWithLock) {
+    std::vector<PartitionTxId> txIds;
+    uint32_t fsId;
+    std::string fsName = "/test";
+    std::string uuid = "uuid";
+    uint64_t sequence;
+
+    // CASE 1: GetLatestTxId success
+    GetLatestTxIdResponse response;
+    response.set_statuscode(FSStatusCode::OK);
+    EXPECT_CALL(mockmdsbasecli_, GetLatestTxId(_, _, _, _))
+        .WillOnce(SetArgPointee<1>(response));
+
+    auto rc = mdsclient_.GetLatestTxIdWithLock(
+        fsId, fsName, uuid, &txIds, &sequence);
+    ASSERT_EQ(rc, FSStatusCode::OK);
+
+    // CASE 2: GetLatestTxId fail
+    response.set_statuscode(FSStatusCode::UNKNOWN_ERROR);
+    EXPECT_CALL(mockmdsbasecli_, GetLatestTxId(_, _, _, _))
+        .WillOnce(SetArgPointee<1>(response));
+
+    rc = mdsclient_.GetLatestTxIdWithLock(
+        fsId, fsName, uuid, &txIds, &sequence);
+    ASSERT_EQ(rc, FSStatusCode::UNKNOWN_ERROR);
+
+    // CASE 3: RPC error or acquire dlock fail/timeout, retry until success
+    int count = 0;
+    EXPECT_CALL(mockmdsbasecli_, GetLatestTxId(_, _, _, _))
+        .Times(6)
+        .WillRepeatedly(
+            Invoke([&](const GetLatestTxIdRequest& request,
+                       GetLatestTxIdResponse* response,
+                       brpc::Controller *cntl,
+                       brpc::Channel *channel) {
+                ASSERT_EQ(request.lock(), true);
+                ASSERT_EQ(request.fsid(), fsId);
+                ASSERT_EQ(request.fsname(), fsName);
+                ASSERT_EQ(request.uuid(), uuid);
+                ++count;
+                if (count == 1) {
+                    response->set_statuscode(FSStatusCode::LOCK_TIMEOUT);
+                } else if (count == 2) {
+                    response->set_statuscode(FSStatusCode::LOCK_FAILED);
+                } else if (count <= 5) {
+                    cntl->SetFailed(112, "Not connected to");
+                } else {
+                    response->set_statuscode(FSStatusCode::OK);
+                    response->set_txsequence(100);
+                }
+            }));
+
+    rc = mdsclient_.GetLatestTxIdWithLock(
+        fsId, fsName, uuid, &txIds, &sequence);
+    ASSERT_EQ(rc, FSStatusCode::OK);
+    ASSERT_EQ(sequence, 100);
 }
 
 TEST_F(MdsClientImplTest, test_GetMetaServerInfo) {

--- a/curvefs/test/client/rpcclient/mock_mds_base_client.h
+++ b/curvefs/test/client/rpcclient/mock_mds_base_client.h
@@ -54,7 +54,12 @@ class MockMDSBaseClient : public MDSBaseClient {
                  void(uint32_t fsId, GetFsInfoResponse *response,
                       brpc::Controller *cntl, brpc::Channel *channel));
 
-    MOCK_METHOD4(CommitTx, void(const std::vector<PartitionTxId>& txIds,
+    MOCK_METHOD4(GetLatestTxId, void(const GetLatestTxIdRequest& request,
+                                     GetLatestTxIdResponse* response,
+                                     brpc::Controller* cntl,
+                                     brpc::Channel* channel));
+
+    MOCK_METHOD4(CommitTx, void(const CommitTxRequest& request,
                                 CommitTxResponse* response,
                                 brpc::Controller* cntl,
                                 brpc::Channel* channel));

--- a/curvefs/test/client/rpcclient/mock_mds_client.h
+++ b/curvefs/test/client/rpcclient/mock_mds_client.h
@@ -63,8 +63,24 @@ class MockMdsClient : public MdsClient {
     MOCK_METHOD2(AllocS3ChunkId,
                  FSStatusCode(uint32_t fsId, uint64_t* chunkId));
 
+    MOCK_METHOD1(GetLatestTxId,
+                 FSStatusCode(std::vector<PartitionTxId>* txIds));
+
+    MOCK_METHOD5(GetLatestTxIdWithLock,
+                 FSStatusCode(uint32_t fsId,
+                              const std::string& fsname,
+                              const std::string& uuid,
+                              std::vector<PartitionTxId>* txIds,
+                              uint64_t* sequence));
+
     MOCK_METHOD1(CommitTx,
-                 TopoStatusCode(const std::vector<PartitionTxId>& txIds));
+                 FSStatusCode(const std::vector<PartitionTxId>& txIds));
+
+    MOCK_METHOD4(CommitTxWithLock,
+                 FSStatusCode(const std::vector<PartitionTxId>& txIds,
+                              const std::string& fsname,
+                              const std::string& uuid,
+                              uint64_t sequence));
 
     MOCK_METHOD2(GetMetaServerInfo,
                  bool(const PeerAddr& addr,

--- a/curvefs/test/client/test_fuse_client.cpp
+++ b/curvefs/test/client/test_fuse_client.cpp
@@ -801,9 +801,9 @@ TEST_F(TestFuseVolumeClient, FuseOpRenameBasic) {
                 txIds[0].txid() == srcTxId + 1 &&
                 txIds[1].partitionid() == dstPartitionId &&
                 txIds[1].txid() == dstTxId + 1) {
-                return TopoStatusCode::TOPO_OK;
+                return FSStatusCode::OK;
             }
-            return TopoStatusCode::TOPO_INTERNAL_ERROR;
+            return FSStatusCode::UNKNOWN_ERROR;
         }));
 
     // step6: unlink source parent inode
@@ -892,9 +892,9 @@ TEST_F(TestFuseVolumeClient, FuseOpRenameOverwrite) {
         .WillOnce(Invoke([&](const std::vector<PartitionTxId> &txIds) {
             if (txIds.size() == 1 && txIds[0].partitionid() == partitionId &&
                 txIds[0].txid() == txId + 1) {
-                return TopoStatusCode::TOPO_OK;
+                return FSStatusCode::OK;
             }
-            return TopoStatusCode::TOPO_INTERNAL_ERROR;
+            return FSStatusCode::UNKNOWN_ERROR;
         }));
 
     // step5: unlink source parent inode
@@ -1043,7 +1043,7 @@ TEST_F(TestFuseVolumeClient, FuseOpRenameParallel) {
     // step4: commit tx
     EXPECT_CALL(*mdsClient_, CommitTx(_))
         .Times(times)
-        .WillRepeatedly(Return(TopoStatusCode::TOPO_OK));
+        .WillRepeatedly(Return(FSStatusCode::OK));
 
     // step5: unlink source directory
     Inode srcParentInode;

--- a/curvefs/test/mds/codec/codec_test.cpp
+++ b/curvefs/test/mds/codec/codec_test.cpp
@@ -51,6 +51,8 @@ TEST(CodecTest, TestEncodeProtobufMessage) {
     fsinfo.set_fstype(FSType::TYPE_VOLUME);
     fsinfo.set_enablesumindir(false);
     fsinfo.set_owner("test");
+    fsinfo.set_txsequence(0);
+    fsinfo.set_txowner("owner");
 
     Volume volume;
     volume.set_volumesize(8192);
@@ -83,6 +85,8 @@ TEST(CodecTest, TestDecodeProtobufMessage) {
     fsinfo.set_fstype(FSType::TYPE_VOLUME);
     fsinfo.set_enablesumindir(false);
     fsinfo.set_owner("test");
+    fsinfo.set_txsequence(0);
+    fsinfo.set_txowner("owner");
 
     Volume volume;
     volume.set_volumesize(8192);

--- a/curvefs/test/mds/fs_manager_test.cpp
+++ b/curvefs/test/mds/fs_manager_test.cpp
@@ -109,6 +109,7 @@ class FSManagerTest : public ::testing::Test {
         fsManager_ = std::make_shared<FsManager>(fsStorage_, spaceManager_,
                                                  metaserverClient_,
                                                  topoManager_, s3Adapter_,
+                                                 nullptr,
                                                  fsManagerOption);
         ASSERT_TRUE(fsManager_->Init());
 

--- a/curvefs/test/mds/fs_manager_test2.cpp
+++ b/curvefs/test/mds/fs_manager_test2.cpp
@@ -116,7 +116,7 @@ class FsManagerTest2 : public testing::Test {
         fsManagerOption.backEndThreadRunInterSec = 1;
         fsManager_ = std::make_shared<FsManager>(
             storage_, spaceManager_, metaServerClient_, topoManager_,
-            s3Adapter_, fsManagerOption);
+            s3Adapter_, nullptr, fsManagerOption);
 
         // spaceService_ = std::make_shared<MockSpaceService>();
         metaserverService_ = std::make_shared<MockMetaserverService>();

--- a/curvefs/test/mds/mds_service_test.cpp
+++ b/curvefs/test/mds/mds_service_test.cpp
@@ -110,13 +110,14 @@ class MdsServiceTest : public ::testing::Test {
         topoManager_ = std::make_shared<MockTopologyManager>(
                             std::make_shared<TopologyImpl>(idGenerator_,
                             tokenGenerator_, topoStorage_), metaserverClient_);
+
         // init fsmanager
         FsManagerOption fsManagerOption;
         fsManagerOption.backEndThreadRunInterSec = 1;
         s3Adapter_ = std::make_shared<MockS3Adapter>();
-        fsManager_ = std::make_shared<FsManager>(fsStorage_, spaceManager_,
-                                            metaserverClient_, topoManager_,
-                                            s3Adapter_, fsManagerOption);
+        fsManager_ = std::make_shared<FsManager>(
+            fsStorage_, spaceManager_, metaserverClient_, topoManager_,
+            s3Adapter_, nullptr, fsManagerOption);
         ASSERT_TRUE(fsManager_->Init());
         return;
     }

--- a/curvefs/test/mds/persist_kvstorage_test.cpp
+++ b/curvefs/test/mds/persist_kvstorage_test.cpp
@@ -59,6 +59,8 @@ class PersistKVStorageTest : public ::testing::Test {
         hello.set_fstype(FSType::TYPE_VOLUME);
         hello.set_enablesumindir(false);
         hello.set_owner("test");
+        hello.set_txsequence(0);
+        hello.set_txowner("owner");
 
         common::Volume volume;
         volume.set_blocksize(4096);
@@ -83,6 +85,8 @@ class PersistKVStorageTest : public ::testing::Test {
         world.set_fstype(FSType::TYPE_S3);
         world.set_enablesumindir(false);
         world.set_owner("test");
+        world.set_txsequence(0);
+        world.set_txowner("owner");
 
         common::S3Info s3info;
         s3info.set_ak("ak");


### PR DESCRIPTION
set client configure item fuseClient.enableMultiMountPointRename to true
for gurantee the consistent of file after rename in multiple mountpoints. (#1369)

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #1369

Problem Summary: dentry losed after rename in multiple mountpoints.

### How it Works:
* for multiple mointpoints, each rename operation needs to acquire a distributed mutex lock from MDS for gurantee the `txId` incremented.
* each lock bind a `uuid` for gurantee the lock can reentrant.
* each rename operation will bind a transaction sequence for discard the stale transaction, which means if the `sequence` of current transaction not greater than the `sequence` of pending transaction, the current transaction should be discarded.
