### PR TITLE
curve-fuse: fix sync directory aborted

### DIFF
--- a/curvefs/src/client/inode_wrapper.cpp
+++ b/curvefs/src/client/inode_wrapper.cpp
@@ -438,7 +438,7 @@ CURVEFS_ERROR InodeWrapper::Sync() {
         case FsFileType::TYPE_FILE:
             return FlushVolumeExtent();
         default:
-            return CURVEFS_ERROR::INVALIDPARAM;
+            return CURVEFS_ERROR::OK;
     }
 }
 
@@ -453,7 +453,7 @@ void InodeWrapper::FlushAsync() {
         case FsFileType::TYPE_FILE:
             return FlushVolumeExtentAsync();
         default:
-            CHECK(false) << "unexpected inode type: " << inode_.type();
+            break;
     }
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #1493

Problem Summary: InodeWrapper can represent a directory, so we shouldn't abort when FsFileType is TYPE_DIRECTORY

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [x] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license
