### PR TITLE
curvefs: missing some optype in output and raft log coder

### DIFF
--- a/curvefs/src/client/common/common.cpp
+++ b/curvefs/src/client/common/common.cpp
@@ -40,8 +40,17 @@ std::ostream &operator<<(std::ostream &os, MetaServerOpType optype) {
     case MetaServerOpType::DeleteDentry:
         os << "DeleteDentry";
         break;
+    case MetaServerOpType::PrepareRenameTx:
+        os << "PrepareRenameTx";
+        break;
     case MetaServerOpType::GetInode:
         os << "GetInode";
+        break;
+    case MetaServerOpType::BatchGetInodeAttr:
+        os << "BatchGetInodeAttr";
+        break;
+    case MetaServerOpType::BatchGetXAttr:
+        os << "BatchGetXAttr";
         break;
     case MetaServerOpType::UpdateInode:
         os << "UpdateInode";

--- a/curvefs/src/client/inode_cache_manager.cpp
+++ b/curvefs/src/client/inode_cache_manager.cpp
@@ -115,6 +115,10 @@ CURVEFS_ERROR InodeCacheManagerImpl::BatchGetInodeAttr(
         }
     }
 
+    if (inodeIds->empty()) {
+        return CURVEFS_ERROR::OK;
+    }
+
     MetaStatusCode ret = metaClient_->BatchGetInodeAttr(fsId_, inodeIds, attr);
     if (MetaStatusCode::OK != ret) {
         LOG(ERROR) << "metaClient BatchGetInodeAttr failed, MetaStatusCode = "
@@ -140,6 +144,10 @@ CURVEFS_ERROR InodeCacheManagerImpl::BatchGetXAttr(
         } else {
             ++iter;
         }
+    }
+
+    if (inodeIds->empty()) {
+        return CURVEFS_ERROR::OK;
     }
 
     MetaStatusCode ret = metaClient_->BatchGetXAttr(fsId_, inodeIds, xattr);

--- a/curvefs/src/metaserver/copyset/raft_log_codec.cpp
+++ b/curvefs/src/metaserver/copyset/raft_log_codec.cpp
@@ -124,6 +124,12 @@ std::unique_ptr<MetaOperator> RaftLogCodec::Decode(CopysetNode* node,
         case OperatorType::GetInode:
             return ParseFromRaftLog<GetInodeOperator, GetInodeRequest>(
                 node, type, meta);
+        case OperatorType::BatchGetInodeAttr:
+            return ParseFromRaftLog<BatchGetInodeAttrOperator,
+                BatchGetInodeAttrRequest>(node, type, meta);
+        case OperatorType::BatchGetXAttr:
+            return ParseFromRaftLog<BatchGetXAttrOperator,
+                BatchGetXAttrRequest>(node, type, meta);
         case OperatorType::CreateInode:
             return ParseFromRaftLog<CreateInodeOperator, CreateInodeRequest>(
                 node, type, meta);


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #xxx <!-- replace xxx with issue number -->
1. Missing some optype in output function will caused Unknow optype.
<img width="1319" alt="168079161-d89ebc79-002e-49fc-8da1-138822609fca" src="https://user-images.githubusercontent.com/13496900/168750118-44e730a3-08b4-4df2-8a4f-e1fa53cc805d.png">

2. Missing some opType in raft log coder will caused error when apply from log  at this opType.
<img width="1436" alt="截屏2022-05-16 10 57 43" src="https://user-images.githubusercontent.com/13496900/168750390-94415a03-4f80-475f-a613-203e967f9881.png">


Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
