### PR TITLE
curvefs: fix filetype inode error in metric

### DIFF
--- a/curvefs/src/mds/topology/topology_item.cpp
+++ b/curvefs/src/mds/topology/topology_item.cpp
@@ -291,6 +291,8 @@ common::PartitionInfo Partition::ToPartitionInfo() {
     info.set_status(status_);
     info.set_inodenum(inodeNum_);
     info.set_dentrynum(dentryNum_);
+    info.mutable_filetype2inodenum()->insert(fileType2InodeNum_.begin(),
+                                             fileType2InodeNum_.end());
     return info;
 }
 

--- a/curvefs/src/metaserver/inode_manager.h
+++ b/curvefs/src/metaserver/inode_manager.h
@@ -39,6 +39,10 @@ using ::curvefs::metaserver::S3ChunkInfoList;
 namespace curvefs {
 namespace metaserver {
 
+using FileType2InodeNumMap =
+    ::google::protobuf::Map<::google::protobuf::int32,
+                            ::google::protobuf::uint64>;
+
 struct InodeParam {
     uint32_t fsId;
     uint64_t length;
@@ -53,10 +57,12 @@ struct InodeParam {
 
 class InodeManager {
  public:
-    InodeManager(const std::shared_ptr<InodeStorage> &inodeStorage,
-        const std::shared_ptr<Trash> &trash)
+    InodeManager(const std::shared_ptr<InodeStorage>& inodeStorage,
+                 const std::shared_ptr<Trash>& trash,
+                 FileType2InodeNumMap* type2InodeNum)
         : inodeStorage_(inodeStorage),
-          trash_(trash) {}
+          trash_(trash),
+          type2InodeNum_(type2InodeNum) {}
 
     MetaStatusCode CreateInode(uint64_t inodeId, const InodeParam &param,
                                Inode *inode);
@@ -74,8 +80,7 @@ class InodeManager {
 
     MetaStatusCode DeleteInode(uint32_t fsId, uint64_t inodeId);
 
-    MetaStatusCode UpdateInode(const UpdateInodeRequest& request, Inode* old,
-                               int* deletedNum);
+    MetaStatusCode UpdateInode(const UpdateInodeRequest& request);
 
     MetaStatusCode GetOrModifyS3ChunkInfo(
         uint32_t fsId,
@@ -132,6 +137,8 @@ class InodeManager {
  private:
     std::shared_ptr<InodeStorage> inodeStorage_;
     std::shared_ptr<Trash> trash_;
+    FileType2InodeNumMap* type2InodeNum_;
+
     NameLock inodeLock_;
 };
 

--- a/curvefs/src/metaserver/metastore.cpp
+++ b/curvefs/src/metaserver/metastore.cpp
@@ -299,8 +299,6 @@ bool MetaStoreImpl::GetPartitionInfoList(
     if (ret == 0) {
         for (const auto& it : partitionMap_) {
             PartitionInfo partitionInfo = it.second->GetPartitionInfo();
-            partitionInfo.set_inodenum(it.second->GetInodeNum());
-            partitionInfo.set_dentrynum(it.second->GetDentryNum());
             partitionInfoList->push_back(std::move(partitionInfo));
         }
         rwLock_.Unlock();

--- a/curvefs/src/metaserver/metastore_fstream.cpp
+++ b/curvefs/src/metaserver/metastore_fstream.cpp
@@ -248,8 +248,6 @@ std::shared_ptr<Iterator> MetaStoreFStream::NewPartitionIterator() {
         auto partitionId = item.first;
         auto partition = item.second;
         auto partitionInfo = partition->GetPartitionInfo();
-        partitionInfo.set_inodenum(partition->GetInodeNum());
-        partitionInfo.set_dentrynum(partition->GetDentryNum());
         LOG(INFO) << "Save partition, partition: " << partitionId
                   << ", partition info: " << partitionInfo.ShortDebugString();
         if (!conv_->SerializeToString(partitionInfo, &value)) {

--- a/curvefs/src/metaserver/partition.h
+++ b/curvefs/src/metaserver/partition.h
@@ -44,7 +44,6 @@ using curvefs::common::PartitionStatus;
 using ::curvefs::metaserver::storage::KVStorage;
 using ::curvefs::metaserver::storage::Iterator;
 using S3ChunkInfoMap = google::protobuf::Map<uint64_t, S3ChunkInfoList>;
-using ::curvefs::metaserver::FsFileType;
 
 constexpr uint64_t kMinPartitionStartId = ROOTINODEID + 1;
 
@@ -173,17 +172,6 @@ class Partition {
     std::shared_ptr<Iterator> GetAllVolumeExtentList();
 
     bool Clear();
-
-    MetaStatusCode UpdatePartitionInfoFsType2InodeNum(MetaStatusCode ret,
-                                                      const FsFileType& type,
-                                                      int32_t count) {
-        if (MetaStatusCode::OK == ret) {
-            partitionInfo_.set_inodenum(partitionInfo_.inodenum() + count);
-            (*partitionInfo_.mutable_filetype2inodenum())[type] += count;
-        }
-
-        return ret;
-    }
 
  private:
     std::shared_ptr<InodeStorage> inodeStorage_;

--- a/curvefs/test/metaserver/s3compact/s3compact_test.cpp
+++ b/curvefs/test/metaserver/s3compact/s3compact_test.cpp
@@ -22,6 +22,7 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <memory>
 
 #include "curvefs/src/metaserver/s3compact_manager.h"
 #include "curvefs/src/metaserver/s3compact_worker.h"
@@ -90,7 +91,9 @@ class S3CompactTest : public ::testing::Test {
         inodeStorage_ =
             std::make_shared<InodeStorage>(kvStorage_, nameGenerator, 0);
         trash_ = std::make_shared<TrashImpl>(inodeStorage_);
-        inodeManager_ = std::make_shared<InodeManager>(inodeStorage_, trash_);
+        filetype2InodeNum_ = std::make_shared<FileType2InodeNumMap>();
+        inodeManager_ = std::make_shared<InodeManager>(
+            inodeStorage_, trash_, filetype2InodeNum_.get());
 
         workerOptions_.s3adapterManager = s3adapterManager_.get();
         workerOptions_.s3infoCache = s3infoCache_.get();
@@ -125,6 +128,7 @@ class S3CompactTest : public ::testing::Test {
     std::unique_ptr<MockCopysetNodeWrapper> mockCopysetNodeWrapper_;
     std::string dataDir_;
     std::shared_ptr<KVStorage> kvStorage_;
+    std::shared_ptr<FileType2InodeNumMap> filetype2InodeNum_;
 };
 
 TEST_F(S3CompactTest, test_CopysetNodeWrapper) {

--- a/curvefs/test/metaserver/s3compact/s3compact_worker_test.cpp
+++ b/curvefs/test/metaserver/s3compact/s3compact_worker_test.cpp
@@ -98,7 +98,9 @@ TEST_F(S3CompactWorkerTest, TestCancelCompact) {
     auto nameGen = std::make_shared<NameGenerator>(1);
     auto inodeStorage =
         std::make_shared<InodeStorage>(mockKvStorage, nameGen, 0);
-    auto inodeManager = std::make_shared<InodeManager>(inodeStorage, nullptr);
+    FileType2InodeNumMap filetype2InodeNum;
+    auto inodeManager = std::make_shared<InodeManager>(inodeStorage, nullptr,
+                                                       &filetype2InodeNum);
     auto copysetNode = std::make_shared<copyset::MockCopysetNode>();
     auto kvs = PrepareInodeList();
 


### PR DESCRIPTION
The filetype2inode information is stored in partitioninfo, and the
restart of the metaserver will cause a rebuild, so the number will be
abnormal

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #xxx <!-- replace xxx with issue number -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
