### PR TITLE
curvefs/client: fix the data iteration error when rpc retry.

### DIFF
--- a/curvefs/src/client/inode_cache_manager.cpp
+++ b/curvefs/src/client/inode_cache_manager.cpp
@@ -119,7 +119,7 @@ CURVEFS_ERROR InodeCacheManagerImpl::BatchGetInodeAttr(
         return CURVEFS_ERROR::OK;
     }
 
-    MetaStatusCode ret = metaClient_->BatchGetInodeAttr(fsId_, inodeIds, attr);
+    MetaStatusCode ret = metaClient_->BatchGetInodeAttr(fsId_, *inodeIds, attr);
     if (MetaStatusCode::OK != ret) {
         LOG(ERROR) << "metaClient BatchGetInodeAttr failed, MetaStatusCode = "
                    << ret << ", MetaStatusCode_Name = "
@@ -150,7 +150,7 @@ CURVEFS_ERROR InodeCacheManagerImpl::BatchGetXAttr(
         return CURVEFS_ERROR::OK;
     }
 
-    MetaStatusCode ret = metaClient_->BatchGetXAttr(fsId_, inodeIds, xattr);
+    MetaStatusCode ret = metaClient_->BatchGetXAttr(fsId_, *inodeIds, xattr);
     if (MetaStatusCode::OK != ret) {
         LOG(ERROR) << "metaClient BatchGetXAttr failed, MetaStatusCode = "
                    << ret << ", MetaStatusCode_Name = "

--- a/curvefs/src/client/rpcclient/metaserver_client.h
+++ b/curvefs/src/client/rpcclient/metaserver_client.h
@@ -92,11 +92,11 @@ class MetaServerClient {
                                     Inode *out, bool* streaming) = 0;
 
     virtual MetaStatusCode BatchGetInodeAttr(uint32_t fsId,
-        std::set<uint64_t> *inodeIds,
+        const std::set<uint64_t> &inodeIds,
         std::list<InodeAttr> *attr) = 0;
 
     virtual MetaStatusCode BatchGetXAttr(uint32_t fsId,
-        std::set<uint64_t> *inodeIds,
+        const std::set<uint64_t> &inodeIds,
         std::list<XAttr> *xattr) = 0;
 
     virtual MetaStatusCode UpdateInode(const Inode &inode,
@@ -125,6 +125,10 @@ class MetaServerClient {
     virtual MetaStatusCode CreateInode(const InodeParam &param, Inode *out) = 0;
 
     virtual MetaStatusCode DeleteInode(uint32_t fsId, uint64_t inodeid) = 0;
+
+    virtual bool SplitRequestInodes(uint32_t fsId,
+        const std::set<uint64_t> &inodeIds,
+        std::vector<std::vector<uint64_t>> *inodeGroups) = 0;
 };
 
 class MetaServerClientImpl : public MetaServerClient {
@@ -162,11 +166,11 @@ class MetaServerClientImpl : public MetaServerClient {
                             Inode *out, bool* streaming) override;
 
     MetaStatusCode BatchGetInodeAttr(uint32_t fsId,
-        std::set<uint64_t> *inodeIds,
+        const std::set<uint64_t> &inodeIds,
         std::list<InodeAttr> *attr) override;
 
     MetaStatusCode BatchGetXAttr(uint32_t fsId,
-        std::set<uint64_t> *inodeIds,
+        const std::set<uint64_t> &inodeIds,
         std::list<XAttr> *xattr) override;
 
     MetaStatusCode UpdateInode(const Inode &inode,
@@ -194,6 +198,10 @@ class MetaServerClientImpl : public MetaServerClient {
     MetaStatusCode CreateInode(const InodeParam &param, Inode *out) override;
 
     MetaStatusCode DeleteInode(uint32_t fsId, uint64_t inodeid) override;
+
+    bool SplitRequestInodes(uint32_t fsId,
+        const std::set<uint64_t> &inodeIds,
+        std::vector<std::vector<uint64_t>> *inodeGroups) override;
 
  private:
     bool ParseS3MetaStreamBuffer(butil::IOBuf* buffer,

--- a/curvefs/test/client/mock_metaserver_client.h
+++ b/curvefs/test/client/mock_metaserver_client.h
@@ -76,11 +76,11 @@ class MockMetaServerClient : public MetaServerClient {
             uint32_t fsId, uint64_t inodeid, Inode *out, bool* streaming));
 
     MOCK_METHOD3(BatchGetInodeAttr, MetaStatusCode(
-        uint32_t fsId, std::set<uint64_t> *inodeIds,
+        uint32_t fsId, const std::set<uint64_t> &inodeIds,
         std::list<InodeAttr> *attr));
 
     MOCK_METHOD3(BatchGetXAttr, MetaStatusCode(
-        uint32_t fsId, std::set<uint64_t> *inodeIds,
+        uint32_t fsId, const std::set<uint64_t> &inodeIds,
         std::list<XAttr> *xattr));
 
     MOCK_METHOD2(UpdateInode,
@@ -112,6 +112,10 @@ class MockMetaServerClient : public MetaServerClient {
             const InodeParam &param, Inode *out));
 
     MOCK_METHOD2(DeleteInode, MetaStatusCode(uint32_t fsId, uint64_t inodeid));
+
+    MOCK_METHOD3(SplitRequestInodes, bool(uint32_t fsId,
+        const std::set<uint64_t> &inodeIds,
+        std::vector<std::vector<uint64_t>> *inodeGroups));
 };
 
 }  // namespace rpcclient

--- a/curvefs/test/client/rpcclient/metaserver_client_test.cpp
+++ b/curvefs/test/client/rpcclient/metaserver_client_test.cpp
@@ -1154,7 +1154,7 @@ TEST_F(MetaServerClientImplTest, test_BatchGetInodeAttr) {
                               SetArgPointee<3>(applyIndex), Return(true)));
 
     MetaStatusCode status = metaserverCli_.BatchGetInodeAttr(
-        fsid, &inodeIds, &attr);
+        fsid, inodeIds, &attr);
     ASSERT_EQ(MetaStatusCode::RPC_ERROR, status);
 
     // test1: batchGetInodeAttr ok
@@ -1176,7 +1176,7 @@ TEST_F(MetaServerClientImplTest, test_BatchGetInodeAttr) {
                   BatchGetInodeAttrResponse>)));
     EXPECT_CALL(*mockMetacache_.get(), UpdateApplyIndex(_, _));
 
-    status = metaserverCli_.BatchGetInodeAttr(fsid, &inodeIds, &attr);
+    status = metaserverCli_.BatchGetInodeAttr(fsid, inodeIds, &attr);
     ASSERT_EQ(MetaStatusCode::OK, status);
     ASSERT_EQ(attr.size(), 2);
     ASSERT_THAT(attr.begin()->inodeid(), AnyOf(inodeId1, inodeId2));
@@ -1192,7 +1192,7 @@ TEST_F(MetaServerClientImplTest, test_BatchGetInodeAttr) {
             DoAll(SetArgPointee<2>(response),
                   Invoke(SetRpcService<BatchGetInodeAttrRequest,
                   BatchGetInodeAttrResponse>)));
-    status = metaserverCli_.BatchGetInodeAttr(fsid, &inodeIds, &attr);
+    status = metaserverCli_.BatchGetInodeAttr(fsid, inodeIds, &attr);
     ASSERT_EQ(MetaStatusCode::NOT_FOUND, status);
 
     // test3: test response do not have applyindex
@@ -1208,7 +1208,7 @@ TEST_F(MetaServerClientImplTest, test_BatchGetInodeAttr) {
                   Invoke(SetRpcService<BatchGetInodeAttrRequest,
                   BatchGetInodeAttrResponse>)));
 
-    status = metaserverCli_.BatchGetInodeAttr(fsid, &inodeIds, &attr);
+    status = metaserverCli_.BatchGetInodeAttr(fsid, inodeIds, &attr);
     ASSERT_EQ(MetaStatusCode::RPC_ERROR, status);
 }
 
@@ -1256,7 +1256,7 @@ TEST_F(MetaServerClientImplTest, test_BatchGetXAttr) {
                               SetArgPointee<3>(applyIndex), Return(true)));
 
     MetaStatusCode status = metaserverCli_.BatchGetXAttr(
-        fsid, &inodeIds, &xattr);
+        fsid, inodeIds, &xattr);
     ASSERT_EQ(MetaStatusCode::RPC_ERROR, status);
 
     // test1: batchGetXAttr ok
@@ -1278,7 +1278,7 @@ TEST_F(MetaServerClientImplTest, test_BatchGetXAttr) {
                   BatchGetXAttrResponse>)));
     EXPECT_CALL(*mockMetacache_.get(), UpdateApplyIndex(_, _));
 
-    status = metaserverCli_.BatchGetXAttr(fsid, &inodeIds, &xattr);
+    status = metaserverCli_.BatchGetXAttr(fsid, inodeIds, &xattr);
     ASSERT_EQ(MetaStatusCode::OK, status);
     ASSERT_EQ(xattr.size(), 2);
     ASSERT_THAT(xattr.begin()->inodeid(), AnyOf(inodeId1, inodeId2));
@@ -1294,7 +1294,7 @@ TEST_F(MetaServerClientImplTest, test_BatchGetXAttr) {
             DoAll(SetArgPointee<2>(response),
                   Invoke(SetRpcService<BatchGetXAttrRequest,
                   BatchGetXAttrResponse>)));
-    status = metaserverCli_.BatchGetXAttr(fsid, &inodeIds, &xattr);
+    status = metaserverCli_.BatchGetXAttr(fsid, inodeIds, &xattr);
     ASSERT_EQ(MetaStatusCode::NOT_FOUND, status);
 
     // test3: test response do not have applyindex
@@ -1310,7 +1310,7 @@ TEST_F(MetaServerClientImplTest, test_BatchGetXAttr) {
                   Invoke(SetRpcService<BatchGetXAttrRequest,
                   BatchGetXAttrResponse>)));
 
-    status = metaserverCli_.BatchGetXAttr(fsid, &inodeIds, &xattr);
+    status = metaserverCli_.BatchGetXAttr(fsid, inodeIds, &xattr);
     ASSERT_EQ(MetaStatusCode::RPC_ERROR, status);
 }
 

--- a/curvefs/test/client/test_inode_cache_manager.cpp
+++ b/curvefs/test/client/test_inode_cache_manager.cpp
@@ -234,7 +234,7 @@ TEST_F(TestInodeCacheManager, BatchGetInodeAttr) {
     attr.set_inodeid(inodeId2);
     attrs.emplace_back(attr);
 
-    EXPECT_CALL(*metaClient_, BatchGetInodeAttr(fsId_, &inodeIds, _))
+    EXPECT_CALL(*metaClient_, BatchGetInodeAttr(fsId_, inodeIds, _))
         .WillOnce(Return(MetaStatusCode::NOT_FOUND))
         .WillOnce(DoAll(SetArgPointee<2>(attrs),
                 Return(MetaStatusCode::OK)));
@@ -274,7 +274,7 @@ TEST_F(TestInodeCacheManager, BatchGetXAttr) {
     xattr.mutable_xattrinfos()->find(XATTRFBYTES)->second = "200";
     xattrs.emplace_back(xattr);
 
-    EXPECT_CALL(*metaClient_, BatchGetXAttr(fsId_, &inodeIds, _))
+    EXPECT_CALL(*metaClient_, BatchGetXAttr(fsId_, inodeIds, _))
         .WillOnce(Return(MetaStatusCode::NOT_FOUND))
         .WillOnce(DoAll(SetArgPointee<2>(xattrs),
                 Return(MetaStatusCode::OK)));


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #xxx <!-- replace xxx with issue number -->
#1427
Problem Summary:
The before logic will crash when rcp retry, the iter will forward when retry but this is not expected.
![截屏2022-05-20 14 37 07](https://user-images.githubusercontent.com/13496900/169468412-ca9eadf9-38b9-45a8-bf3b-df0cf16a5b0e.png)


### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
