### PR TITLE
curvefs:modify mds.conf

### DIFF
--- a/curvefs/conf/mds.conf
+++ b/curvefs/conf/mds.conf
@@ -44,16 +44,16 @@ leader.electionTimeoutMs=0
 #
 # time interval flush data to db
 mds.topology.TopologyUpdateToRepoSec=60
-# max partition number in copyset 2^8
-mds.topology.MaxPartitionNumberInCopyset=256
-# id number in each partition 2^24 [0, 2^24-1]
-mds.topology.IdNumberInPartition=16777216
+# max partition number in copyset 2^7
+mds.topology.MaxPartitionNumberInCopyset=128
+# id number in each partition 2^20 [0, 2^20-1]
+mds.topology.IdNumberInPartition=1048676
 # initial copyset number in cluster
-mds.topology.InitialCopysetNumber=10
+mds.topology.InitialCopysetNumber=12
 # min avaiable copyset num in cluster
-mds.topology.MinAvailableCopysetNum=10
-# default create partition number 3
-mds.topology.CreatePartitionNumber=3
+mds.topology.MinAvailableCopysetNum=12
+# default create partition number 12
+mds.topology.CreatePartitionNumber=12
 # max copyset num in metaserver
 mds.topology.MaxCopysetNumInMetaserver=100
 # Topology update metric interval
@@ -89,8 +89,8 @@ mds.copyset.scheduler.intervalSec=5
 mds.leader.scheduler.intervalSec=5
 # the percentage difference for copysetScheduler to
 # determine whether resource balancing is required
-# based on the difference in resource usage percent, default is 30%
-mds.copyset.scheduler.balanceRatioPercent=30
+# based on the difference in resource usage percent, default is 15%
+mds.copyset.scheduler.balanceRatioPercent=15
 # Concurrency of operator on each metaserver
 mds.schduler.operator.concurrent=1
 # transfer leader timeout, after the timeout, mds removes the operator from the memory


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #1529 

Problem Summary:

### What is changed and how it works?

What's Changed:

1、原来的patition 格式默认是3，这个数字太小了。这个会导致一个fs的元数据只能分布在3个copyset中。现在把这个数字改成和集群的初始copyset一致，可以让fs的元数据初始分布更均匀。
2、调低了partition中的inode的个数，让fs尽量使用更多的partition去让元数据分布的更均衡。
3、调低了copyset中的partition的个数，避免一个copyset管理太多的元数据。
4、集群默认的copyset个数调整为3的倍数。

1. The original patition format defaults to 3, which is too small. This will cause the metadata of an fs to only be distributed in 3 copies. Now change this number to be consistent with the initial copy of the cluster, which can make the initial distribution of fs metadata more uniform.
2. Reduced the number of inodes in the partition, and let fs use as many partitions as possible to make the metadata distribution more balanced.
3. Reduced the number of partitions in the copy to avoid managing too much metadata in one copy.
4. The default number of copies in the cluster is adjusted to a multiple of 3.

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
