### PR TITLE
curve-chunkserver: use default generated copy constructor and copy assigment in FilePoolOptions

### DIFF
--- a/src/chunkserver/datastore/file_pool.h
+++ b/src/chunkserver/datastore/file_pool.h
@@ -76,33 +76,6 @@ struct FilePoolOptions {
         ::memset(metaPath, 0, 256);
         ::memset(filePoolDir, 0, 256);
     }
-
-    FilePoolOptions& operator=(const FilePoolOptions& other) {
-        getFileFromPool = other.getFileFromPool;
-        needClean = other.needClean;
-        bytesPerWrite = other.bytesPerWrite;
-        iops4clean = other.iops4clean;
-        metaFileSize = other.metaFileSize;
-        fileSize = other.fileSize;
-        retryTimes = other.retryTimes;
-        metaPageSize = other.metaPageSize;
-        ::memcpy(metaPath, other.metaPath, 256);
-        ::memcpy(filePoolDir, other.filePoolDir, 256);
-        return *this;
-    }
-
-    FilePoolOptions(const FilePoolOptions& other) {
-        getFileFromPool = other.getFileFromPool;
-        needClean = other.needClean;
-        bytesPerWrite = other.bytesPerWrite;
-        iops4clean = other.iops4clean;
-        metaFileSize = other.metaFileSize;
-        fileSize = other.fileSize;
-        retryTimes = other.retryTimes;
-        metaPageSize = other.metaPageSize;
-        ::memcpy(metaPath, other.metaPath, 256);
-        ::memcpy(filePoolDir, other.filePoolDir, 256);
-    }
 };
 
 typedef struct FilePoolState {


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #1443 

Problem Summary: optimization some place

### What is changed and how it works?

What's Changed: change the FilePoolOptions some functions.

How it Works: we know this struct is memory contiguous. we can use the c++ default function to do it.

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
