### PR TITLE
curvefs fix load copyset stuck heartbeat #1468

### DIFF
--- a/curvefs/proto/heartbeat.proto
+++ b/curvefs/proto/heartbeat.proto
@@ -37,7 +37,8 @@ message CopySetInfo {
     required common.Peer leaderPeer = 5;
     repeated common.PartitionInfo partitionInfoList = 6;
     optional ConfigChangeInfo configChangeInfo = 7;
-    // required CopySetState state = 8;
+    optional bool isCopysetLoading = 8;
+    // required CopySetState state = 9;
 };
 
 message ConfigChangeInfo {

--- a/curvefs/proto/topology.proto
+++ b/curvefs/proto/topology.proto
@@ -100,7 +100,8 @@ message CopysetData {
     required uint32 PoolId = 2;
     required uint64 epoch = 3;
     repeated uint32 MetaServerIds = 4;
-    required uint32 PartitionNumber = 5;
+    // delete PartitionNumber, for compatibility reasons, don't use number 5
+    // required uint32 PartitionNumber = 5;
     optional bool availFlag = 6;
 }
 

--- a/curvefs/src/mds/heartbeat/heartbeat_manager.cpp
+++ b/curvefs/src/mds/heartbeat/heartbeat_manager.cpp
@@ -159,7 +159,11 @@ void HeartbeatManager::MetaServerHeartbeat(
         // if a copyset is the leader, update (e.g. epoch) topology according
         // to its info
         if (request.metaserverid() == reportCopySetInfo.GetLeader()) {
-            topoUpdater_->UpdateTopo(reportCopySetInfo, partitionList);
+            topoUpdater_->UpdateCopysetTopo(reportCopySetInfo);
+            if (!value.has_iscopysetloading() || !value.iscopysetloading()) {
+                topoUpdater_->UpdatePartitionTopo(reportCopySetInfo.GetId(),
+                                                  partitionList);
+            }
         }
     }
 }
@@ -236,8 +240,6 @@ bool HeartbeatManager::TransformHeartbeatCopySetInfoToTopologyOne(
 
     // set leader
     topoCopysetInfo.SetLeader(leader);
-
-    topoCopysetInfo.SetPartitionNum(info.partitioninfolist_size());
 
     // set info of configuration changes
     if (info.configchangeinfo().IsInitialized()) {

--- a/curvefs/src/mds/heartbeat/topo_updater.cpp
+++ b/curvefs/src/mds/heartbeat/topo_updater.cpp
@@ -29,13 +29,6 @@ namespace mds {
 namespace heartbeat {
 using curvefs::mds::topology::TopoStatusCode;
 
-void TopoUpdater::UpdateTopo(
-    const ::curvefs::mds::topology::CopySetInfo& reportCopySetInfo,
-    const std::list<::curvefs::mds::topology::Partition>& partitionList) {
-    UpdateCopysetTopo(reportCopySetInfo);
-    UpdatePartitionTopo(reportCopySetInfo.GetId(), partitionList);
-}
-
 void TopoUpdater::UpdateCopysetTopo(
     const ::curvefs::mds::topology::CopySetInfo& reportCopySetInfo) {
     curvefs::mds::topology::CopySetInfo recordCopySetInfo;
@@ -96,18 +89,6 @@ void TopoUpdater::UpdateCopysetTopo(
                        << ", but epoch is same: "
                        << recordCopySetInfo.GetEpoch();
             return;
-        }
-
-        if (reportCopySetInfo.GetPartitionNum() !=
-            recordCopySetInfo.GetPartitionNum()) {
-            LOG(WARNING) << "copyset(" << reportCopySetInfo.GetPoolId() << ","
-                         << reportCopySetInfo.GetId()
-                         << "), partitionNum in topogy = "
-                         << recordCopySetInfo.GetPartitionNum()
-                         << ", partitionNum in hearbeat = "
-                         << reportCopySetInfo.GetPartitionNum()
-                         << ", need update in topo";
-            needUpdate = true;
         }
 
         // no configuration changes in heartbeat report (no candidate)

--- a/curvefs/src/mds/heartbeat/topo_updater.h
+++ b/curvefs/src/mds/heartbeat/topo_updater.h
@@ -41,24 +41,25 @@ class TopoUpdater {
     ~TopoUpdater() {}
 
     /*
-     * @brief UpdateTopo this function will be called by leader copyset
+     * @brief UpdateCopysetTopo this function will be called by leader copyset
      *                   for updating copyset epoch, replicas relationship and
-     *                   statistical data according to reportCopySetInfo and
-     *                   partition info
+     *                   statistical data according to reportCopySetInfo
      * @param[in] reportCopySetInfo copyset info reported by metaserver
+     */
+    void UpdateCopysetTopo(
+        const ::curvefs::mds::topology::CopySetInfo &reportCopySetInfo);
+
+    /*
+     * @brief UpdatePartitionTopo this function will be called by leader copyset
+     *                   for updating partition info
      * @param[in] partitionList partition info list reported by metaserver
      */
-    void UpdateTopo(
-        const ::curvefs::mds::topology::CopySetInfo &reportCopySetInfo,
+    void UpdatePartitionTopo(
+        CopySetIdType copySetId,
         const std::list<::curvefs::mds::topology::Partition> &partitionList);
 
  public:
     // public for test
-    void UpdateCopysetTopo(
-        const ::curvefs::mds::topology::CopySetInfo &reportCopySetInfo);
-    void UpdatePartitionTopo(
-        CopySetIdType copySetId,
-        const std::list<::curvefs::mds::topology::Partition> &partitionList);
     bool CanPartitionStatusChange(PartitionStatus statusInTopo,
                                   PartitionStatus statusInHeartbeat);
 

--- a/curvefs/src/mds/topology/topology.cpp
+++ b/curvefs/src/mds/topology/topology.cpp
@@ -548,7 +548,6 @@ TopoStatusCode TopologyImpl::AddPartition(const Partition &data) {
                     return TopoStatusCode::TOPO_STORGE_FAIL;
                 }
                 partitionMap_[id] = data;
-                it->second.AddPartitionNum();
                 it->second.AddPartitionId(id);
                 it->second.SetDirtyFlag(true);
                 return TopoStatusCode::TOPO_OK;
@@ -574,7 +573,7 @@ TopoStatusCode TopologyImpl::RemovePartition(PartitionIdType id) {
         CopySetKey key(it->second.GetPoolId(), it->second.GetCopySetId());
         auto ix = copySetMap_.find(key);
         if (ix != copySetMap_.end()) {
-            ix->second.ReducePartitionNum();
+            ix->second.RemovePartitionId(id);
         }
         partitionMap_.erase(it);
         return TopoStatusCode::TOPO_OK;
@@ -1065,7 +1064,6 @@ TopoStatusCode TopologyImpl::UpdateCopySetTopo(const CopySetInfo &data) {
         WriteLockGuard wlockCopySet(it->second.GetRWLockRef());
         it->second.SetLeader(data.GetLeader());
         it->second.SetEpoch(data.GetEpoch());
-        it->second.SetPartitionNum(data.GetPartitionNum());
         it->second.SetCopySetMembers(data.GetCopySetMembers());
         it->second.SetDirtyFlag(true);
         if (data.HasCandidate()) {

--- a/curvefs/src/mds/topology/topology_item.cpp
+++ b/curvefs/src/mds/topology/topology_item.cpp
@@ -219,7 +219,6 @@ bool CopySetInfo::SerializeToString(std::string *value) const {
     data.set_copysetid(copySetId_);
     data.set_poolid(poolId_);
     data.set_epoch(epoch_);
-    data.set_partitionnumber(partitionNum_);
     for (MetaServerIdType msId : peers_) {
         data.add_metaserverids(msId);
     }
@@ -233,7 +232,6 @@ bool CopySetInfo::ParseFromString(const std::string &value) {
     poolId_ = data.poolid();
     copySetId_ = data.copysetid();
     epoch_ = data.epoch();
-    partitionNum_ = data.partitionnumber();
     if (data.has_availflag()) {
         available_ = data.availflag();
     } else {
@@ -285,13 +283,8 @@ common::PartitionInfo Partition::ToPartitionInfo() {
     info.set_end(idEnd_);
     info.set_txid(txId_);
     info.set_status(status_);
-    if (inodeNum_ != UNINITIALIZE_COUNT) {
-        info.set_inodenum(inodeNum_);
-    }
-
-    if (dentryNum_ != UNINITIALIZE_COUNT) {
-        info.set_dentrynum(dentryNum_);
-    }
+    info.set_inodenum(inodeNum_);
+    info.set_dentrynum(dentryNum_);
     return info;
 }
 

--- a/curvefs/src/mds/topology/topology_item.h
+++ b/curvefs/src/mds/topology/topology_item.h
@@ -473,7 +473,6 @@ class CopySetInfo {
           copySetId_(UNINITIALIZE_ID),
           leader_(UNINITIALIZE_ID),
           epoch_(0),
-          partitionNum_(0),
           hasCandidate_(false),
           candidate_(UNINITIALIZE_ID),
           dirty_(false),
@@ -484,7 +483,6 @@ class CopySetInfo {
           copySetId_(id),
           leader_(UNINITIALIZE_ID),
           epoch_(0),
-          partitionNum_(0),
           hasCandidate_(false),
           candidate_(UNINITIALIZE_ID),
           dirty_(false),
@@ -496,7 +494,7 @@ class CopySetInfo {
           leader_(v.leader_),
           epoch_(v.epoch_),
           peers_(v.peers_),
-          partitionNum_(v.partitionNum_),
+          partitionIds_(v.partitionIds_),
           hasCandidate_(v.hasCandidate_),
           candidate_(v.candidate_),
           dirty_(v.dirty_),
@@ -511,7 +509,7 @@ class CopySetInfo {
         leader_ = v.leader_;
         epoch_ = v.epoch_;
         peers_ = v.peers_;
-        partitionNum_ = v.partitionNum_;
+        partitionIds_ = v.partitionIds_;
         hasCandidate_ = v.hasCandidate_;
         candidate_ = v.candidate_;
         dirty_ = v.dirty_;
@@ -551,13 +549,7 @@ class CopySetInfo {
 
     bool SetCopySetMembersByJson(const std::string &jsonStr);
 
-    uint64_t GetPartitionNum() const { return partitionNum_; }
-
-    void SetPartitionNum(u_int64_t number) { partitionNum_ = number; }
-
-    void AddPartitionNum() { partitionNum_ += 1; }
-
-    void ReducePartitionNum() { partitionNum_ -= 1; }
+    uint64_t GetPartitionNum() const { return partitionIds_.size(); }
 
     bool HasCandidate() const { return hasCandidate_; }
 
@@ -592,6 +584,8 @@ class CopySetInfo {
 
     void AddPartitionId(const PartitionIdType &id) { partitionIds_.insert(id); }
 
+    void RemovePartitionId(PartitionIdType id) { partitionIds_.erase(id); }
+
     const std::set<PartitionIdType> &GetPartitionIds() const {
         return partitionIds_;
     }
@@ -602,8 +596,6 @@ class CopySetInfo {
     MetaServerIdType leader_;
     EpochType epoch_;
     std::set<MetaServerIdType> peers_;
-    // TODO(chengyi01): replace it whith partitionIds.size()
-    uint64_t partitionNum_;
     std::set<PartitionIdType> partitionIds_;
     bool hasCandidate_;
     MetaServerIdType candidate_;
@@ -644,8 +636,8 @@ class Partition {
           idEnd_(0),
           txId_(0),
           status_(PartitionStatus::READWRITE),
-          inodeNum_(UNINITIALIZE_COUNT),
-          dentryNum_(UNINITIALIZE_COUNT) {
+          inodeNum_(0),
+          dentryNum_(0) {
         InitFileType2InodeNum();
     }
 
@@ -659,8 +651,8 @@ class Partition {
           idEnd_(idEnd),
           txId_(0),
           status_(PartitionStatus::READWRITE),
-          inodeNum_(UNINITIALIZE_COUNT),
-          dentryNum_(UNINITIALIZE_COUNT) {
+          inodeNum_(0),
+          dentryNum_(0) {
         InitFileType2InodeNum();
     }
 
@@ -704,8 +696,8 @@ class Partition {
         idEnd_ = v.end();
         txId_ = v.txid();
         status_ = v.status();
-        inodeNum_ = v.has_inodenum() ? v.inodenum() : UNINITIALIZE_COUNT;
-        dentryNum_ = v.has_dentrynum() ? v.dentrynum() : UNINITIALIZE_COUNT;
+        inodeNum_ = v.has_inodenum() ? v.inodenum() : 0;
+        dentryNum_ = v.has_dentrynum() ? v.dentrynum() : 0;
         for (auto const& i : v.filetype2inodenum()) {
             fileType2InodeNum_.emplace(static_cast<FileType>(i.first),
                                        i.second);

--- a/curvefs/src/mds/topology/topology_manager.cpp
+++ b/curvefs/src/mds/topology/topology_manager.cpp
@@ -946,13 +946,8 @@ void TopologyManager::ListPartition(const ListPartitionRequest *request,
         info->set_end(partition.GetIdEnd());
         info->set_txid(partition.GetTxId());
         info->set_status(partition.GetStatus());
-        if (partition.GetInodeNum() != UNINITIALIZE_COUNT) {
-            info->set_inodenum(partition.GetInodeNum());
-        }
-
-        if (partition.GetDentryNum() != UNINITIALIZE_COUNT) {
-            info->set_dentrynum(partition.GetDentryNum());
-        }
+        info->set_inodenum(partition.GetInodeNum());
+        info->set_dentrynum(partition.GetDentryNum());
     }
 }
 

--- a/curvefs/src/metaserver/metastore.h
+++ b/curvefs/src/metaserver/metastore.h
@@ -96,7 +96,8 @@ class MetaStore {
         const DeletePartitionRequest* request,
         DeletePartitionResponse* response) = 0;
 
-    virtual std::list<PartitionInfo> GetPartitionInfoList() = 0;
+    virtual bool GetPartitionInfoList(
+                            std::list<PartitionInfo> *partitionInfoList) = 0;
 
     virtual std::shared_ptr<StreamServer> GetStreamServer() = 0;
 
@@ -175,7 +176,8 @@ class MetaStoreImpl : public MetaStore {
     MetaStatusCode DeletePartition(const DeletePartitionRequest* request,
                                    DeletePartitionResponse* response) override;
 
-    std::list<PartitionInfo> GetPartitionInfoList() override;
+    bool GetPartitionInfoList(
+                        std::list<PartitionInfo> *partitionInfoList) override;
 
     std::shared_ptr<StreamServer> GetStreamServer() override;
 

--- a/curvefs/test/mds/topology/test_topology.cpp
+++ b/curvefs/test/mds/topology/test_topology.cpp
@@ -1624,6 +1624,7 @@ TEST_F(TestTopology, GetAvailableCopyset_success) {
     CopySetIdType csId = 0x51;
     CopySetIdType csId2 = 0x52;
     CopySetIdType csId3 = 0x53;
+    FsIdType fsId = 0x1;
 
     PrepareAddPool(poolId);
     PrepareAddZone(zoneId);
@@ -1641,7 +1642,10 @@ TEST_F(TestTopology, GetAvailableCopyset_success) {
     int num1 = topology_->GetAvailableCopysetNum();
     ASSERT_EQ(num1, 1);
 
-    data.SetPartitionNum(256);
+    for (int i = 0; i < 256; i++) {
+        PrepareAddPartition(fsId, poolId, csId, i, 1, 100);
+    }
+
     ASSERT_EQ(TopoStatusCode::TOPO_OK, topology_->UpdateCopySetTopo(data));
     ret = topology_->GetAvailableCopyset(&data);
     ASSERT_EQ(false, ret);

--- a/curvefs/test/metaserver/mock/mock_metastore.h
+++ b/curvefs/test/metaserver/mock/mock_metastore.h
@@ -45,7 +45,7 @@ class MockMetaStore : public curvefs::metaserver::MetaStore {
                                                  CreatePartitionResponse*));
     MOCK_METHOD2(DeletePartition, MetaStatusCode(const DeletePartitionRequest*,
                                                  DeletePartitionResponse*));
-    MOCK_METHOD0(GetPartitionInfoList, std::list<PartitionInfo>());
+    MOCK_METHOD1(GetPartitionInfoList, bool(std::list<PartitionInfo> *));
 
     MOCK_METHOD2(CreateDentry, MetaStatusCode(const CreateDentryRequest*,
                                               CreateDentryResponse*));


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #1468

Problem Summary: curvefs fix load copyset stuck heartbeat #1468

### What is changed and how it works?

When copyset is loading, it will stuck heartbeat when get partition info list. I make some changes.
1. When copyset is loading, heartbeat do not send partition info in copyset.
2. When copyset get partition, use try lock instead of lock.
3. Do not use heartbeat partition num to update topo.
