### PR TITLE
curvefs/client: add client read qps and latancy metric

### DIFF
--- a/curvefs/src/client/fuse_s3_client.cpp
+++ b/curvefs/src/client/fuse_s3_client.cpp
@@ -174,6 +174,7 @@ CURVEFS_ERROR FuseS3Client::FuseOpRead(fuse_req_t req, fuse_ino_t ino,
             return CURVEFS_ERROR::INVALIDPARAM;
     }
 
+    uint64_t start = butil::cpuwide_time_us();
     std::shared_ptr<InodeWrapper> inodeWrapper;
     CURVEFS_ERROR ret = inodeManager_->GetInode(ino, inodeWrapper);
     if (ret != CURVEFS_ERROR::OK) {
@@ -203,6 +204,9 @@ CURVEFS_ERROR FuseS3Client::FuseOpRead(fuse_req_t req, fuse_ino_t ino,
 
     if (fsMetric_.get() != nullptr) {
         fsMetric_->userRead.bps.count << rRet;
+        fsMetric_->userRead.qps.count << 1;
+        uint64_t duration = butil::cpuwide_time_us() - start;
+        fsMetric_->userRead.latency << duration;
     }
 
     ::curve::common::UniqueLock lgGuard = inodeWrapper->GetUniqueLock();


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #1455 

Problem Summary: curvefs client read qps and latancy is missing 

### What is changed and how it works?

What's Changed:

How it Works: add curvefs client read qps and latancy

Side effects(Breaking backward compatibility? Performance regression?): no

### Check List

- [*] Relevant documentation/comments is changed or added
- [*] I acknowledge that all my contributions will be made under the project's license
