### PR TITLE
curvefs/tool: fix query inode coredump

### DIFF
--- a/curvefs/src/tools/query/curvefs_inode.cpp
+++ b/curvefs/src/tools/query/curvefs_inode.cpp
@@ -86,11 +86,11 @@ int InodeTool::Init() {
 
     for (size_t i = 0; i < poolsId.size(); ++i) {
         curvefs::metaserver::GetInodeRequest request;
-        request.set_poolid(std::stoi(poolsId[i]));
-        request.set_copysetid(std::stoi(copysetsId[i]));
-        request.set_partitionid(std::stoi(partitionId[i]));
-        request.set_fsid(std::stoi(fsId[i]));
-        request.set_inodeid(std::stoi(inodeId[i]));
+        request.set_poolid(std::stoul((poolsId[i])));
+        request.set_copysetid(std::stoul((copysetsId[i])));
+        request.set_partitionid(std::stoul((partitionId[i])));
+        request.set_fsid(std::stoul((fsId[i])));
+        request.set_inodeid(std::stoull(inodeId[i]));
         SetStreamingRpc(false);
         request.set_supportstreaming(true);
         AddRequest(request);

--- a/curvefs/src/tools/query/curvefs_inode_s3infomap.cpp
+++ b/curvefs/src/tools/query/curvefs_inode_s3infomap.cpp
@@ -103,11 +103,11 @@ int InodeS3InfoMapTool::Init() {
 
     for (size_t i = 0; i < poolsId.size(); ++i) {
         curvefs::metaserver::GetOrModifyS3ChunkInfoRequest request;
-        request.set_poolid(std::stoi(poolsId[i]));
-        request.set_copysetid(std::stoi(copysetsId[i]));
-        request.set_partitionid(std::stoi(partitionId[i]));
-        request.set_fsid(std::stoi(fsId[i]));
-        request.set_inodeid(std::stoi(inodeId[i]));
+        request.set_poolid(std:: stoul((poolsId[i])));
+        request.set_copysetid(std:: stoul((copysetsId[i])));
+        request.set_partitionid(std:: stoul((partitionId[i])));
+        request.set_fsid(std:: stoul((fsId[i])));
+        request.set_inodeid(std:: stoull((inodeId[i])));
         request.set_returns3chunkinfomap(true);
         SetStreamingRpc(true);
         request.set_supportstreaming(isStreaming_);


### PR DESCRIPTION

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #1476  <!-- replace xxx with issue number -->

Problem Summary:

### What is changed and how it works?

What's Changed:

inodeId should be uint64_t, use std::stoi to convert the address out of
bounds, should be std::stoull

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
