### PR TITLE
curvefs: fix tool list-copysetInfo error

### DIFF
--- a/curvefs/src/mds/topology/topology_item.h
+++ b/curvefs/src/mds/topology/topology_item.h
@@ -709,6 +709,7 @@ class Partition {
         partition.set_fsid(fsId_);
         partition.set_poolid(poolId_);
         partition.set_copysetid(copySetId_);
+        partition.set_partitionid(partitionId_);
         partition.set_start(idStart_);
         partition.set_end(idEnd_);
         partition.set_txid(txId_);

--- a/curvefs/src/mds/topology/topology_manager.cpp
+++ b/curvefs/src/mds/topology/topology_manager.cpp
@@ -1099,6 +1099,7 @@ void TopologyManager::GetCopysetInfo(const uint32_t& poolId,
                 partition->set_fsid(tmp.GetFsId());
                 partition->set_poolid(tmp.GetPoolId());
                 partition->set_copysetid(tmp.GetCopySetId());
+                partition->set_partitionid(tmp.GetPartitionId());
                 partition->set_start(tmp.GetIdStart());
                 partition->set_end(tmp.GetIdEnd());
                 partition->set_txid(tmp.GetTxId());


### PR DESCRIPTION
partitionId is not set in transition constructor

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #1541 <!-- replace xxx with issue number -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
