### PR TITLE
curvefs/metaserver: fixed s3chunkinfo was padding into inode when it …

### DIFF
--- a/curvefs/src/metaserver/metastore.cpp
+++ b/curvefs/src/metaserver/metastore.cpp
@@ -529,15 +529,11 @@ MetaStatusCode MetaStoreImpl::GetOrModifyS3ChunkInfo(
                                            request->s3chunkinforemove(),
                                            request->returns3chunkinfomap(),
                                            iterator);
-    if (rc == MetaStatusCode::OK && !request->supportstreaming()) {
+    if (rc == MetaStatusCode::OK &&
+        !request->supportstreaming() &&
+        request->returns3chunkinfomap()) {
         rc = partition->PaddingInodeS3ChunkInfo(
             fsId, inodeId, response->mutable_s3chunkinfomap(), 0);
-    }
-
-    if (rc == MetaStatusCode::OK && !request->supportstreaming()) {
-        rc = partition->PaddingInodeS3ChunkInfo(
-            request->fsid(), request->inodeid(),
-            response->mutable_s3chunkinfomap(), 0);
     }
 
     response->set_statuscode(rc);

--- a/curvefs/test/metaserver/metastore_test.cpp
+++ b/curvefs/test/metaserver/metastore_test.cpp
@@ -1486,6 +1486,37 @@ TEST_F(MetastoreTest, GetOrModifyS3ChunkInfo) {
         ASSERT_EQ(response.statuscode(), rc);
         ASSERT_EQ(response.mutable_s3chunkinfomap()->size(), 2);
     }
+
+    // CASE 4: GetOrModifyS3ChunkInfo success with unsupport streaming
+    // and without return s3chunkinfo
+    {
+        LOG(INFO) << "CASE 3: GetOrModifyS3ChunkInfo success"
+                  << " with unsupport streaming";
+        GetOrModifyS3ChunkInfoRequest request;
+        GetOrModifyS3ChunkInfoResponse response;
+        std::vector<uint64_t> chunkIndexs{ 1, 2 };
+        std::vector<S3ChunkInfoList> lists2add{
+            GenS3ChunkInfoList(100, 200),
+            GenS3ChunkInfoList(300, 400),
+        };
+
+        request.set_partitionid(partitionId);
+        request.set_fsid(fsId);
+        request.set_inodeid(inodeId);
+        request.set_supportstreaming(false);
+        request.set_returns3chunkinfomap(false);
+        for (size_t i = 0; i < chunkIndexs.size(); i++) {
+            request.mutable_s3chunkinfoadd()->insert(
+                { chunkIndexs[i], lists2add[i] });
+        }
+
+        std::shared_ptr<Iterator> iterator;
+        MetaStatusCode rc = metastore.GetOrModifyS3ChunkInfo(
+            &request, &response, &iterator);
+        ASSERT_EQ(rc, MetaStatusCode::OK);
+        ASSERT_EQ(response.statuscode(), rc);
+        ASSERT_EQ(response.mutable_s3chunkinfomap()->size(), 0);
+    }
 }
 
 TEST_F(MetastoreTest, GetInodeWithPaddingS3Meta) {


### PR DESCRIPTION
…wasnt needed.

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #xxx <!-- replace xxx with issue number -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
