### PR TITLE
curvefs: improve performance of command ls -*.

### DIFF
--- a/curvefs/conf/client.conf
+++ b/curvefs/conf/client.conf
@@ -52,7 +52,8 @@ excutorOpt.maxRPCTimeoutMS=8000
 excutorOpt.maxRetrySleepIntervalUS=8000000
 excutorOpt.minRetryTimesForceTimeoutBackoff=5
 excutorOpt.maxRetryTimesBeforeConsiderSuspend=20
-excutorOpt.batchLimit=10000
+# batch limit of get inode attr and xattr
+excutorOpt.batchInodeAttrLimit=10000
 
 #### spaceserver
 spaceserver.spaceaddr=127.0.0.1:19999  # __ANSIBLE_TEMPLATE__ {{ groups.space | join_peer(hostvars, "space_listen_port") }} __ANSIBLE_TEMPLATE__
@@ -99,6 +100,8 @@ fuseClient.enableMultiMountPointRename=true
 fuseClient.enableSplice=false
 # thread number of listDentry when get summary xattr
 fuseClient.listDentryThreads=10
+# disable xattr on one mountpoint can fast 'ls -l'
+fuseClient.disableXattr=false
 
 #### volume
 volume.bigFileSize=1048576

--- a/curvefs/proto/metaserver.proto
+++ b/curvefs/proto/metaserver.proto
@@ -372,6 +372,8 @@ message InodeAttr {
     optional uint64 rdev = 16;
     optional uint32 dtime = 17;
     optional uint32 openmpcount = 18;
+    map<string, string> xattr = 19;
+    repeated uint64 parent = 20;
 }
 
 message BatchGetInodeAttrRequest {

--- a/curvefs/src/client/common/config.cpp
+++ b/curvefs/src/client/common/config.cpp
@@ -98,7 +98,8 @@ void InitExcutorOption(Configuration *conf, ExcutorOpt *opts) {
                               &opts->minRetryTimesForceTimeoutBackoff);
     conf->GetValueFatalIfFail("excutorOpt.maxRetryTimesBeforeConsiderSuspend",
                               &opts->maxRetryTimesBeforeConsiderSuspend);
-    conf->GetValueFatalIfFail("excutorOpt.batchLimit", &opts->batchLimit);
+    conf->GetValueFatalIfFail("excutorOpt.batchInodeAttrLimit",
+                              &opts->batchInodeAttrLimit);
     conf->GetValueFatalIfFail("fuseClient.enableMultiMountPointRename",
                               &opts->enableRenameParallel);
 }
@@ -259,6 +260,8 @@ void InitFuseClientOption(Configuration *conf, FuseClientOption *clientOption) {
                               &clientOption->dummyServerStartPort);
     conf->GetValueFatalIfFail("fuseClient.enableMultiMountPointRename",
                               &clientOption->enableMultiMountPointRename);
+    conf->GetValueFatalIfFail("fuseClient.disableXattr",
+                              &clientOption->disableXattr);
 
     LOG_IF(WARNING, conf->GetBoolValue("fuseClient.enableSplice",
                                        &clientOption->enableFuseSplice))

--- a/curvefs/src/client/common/config.h
+++ b/curvefs/src/client/common/config.h
@@ -66,7 +66,7 @@ struct ExcutorOpt {
     uint64_t maxRetrySleepIntervalUS = 64ull * 1000 * 1000;
     uint64_t minRetryTimesForceTimeoutBackoff = 5;
     uint64_t maxRetryTimesBeforeConsiderSuspend = 20;
-    uint32_t batchLimit = 100;
+    uint32_t batchInodeAttrLimit = 10000;
     bool enableRenameParallel = false;
 };
 
@@ -186,12 +186,10 @@ struct FuseClientOption {
     uint64_t dCacheLruSize;
     bool enableICacheMetrics;
     bool enableDCacheMetrics;
-
     uint32_t dummyServerStartPort;
-
     bool enableMultiMountPointRename = false;
-
     bool enableFuseSplice = false;
+    bool disableXattr = false;
 };
 
 void InitFuseClientOption(Configuration *conf, FuseClientOption *clientOption);

--- a/curvefs/src/client/dentry_cache_manager.h
+++ b/curvefs/src/client/dentry_cache_manager.h
@@ -24,10 +24,13 @@
 #ifndef CURVEFS_SRC_CLIENT_DENTRY_CACHE_MANAGER_H_
 #define CURVEFS_SRC_CLIENT_DENTRY_CACHE_MANAGER_H_
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <list>
 #include <unordered_map>
+#include <map>
+#include <utility>
 
 #include "curvefs/src/client/rpcclient/metaserver_client.h"
 #include "curvefs/src/client/error_code.h"
@@ -44,6 +47,8 @@ namespace client {
 
 using rpcclient::MetaServerClient;
 using rpcclient::MetaServerClientImpl;
+
+static const char* kDentryKeyDelimiter = ":";
 
 class DentryCacheManager {
  public:
@@ -75,8 +80,6 @@ class DentryCacheManager {
  protected:
     uint32_t fsId_;
 };
-
-static const char* kDentryKeyDelimiter = ":";
 
 class DentryCacheManagerImpl : public DentryCacheManager {
  public:

--- a/curvefs/src/client/fuse_client.h
+++ b/curvefs/src/client/fuse_client.h
@@ -160,10 +160,11 @@ class FuseClient {
     virtual CURVEFS_ERROR FuseOpReleaseDir(fuse_req_t req, fuse_ino_t ino,
                                            struct fuse_file_info* fi);
 
-    virtual CURVEFS_ERROR FuseOpReadDir(fuse_req_t req, fuse_ino_t ino,
-                                        size_t size, off_t off,
-                                        struct fuse_file_info* fi,
-                                        char** buffer, size_t* rSize);
+    virtual CURVEFS_ERROR FuseOpReadDirPlus(fuse_req_t req, fuse_ino_t ino,
+                                            size_t size, off_t off,
+                                            struct fuse_file_info* fi,
+                                            char** buffer, size_t* rSize,
+                                            bool cacheDir);
 
     virtual CURVEFS_ERROR FuseOpRename(fuse_req_t req, fuse_ino_t parent,
                                        const char* name, fuse_ino_t newparent,
@@ -251,10 +252,6 @@ class FuseClient {
 
     CURVEFS_ERROR RemoveNode(fuse_req_t req, fuse_ino_t parent,
                              const char* name, bool idDir);
-
-    void GetDentryParamFromInode(
-        const std::shared_ptr<InodeWrapper> &inodeWrapper_,
-        fuse_entry_param *param);
 
     int SetHostPortInMountPoint(Mountpoint* out) {
         char hostname[kMaxHostNameLength];

--- a/curvefs/src/client/inode_cache_manager.cpp
+++ b/curvefs/src/client/inode_cache_manager.cpp
@@ -24,8 +24,9 @@
 #include "curvefs/src/client/inode_cache_manager.h"
 
 #include <glog/logging.h>
-
+#include <cstdint>
 #include <map>
+#include <memory>
 #include <utility>
 #include "curvefs/proto/metaserver.pb.h"
 #include "curvefs/src/client/error_code.h"
@@ -46,17 +47,16 @@ namespace client {
 
 using NameLockGuard = ::curve::common::GenericNameLockGuard<Mutex>;
 
-CURVEFS_ERROR InodeCacheManagerImpl::GetInode(uint64_t inodeid,
+CURVEFS_ERROR InodeCacheManagerImpl::GetInode(uint64_t inodeId,
     std::shared_ptr<InodeWrapper> &out) {
-    NameLockGuard lock(nameLock_, std::to_string(inodeid));
-    bool ok = iCache_->Get(inodeid, &out);
+    NameLockGuard lock(nameLock_, std::to_string(inodeId));
+    bool ok = iCache_->Get(inodeId, &out);
     if (ok) {
-        // if enableCto and file is unopen, we need reload from
-        // metaserver
+        // if enableCto, we need and is unopen, we need reload from metaserver
         if (curvefs::client::common::FLAGS_enableCto && !out->IsOpen()) {
             VLOG(6) << "InodeCacheManagerImpl, GetInode: enableCto and inode: "
-                    << inodeid << " opencount is 0";
-            iCache_->Remove(inodeid);
+                    << inodeId << " opencount is 0";
+            iCache_->Remove(inodeId);
         } else {
             return CURVEFS_ERROR::OK;
         }
@@ -66,12 +66,13 @@ CURVEFS_ERROR InodeCacheManagerImpl::GetInode(uint64_t inodeid,
     bool streaming;
 
     MetaStatusCode ret2 = metaClient_->GetInode(
-        fsId_, inodeid, &inode, &streaming);
+        fsId_, inodeId, &inode, &streaming);
+
     if (ret2 != MetaStatusCode::OK) {
         LOG_IF(ERROR, ret2 != MetaStatusCode::NOT_FOUND)
             << "metaClient_ GetInode failed, MetaStatusCode = " << ret2
             << ", MetaStatusCode_Name = " << MetaStatusCode_Name(ret2)
-            << ", inodeid = " << inodeid;
+            << ", inodeid = " << inodeId;
         return MetaStatusCodeToCurvefsErrCode(ret2);
     }
 
@@ -97,12 +98,53 @@ CURVEFS_ERROR InodeCacheManagerImpl::GetInode(uint64_t inodeid,
     }
 
     std::shared_ptr<InodeWrapper> eliminatedOne;
-    bool eliminated = iCache_->Put(inodeid, out, &eliminatedOne);
+    bool eliminated = iCache_->Put(inodeId, out, &eliminatedOne);
     if (eliminated) {
         VLOG(3) << "GetInode eliminate one inode, ino: "
                 << eliminatedOne->GetInodeId();
         eliminatedOne->FlushAsync();
     }
+    return CURVEFS_ERROR::OK;
+}
+
+CURVEFS_ERROR InodeCacheManagerImpl::GetInodeAttr(uint64_t inodeId,
+    InodeAttr *out, uint64_t parentId) {
+    NameLockGuard lock(nameLock_, std::to_string(inodeId));
+    // 1. find in icache
+    std::shared_ptr<InodeWrapper> inodeWrapper;
+    bool ok = iCache_->Get(inodeId, &inodeWrapper);
+    if (ok) {
+        if (curvefs::client::common::FLAGS_enableCto &&
+            !inodeWrapper->IsOpen()) {
+            iCache_->Remove(inodeId);
+        } else {
+            inodeWrapper->GetInodeAttrLocked(out);
+            return CURVEFS_ERROR::OK;
+        }
+    }
+
+    // 2. get form metaserver
+    std::set<uint64_t> inodeIds;
+    std::list<InodeAttr> attrs;
+    inodeIds.emplace(inodeId);
+    MetaStatusCode ret = metaClient_->BatchGetInodeAttr(
+        fsId_, inodeIds, &attrs);
+    if (MetaStatusCode::OK != ret) {
+        LOG(ERROR) << "metaClient BatchGetInodeAttr failed"
+                   << ", inodeId = " << inodeId
+                   << ", MetaStatusCode = " << ret
+                   << ", MetaStatusCode_Name = " << MetaStatusCode_Name(ret);
+        return MetaStatusCodeToCurvefsErrCode(ret);
+    }
+
+    if (attrs.size() !=  1) {
+        LOG(ERROR) << "metaClient BatchGetInodeAttr error,"
+                   << " getSize is 1, inodeId = " << inodeId
+                   << "but real size = " << attrs.size();
+        return CURVEFS_ERROR::INTERNAL;
+    }
+
+    *out = *attrs.begin();
     return CURVEFS_ERROR::OK;
 }
 
@@ -135,6 +177,52 @@ CURVEFS_ERROR InodeCacheManagerImpl::BatchGetInodeAttr(
                    << MetaStatusCode_Name(ret);
     }
     return MetaStatusCodeToCurvefsErrCode(ret);
+}
+
+CURVEFS_ERROR InodeCacheManagerImpl::BatchGetInodeAttrAsync(
+    uint64_t parentId,
+    const std::set<uint64_t> &inodeIds,
+    std::map<uint64_t, InodeAttr> *attrs) {
+    if (inodeIds.empty()) {
+        return CURVEFS_ERROR::OK;
+    }
+
+    NameLockGuard lg(asyncNameLock_, std::to_string(parentId));
+    bool ok  = iAttrCache_->Get(parentId, attrs);
+    if (ok) {
+        return CURVEFS_ERROR::OK;
+    }
+
+    // split inodeIds by partitionId and batch limit
+    std::vector<std::vector<uint64_t>> inodeGroups;
+    if (!metaClient_->SplitRequestInodes(fsId_, inodeIds, &inodeGroups)) {
+        return CURVEFS_ERROR::NOTEXIST;
+    }
+
+    std::shared_ptr<CountDownEvent> cond =
+        std::make_shared<CountDownEvent>(inodeGroups.size());
+    for (const auto& it : inodeGroups) {
+        VLOG(3) << "BatchGetInodeAttrAsync Send " << it.size();
+        auto* done = new BatchGetInodeAttrAsyncDone(shared_from_this(),
+                                                    cond, parentId);
+        MetaStatusCode ret = metaClient_->BatchGetInodeAttrAsync(fsId_, it,
+                                                                 done);
+        if (MetaStatusCode::OK != ret) {
+            LOG(ERROR) << "metaClient BatchGetInodeAsync failed,"
+                       << " MetaStatusCode = " << ret
+                       << ", MetaStatusCode_Name = "
+                       << MetaStatusCode_Name(ret);
+        }
+    }
+
+    // wait for all sudrequest finished
+    cond->Wait();
+
+    ok  = iAttrCache_->Get(parentId, attrs);
+    if (!ok) {
+        LOG(WARNING) << "get attrs form iAttrCache_ failed.";
+    }
+    return CURVEFS_ERROR::OK;
 }
 
 CURVEFS_ERROR InodeCacheManagerImpl::BatchGetXAttr(
@@ -194,29 +282,34 @@ CURVEFS_ERROR InodeCacheManagerImpl::CreateInode(
     return CURVEFS_ERROR::OK;
 }
 
-CURVEFS_ERROR InodeCacheManagerImpl::DeleteInode(uint64_t inodeid) {
-    NameLockGuard lock(nameLock_, std::to_string(inodeid));
-    iCache_->Remove(inodeid);
-    MetaStatusCode ret = metaClient_->DeleteInode(fsId_, inodeid);
+CURVEFS_ERROR InodeCacheManagerImpl::DeleteInode(uint64_t inodeId) {
+    NameLockGuard lock(nameLock_, std::to_string(inodeId));
+    iCache_->Remove(inodeId);
+    MetaStatusCode ret = metaClient_->DeleteInode(fsId_, inodeId);
     if (ret != MetaStatusCode::OK && ret != MetaStatusCode::NOT_FOUND) {
         LOG(ERROR) << "metaClient_ DeleteInode failed, MetaStatusCode = " << ret
                    << ", MetaStatusCode_Name = " << MetaStatusCode_Name(ret)
-                   << ", inodeid = " << inodeid;
+                   << ", inodeId = " << inodeId;
         return MetaStatusCodeToCurvefsErrCode(ret);
     }
 
     curve::common::LockGuard lg2(dirtyMapMutex_);
-    dirtyMap_.erase(inodeid);
+    dirtyMap_.erase(inodeId);
     return CURVEFS_ERROR::OK;
 }
 
-void InodeCacheManagerImpl::ClearInodeCache(uint64_t inodeid) {
+void InodeCacheManagerImpl::AddInodeAttrs(
+    uint64_t parentId, const RepeatedPtrField<InodeAttr>& inodeAttrs) {
+    iAttrCache_->Set(parentId, inodeAttrs);
+}
+
+void InodeCacheManagerImpl::ClearInodeCache(uint64_t inodeId) {
     {
-        NameLockGuard lock(nameLock_, std::to_string(inodeid));
-        iCache_->Remove(inodeid);
+        NameLockGuard lock(nameLock_, std::to_string(inodeId));
+        iCache_->Remove(inodeId);
     }
     curve::common::LockGuard lg2(dirtyMapMutex_);
-    dirtyMap_.erase(inodeid);
+    dirtyMap_.erase(inodeId);
 }
 
 void InodeCacheManagerImpl::ShipToFlush(
@@ -241,6 +334,11 @@ void InodeCacheManagerImpl::FlushInodeOnce() {
         curve::common::UniqueLock ulk = it->second->GetUniqueLock();
         it->second->FlushAsync();
     }
+}
+
+void InodeCacheManagerImpl::ReleaseCache(uint64_t parentId) {
+    NameLockGuard lg(asyncNameLock_, std::to_string(parentId));
+    iAttrCache_->Release(parentId);
 }
 
 }  // namespace client

--- a/curvefs/src/client/inode_cache_manager.h
+++ b/curvefs/src/client/inode_cache_manager.h
@@ -24,12 +24,16 @@
 #ifndef CURVEFS_SRC_CLIENT_INODE_CACHE_MANAGER_H_
 #define CURVEFS_SRC_CLIENT_INODE_CACHE_MANAGER_H_
 
+#include <cstdint>
 #include <memory>
 #include <unordered_map>
 #include <map>
 #include <set>
 #include <list>
+#include <vector>
+#include <utility>
 
+#include "curvefs/src/client/rpcclient/task_excutor.h"
 #include "src/common/lru_cache.h"
 
 #include "curvefs/src/client/rpcclient/metaserver_client.h"
@@ -50,6 +54,52 @@ namespace client {
 using rpcclient::MetaServerClient;
 using rpcclient::MetaServerClientImpl;
 using rpcclient::InodeParam;
+using rpcclient::MetaServerClientDone;
+using rpcclient::BatchGetInodeAttrDone;
+using curve::common::CountDownEvent;
+
+class InodeAttrCache {
+ public:
+    InodeAttrCache() {}
+    ~InodeAttrCache() {}
+
+    bool Get(uint64_t parentId, std::map<uint64_t, InodeAttr> *imap) {
+        curve::common::LockGuard lg(iAttrCacheMutex_);
+        auto iter = iAttrCache_.find(parentId);
+        if (iter != iAttrCache_.end()) {
+            *imap = iter->second;
+            return true;
+        }
+        return false;
+    }
+
+    void Set(uint64_t parentId, const RepeatedPtrField<InodeAttr>& inodeAttrs) {
+        curve::common::LockGuard lg(iAttrCacheMutex_);
+        VLOG(1) << "parentId = " << parentId
+                << ", iAttrCache set size = " << inodeAttrs.size();
+        auto& inner = iAttrCache_[parentId];
+        for (const auto &it : inodeAttrs) {
+            inner.emplace(it.inodeid(), it);
+        }
+    }
+
+    void Release(uint64_t parentId) {
+        curve::common::LockGuard lg(iAttrCacheMutex_);
+        auto size = iAttrCache_.size();
+        auto iter = iAttrCache_.find(parentId);
+        if (iter != iAttrCache_.end()) {
+            iAttrCache_.erase(iter);
+        }
+        VLOG(1) << "inodeId = " << parentId
+                << ", inode attr cache release, before = "
+                << size << ", after = " << iAttrCache_.size();
+    }
+
+ private:
+    // inodeAttr cache; <parentId, <inodeId, inodeAttr>>
+    std::map<uint64_t, std::map<uint64_t, InodeAttr>> iAttrCache_;
+    curve::common::Mutex iAttrCacheMutex_;
+};
 
 class InodeCacheManager {
  public:
@@ -63,12 +113,20 @@ class InodeCacheManager {
 
     virtual CURVEFS_ERROR Init(uint64_t cacheSize, bool enableCacheMetrics) = 0;
 
-    virtual CURVEFS_ERROR GetInode(uint64_t inodeid,
+    virtual CURVEFS_ERROR GetInode(uint64_t inodeId,
         std::shared_ptr<InodeWrapper> &out) = 0;   // NOLINT
+
+    virtual CURVEFS_ERROR GetInodeAttr(uint64_t inodeId,
+        InodeAttr *out, uint64_t parentId = 0) = 0;
 
     virtual CURVEFS_ERROR BatchGetInodeAttr(
         std::set<uint64_t> *inodeIds,
         std::list<InodeAttr> *attrs) = 0;
+
+    virtual CURVEFS_ERROR BatchGetInodeAttrAsync(
+        uint64_t parentId,
+        const std::set<uint64_t> &inodeIds,
+        std::map<uint64_t, InodeAttr> *attrs) = 0;
 
     virtual CURVEFS_ERROR BatchGetXAttr(std::set<uint64_t> *inodeIds,
         std::list<XAttr> *xattrs) = 0;
@@ -76,9 +134,12 @@ class InodeCacheManager {
     virtual CURVEFS_ERROR CreateInode(const InodeParam &param,
         std::shared_ptr<InodeWrapper> &out) = 0;   // NOLINT
 
-    virtual CURVEFS_ERROR DeleteInode(uint64_t inodeid) = 0;
+    virtual CURVEFS_ERROR DeleteInode(uint64_t inodeId) = 0;
 
-    virtual void ClearInodeCache(uint64_t inodeid) = 0;
+    virtual void AddInodeAttrs(uint64_t parentId,
+        const RepeatedPtrField<InodeAttr>& inodeAttrs) = 0;
+
+    virtual void ClearInodeCache(uint64_t inodeId) = 0;
 
     virtual void ShipToFlush(
         const std::shared_ptr<InodeWrapper> &inodeWrapper) = 0;
@@ -87,20 +148,25 @@ class InodeCacheManager {
 
     virtual void FlushInodeOnce() = 0;
 
+    virtual void ReleaseCache(uint64_t parentId) = 0;
+
  protected:
     uint32_t fsId_;
 };
 
-class InodeCacheManagerImpl : public InodeCacheManager {
+class InodeCacheManagerImpl : public InodeCacheManager,
+    public std::enable_shared_from_this<InodeCacheManagerImpl> {
  public:
     InodeCacheManagerImpl()
       : metaClient_(std::make_shared<MetaServerClientImpl>()),
-        iCache_(nullptr) {}
+        iCache_(nullptr),
+        iAttrCache_(nullptr) {}
 
     explicit InodeCacheManagerImpl(
         const std::shared_ptr<MetaServerClient> &metaClient)
       : metaClient_(metaClient),
-        iCache_(nullptr) {}
+        iCache_(nullptr),
+        iAttrCache_(nullptr) {}
 
     CURVEFS_ERROR Init(uint64_t cacheSize, bool enableCacheMetrics) override {
         if (enableCacheMetrics) {
@@ -111,24 +177,35 @@ class InodeCacheManagerImpl : public InodeCacheManager {
             iCache_ = std::make_shared<
                 LRUCache<uint64_t, std::shared_ptr<InodeWrapper>>>(cacheSize);
         }
+        iAttrCache_ = std::make_shared<InodeAttrCache>();
         return CURVEFS_ERROR::OK;
     }
 
-    CURVEFS_ERROR GetInode(uint64_t inodeid,
-        std::shared_ptr<InodeWrapper> &out) override;    // NOLINT
+    CURVEFS_ERROR GetInode(uint64_t inodeId,
+        std::shared_ptr<InodeWrapper> &out) override;
+
+    CURVEFS_ERROR GetInodeAttr(uint64_t inodeId,
+        InodeAttr *out, uint64_t parentId) override;
 
     CURVEFS_ERROR BatchGetInodeAttr(std::set<uint64_t> *inodeIds,
         std::list<InodeAttr> *attrs) override;
+
+    CURVEFS_ERROR BatchGetInodeAttrAsync(uint64_t parentId,
+        const std::set<uint64_t> &inodeIds,
+        std::map<uint64_t, InodeAttr> *attrs = nullptr) override;
 
     CURVEFS_ERROR BatchGetXAttr(std::set<uint64_t> *inodeIds,
         std::list<XAttr> *xattrs) override;
 
     CURVEFS_ERROR CreateInode(const InodeParam &param,
-        std::shared_ptr<InodeWrapper> &out) override;    // NOLINT
+        std::shared_ptr<InodeWrapper> &out) override;
 
-    CURVEFS_ERROR DeleteInode(uint64_t inodeid) override;
+    CURVEFS_ERROR DeleteInode(uint64_t inodeId) override;
 
-    void ClearInodeCache(uint64_t inodeid) override;
+    void AddInodeAttrs(uint64_t parentId,
+        const RepeatedPtrField<InodeAttr>& inodeAttrs) override;
+
+    void ClearInodeCache(uint64_t inodeId) override;
 
     void ShipToFlush(
         const std::shared_ptr<InodeWrapper> &inodeWrapper) override;
@@ -137,17 +214,56 @@ class InodeCacheManagerImpl : public InodeCacheManager {
 
     void FlushInodeOnce() override;
 
+    void ReleaseCache(uint64_t parentId) override;
+
  private:
     std::shared_ptr<MetaServerClient> metaClient_;
     std::shared_ptr<LRUCache<uint64_t, std::shared_ptr<InodeWrapper>>> iCache_;
+
+    std::shared_ptr<InodeAttrCache> iAttrCache_;
 
     // dirty map, key is inodeid
     std::map<uint64_t, std::shared_ptr<InodeWrapper>> dirtyMap_;
     curve::common::Mutex dirtyMapMutex_;
 
     curve::common::GenericNameLock<Mutex> nameLock_;
+
+    curve::common::GenericNameLock<Mutex> asyncNameLock_;
 };
 
+class BatchGetInodeAttrAsyncDone : public BatchGetInodeAttrDone {
+ public:
+    BatchGetInodeAttrAsyncDone(
+        const std::shared_ptr<InodeCacheManager> &inodeCacheManager,
+        std::shared_ptr<CountDownEvent> cond,
+        uint64_t parentId):
+        inodeCacheManager_(inodeCacheManager),
+        cond_(cond),
+        parentId_(parentId) {}
+    ~BatchGetInodeAttrAsyncDone() {}
+
+    void Run() override {
+        std::unique_ptr<BatchGetInodeAttrAsyncDone> self_guard(this);
+        MetaStatusCode ret = GetStatusCode();
+        if (ret != MetaStatusCode::OK) {
+            LOG(ERROR) << "BatchGetInodeAttrAsync failed, "
+                       << "parentId = " << parentId_
+                       << ", MetaStatusCode: " << ret
+                       << ", MetaStatusCode_Name: " << MetaStatusCode_Name(ret);
+        } else {
+            auto inodeAttrs = GetInodeAttrs();
+            VLOG(3) << "BatchGetInodeAttrAsyncDone update inodeAttrCache"
+                    << " size = " << inodeAttrs.size();
+            inodeCacheManager_->AddInodeAttrs(parentId_, inodeAttrs);
+        }
+        cond_->Signal();
+    };
+
+ private:
+    std::shared_ptr<InodeCacheManager> inodeCacheManager_;
+    std::shared_ptr<CountDownEvent> cond_;
+    uint64_t parentId_;
+};
 
 }  // namespace client
 }  // namespace curvefs

--- a/curvefs/src/client/lease/lease_excutor.cpp
+++ b/curvefs/src/client/lease/lease_excutor.cpp
@@ -82,7 +82,8 @@ bool LeaseExecutor::RefreshLease() {
     std::vector<PartitionTxId> latestTxIdList;
     FSStatusCode ret = mdsCli_->RefreshSession(txIds, &latestTxIdList);
     if (ret != FSStatusCode::OK) {
-        LOG(ERROR) << "LeaseExecutor refresh session fail, ret = " << ret;
+        LOG(ERROR) << "LeaseExecutor refresh session fail, ret = " << ret
+                   << "errorName = " << FSStatusCode_Name(ret);
         return true;
     }
 

--- a/curvefs/src/client/main.cpp
+++ b/curvefs/src/client/main.cpp
@@ -47,7 +47,11 @@ static const struct fuse_lowlevel_ops curve_ll_oper = {
     release : FuseOpRelease,
     fsync : FuseOpFsync,
     opendir : FuseOpOpenDir,
+    #if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)
+    readdir : 0,
+    #else
     readdir : FuseOpReadDir,
+    #endif
     releasedir : FuseOpReleaseDir,
     fsyncdir : 0,
     statfs : FuseOpStatFs,
@@ -72,7 +76,7 @@ static const struct fuse_lowlevel_ops curve_ll_oper = {
     fallocate : 0,
     #endif
     #if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)
-    readdirplus : 0,
+    readdirplus : FuseOpReadDirPlus,
     #endif
     #if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 4)
     copy_file_range : 0,

--- a/curvefs/src/client/rpcclient/metaserver_client.h
+++ b/curvefs/src/client/rpcclient/metaserver_client.h
@@ -95,6 +95,9 @@ class MetaServerClient {
         const std::set<uint64_t> &inodeIds,
         std::list<InodeAttr> *attr) = 0;
 
+    virtual MetaStatusCode BatchGetInodeAttrAsync(uint32_t fsId,
+        const std::vector<uint64_t> &inodeIds, MetaServerClientDone *done) = 0;
+
     virtual MetaStatusCode BatchGetXAttr(uint32_t fsId,
         const std::set<uint64_t> &inodeIds,
         std::list<XAttr> *xattr) = 0;
@@ -176,6 +179,10 @@ class MetaServerClientImpl : public MetaServerClient {
     MetaStatusCode BatchGetInodeAttr(uint32_t fsId,
         const std::set<uint64_t> &inodeIds,
         std::list<InodeAttr> *attr) override;
+
+    MetaStatusCode BatchGetInodeAttrAsync(uint32_t fsId,
+        const std::vector<uint64_t> &inodeIds,
+        MetaServerClientDone *done) override;
 
     MetaStatusCode BatchGetXAttr(uint32_t fsId,
         const std::set<uint64_t> &inodeIds,

--- a/curvefs/src/client/xattr_manager.cpp
+++ b/curvefs/src/client/xattr_manager.cpp
@@ -66,12 +66,12 @@ bool AddUllStringToFirst(uint64_t *first, const std::string &second) {
     return false;
 }
 
-CURVEFS_ERROR XattrManager::CalOneLayerSumInfo(Inode *inode) {
+CURVEFS_ERROR XattrManager::CalOneLayerSumInfo(InodeAttr *attr) {
     std::stack<uint64_t> iStack;
     // use set can deal with hard link
     std::set<uint64_t> inodeIds;
     std::list<InodeAttr> attrs;
-    auto ino = inode->inodeid();
+    auto ino = attr->inodeid();
 
     std::list<Dentry> dentryList;
     auto ret = dentryManager_->ListDentry(ino, &dentryList,
@@ -99,27 +99,27 @@ CURVEFS_ERROR XattrManager::CalOneLayerSumInfo(Inode *inode) {
             summaryInfo.fbytes += it.length();
         }
         if (!(AddUllStringToFirst(
-                &(inode->mutable_xattr()->find(XATTRFILES)->second),
+                &(attr->mutable_xattr()->find(XATTRFILES)->second),
                 summaryInfo.files, true) &&
             AddUllStringToFirst(
-                &(inode->mutable_xattr()->find(XATTRSUBDIRS)->second),
+                &(attr->mutable_xattr()->find(XATTRSUBDIRS)->second),
                 summaryInfo.subdirs, true) &&
             AddUllStringToFirst(
-                &(inode->mutable_xattr()->find(XATTRENTRIES)->second),
+                &(attr->mutable_xattr()->find(XATTRENTRIES)->second),
                 summaryInfo.entries, true) &&
             AddUllStringToFirst(
-                &(inode->mutable_xattr()->find(XATTRFBYTES)->second),
-                summaryInfo.fbytes + inode->length(), true))) {
+                &(attr->mutable_xattr()->find(XATTRFBYTES)->second),
+                summaryInfo.fbytes + attr->length(), true))) {
             ret = CURVEFS_ERROR::INTERNAL;
         }
     }
     return ret;
 }
 
-CURVEFS_ERROR XattrManager::FastCalOneLayerSumInfo(Inode *inode) {
+CURVEFS_ERROR XattrManager::FastCalOneLayerSumInfo(InodeAttr *attr) {
     if (!AddUllStringToFirst(
-        &(inode->mutable_xattr()->find(XATTRFBYTES)->second),
-        inode->length(), true)) {
+        &(attr->mutable_xattr()->find(XATTRFBYTES)->second),
+        attr->length(), true)) {
         return CURVEFS_ERROR::INTERNAL;
     }
     return CURVEFS_ERROR::OK;
@@ -231,7 +231,7 @@ void XattrManager::ConcurrentGetInodeAttr(
     }
 }
 
-CURVEFS_ERROR XattrManager::CalAllLayerSumInfo(Inode *inode) {
+CURVEFS_ERROR XattrManager::CalAllLayerSumInfo(InodeAttr *attr) {
     std::stack<uint64_t> iStack;
     std::mutex stackMutex;
 
@@ -242,7 +242,7 @@ CURVEFS_ERROR XattrManager::CalAllLayerSumInfo(Inode *inode) {
     SummaryInfo summaryInfo;
     std::mutex valueMutex;
 
-    auto ino = inode->inodeid();
+    auto ino = attr->inodeid();
     iStack.emplace(ino);
     std::vector<Thread> threadpool;
     Atomic<uint32_t> inflightNum(0);
@@ -277,21 +277,21 @@ CURVEFS_ERROR XattrManager::CalAllLayerSumInfo(Inode *inode) {
         summaryInfo.fbytes -= it.second;
     }
 
-    inode->mutable_xattr()->insert({XATTRRFILES,
+    attr->mutable_xattr()->insert({XATTRRFILES,
         std::to_string(summaryInfo.files)});
-    inode->mutable_xattr()->insert({XATTRRSUBDIRS,
+    attr->mutable_xattr()->insert({XATTRRSUBDIRS,
         std::to_string(summaryInfo.subdirs)});
-    inode->mutable_xattr()->insert({XATTRRENTRIES,
+    attr->mutable_xattr()->insert({XATTRRENTRIES,
         std::to_string(summaryInfo.entries)});
-    inode->mutable_xattr()->insert({XATTRRFBYTES,
-        std::to_string(summaryInfo.fbytes + inode->length())});
+    attr->mutable_xattr()->insert({XATTRRFBYTES,
+        std::to_string(summaryInfo.fbytes + attr->length())});
     return CURVEFS_ERROR::OK;
 }
 
 void XattrManager::ConcurrentGetInodeXattr(
     std::stack<uint64_t> *iStack,
     std::mutex *stackMutex,
-    Inode *inode,
+    InodeAttr *attr,
     std::mutex *inodeMutex,
     Atomic<uint32_t> *inflightNum,
     Atomic<bool> *ret) {
@@ -349,16 +349,16 @@ void XattrManager::ConcurrentGetInodeXattr(
                 // record summary info to target inode
                 std::lock_guard<std::mutex> guard(*inodeMutex);
                 if (!(AddUllStringToFirst(
-                    &(inode->mutable_xattr()->find(XATTRRFILES)->second),
+                    &(attr->mutable_xattr()->find(XATTRRFILES)->second),
                     summaryInfo.files, true) &&
                     AddUllStringToFirst(
-                    &(inode->mutable_xattr()->find(XATTRRSUBDIRS)->second),
+                    &(attr->mutable_xattr()->find(XATTRRSUBDIRS)->second),
                     summaryInfo.subdirs, true) &&
                     AddUllStringToFirst(
-                    &(inode->mutable_xattr()->find(XATTRRENTRIES)->second),
+                    &(attr->mutable_xattr()->find(XATTRRENTRIES)->second),
                     summaryInfo.entries, true) &&
                     AddUllStringToFirst(
-                    &(inode->mutable_xattr()->find(XATTRRFBYTES)->second),
+                    &(attr->mutable_xattr()->find(XATTRRFBYTES)->second),
                     summaryInfo.fbytes, true))) {
                     ret->store(false);
                     return;
@@ -371,29 +371,29 @@ void XattrManager::ConcurrentGetInodeXattr(
     }
 }
 
-CURVEFS_ERROR XattrManager::FastCalAllLayerSumInfo(Inode *inode) {
+CURVEFS_ERROR XattrManager::FastCalAllLayerSumInfo(InodeAttr *attr) {
     std::stack<uint64_t> iStack;
     std::mutex stackMutex;
     std::mutex inodeMutex;
 
-    auto ino = inode->inodeid();
+    auto ino = attr->inodeid();
     iStack.emplace(ino);
     // add the size of itself first
     if (!AddUllStringToFirst(
-            &(inode->mutable_xattr()->find(XATTRFBYTES)->second),
-            inode->length(), true)) {
+            &(attr->mutable_xattr()->find(XATTRFBYTES)->second),
+            attr->length(), true)) {
         return CURVEFS_ERROR::INTERNAL;
     }
 
     // add first layer summary to all layer summary info
-    inode->mutable_xattr()->insert({XATTRRFILES,
-        inode->xattr().find(XATTRFILES)->second});
-    inode->mutable_xattr()->insert({XATTRRSUBDIRS,
-        inode->xattr().find(XATTRSUBDIRS)->second});
-    inode->mutable_xattr()->insert({XATTRRENTRIES,
-        inode->xattr().find(XATTRENTRIES)->second});
-    inode->mutable_xattr()->insert({XATTRRFBYTES,
-        inode->xattr().find(XATTRFBYTES)->second});
+    attr->mutable_xattr()->insert({XATTRRFILES,
+        attr->xattr().find(XATTRFILES)->second});
+    attr->mutable_xattr()->insert({XATTRRSUBDIRS,
+        attr->xattr().find(XATTRSUBDIRS)->second});
+    attr->mutable_xattr()->insert({XATTRRENTRIES,
+        attr->xattr().find(XATTRENTRIES)->second});
+    attr->mutable_xattr()->insert({XATTRRFBYTES,
+        attr->xattr().find(XATTRFBYTES)->second});
 
     std::vector<Thread> threadpool;
     Atomic<uint32_t> inflightNum(0);
@@ -402,7 +402,7 @@ CURVEFS_ERROR XattrManager::FastCalAllLayerSumInfo(Inode *inode) {
         try {
             threadpool.emplace_back(Thread(
                 &XattrManager::ConcurrentGetInodeXattr,
-                this, &iStack, &stackMutex, inode,
+                this, &iStack, &stackMutex, attr,
                 &inodeMutex, &inflightNum, &ret));
         } catch (const std::exception& e) {
             LOG(WARNING) << "FastCalAllLayerSumInfo create thread failed,"

--- a/curvefs/src/client/xattr_manager.h
+++ b/curvefs/src/client/xattr_manager.h
@@ -74,13 +74,13 @@ class XattrManager {
         isStop_.store(true);
     }
 
-    CURVEFS_ERROR CalOneLayerSumInfo(Inode *inode);
+    CURVEFS_ERROR CalOneLayerSumInfo(InodeAttr *attr);
 
-    CURVEFS_ERROR CalAllLayerSumInfo(Inode *inode);
+    CURVEFS_ERROR CalAllLayerSumInfo(InodeAttr *attr);
 
-    CURVEFS_ERROR FastCalOneLayerSumInfo(Inode *inode);
+    CURVEFS_ERROR FastCalOneLayerSumInfo(InodeAttr *attr);
 
-    CURVEFS_ERROR FastCalAllLayerSumInfo(Inode *inode);
+    CURVEFS_ERROR FastCalAllLayerSumInfo(InodeAttr *attr);
 
     CURVEFS_ERROR UpdateParentInodeXattr(uint64_t parentId,
         const XAttr &xattr, bool direction);
@@ -111,7 +111,7 @@ class XattrManager {
     void ConcurrentGetInodeXattr(
         std::stack<uint64_t> *iStack,
         std::mutex *stackMutex,
-        Inode *inode,
+        InodeAttr *attr,
         std::mutex *inodeMutex,
         Atomic<uint32_t> *inflightNum,
         Atomic<bool> *ret);

--- a/curvefs/src/mds/metaserverclient/metaserver_client.cpp
+++ b/curvefs/src/mds/metaserverclient/metaserver_client.cpp
@@ -247,6 +247,7 @@ FSStatusCode MetaserverClient::CreatePartition(
     partition->set_end(idEnd);
     partition->set_txid(0);
     partition->set_status(PartitionStatus::READWRITE);
+    LOG(INFO) << "CreatePartition request: " << request.ShortDebugString();
 
     auto fp = &MetaServerService_Stub::CreatePartition;
     LeaderCtx ctx;

--- a/curvefs/src/metaserver/inode_storage.cpp
+++ b/curvefs/src/metaserver/inode_storage.cpp
@@ -117,6 +117,7 @@ MetaStatusCode InodeStorage::GetAttr(const Key4Inode& key,
     attr->set_mode(inode.mode());
     attr->set_nlink(inode.nlink());
     attr->set_type(inode.type());
+    *(attr->mutable_parent()) = inode.parent();
     if (inode.has_symlink()) {
         attr->set_symlink(inode.symlink());
     }
@@ -128,6 +129,9 @@ MetaStatusCode InodeStorage::GetAttr(const Key4Inode& key,
     }
     if (inode.has_openmpcount()) {
         attr->set_openmpcount(inode.openmpcount());
+    }
+    if (inode.xattr_size() > 0) {
+        *(attr->mutable_xattr()) = inode.xattr();
     }
     return MetaStatusCode::OK;
 }

--- a/curvefs/test/client/mock_inode_cache_manager.h
+++ b/curvefs/test/client/mock_inode_cache_manager.h
@@ -27,6 +27,7 @@
 #include <memory>
 #include <set>
 #include <list>
+#include <map>
 
 #include "curvefs/src/client/inode_cache_manager.h"
 
@@ -42,10 +43,17 @@ class MockInodeCacheManager : public InodeCacheManager {
         uint64_t cacheSize, bool enableCacheMetrics));
 
     MOCK_METHOD2(GetInode, CURVEFS_ERROR(
-        uint64_t inodeid, std::shared_ptr<InodeWrapper> &out));     // NOLINT
+        uint64_t inodeId, std::shared_ptr<InodeWrapper> &out));     // NOLINT
+
+    MOCK_METHOD3(GetInodeAttr, CURVEFS_ERROR(
+        uint64_t inodeId, InodeAttr *out, uint64_t parentId));
 
     MOCK_METHOD2(BatchGetInodeAttr, CURVEFS_ERROR(
         std::set<uint64_t> *inodeIds, std::list<InodeAttr> *attrs));
+
+    MOCK_METHOD3(BatchGetInodeAttrAsync,
+        CURVEFS_ERROR(uint64_t parentId, const std::set<uint64_t> &inodeIds,
+        std::map<uint64_t, InodeAttr> *attrs));
 
     MOCK_METHOD2(BatchGetXAttr, CURVEFS_ERROR(
         std::set<uint64_t> *inodeIds, std::list<XAttr> *xattrs));
@@ -55,6 +63,9 @@ class MockInodeCacheManager : public InodeCacheManager {
 
     MOCK_METHOD1(DeleteInode, CURVEFS_ERROR(uint64_t inodeid));
 
+    MOCK_METHOD2(AddInodeAttrs, void(uint64_t parentId,
+        const RepeatedPtrField<InodeAttr>& inodeAttrs));
+
     MOCK_METHOD1(ClearInodeCache, void(uint64_t inodeid));
 
     MOCK_METHOD1(ShipToFlush, void(
@@ -63,6 +74,8 @@ class MockInodeCacheManager : public InodeCacheManager {
     MOCK_METHOD0(FlushAll, void());
 
     MOCK_METHOD0(FlushInodeOnce, void());
+
+    MOCK_METHOD1(ReleaseCache, void(uint64_t parentId));
 };
 
 }  // namespace client

--- a/curvefs/test/client/mock_metaserver_client.h
+++ b/curvefs/test/client/mock_metaserver_client.h
@@ -79,6 +79,10 @@ class MockMetaServerClient : public MetaServerClient {
         uint32_t fsId, const std::set<uint64_t> &inodeIds,
         std::list<InodeAttr> *attr));
 
+    MOCK_METHOD3(BatchGetInodeAttrAsync, MetaStatusCode(
+        uint32_t fsId, const std::vector<uint64_t> &inodeIds,
+        MetaServerClientDone *done));
+
     MOCK_METHOD3(BatchGetXAttr, MetaStatusCode(
         uint32_t fsId, const std::set<uint64_t> &inodeIds,
         std::list<XAttr> *xattr));


### PR DESCRIPTION
1. Get inodeAttr when need attr only intead of get inode.
2. Impliment readdirplus api.
3. Add iAttrCache for fast get some xattr when ls -l.

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #xxx <!-- replace xxx with issue number -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
