### PR TITLE
Curve/tool fs status metaserver

### DIFF
--- a/tools-v2/internal/error/error.go
+++ b/tools-v2/internal/error/error.go
@@ -43,46 +43,63 @@ type CmdError struct {
 	Message string `json:"message"` // exit message
 }
 
-func NewSucessCmdError() CmdError {
-	return CmdError{
+var (
+	AllError []*CmdError
+)
+
+func NewSucessCmdError() *CmdError {
+	ret := &CmdError{
 		Code:    CODE_SUCCESS,
 		Message: "success",
 	}
+	AllError = append(AllError, ret)
+	return ret
 }
 
-func NewInternalCmdError(code int, message string) CmdError {
-	return CmdError{
+func NewInternalCmdError(code int, message string) *CmdError {
+	ret := &CmdError{
 		Code:    CODE_INTERNAL + code,
 		Message: message,
 	}
+
+	AllError = append(AllError, ret)
+	return ret
 }
 
-func NewRpcError(code int, message string) CmdError {
-	return CmdError{
+func NewRpcError(code int, message string) *CmdError {
+	ret := &CmdError{
 		Code:    CODE_RPC + code,
 		Message: message,
 	}
+	AllError = append(AllError, ret)
+	return ret
 }
 
-func NewRpcReultCmdError(code int, message string) CmdError {
-	return CmdError{
+func NewRpcReultCmdError(code int, message string) *CmdError {
+	ret := &CmdError{
 		Code:    CODE_RPC_RESULT + code,
 		Message: message,
 	}
+	AllError = append(AllError, ret)
+	return ret
 }
 
-func NewHttpError(code int, message string) CmdError {
-	return CmdError{
+func NewHttpError(code int, message string) *CmdError {
+	ret := &CmdError{
 		Code:    CODE_HTTP + code,
 		Message: message,
 	}
+	AllError = append(AllError, ret)
+	return ret
 }
 
-func NewHttpResultCmdError(code int, message string) CmdError {
-	return CmdError{
+func NewHttpResultCmdError(code int, message string) *CmdError {
+	ret := &CmdError{
 		Code:    CODE_HTTP_RESULT + code,
 		Message: message,
 	}
+	AllError = append(AllError, ret)
+	return ret
 }
 
 func (cmd CmdError) TypeCode() int {
@@ -117,15 +134,18 @@ func (e *CmdError) Format(args ...interface{}) {
 // The importance of the error is considered to be related to the code,
 // please use it under the condition that the smaller the code,
 // the more important the error is.
-func MostImportantCmdError(err []CmdError) CmdError {
+func MostImportantCmdError(err []*CmdError) *CmdError {
 	if len(err) == 0 {
+<<<<<<< HEAD
 		return CmdError {
+=======
+		return &CmdError{
+>>>>>>> curve: fs status mds
 			Code:    CODE_UNKNOWN,
 			Message: "unknown error",
 		}
 	}
-	var ret CmdError
-	ret.Code = CODE_UNKNOWN
+	ret := err[0]
 	for _, e := range err {
 		if e.Code < ret.Code {
 			ret = e
@@ -134,8 +154,8 @@ func MostImportantCmdError(err []CmdError) CmdError {
 	return ret
 }
 
-// keep the most important wrong id, all wrong me s sa
-func MergeCmdError(err []CmdError) CmdError {
+// keep the most important wrong id, all wrong message will be kept
+func MergeCmdError(err []*CmdError) CmdError {
 	if len(err) == 0 {
 		return CmdError{
 			Code:    CODE_UNKNOWN,
@@ -156,23 +176,53 @@ func MergeCmdError(err []CmdError) CmdError {
 }
 
 var (
-	ErrSuccess = NewSucessCmdError()
+	ErrSuccess = NewSucessCmdError
 
 	// internal error
+<<<<<<< HEAD
 	ErrHttpCreateGetRequest = NewInternalCmdError(1, "create http get request failed, the error is: %s")
 	ErrDataNoExpected       = NewInternalCmdError(2, "data: %s is not as expected, the error is: %s")
 	ErrHttpClient           = NewInternalCmdError(3, "http client gets error: %s")
 	ErrRpcDial              = NewInternalCmdError(4, "dial to rpc server %s failed, the error is: %s")
 	ErrUnmarshalJson        = NewInternalCmdError(5, "unmarshal json error, the json is %s, the error is %s")
 	ErrParseMetric          = NewInternalCmdError(6, "parse metric %s err!")
+=======
+	ErrHttpCreateGetRequest = func() *CmdError {
+		return NewInternalCmdError(1, "create http get request failed, the error is: %s")
+	}
+	ErrDataNoExpected = func() *CmdError {
+		return NewInternalCmdError(2, "data: %s is not as expected, the error is: %s")
+	}
+	ErrHttpClient = func() *CmdError {
+		return NewInternalCmdError(3, "http client gets error: %s")
+	}
+	ErrRpcDial = func() *CmdError {
+		return NewInternalCmdError(4, "dial to rpc server %s failed, the error is: %s")
+	}
+	ErrUnmarshalJson = func() *CmdError {
+		return NewInternalCmdError(5, "unmarshal json error, the json is %s, the error is %s")
+	}
+	ErrParseMetric = func() *CmdError {
+		return NewInternalCmdError(6, "parse metric %s err!")
+	}
+	ErrGetMetaserverAddr = func() *CmdError {
+		return NewInternalCmdError(7, "get metaserver addr failed, the error is: %s")
+	}
+>>>>>>> curve: fs status mds
 
 	// http error
-	ErrHttpUnreadableResult = NewHttpResultCmdError(1, "http response is unreadable, the uri is: %s, the error is: %s")
-	ErrHttpResultNoExpected = NewHttpResultCmdError(2, "http response is not expected, the hosts is: %s, the suburi is: %s, the result is: %s")
-	ErrHttpStatus           = func(statusCode int) CmdError {
+	ErrHttpUnreadableResult = func() *CmdError {
+		return NewHttpResultCmdError(1, "http response is unreadable, the uri is: %s, the error is: %s")
+	}
+	ErrHttpResultNoExpected = func() *CmdError {
+		return NewHttpResultCmdError(2, "http response is not expected, the hosts is: %s, the suburi is: %s, the result is: %s")
+	}
+	ErrHttpStatus = func(statusCode int) *CmdError {
 		return NewHttpError(statusCode, "the url is: %s, http status code is: %d")
 	}
 
 	// rpc error
-	ErrRpcCall = NewRpcReultCmdError(1, "rpc call is fail, the addr is: %s, the func is %s, the error is: %s")
+	ErrRpcCall = func() *CmdError {
+		return NewRpcReultCmdError(1, "rpc call is fail, the addr is: %s, the func is %s, the error is: %s")
+	}
 )

--- a/tools-v2/pkg/cli/command/curvefs/status/metaserver/metaserver.go
+++ b/tools-v2/pkg/cli/command/curvefs/status/metaserver/metaserver.go
@@ -16,109 +16,98 @@
 
 /*
  * Project: CurveCli
- * Created Date: 2022-06-06
+ * Created Date: 2022-06-07
  * Author: chengyi (Cyber-SiKu)
  */
 
-package mds
+package metaserver
 
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/liushuochen/gotable"
 	cmderror "github.com/opencurve/curve/tools-v2/internal/error"
 	cobrautil "github.com/opencurve/curve/tools-v2/internal/utils"
 	basecmd "github.com/opencurve/curve/tools-v2/pkg/cli/command"
+	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvefs/list/topology"
 	config "github.com/opencurve/curve/tools-v2/pkg/config"
 	"github.com/opencurve/curve/tools-v2/pkg/output"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
-type MdsCommand struct {
+type MetaserverCommand struct {
 	basecmd.FinalCurveCmd
-	mainAddrs  []string
-	dummyAddrs []string
 	metrics    []basecmd.Metric
 	rows       []map[string]string
 }
 
 const (
-	STATUS_SUBURI  = "/vars/curvefs_mds_status"
+	STATUS_SUBURI  = "/vars/pid"
 	VERSION_SUBURI = "/vars/curve_version"
 )
 
-var _ basecmd.FinalCurveCmdFunc = (*MdsCommand)(nil) // check interface
+var _ basecmd.FinalCurveCmdFunc = (*MetaserverCommand)(nil) // check interface
 
-func NewMdsCommand() *cobra.Command {
-	mdsCmd := &MdsCommand{
+func NewMetaserverCommand() *cobra.Command {
+	mdsCmd := &MetaserverCommand{
 		FinalCurveCmd: basecmd.FinalCurveCmd{
-			Use:   "mds",
-			Short: "get the inode usage of curvefs",
+			Use:   "metaserver",
+			Short: "get metaserver status of curvefs",
 		},
 	}
 	basecmd.NewFinalCurveCli(&mdsCmd.FinalCurveCmd, mdsCmd)
 	return mdsCmd.Cmd
 }
 
-func (mCmd *MdsCommand) AddFlags() {
+func (mCmd *MetaserverCommand) AddFlags() {
 	config.AddFsMdsAddrFlag(mCmd.Cmd)
 	config.AddHttpTimeoutFlag(mCmd.Cmd)
 	config.AddFsMdsDummyAddrFlag(mCmd.Cmd)
 }
 
-func (mCmd *MdsCommand) Init(cmd *cobra.Command, args []string) error {
-	table, err := gotable.Create("addr", "dummyAddr", "version", "status")
+func (mCmd *MetaserverCommand) Init(cmd *cobra.Command, args []string) error {
+	externalAddrs, internalAddrs, errMetaserver := topology.GetMetaserverAddrs()
+	if errMetaserver.TypeCode() != cmderror.CODE_SUCCESS {
+		return fmt.Errorf(errMetaserver.Message)
+	}
+
+	table, err := gotable.Create("externalAddr", "internalAddr", "version", "status")
 	if err != nil {
 		cobra.CheckErr(err)
 	}
 	mCmd.Table = table
 
-	// set main addr
-	addrs := viper.GetString(config.VIPER_CURVEFS_MDSADDR)
-	mCmd.mainAddrs = strings.Split(addrs, ",")
-	for _, addr := range mCmd.mainAddrs {
+	for i, addr := range externalAddrs {
 		if !cobrautil.IsValidAddr(addr) {
-			return fmt.Errorf("invalid addr: %s", addr)
+			return fmt.Errorf("invalid metaserver external addr: %s", addr)
 		}
-	}
 
-	// set dummy addr
-	addrs = viper.GetString(config.VIPER_CURVEFS_MDSDUMMYADDR)
-	mCmd.dummyAddrs = strings.Split(addrs, ",")
-	for _, addr := range mCmd.dummyAddrs {
-		if !cobrautil.IsValidAddr(addr) {
-			return fmt.Errorf("invalid dummy addr: %s", addr)
-		}
-		// Use the dummy port to access the metric service
+		// set metrics
 		timeout := viper.GetDuration(config.VIPER_GLOBALE_HTTPTIMEOUT)
-
 		addrs := []string{addr}
 		statusMetric := basecmd.NewMetric(addrs, STATUS_SUBURI, timeout)
 		mCmd.metrics = append(mCmd.metrics, *statusMetric)
 		versionMetric := basecmd.NewMetric(addrs, VERSION_SUBURI, timeout)
 		mCmd.metrics = append(mCmd.metrics, *versionMetric)
-	}
 
-	for i := range mCmd.mainAddrs {
+		// set rows
 		row := make(map[string]string)
-		row["addr"] = mCmd.mainAddrs[i]
-		row["dummyAddr"] = mCmd.dummyAddrs[i]
+		row["externalAddr"] = addr
+		row["internalAddr"] = internalAddrs[i]
 		row["status"] = "offline"
 		row["version"] = "unknown"
 		mCmd.rows = append(mCmd.rows, row)
 	}
-
 	return nil
 }
 
-func (mCmd *MdsCommand) Print(cmd *cobra.Command, args []string) error {
+func (mCmd *MetaserverCommand) Print(cmd *cobra.Command, args []string) error {
 	return output.FinalCmdOutput(&mCmd.FinalCurveCmd, mCmd)
 }
 
-func (mCmd *MdsCommand) RunCommand(cmd *cobra.Command, args []string) error {
+func (mCmd *MetaserverCommand) RunCommand(cmd *cobra.Command, args []string) error {
 	results := make(chan basecmd.MetricResult, config.MaxChannelSize())
 	size := 0
 	for _, metric := range mCmd.metrics {
@@ -147,8 +136,12 @@ func (mCmd *MdsCommand) RunCommand(cmd *cobra.Command, args []string) error {
 	count := 0
 	for res := range results {
 		for _, row := range mCmd.rows {
-			if res.Err.TypeCode() == cmderror.CODE_SUCCESS && row["dummyAddr"] == res.Addr {
-				row[res.Key] = res.Value
+			if res.Err.TypeCode() == cmderror.CODE_SUCCESS && row["externalAddr"] == res.Addr {
+				if res.Key == "status" {
+					row[res.Key] = "online"	
+				} else {
+					row[res.Key] = res.Value
+				}
 			}
 		}
 		count++
@@ -156,6 +149,7 @@ func (mCmd *MdsCommand) RunCommand(cmd *cobra.Command, args []string) error {
 			break
 		}
 	}
+
 	mCmd.Table.AddRows(mCmd.rows)
 	jsonResult, err := mCmd.Table.JSON(0)
 	if err != nil {
@@ -170,6 +164,6 @@ func (mCmd *MdsCommand) RunCommand(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func (mCmd *MdsCommand) ResultPlainOutput() error {
+func (mCmd *MetaserverCommand) ResultPlainOutput() error {
 	return output.FinalCmdOutputPlain(&mCmd.FinalCurveCmd, mCmd)
 }

--- a/tools-v2/pkg/cli/command/curvefs/status/status.go
+++ b/tools-v2/pkg/cli/command/curvefs/status/status.go
@@ -25,6 +25,10 @@ package status
 import (
 	basecmd "github.com/opencurve/curve/tools-v2/pkg/cli/command"
 	mds "github.com/opencurve/curve/tools-v2/pkg/cli/command/curvefs/status/mds"
+<<<<<<< HEAD
+=======
+	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvefs/status/metaserver"
+>>>>>>> curve: fs status mds
 	"github.com/spf13/cobra"
 )
 
@@ -37,6 +41,10 @@ var _ basecmd.MidCurveCmdFunc = (*StatusCommand)(nil) // check interface
 func (statusCmd *StatusCommand) AddSubCommands() {
 	statusCmd.Cmd.AddCommand(
 		mds.NewMdsCommand(),
+<<<<<<< HEAD
+=======
+		metaserver.NewMetaserverCommand(),
+>>>>>>> curve: fs status mds
 	)
 }
 

--- a/tools-v2/pkg/cli/command/curvefs/usage/inode/inode.go
+++ b/tools-v2/pkg/cli/command/curvefs/usage/inode/inode.go
@@ -51,7 +51,7 @@ type InodeNumCommand struct {
 
 type Result struct {
 	Result string
-	Error  cmderror.CmdError
+	Error  *cmderror.CmdError
 	Hosts  []string
 	SubUri string
 }
@@ -141,9 +141,8 @@ func (iCmd *InodeNumCommand) RunCommand(cmd *cobra.Command, args []string) error
 				resMap := strings.Split(data, ":")
 				preMap := strings.Split(resMap[0], "_")
 				if len(resMap) != 2 && len(preMap) < 4 {
-					splitErr := cmderror.ErrDataNoExpected
+					splitErr := cmderror.ErrDataNoExpected()
 					splitErr.Format(data, "the length of the data does not meet the requirements")
-					iCmd.AllError = append(iCmd.AllError, splitErr)
 				} else {
 					num, errNum := strconv.ParseInt(resMap[1], 10, 64)
 					id, errId := strconv.ParseUint(preMap[3], 10, 32)
@@ -161,14 +160,12 @@ func (iCmd *InodeNumCommand) RunCommand(cmd *cobra.Command, args []string) error
 						row["num"] = strconv.FormatInt(num, 10)
 						rows = append(rows, row)
 					} else {
-						toErr := cmderror.ErrDataNoExpected
+						toErr := cmderror.ErrDataNoExpected()
 						toErr.Format(data)
-						iCmd.AllError = append(iCmd.AllError, toErr)
 					}
 				}
 			}
 		}
-		iCmd.AllError = append(iCmd.AllError, res.Error)
 		count++
 		if count >= size {
 			break

--- a/tools-v2/pkg/cli/curvecli.go
+++ b/tools-v2/pkg/cli/curvecli.go
@@ -30,7 +30,6 @@ import (
 	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvefs"
 	"github.com/opencurve/curve/tools-v2/pkg/cli/command/version"
 	config "github.com/opencurve/curve/tools-v2/pkg/config"
-	output "github.com/opencurve/curve/tools-v2/pkg/output"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -66,11 +65,9 @@ func newCurveCommand() *cobra.Command {
 
 	cmd.Flags().BoolP("version", "v", false, "Print curve version")
 	cmd.PersistentFlags().BoolP("help", "h", false, "Print usage")
-	cmd.PersistentFlags().StringP("format", "f", output.FORMAT_PLAIN, "Output format (json|plain)")
 	cmd.PersistentFlags().StringVarP(&config.ConfPath, "conf", "c", "", "config file (default is $HOME/.curve/curve.yaml or /etc/curve/curve.yaml)")
 	config.AddShowErrorPFlag(cmd)
 	viper.BindPFlag("useViper", cmd.PersistentFlags().Lookup("viper"))
-	viper.BindPFlag("format", cmd.PersistentFlags().Lookup("format"))
 
 	addSubCommands(cmd)
 	setupRootCommand(cmd)

--- a/tools-v2/pkg/config/config.go
+++ b/tools-v2/pkg/config/config.go
@@ -54,6 +54,21 @@ func InitConfig() {
 	}
 }
 
+// format
+const (
+	FORMAT_JSON  = "json"
+	FORMAT_PLAIN = "plain"
+	FORMAT_NOOUT = "noout"
+)
+func AddFormatFlag(cmd *cobra.Command) {
+	cmd.Flags().StringP("format", "f", FORMAT_PLAIN, "Output format (json|plain)")
+	err := viper.BindPFlag("format", cmd.Flags().Lookup("format"))
+	if err != nil {
+		cobra.CheckErr(err)
+	}
+}
+
+// http timeout
 func AddHttpTimeoutFlag(cmd *cobra.Command) {
 	cmd.Flags().Duration("httptimeout", 500*time.Millisecond, "http timeout")
 	err := viper.BindPFlag("global.httpTimeout", cmd.Flags().Lookup("httptimeout"))
@@ -62,6 +77,7 @@ func AddHttpTimeoutFlag(cmd *cobra.Command) {
 	}
 }
 
+// rpc time out
 func AddRpcTimeoutFlag(cmd *cobra.Command) {
 	cmd.Flags().Duration("rpctimeout", 10000*time.Millisecond, "rpc timeout")
 	err := viper.BindPFlag("global.rpcTimeout", cmd.Flags().Lookup("rpctimeout"))
@@ -79,7 +95,11 @@ func AddRpcRetryTimesFlag(cmd *cobra.Command) {
 	}
 }
 
+<<<<<<< HEAD
 // mds addr 
+=======
+// mds addr
+>>>>>>> curve: fs status mds
 func AddFsMdsAddrFlag(cmd *cobra.Command) {
 	cmd.Flags().String("mdsaddr", "", "mds address, should be like 127.0.0.1:6700,127.0.0.1:6701,127.0.0.1:6702")
 	err := viper.BindPFlag("curvefs.mdsAddr", cmd.Flags().Lookup("mdsaddr"))
@@ -137,6 +157,6 @@ const (
 	VIPER_GLOBALE_RPCRETRYTIMES = "global.rpcRetryTimes"
 
 	// curvefs
-	VIPER_CURVEFS_MDSADDR = "curvefs.mdsAddr"
+	VIPER_CURVEFS_MDSADDR      = "curvefs.mdsAddr"
 	VIPER_CURVEFS_MDSDUMMYADDR = "curvefs.mdsDummyAddr"
 )


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #xxx <!-- replace xxx with issue number -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

```
curve fs status metaserver
+--------------------+--------------------+----------------+--------+
|    externalAddr    |    internalAddr    |    version     | status |
+--------------------+--------------------+----------------+--------+
| 10.219.192.50:6800 | 10.219.192.50:6800 | 6de073a7+debug | online |
| 10.219.192.50:6802 | 10.219.192.50:6802 | 6de073a7+debug | online |
| 10.219.192.50:6801 | 10.219.192.50:6801 | 6de073a7+debug | online |
+--------------------+--------------------+----------------+--------+
curve fs status metaserver --format json
{
"error": {
"code": 0,
"message": "success"
},
"result": [
{
"externalAddr": "10.219.192.50:6800",
"internalAddr": "10.219.192.50:6800",
"status": "online",
"version": "6de073a7+debug"
},
{
"externalAddr": "10.219.192.50:6802",
"internalAddr": "10.219.192.50:6802",
"status": "online",
"version": "6de073a7+debug"
},
{
"externalAddr": "10.219.192.50:6801",
"internalAddr": "10.219.192.50:6801",
"status": "online",
"version": "6de073a7+debug"
}
]
}
```

![image](https://user-images.githubusercontent.com/15775037/173021432-ca464cab-216b-4a09-be00-2eff3852901c.png)
![image](https://user-images.githubusercontent.com/15775037/173021474-b4b13cf6-6149-47b9-a299-0252847bbc05.png)


Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
