### PR TITLE
curvefs/metaserver: now we removed several containers which takes a l…

### DIFF
--- a/curvefs/conf/metaserver.conf
+++ b/curvefs/conf/metaserver.conf
@@ -229,10 +229,25 @@ storage.rocksdb.ordered_write_buffer_size=134217728
 # rocksdb column family's max_write_buffer_number
 # for store dentry and inode's s3chunkinfo list (default: 15)
 storage.rocksdb.ordered_max_write_buffer_number=15
-# rocksdb block cache(LRU) capacity (default: 512MB)
-storage.rocksdb.block_cache_capacity=536870912
+# rocksdb block cache(LRU) capacity (default: 2GB)
+storage.rocksdb.block_cache_capacity=2147483648
 # rocksdb memtable prefix bloom size ratio (size=write_buffer_size*memtable_prefix_bloom_size_ratio)
 storage.rocksdb.memtable_prefix_bloom_size_ratio=0.1
+# dump rocksdb.stats to LOG every stats_dump_period_sec
+storage.rocksdb.stats_dump_period_sec=180
+# rocksdb perf level:
+#   0: kDisable
+#   1: kEnableCount
+#   2: kEnableTimeAndCPUTimeExceptForMutex
+#   3: kEnableTimeExceptForMutex
+#   4: kEnableTime
+# see also: https://github.com/facebook/rocksdb/wiki/Perf-Context-and-IO-Stats-Context#profile-levels-and-costs
+storage.rocksdb.perf_level=0
+# all rocksdb operations which latency greater than perf_slow_operation_us
+# will be considered a slow operation
+storage.rocksdb.perf_slow_us=100
+# rocksdb perf sampling ratio
+storage.rocksdb.perf_sampling_ratio=0
 # if the number of inode's s3chunkinfo exceed the limit_size,
 # we will sending its with rpc streaming instead of
 # padding its into inode (default: 25000, about 25000 * 41 (byte) = 1MB)

--- a/curvefs/proto/metaserver.proto
+++ b/curvefs/proto/metaserver.proto
@@ -79,6 +79,10 @@ message Dentry {
     optional uint64 txSequence = 8;
 }
 
+message DentryVec {
+    repeated Dentry dentrys = 1;
+}
+
 message GetDentryResponse {
     required MetaStatusCode statusCode = 1;
     optional Dentry dentry = 2;
@@ -333,6 +337,10 @@ message MetaServerMetadata {
     required uint32 checksum = 4;
 }
 
+message InodeAuxInfo {
+    required uint64 s3MetaSize = 1;
+}
+
 message GetOrModifyS3ChunkInfoRequest {
     required uint32 poolId = 1;
     required uint32 copysetId = 2;
@@ -429,7 +437,7 @@ message GetVolumeExtentRequest {
 message GetVolumeExtentResponse {
     required MetaStatusCode statusCode = 1;
     optional uint64 appliedIndex = 2;
-    optional VolumeExtentList slices = 3; 
+    optional VolumeExtentList slices = 3;
 }
 
 message UpdateVolumeExtentRequest {

--- a/curvefs/src/metaserver/dentry_manager.cpp
+++ b/curvefs/src/metaserver/dentry_manager.cpp
@@ -56,31 +56,32 @@ void DentryManager::Log4Code(const std::string& request, MetaStatusCode rc) {
     }
 }
 
-MetaStatusCode DentryManager::CreateDentry(const Dentry& dentry,
-                                           bool isLoadding) {
+MetaStatusCode DentryManager::CreateDentry(const Dentry& dentry) {
     Log4Dentry("CreateDentry", dentry);
-    MetaStatusCode rc;
-    // invoke only from snapshot loading
-    if (dentry.flag() & DentryFlag::TRANSACTION_PREPARE_FLAG) {
-        rc = dentryStorage_->HandleTx(DentryStorage::TX_OP_TYPE::PREPARE,
-                                      dentry);
-    } else {
-        rc = dentryStorage_->Insert(dentry, isLoadding);
-    }
+    MetaStatusCode rc = dentryStorage_->Insert(dentry);
     Log4Code("CreateDentry", rc);
+    return rc;
+}
+
+MetaStatusCode DentryManager::CreateDentry(const DentryVec& vec,
+                                           bool merge) {
+    VLOG(9) << "Receive CreateDentryVec request, dentryVec = ("
+            << vec.ShortDebugString() << ")";
+    MetaStatusCode rc = dentryStorage_->Insert(vec, merge);
+    Log4Code("CreateDentryVec", rc);
     return rc;
 }
 
 MetaStatusCode DentryManager::DeleteDentry(const Dentry& dentry) {
     Log4Dentry("DeleteDentry", dentry);
-    auto rc = dentryStorage_->Delete(dentry);
+    MetaStatusCode rc = dentryStorage_->Delete(dentry);
     Log4Code("DeleteDentry", rc);
     return rc;
 }
 
 MetaStatusCode DentryManager::GetDentry(Dentry* dentry) {
     Log4Dentry("GetDentry", *dentry);
-    auto rc = dentryStorage_->Get(dentry);
+    MetaStatusCode rc = dentryStorage_->Get(dentry);
     Log4Code("GetDentry", rc);
     return rc;
 }
@@ -90,7 +91,7 @@ MetaStatusCode DentryManager::ListDentry(const Dentry& dentry,
                                          uint32_t limit,
                                          bool onlyDir) {
     Log4Dentry("ListDentry", dentry);
-    auto rc = dentryStorage_->List(dentry, dentrys, limit, onlyDir);
+    MetaStatusCode rc = dentryStorage_->List(dentry, dentrys, limit, onlyDir);
     Log4Code("ListDentry", rc);
     return rc;
 }

--- a/curvefs/src/metaserver/dentry_manager.h
+++ b/curvefs/src/metaserver/dentry_manager.h
@@ -40,7 +40,10 @@ class DentryManager {
     DentryManager(std::shared_ptr<DentryStorage> dentryStorage,
                   std::shared_ptr<TxManager> txManger);
 
-    MetaStatusCode CreateDentry(const Dentry& dentry, bool isLoadding = false);
+    MetaStatusCode CreateDentry(const Dentry& dentry);
+
+    // only invoked from snapshot loadding
+    MetaStatusCode CreateDentry(const DentryVec& vec, bool merge);
 
     MetaStatusCode DeleteDentry(const Dentry& dentry);
 
@@ -63,6 +66,7 @@ class DentryManager {
     std::shared_ptr<DentryStorage> dentryStorage_;
     std::shared_ptr<TxManager> txManager_;
 };
+
 }  // namespace metaserver
 }  // namespace curvefs
 

--- a/curvefs/src/metaserver/dentry_storage.cpp
+++ b/curvefs/src/metaserver/dentry_storage.cpp
@@ -22,20 +22,21 @@
 
 #include <vector>
 #include <memory>
+#include <algorithm>
 
 #include "src/common/string_util.h"
 #include "curvefs/src/metaserver/dentry_storage.h"
-#include "curvefs/src/metaserver/storage/utils.h"
 
 namespace curvefs {
 namespace metaserver {
 
-using curve::common::ReadLockGuard;
-using curve::common::WriteLockGuard;
-using ::curve::common::SplitString;
+using ::curve::common::ReadLockGuard;
+using ::curve::common::WriteLockGuard;
 using ::curve::common::StringStartWith;
-using ::curvefs::metaserver::storage::Hash;
 using ::curvefs::metaserver::storage::Status;
+using ::curvefs::metaserver::storage::Key4Dentry;
+using ::curvefs::metaserver::storage::Prefix4SameParentDentry;
+using ::curvefs::metaserver::storage::Prefix4AllDentry;
 
 bool operator==(const Dentry& lhs, const Dentry& rhs) {
     return EQUAL(fsid) && EQUAL(parentinodeid) && EQUAL(name) &&
@@ -49,41 +50,123 @@ bool operator<(const Dentry& lhs, const Dentry& rhs) {
            LESS4(fsid, parentinodeid, name, txid);
 }
 
-DentryStorage::DentryStorage(std::shared_ptr<KVStorage> kvStorage,
-                             const std::string& tablename)
-    : kvStorage_(kvStorage),
-      tablename_(tablename) {}
-
-inline std::string DentryStorage::DentryKey(const Dentry& dentry,
-                                            bool ignoreTxId) {
-    std::ostringstream oss;
-    std::string txId = ignoreTxId ? "" : std::to_string(dentry.txid());
-    oss << dentry.fsid() << ":" << dentry.parentinodeid() << ":"
-        << Hash(dentry.name()) << ":" << txId;
-    return oss.str();
-}
-
-inline std::string DentryStorage::SameParentKey(const Dentry& dentry) {
-    std::ostringstream oss;
-    oss << dentry.fsid() << ":" << dentry.parentinodeid() << ":";
-    return oss.str();
-}
-
-bool DentryStorage::BelongSameOne(const Dentry& lhs, const Dentry& rhs) {
-    return EQUAL(fsid) && EQUAL(parentinodeid) &&
-           EQUAL(name) && lhs.txid() <= rhs.txid();
-}
-
-bool DentryStorage::IsSameDentry(const Dentry& lhs, const Dentry& rhs) {
+static bool BelongSomeOne(const Dentry& lhs, const Dentry& rhs) {
     return EQUAL(fsid) && EQUAL(parentinodeid) && EQUAL(name) &&
            EQUAL(inodeid);
 }
 
-inline bool DentryStorage::HasDeleteMarkFlag(const Dentry& dentry) {
+static bool HasDeleteMarkFlag(const Dentry& dentry) {
     return (dentry.flag() & DentryFlag::DELETE_MARK_FLAG) != 0;
 }
 
-bool DentryStorage::CompressDentry(BTree* dentrys) {
+DentryVector::DentryVector(DentryVec* vec)
+    : vec_(vec),
+      nPendingAdd_(0),
+      nPendingDel_(0) {}
+
+void DentryVector::Insert(const Dentry& dentry) {
+    for (const Dentry& item : vec_->dentrys()) {
+        if (item == dentry) {
+            return;
+        }
+    }
+    vec_->add_dentrys()->CopyFrom(dentry);
+    nPendingAdd_ += 1;
+}
+
+void DentryVector::Delete(const Dentry& dentry) {
+    for (size_t i = 0; i < vec_->dentrys_size(); i++) {
+        if (vec_->dentrys(i) == dentry) {
+            vec_->mutable_dentrys()->DeleteSubrange(i, 1);
+            nPendingDel_ += 1;
+            break;
+        }
+    }
+}
+
+void DentryVector::Merge(const DentryVec& src) {
+    for (const auto& dentry : src.dentrys()) {
+        vec_->add_dentrys()->CopyFrom(dentry);
+    }
+    nPendingAdd_ = src.dentrys_size();
+}
+
+void DentryVector::Filter(uint64_t maxTxId, BTree* btree) {
+    for (const Dentry& dentry : vec_->dentrys()) {
+        if (dentry.txid() <= maxTxId) {
+            btree->insert(dentry);
+        }
+    }
+}
+
+void DentryVector::Confirm(uint64_t* count) {
+    if (nPendingDel_ > *count + nPendingAdd_) {
+        LOG(ERROR) << "there are multi delete, count = " << *count
+                   << ", nPendingAdd = " << nPendingAdd_
+                   << ", nPendingDel = " << nPendingDel_;
+        *count = 0;
+        return;
+    }
+    *count = *count + nPendingAdd_ - nPendingDel_;
+}
+
+DentryList::DentryList(std::vector<Dentry>* list,
+                       uint32_t limit,
+                       const std::string& exclude,
+                       uint64_t maxTxId,
+                       bool onlyDir)
+    : list_(list),
+      size_(0),
+      limit_(limit),
+      exclude_(exclude),
+      maxTxId_(maxTxId),
+      onlyDir_(onlyDir) {}
+
+void DentryList::PushBack(DentryVec* vec) {
+    // NOTE: it's a cheap operation becacuse the size of
+    // dentryVec must less than 2
+    BTree dentrys;
+    DentryVector vector(vec);
+    vector.Filter(maxTxId_, &dentrys);
+    auto last = dentrys.rbegin();
+    if (IsFull()) {
+        return;
+    } else if (dentrys.size() == 0 || HasDeleteMarkFlag(*last)) {
+        return;
+    } else if (onlyDir_ && last->type() != FsFileType::TYPE_DIRECTORY) {
+        return;
+    } else if (last->name() == exclude_) {
+        return;
+    }
+
+    size_++;
+    list_->push_back(*last);
+    VLOG(9) << "Push dentry, dentry = (" << last->ShortDebugString() << ")";
+}
+
+uint32_t DentryList::Size() {
+    return size_;
+}
+
+bool DentryList::IsFull() {
+    return limit_ != 0 && size_ >= limit_;
+}
+
+DentryStorage::DentryStorage(std::shared_ptr<KVStorage> kvStorage,
+                             std::shared_ptr<NameGenerator> nameGenerator,
+                             uint64_t nDentry)
+    : kvStorage_(kvStorage),
+      table4Dentry_(nameGenerator->GetDentryTableName()),
+      nDentry_(nDentry),
+      conv_() {}
+
+std::string DentryStorage::DentryKey(const Dentry& dentry) {
+    Key4Dentry key(dentry.fsid(), dentry.parentinodeid(), dentry.name());
+    return conv_.SerializeToString(key);
+}
+
+bool DentryStorage::CompressDentry(DentryVec* vec, BTree* dentrys) {
+    DentryVector vector(vec);
     std::vector<Dentry> deleted;
     if (dentrys->size() == 2) {
         deleted.push_back(*dentrys->begin());
@@ -91,44 +174,43 @@ bool DentryStorage::CompressDentry(BTree* dentrys) {
     if (HasDeleteMarkFlag(*dentrys->rbegin())) {
         deleted.push_back(*dentrys->rbegin());
     }
-    for (const auto& item : deleted) {
-        Status s = kvStorage_->SDel(tablename_, DentryKey(item));
-        if (!s.ok() && !s.IsNotFound()) {
-            return false;
-        }
+    for (const auto& dentry : deleted) {
+        vector.Delete(dentry);
     }
-    return true;
+
+    Status s;
+    std::string skey = DentryKey(*dentrys->begin());
+    if (vec->dentrys_size() == 0) {  // delete directly
+        s = kvStorage_->SDel(table4Dentry_, skey);
+    } else {
+        s = kvStorage_->SSet(table4Dentry_, skey, *vec);
+    }
+
+    if (s.ok()) {
+        vector.Confirm(&nDentry_);
+        return true;
+    }
+    return false;
 }
 
 // NOTE: Find() return the dentry which has the latest txid,
 // and it will clean the old txid's dentry if you specify compress to true
 MetaStatusCode DentryStorage::Find(const Dentry& in,
                                    Dentry* out,
+                                   DentryVec* vec,
                                    bool compress) {
-    uint64_t maxTxId = in.txid();
-    std::string prefix = DentryKey(in, true);
-    auto iterator = kvStorage_->SSeek(tablename_, prefix);
-    if (iterator->Status() < 0) {
+    std::string skey = DentryKey(in);
+    Status s = kvStorage_->SGet(table4Dentry_, skey, vec);
+    if (s.IsNotFound()) {
+        return MetaStatusCode::NOT_FOUND;
+    } else if (!s.ok()) {
         return MetaStatusCode::STORAGE_INTERNAL_ERROR;
     }
 
-    // find dentry which belongs to one
-    Dentry dentry;
+    // status = OK
     BTree dentrys;
-    for (iterator->SeekToFirst(); iterator->Valid(); iterator->Next()) {
-        std::string key = iterator->Key();
-        std::string value = iterator->Value();
-        if (!StringStartWith(key, prefix)) {
-            break;
-        } else if (!iterator->ParseFromValue(&dentry)) {
-            return MetaStatusCode::PARSE_FROM_STRING_FAILED;
-        }
-
-        if (dentry.txid() <= maxTxId) {
-            dentrys.emplace(dentry);
-        }
-    }
-
+    DentryVector vector(vec);
+    vector.Filter(in.txid(), &dentrys);
     size_t size = dentrys.size();
     if (size > 2) {
         LOG(ERROR) << "There are more than 2 dentrys";
@@ -146,56 +228,101 @@ MetaStatusCode DentryStorage::Find(const Dentry& in,
         *out = *dentrys.rbegin();
     }
 
-    if (compress && !CompressDentry(&dentrys)) {
+    if (compress && !CompressDentry(vec, &dentrys)) {
         rc = MetaStatusCode::STORAGE_INTERNAL_ERROR;
     }
     return rc;
 }
 
-MetaStatusCode DentryStorage::Insert(const Dentry& dentry, bool isLoadding) {
-    WriteLockGuard w(rwLock_);
+MetaStatusCode DentryStorage::Insert(const Dentry& dentry) {
+    WriteLockGuard lg(rwLock_);
 
-    if (!isLoadding) {
-        Dentry out;
-        MetaStatusCode rc = Find(dentry, &out, true);
-        if (rc == MetaStatusCode::OK) {
-            if (IsSameDentry(out, dentry)) {
-                return MetaStatusCode::IDEMPOTENCE_OK;
-            }
-            return MetaStatusCode::DENTRY_EXIST;
-        } else if (rc != MetaStatusCode::NOT_FOUND) {
+    Dentry out;
+    DentryVec vec;
+    MetaStatusCode rc = Find(dentry, &out, &vec, true);
+    if (rc == MetaStatusCode::OK) {
+        if (BelongSomeOne(out, dentry)) {
+            return MetaStatusCode::IDEMPOTENCE_OK;
+        }
+        return MetaStatusCode::DENTRY_EXIST;
+    } else if (rc != MetaStatusCode::NOT_FOUND) {
+        return MetaStatusCode::STORAGE_INTERNAL_ERROR;
+    }
+
+    // rc == MetaStatusCode::NOT_FOUND
+    DentryVector vector(&vec);
+    vector.Insert(dentry);
+    std::string skey = DentryKey(dentry);
+    Status s = kvStorage_->SSet(table4Dentry_, skey, vec);
+    if (!s.ok()) {
+        LOG(ERROR) << "Insert dentry failed, status = " << s.ToString();
+        return MetaStatusCode::STORAGE_INTERNAL_ERROR;
+    }
+    vector.Confirm(&nDentry_);
+    return MetaStatusCode::OK;
+}
+
+MetaStatusCode DentryStorage::Insert(const DentryVec& vec, bool merge) {
+    WriteLockGuard lg(rwLock_);
+
+    Status s;
+    DentryVec oldVec;
+    std::string skey = DentryKey(vec.dentrys(0));
+    if (merge) {  // for old version dumpfile (v1)
+        s = kvStorage_->SGet(table4Dentry_, skey, &oldVec);
+        if (s.IsNotFound()) {
+            // do nothing
+        } else if (!s.ok()) {
             return MetaStatusCode::STORAGE_INTERNAL_ERROR;
         }
     }
 
-    // MetaStatusCode::NOT_FOUND
-    Status s = kvStorage_->SSet(tablename_, DentryKey(dentry), dentry);
-    return s.ok() ? MetaStatusCode::OK :
-                    MetaStatusCode::STORAGE_INTERNAL_ERROR;
+    DentryVector vector(&oldVec);
+    vector.Merge(vec);
+    s = kvStorage_->SSet(table4Dentry_, skey, oldVec);
+    if (!s.ok()) {
+        LOG(ERROR) << "Insert dentry vector failed, status = " << s.ToString();
+        return MetaStatusCode::STORAGE_INTERNAL_ERROR;
+    }
+    vector.Confirm(&nDentry_);
+    return MetaStatusCode::OK;
 }
 
 MetaStatusCode DentryStorage::Delete(const Dentry& dentry) {
-    WriteLockGuard w(rwLock_);
+    WriteLockGuard lg(rwLock_);
 
     Dentry out;
-    MetaStatusCode rc = Find(dentry, &out, true);
+    DentryVec vec;
+    MetaStatusCode rc = Find(dentry, &out, &vec, true);
     if (rc == MetaStatusCode::NOT_FOUND) {
         return MetaStatusCode::NOT_FOUND;
     } else if (rc != MetaStatusCode::OK) {
         return MetaStatusCode::STORAGE_INTERNAL_ERROR;
     }
 
-    // MetaStatusCode::OK
-    Status s = kvStorage_->SDel(tablename_, DentryKey(out));
-    return s.ok() ? MetaStatusCode::OK :
-                    MetaStatusCode::STORAGE_INTERNAL_ERROR;
+    Status s;
+    DentryVector vector(&vec);
+    vector.Delete(out);
+    std::string skey = DentryKey(dentry);
+    if (vec.dentrys_size() == 0) {
+        s = kvStorage_->SDel(table4Dentry_, skey);
+    } else {
+        s = kvStorage_->SSet(table4Dentry_, skey, vec);
+    }
+
+    if (s.ok()) {
+        vector.Confirm(&nDentry_);
+        return MetaStatusCode::OK;
+    }
+    return MetaStatusCode::STORAGE_INTERNAL_ERROR;
 }
 
 MetaStatusCode DentryStorage::Get(Dentry* dentry) {
-    ReadLockGuard r(rwLock_);
+    ReadLockGuard lg(rwLock_);
 
     Dentry out;
-    MetaStatusCode rc = Find(*dentry, &out, false);
+    DentryVec vec;
+    MetaStatusCode rc = Find(*dentry, &out, &vec, false);
     if (rc == MetaStatusCode::NOT_FOUND) {
         return MetaStatusCode::NOT_FOUND;
     } else if (rc != MetaStatusCode::OK) {
@@ -211,90 +338,88 @@ MetaStatusCode DentryStorage::List(const Dentry& dentry,
                                    std::vector<Dentry>* dentrys,
                                    uint32_t limit,
                                    bool onlyDir) {
-    ReadLockGuard r(rwLock_);
-    std::string prefix = SameParentKey(dentry);
-    std::string lkey = prefix;
-    if (dentry.name().size() > 0) {
-        size_t hash4name = Hash(dentry.name());
-        lkey = lkey + std::to_string(hash4name) + ":";
+    ReadLockGuard lg(rwLock_);
+
+    // 1. precheck for dentry vector
+    // NOTE: we should gurantee the vector is empty
+    if (nullptr == dentrys || dentrys->size() > 0) {
+        LOG(ERROR) << "input dentry vector is invalid";
+        return MetaStatusCode::PARAM_ERROR;
     }
 
-    auto iter = kvStorage_->SSeek(tablename_, lkey);
-    if (iter->Status() < 0) {
+    // 2. prepare seek lower key
+    uint32_t fsId = dentry.fsid();
+    uint64_t parentInodeId = dentry.parentinodeid();
+    std::string name = dentry.name();
+    Prefix4SameParentDentry prefix(fsId, parentInodeId);
+    std::string sprefix = conv_.SerializeToString(prefix);  // "1:1:"
+    Key4Dentry key(fsId, parentInodeId, name);
+    std::string lower = conv_.SerializeToString(key);  // "1:1:", "1:1:/a/b/c"
+
+    VLOG(3) << "ListDentry request: dentry = ("
+            << dentry.ShortDebugString() << ")"
+            << ", limit = " << limit << ", onlyDir = " << onlyDir
+            << ", lower key = " << lower;
+
+    // 3. iterator key/value pair one by one
+    auto iterator = kvStorage_->SSeek(table4Dentry_, lower);
+    iterator->DisablePrefixChecking();
+    if (iterator->Status() < 0) {
         return MetaStatusCode::STORAGE_INTERNAL_ERROR;
     }
-    iter->DisablePrefixChecking();
 
-    uint32_t count = 0;
-    auto push = [&](BTree* temp) {
-        bool select = true;
-        if (limit != 0 && count >= limit) {
-            select = false;
-        } else if (temp->size() == 0 || HasDeleteMarkFlag(*temp->rbegin())) {
-            select = false;
-        } else if (onlyDir &&
-            temp->rbegin()->type() != FsFileType::TYPE_DIRECTORY) {
-            select = false;
-        }
-
-        if (select) {
-            count++;
-            auto iter = temp->rbegin();
-            dentrys->push_back(*iter);
-            VLOG(9) << "ListDentry, dentry = ("
-                    << iter->ShortDebugString() << ")";
-        }
-        temp->clear();
-    };
-
-    Dentry current;
-    BTree temp;
-    std::string exclude = dentry.name();
-    uint64_t maxTxId = dentry.txid();
-    for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
-        std::string key = iter->Key();
-        std::string value = iter->Value();
-        if (!StringStartWith(key, prefix)) {
+    DentryVec current;
+    DentryList list(dentrys, limit, name, dentry.txid(), onlyDir);
+    for (iterator->SeekToFirst(); iterator->Valid(); iterator->Next()) {
+        std::string skey = iterator->Key();
+        std::string svalue = iterator->Value();
+        if (!StringStartWith(skey, sprefix)) {
             break;
-        } else if (!iter->ParseFromValue(&current)) {
+        } else if (!iterator->ParseFromValue(&current)) {
             return MetaStatusCode::PARSE_FROM_STRING_FAILED;
         }
 
-        if (current.name() != exclude && current.txid() <= maxTxId) {
-            if (temp.size() == 0) {
-                temp.emplace(current);
-            } else if (temp.rbegin()->name() == current.name()) {
-                // belong same dentry
-                temp.emplace(current);
-            } else {
-                push(&temp);
-                temp.emplace(current);
-            }
+        list.PushBack(&current);
+        if (list.IsFull()) {
+            break;
         }
     }
 
-    push(&temp);
-    return dentrys->empty() ? MetaStatusCode::NOT_FOUND : MetaStatusCode::OK;
+    if (list.Size() == 0) {
+        return MetaStatusCode::NOT_FOUND;
+    }
+    return MetaStatusCode::OK;
 }
 
 MetaStatusCode DentryStorage::HandleTx(TX_OP_TYPE type, const Dentry& dentry) {
-    WriteLockGuard w(rwLock_);
+    WriteLockGuard lg(rwLock_);
 
     Status s;
-    Dentry dummy;
-    std::string value;
-    auto rc = MetaStatusCode::OK;
+    Dentry out;
+    DentryVec vec;
+    DentryVector vector(&vec);
+    std::string skey = DentryKey(dentry);
+    MetaStatusCode rc = MetaStatusCode::OK;
     switch (type) {
         case TX_OP_TYPE::PREPARE:
-            // For idempotence, do not judge the return value
-            s = kvStorage_->SSet(tablename_, DentryKey(dentry), dentry);
+            s = kvStorage_->SGet(table4Dentry_, skey, &vec);
+            if (!s.ok() && !s.IsNotFound()) {
+                rc = MetaStatusCode::STORAGE_INTERNAL_ERROR;
+                break;
+            }
+
+            // OK || NOT_FOUND
+            vector.Insert(dentry);
+            s = kvStorage_->SSet(table4Dentry_, skey, vec);
             if (!s.ok()) {
                 rc = MetaStatusCode::STORAGE_INTERNAL_ERROR;
+            } else {
+                vector.Confirm(&nDentry_);
             }
             break;
 
         case TX_OP_TYPE::COMMIT:
-            rc = Find(dentry, &dummy, true);
+            rc = Find(dentry, &out, &vec, true);
             if (rc == MetaStatusCode::OK ||
                 rc == MetaStatusCode::NOT_FOUND) {
                 rc = MetaStatusCode::OK;
@@ -302,9 +427,23 @@ MetaStatusCode DentryStorage::HandleTx(TX_OP_TYPE type, const Dentry& dentry) {
             break;
 
         case TX_OP_TYPE::ROLLBACK:
-            s = kvStorage_->SDel(tablename_, DentryKey(dentry));
+            s = kvStorage_->SGet(table4Dentry_, skey, &vec);
             if (!s.ok() && !s.IsNotFound()) {
                 rc = MetaStatusCode::STORAGE_INTERNAL_ERROR;
+                break;
+            }
+
+            // OK || NOT_FOUND
+            vector.Delete(dentry);
+            if (vec.dentrys_size() == 0) {  // delete directly
+                s = kvStorage_->SDel(table4Dentry_, skey);
+            } else {
+                s = kvStorage_->SSet(table4Dentry_, skey, vec);
+            }
+            if (!s.ok()) {
+                rc = MetaStatusCode::STORAGE_INTERNAL_ERROR;
+            } else {
+                vector.Confirm(&nDentry_);
             }
             break;
 
@@ -316,17 +455,40 @@ MetaStatusCode DentryStorage::HandleTx(TX_OP_TYPE type, const Dentry& dentry) {
 }
 
 std::shared_ptr<Iterator> DentryStorage::GetAll() {
-    return kvStorage_->SGetAll(tablename_);
+    ReadLockGuard lg(rwLock_);
+    return kvStorage_->SGetAll(table4Dentry_);
 }
 
 size_t DentryStorage::Size() {
-    return kvStorage_->SSize(tablename_);
+    ReadLockGuard lg(rwLock_);
+    return nDentry_;
+}
+
+bool DentryStorage::Empty() {
+    ReadLockGuard lg(rwLock_);
+
+    std::string sprefix = conv_.SerializeToString(Prefix4AllDentry());
+    auto iterator = kvStorage_->SSeek(table4Dentry_, sprefix);
+    if (iterator->Status() != 0) {
+        LOG(ERROR) << "failed to get iterator for all inode";
+        return false;
+    }
+
+    for (iterator->SeekToFirst(); iterator->Valid(); iterator->Next()) {
+        return false;
+    }
+    return true;
 }
 
 MetaStatusCode DentryStorage::Clear() {
-    ReadLockGuard w(rwLock_);
-    Status s = kvStorage_->SClear(tablename_);
-    return s.ok() ? MetaStatusCode::OK : MetaStatusCode::STORAGE_INTERNAL_ERROR;
+    WriteLockGuard lg(rwLock_);
+    Status s = kvStorage_->SClear(table4Dentry_);
+    if (!s.ok()) {
+        LOG(ERROR) << "failed to clear dentry table, status = " << s.ToString();
+        return MetaStatusCode::STORAGE_INTERNAL_ERROR;
+    }
+    nDentry_ = 0;
+    return MetaStatusCode::OK;
 }
 
 }  // namespace metaserver

--- a/curvefs/src/metaserver/inode_manager.cpp
+++ b/curvefs/src/metaserver/inode_manager.cpp
@@ -452,7 +452,7 @@ MetaStatusCode InodeManager::InsertInode(const Inode &inode) {
 }
 
 bool InodeManager::GetInodeIdList(std::list<uint64_t>* inodeIdList) {
-    return inodeStorage_->GetInodeIdList(inodeIdList);
+    return inodeStorage_->GetAllInodeId(inodeIdList);
 }
 
 MetaStatusCode InodeManager::UpdateVolumeExtentSliceLocked(

--- a/curvefs/src/metaserver/inode_manager.h
+++ b/curvefs/src/metaserver/inode_manager.h
@@ -132,7 +132,6 @@ class InodeManager {
  private:
     std::shared_ptr<InodeStorage> inodeStorage_;
     std::shared_ptr<Trash> trash_;
-
     NameLock inodeLock_;
 };
 

--- a/curvefs/src/metaserver/inode_storage.h
+++ b/curvefs/src/metaserver/inode_storage.h
@@ -23,46 +23,39 @@
 #ifndef CURVEFS_SRC_METASERVER_INODE_STORAGE_H_
 #define CURVEFS_SRC_METASERVER_INODE_STORAGE_H_
 
-#include <functional>
-#include <utility>
-#include <unordered_map>
-#include <unordered_set>
 #include <list>
 #include <string>
 #include <memory>
+#include <utility>
+#include <functional>
+#include <unordered_map>
+#include <unordered_set>
 
+#include "absl/container/btree_set.h"
+#include "absl/container/btree_map.h"
 #include "src/common/concurrent/rw_lock.h"
 #include "curvefs/proto/metaserver.pb.h"
 #include "curvefs/src/metaserver/storage/converter.h"
 #include "curvefs/src/metaserver/storage/utils.h"
 #include "curvefs/src/metaserver/storage/storage.h"
 
-using curve::common::RWLock;
-using curve::common::ReadLockGuard;
-using curve::common::WriteLockGuard;
-using ::curvefs::metaserver::storage::Status;
-using ::curvefs::metaserver::storage::Iterator;
-using ::curvefs::metaserver::storage::KVStorage;
-using ::curvefs::metaserver::storage::StorageTransaction;
-using ::curvefs::metaserver::storage::Hash;
-
 namespace curvefs {
 namespace metaserver {
 
+using ::curve::common::RWLock;
+using ::curvefs::metaserver::storage::Iterator;
+using ::curvefs::metaserver::storage::KVStorage;
+using ::curvefs::metaserver::storage::StorageTransaction;
 using ::curvefs::metaserver::storage::Key4Inode;
 using ::curvefs::metaserver::storage::Converter;
+using ::curvefs::metaserver::storage::NameGenerator;
 using S3ChunkInfoMap = google::protobuf::Map<uint64_t, S3ChunkInfoList>;
-
-enum TABLE_TYPE : unsigned char {
-    kTypeInode = 1,
-    kTypeS3ChunkInfo = 2,
-    kTypeVolumeExtent = 3,
-};
 
 class InodeStorage {
  public:
     InodeStorage(std::shared_ptr<KVStorage> kvStorage,
-                 const std::string& tablename);
+                 std::shared_ptr<NameGenerator> nameGenerator,
+                 uint64_t nInode);
 
     /**
      * @brief insert inode to storage
@@ -109,6 +102,20 @@ class InodeStorage {
      */
     MetaStatusCode Update(const Inode& inode);
 
+    std::shared_ptr<Iterator> GetAllInode();
+
+    bool GetAllInodeId(std::list<uint64_t>* ids);
+
+    // NOTE: the return size is accurate under normal cluster status,
+    // but under abnormal status, the return size maybe less than
+    // the real value for delete the unexist inode multi-times.
+    size_t Size();
+
+    bool Empty();
+
+    MetaStatusCode Clear();
+
+    // s3chunkinfo
     MetaStatusCode ModifyInodeS3ChunkInfoList(uint32_t fsId,
                                               uint64_t inodeId,
                                               uint64_t chunkIndex,
@@ -125,8 +132,7 @@ class InodeStorage {
 
     std::shared_ptr<Iterator> GetAllS3ChunkInfoList();
 
-    std::shared_ptr<Iterator> GetAllInode();
-
+    // volume extent
     std::shared_ptr<Iterator> GetAllVolumeExtentList();
 
     MetaStatusCode UpdateVolumeExtentSlice(uint32_t fsId,
@@ -142,13 +148,12 @@ class InodeStorage {
                                            uint64_t offset,
                                            VolumeExtentSlice* slice);
 
-    size_t Size();
-
-    MetaStatusCode Clear();
-
-    bool GetInodeIdList(std::list<uint64_t>* inodeIdList);
-
  private:
+    bool UpdateInodeS3MetaSize(uint32_t fsId, uint64_t inodeId,
+                               uint64_t size4add, uint64_t size4del);
+
+    uint64_t GetInodeS3MetaSize(uint32_t fsId, uint64_t inodeId);
+
     MetaStatusCode AddS3ChunkInfoList(
         std::shared_ptr<StorageTransaction> txn,
         uint32_t fsId,
@@ -163,57 +168,18 @@ class InodeStorage {
         uint64_t chunkIndex,
         const S3ChunkInfoList* list2del);
 
-    static std::string RealTablename(TABLE_TYPE type,
-                                     const std::string& tablename) {
-        std::ostringstream oss;
-        oss << type << ":" << tablename;
-        return oss.str();
-    }
-
-    static std::string InodeS3MetaSizeKey(uint32_t fsId, uint64_t inodeId) {
-        std::ostringstream oss;
-        oss << fsId << ":" << inodeId;
-        return oss.str();
-    }
-
-    bool UpdateInodeS3MetaSize(uint32_t fsId, uint64_t inodeId,
-                               uint64_t size4add, uint64_t size4del) {
-        std::string key = InodeS3MetaSizeKey(fsId, inodeId);
-        uint64_t size = inodeS3MetaSize_[key] + size4add;
-        if (size < size4del) {
-            return false;
-        }
-        inodeS3MetaSize_[key] = size - size4del;
-        return true;
-    }
-
-    uint64_t GetInodeS3MetaSize(uint32_t fsId, uint64_t inodeId) {
-        std::string key = InodeS3MetaSizeKey(fsId, inodeId);
-        return inodeS3MetaSize_[key];
-    }
-
-    bool FindKey(const std::string& key) {
-        return keySet_.find(key) != keySet_.end();
-    }
-
-    void InsertKey(const std::string& key) {
-        keySet_.insert(key);
-    }
-
-    void EraseKey(const std::string& key) {
-        keySet_.erase(key);
-    }
-
  private:
+    // FIXME: please remove this lock, because we has locked each inode
+    // in inode manager, this lock only for proetct storage, but now we
+    // use rocksdb storage, it support write in parallel.
     RWLock rwLock_;
     std::shared_ptr<KVStorage> kvStorage_;
-    std::string table4inode_;
-    std::string table4s3chunkinfo_;
-    std::string table4volumeextent_;
+    std::string table4Inode_;
+    std::string table4S3ChunkInfo_;
+    std::string table4VolumeExtent_;
+    std::string table4InodeAuxInfo_;
+    size_t nInode_;
     Converter conv_;
-    std::unordered_set<std::string> keySet_;
-    // key: Hash(inode), value: the number of inode's chunkinfo size
-    std::unordered_map<std::string, uint64_t> inodeS3MetaSize_;
 };
 
 }  // namespace metaserver

--- a/curvefs/src/metaserver/metaserver.cpp
+++ b/curvefs/src/metaserver/metaserver.cpp
@@ -36,6 +36,7 @@
 #include "curvefs/src/metaserver/s3compact_manager.h"
 #include "curvefs/src/metaserver/trash_manager.h"
 #include "curvefs/src/metaserver/storage/storage.h"
+#include "curvefs/src/metaserver/storage/rocksdb_perf.h"
 #include "src/common/crc32.h"
 #include "src/common/curve_version.h"
 #include "src/common/s3_adapter.h"
@@ -503,6 +504,15 @@ void Metaserver::InitStorage() {
     LOG_IF(FATAL, !conf_->GetDoubleValue(
         "storage.rocksdb.memtable_prefix_bloom_size_ratio",
         &storageOptions_.memtablePrefixBloomSizeRatio));
+    LOG_IF(FATAL, !conf_->GetUInt64Value(
+        "storage.rocksdb.stats_dump_period_sec",
+        &storageOptions_.statsDumpPeriodSec));
+    conf_->GetValueFatalIfFail("storage.rocksdb.perf_level",
+                               &FLAGS_rocksdb_perf_level);
+    conf_->GetValueFatalIfFail("storage.rocksdb.perf_slow_us",
+                               &FLAGS_rocksdb_perf_slow_us);
+    conf_->GetValueFatalIfFail("storage.rocksdb.perf_sampling_ratio",
+                               &FLAGS_rocksdb_perf_sampling_ratio);
     LOG_IF(FATAL, !conf_->GetUInt64Value(
         "storage.s3_meta_inside_inode.limit_size",
         &storageOptions_.s3MetaLimitSizeInsideInode));

--- a/curvefs/src/metaserver/metastore.cpp
+++ b/curvefs/src/metaserver/metastore.cpp
@@ -37,6 +37,8 @@
 namespace curvefs {
 namespace metaserver {
 
+using ::curve::common::ReadLockGuard;
+using ::curve::common::WriteLockGuard;
 using ::curvefs::metaserver::storage::DumpFileClosure;
 using KVStorage = ::curvefs::metaserver::storage::KVStorage;
 using Key4S3ChunkInfoList = ::curvefs::metaserver::storage::Key4S3ChunkInfoList;
@@ -212,7 +214,7 @@ MetaStatusCode MetaStoreImpl::CreateDentry(const CreateDentryRequest* request,
         response->set_statuscode(status);
         return status;
     }
-    MetaStatusCode status = partition->CreateDentry(request->dentry(), false);
+    MetaStatusCode status = partition->CreateDentry(request->dentry());
     response->set_statuscode(status);
     return status;
 }

--- a/curvefs/src/metaserver/metastore_fstream.h
+++ b/curvefs/src/metaserver/metastore_fstream.h
@@ -65,7 +65,8 @@ class MetaStoreFStream {
                    const std::string& key,
                    const std::string& value);
 
-    bool LoadDentry(uint32_t partitionId,
+    bool LoadDentry(uint8_t version,
+                    uint32_t partitionId,
                     const std::string& key,
                     const std::string& value);
 

--- a/curvefs/src/metaserver/partition.cpp
+++ b/curvefs/src/metaserver/partition.cpp
@@ -30,19 +30,33 @@
 #include "curvefs/proto/metaserver.pb.h"
 #include "curvefs/src/metaserver/s3compact_manager.h"
 #include "curvefs/src/metaserver/trash_manager.h"
+#include "curvefs/src/metaserver/storage/converter.h"
 
 namespace curvefs {
 namespace metaserver {
+
+using ::curvefs::metaserver::storage::NameGenerator;
 
 Partition::Partition(const PartitionInfo& paritionInfo,
                      std::shared_ptr<KVStorage> kvStorage) {
     assert(paritionInfo.start() <= paritionInfo.end());
     partitionInfo_ = paritionInfo;
 
+    uint64_t nInode = 0;
+    uint64_t nDentry = 0;
+    uint32_t partitionId = paritionInfo.partitionid();
+    if (paritionInfo.has_inodenum()) {
+        nInode = paritionInfo.inodenum();
+    }
+    if (paritionInfo.has_dentrynum()) {
+        nDentry = paritionInfo.dentrynum();
+    }
+    auto tableName = std::make_shared<NameGenerator>(partitionId);
     inodeStorage_ = std::make_shared<InodeStorage>(
-        kvStorage, GetInodeTablename());
+        kvStorage, tableName, nInode);
     dentryStorage_ = std::make_shared<DentryStorage>(
-        kvStorage, GetDentryTablename());
+        kvStorage, tableName, nDentry);
+
     trash_ = std::make_shared<TrashImpl>(inodeStorage_);
     inodeManager_ = std::make_shared<InodeManager>(inodeStorage_, trash_);
     txManager_ = std::make_shared<TxManager>(dentryStorage_);
@@ -60,8 +74,7 @@ Partition::Partition(const PartitionInfo& paritionInfo,
     }
 }
 
-// dentry
-MetaStatusCode Partition::CreateDentry(const Dentry& dentry, bool isLoadding) {
+MetaStatusCode Partition::CreateDentry(const Dentry& dentry) {
     if (!IsInodeBelongs(dentry.fsid(), dentry.parentinodeid())) {
         return MetaStatusCode::PARTITION_ID_MISSMATCH;
     }
@@ -69,19 +82,31 @@ MetaStatusCode Partition::CreateDentry(const Dentry& dentry, bool isLoadding) {
     if (GetStatus() == PartitionStatus::DELETING) {
         return MetaStatusCode::PARTITION_DELETING;
     }
-    MetaStatusCode ret = dentryManager_->CreateDentry(dentry, isLoadding);
+    MetaStatusCode ret = dentryManager_->CreateDentry(dentry);
     if (MetaStatusCode::OK == ret) {
-        if (!isLoadding) {
-            return inodeManager_->UpdateInodeWhenCreateOrRemoveSubNode(
-                dentry.fsid(), dentry.parentinodeid(), true);
-        } else {
-            return MetaStatusCode::OK;
-        }
+        return inodeManager_->UpdateInodeWhenCreateOrRemoveSubNode(
+            dentry.fsid(), dentry.parentinodeid(), true);
     } else if (MetaStatusCode::IDEMPOTENCE_OK == ret) {
         return MetaStatusCode::OK;
     } else {
         return ret;
     }
+}
+
+MetaStatusCode Partition::LoadDentry(const DentryVec& vec, bool merge) {
+    auto dentry = vec.dentrys(0);
+    if (!IsInodeBelongs(dentry.fsid(), dentry.parentinodeid())) {
+        return MetaStatusCode::PARTITION_ID_MISSMATCH;
+    } else if (GetStatus() == PartitionStatus::DELETING) {
+        return MetaStatusCode::PARTITION_DELETING;
+    }
+
+    MetaStatusCode rc = dentryManager_->CreateDentry(vec, merge);
+    if (rc == MetaStatusCode::OK ||
+        rc == MetaStatusCode::IDEMPOTENCE_OK) {
+        return MetaStatusCode::OK;
+    }
+    return rc;
 }
 
 MetaStatusCode Partition::DeleteDentry(const Dentry& dentry) {
@@ -315,11 +340,11 @@ bool Partition::GetInodeIdList(std::list<uint64_t>* InodeIdList) {
 
 bool Partition::IsDeletable() {
     // if patition has no inode or no dentry, it is deletable
-    if (dentryStorage_->Size() != 0) {
+    if (!dentryStorage_->Empty()) {
         return false;
     }
 
-    if (inodeStorage_->Size() != 0) {
+    if (!inodeStorage_->Empty()) {
         return false;
     }
 
@@ -360,7 +385,12 @@ uint32_t Partition::GetPartitionId() const {
     return partitionInfo_.partitionid();
 }
 
-PartitionInfo Partition::GetPartitionInfo() { return partitionInfo_; }
+PartitionInfo Partition::GetPartitionInfo() {
+    auto partitionInfo = partitionInfo_;
+    partitionInfo.set_inodenum(GetInodeNum());
+    partitionInfo.set_dentrynum(GetDentryNum());
+    return partitionInfo;
+}
 
 std::shared_ptr<Iterator> Partition::GetAllInode() {
     return inodeStorage_->GetAllInode();
@@ -387,6 +417,7 @@ bool Partition::Clear() {
         return false;
     }
     partitionInfo_.set_inodenum(0);
+    partitionInfo_.set_dentrynum(0);
     for (auto& it : *partitionInfo_.mutable_filetype2inodenum()) {
         it.second = 0;
     }
@@ -409,6 +440,10 @@ uint32_t Partition::GetInodeNum() {
 
 uint32_t Partition::GetDentryNum() {
     return static_cast<uint32_t>(dentryStorage_->Size());
+}
+
+bool Partition::EmptyInodeStorage() {
+    return inodeStorage_->Empty();
 }
 
 std::string Partition::GetInodeTablename() {

--- a/curvefs/src/metaserver/partition.h
+++ b/curvefs/src/metaserver/partition.h
@@ -57,7 +57,9 @@ class Partition {
     ~Partition() {}
 
     // dentry
-    MetaStatusCode CreateDentry(const Dentry& dentry, bool isLoadding = false);
+    MetaStatusCode CreateDentry(const Dentry& dentry);
+
+    MetaStatusCode LoadDentry(const DentryVec& vec, bool merge);
 
     MetaStatusCode DeleteDentry(const Dentry& dentry);
 
@@ -147,6 +149,8 @@ class Partition {
     uint32_t GetInodeNum();
 
     uint32_t GetDentryNum();
+
+    bool EmptyInodeStorage();
 
     void SetStatus(PartitionStatus status) {
         partitionInfo_.set_status(status);

--- a/curvefs/src/metaserver/partition_cleaner.cpp
+++ b/curvefs/src/metaserver/partition_cleaner.cpp
@@ -66,7 +66,7 @@ bool PartitionCleaner::ScanPartition() {
     }
 
     uint32_t partitionId = partition_->GetPartitionId();
-    if (partition_->GetInodeNum() == 0) {
+    if (partition_->EmptyInodeStorage()) {
         LOG(INFO) << "Inode num is 0, delete partition from metastore"
                   << ", partitonId = " << partitionId;
         MetaStatusCode ret = DeletePartition();

--- a/curvefs/src/metaserver/storage/config.h
+++ b/curvefs/src/metaserver/storage/config.h
@@ -56,7 +56,10 @@ struct StorageOptions {
 
     double memtablePrefixBloomSizeRatio;
 
-    // misc config item
+    uint64_t statsDumpPeriodSec;
+
+    size_t keyPrefixLength;
+
     uint64_t s3MetaLimitSizeInsideInode;
 };
 

--- a/curvefs/src/metaserver/storage/converter.cpp
+++ b/curvefs/src/metaserver/storage/converter.cpp
@@ -22,11 +22,13 @@
 
 #include <glog/logging.h>
 
+#include <cstring>
 #include <string>
 #include <vector>
 #include <limits>
 #include <iomanip>
 #include <iostream>
+#include <iterator>
 
 #include "absl/strings/str_cat.h"
 #include "src/common/string_util.h"
@@ -46,6 +48,48 @@ static const char* const kDelimiter = ":";
 static bool CompareType(const std::string& str, KEY_TYPE keyType) {
     uint32_t n;
     return StringToUl(str, &n) && n == keyType;
+}
+
+NameGenerator::NameGenerator(uint32_t partitionId)
+    : tableName4Inode_(Format(kTypeInode, partitionId)),
+      tableName4S3ChunkInfo_(Format(kTypeS3ChunkInfo, partitionId)),
+      tableName4Dentry_(Format(kTypeDentry, partitionId)),
+      tableName4VolumeExtent_(Format(kTypeVolumeExtent, partitionId)),
+      tableName4InodeAuxInfo_(Format(kTypeInodeAuxInfo, partitionId)) {}
+
+std::string NameGenerator::GetInodeTableName() const {
+    return tableName4Inode_;
+}
+
+std::string NameGenerator::GetS3ChunkInfoTableName() const {
+    return tableName4S3ChunkInfo_;
+}
+
+std::string NameGenerator::GetDentryTableName() const {
+    return tableName4Dentry_;
+}
+
+std::string NameGenerator::GetVolumnExtentTableName() const {
+    return tableName4VolumeExtent_;
+}
+
+std::string NameGenerator::GetInodeAuxInfoTableName() const {
+    return tableName4InodeAuxInfo_;
+}
+
+size_t NameGenerator::GetFixedLength() {
+    size_t length = sizeof(kTypeInode) + sizeof(uint32_t) + strlen(kDelimiter);
+    LOG(INFO) << "Tablename fixed length is " << length;
+    return length;
+}
+
+std::string NameGenerator::Format(KEY_TYPE type, uint32_t partitionId) {
+    char buffer[sizeof(uint32_t)];
+    std::memcpy(buffer, reinterpret_cast<char*>(&partitionId),
+                sizeof(uint32_t));
+    std::ostringstream oss;
+    oss << type << kDelimiter << std::string(buffer, sizeof(uint32_t));
+    return oss.str();
 }
 
 Key4Inode::Key4Inode()
@@ -189,17 +233,65 @@ bool Prefix4AllS3ChunkInfoList::ParseFromString(const std::string& value) {
     return items.size() == 1 && CompareType(items[0], keyType_);
 }
 
-std::string Converter::SerializeToString(const StorageKey& key) {
-    return key.SerializeToString();
+Key4Dentry::Key4Dentry(uint32_t fsId,
+                       uint64_t parentInodeId,
+                       const std::string& name)
+    : fsId(fsId), parentInodeId(parentInodeId), name(name) {}
+
+std::string Key4Dentry::SerializeToString() const {
+    return absl::StrCat(keyType_, kDelimiter, fsId,
+                        kDelimiter, parentInodeId,
+                        kDelimiter, name);
 }
 
-bool Converter::SerializeToString(const google::protobuf::Message& entry,
-                                  std::string* value) {
-    if (!entry.IsInitialized()) {
-        LOG(ERROR) << "Message not initialized";
+bool Key4Dentry::ParseFromString(const std::string& value) {
+    std::vector<std::string> items;
+    SplitString(value, ":", &items);
+    if (items.size() < 3 ||
+        !CompareType(items[0], keyType_) ||
+        !StringToUl(items[1], &fsId) ||
+        !StringToUll(items[2], &parentInodeId)) {
         return false;
     }
-    return entry.SerializeToString(value);
+
+    size_t prefixLength = sizeof(keyType_) +
+                          items[1].size() +
+                          items[2].size() +
+                          3 * strlen(kDelimiter);
+    if (value.size() < prefixLength) {
+        return false;
+    }
+    name = value.substr(prefixLength);
+    return true;
+}
+
+Prefix4SameParentDentry::Prefix4SameParentDentry(uint32_t fsId,
+                                                 uint64_t parentInodeId)
+    : fsId(fsId), parentInodeId(parentInodeId) {}
+
+std::string Prefix4SameParentDentry::SerializeToString() const {
+    return absl::StrCat(keyType_, kDelimiter, fsId,
+                        kDelimiter, parentInodeId,
+                        kDelimiter);
+}
+
+bool Prefix4SameParentDentry::ParseFromString(const std::string& value) {
+    std::vector<std::string> items;
+    SplitString(value, ":", &items);
+    return items.size() == 3 && CompareType(items[0], keyType_) &&
+           StringToUl(items[1], &fsId) && StringToUll(items[2], &parentInodeId);
+}
+
+std::string Prefix4AllDentry::SerializeToString() const {
+    std::ostringstream oss;
+    oss << keyType_ << ":";
+    return oss.str();
+}
+
+bool Prefix4AllDentry::ParseFromString(const std::string& value) {
+    std::vector<std::string> items;
+    SplitString(value, ":", &items);
+    return items.size() == 1 && CompareType(items[0], keyType_);
 }
 
 Key4VolumeExtentSlice::Key4VolumeExtentSlice(uint32_t fsId,
@@ -246,6 +338,34 @@ bool Prefix4AllVolumeExtent::ParseFromString(const std::string &value) {
     std::vector<std::string> items;
     SplitString(value, kDelimiter, &items);
     return items.size() == 1 && CompareType(items[0], keyType_);
+}
+
+Key4InodeAuxInfo::Key4InodeAuxInfo(uint32_t fsId,
+                                   uint64_t inodeId)
+    : fsId(fsId), inodeId(inodeId) {}
+
+std::string Key4InodeAuxInfo::SerializeToString() const {
+    return absl::StrCat(keyType_, kDelimiter, fsId, kDelimiter, inodeId);
+}
+
+bool Key4InodeAuxInfo::ParseFromString(const std::string& value) {
+    std::vector<std::string> items;
+    SplitString(value, kDelimiter, &items);
+    return items.size() == 3 && CompareType(items[0], keyType_) &&
+           StringToUl(items[1], &fsId) && StringToUll(items[2], &inodeId);
+}
+
+std::string Converter::SerializeToString(const StorageKey& key) {
+    return key.SerializeToString();
+}
+
+bool Converter::SerializeToString(const google::protobuf::Message& entry,
+                                  std::string* value) {
+    if (!entry.IsInitialized()) {
+        LOG(ERROR) << "Message not initialized";
+        return false;
+    }
+    return entry.SerializeToString(value);
 }
 
 }  // namespace storage

--- a/curvefs/src/metaserver/storage/iterator.h
+++ b/curvefs/src/metaserver/storage/iterator.h
@@ -54,9 +54,7 @@ class Iterator {
 
     virtual int Status() = 0;
 
-    virtual bool ParseFromValue(ValueType* value) {
-        return true;
-    }
+    virtual bool ParseFromValue(ValueType* value) { return true; }
 
     virtual void DisablePrefixChecking() {}
 };

--- a/curvefs/src/metaserver/storage/memory_storage.cpp
+++ b/curvefs/src/metaserver/storage/memory_storage.cpp
@@ -134,10 +134,9 @@ do {                                            \
 do {                                            \
     auto container = GET_CONTAINER(TYPE, NAME); \
     auto iter = container->find(KEY);           \
-    if (iter == container->end()) {             \
-        return Status::NotFound();              \
+    if (iter != container->end()) {             \
+        container->erase(iter);                 \
     }                                           \
-    container->erase(iter);                     \
     return Status::OK();                        \
 } while (0)
 

--- a/curvefs/src/metaserver/storage/rocksdb_perf.cpp
+++ b/curvefs/src/metaserver/storage/rocksdb_perf.cpp
@@ -1,0 +1,164 @@
+/*
+ *  Copyright (c) 2022 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * Project: Curve
+ * Date: 2022-06-10
+ * Author: Jingli Chen (Wine93)
+ */
+
+#include <glog/logging.h>
+
+#include <ostream>
+#include <iostream>
+
+#include "butil/fast_rand.h"
+#include "src/common/timeutility.h"
+#include "curvefs/src/metaserver/storage/rocksdb_perf.h"
+
+static bool pass_uint32(const char*, uint32_t) { return true; }
+static bool pass_uint64(const char*, uint64_t) { return true; }
+static bool pass_double(const char*, double) { return true; }
+
+DEFINE_uint32(rocksdb_perf_level, 0, "rocksdb perf level");
+DEFINE_validator(rocksdb_perf_level, &pass_uint32);
+DEFINE_uint64(rocksdb_perf_slow_us, 100,
+              "rocksdb perf slow operation microseconds");
+DEFINE_validator(rocksdb_perf_slow_us, &pass_uint64);
+DEFINE_double(rocksdb_perf_sampling_ratio, 0,
+              "rocksdb perf sampling ratio");
+DEFINE_validator(rocksdb_perf_sampling_ratio, &pass_double);
+
+namespace curvefs {
+namespace metaserver {
+namespace storage {
+
+using ::curve::common::TimeUtility;
+
+const uint32_t RocksDBPerfGuard::kPerfLevelOutOfBounds_ = 5;
+
+std::ostream& operator<<(std::ostream& os, OPERATOR_TYPE type) {
+    switch (type) {
+        case OP_GET:
+            os << "GET";
+            break;
+        case OP_PUT:
+            os << "PUT";
+            break;
+        case OP_DELETE:
+            os << "DELETE";
+            break;
+        case OP_DELETE_RANGE:
+            os << "DELETE_RANGE";
+            break;
+        case OP_GET_ITERATOR:
+            os << "GET_ITERATOR";
+            break;
+        case OP_GET_SNAPSHOT:
+            os << "GET_SNAPSHOT";
+            break;
+        case OP_CLEAR_SNAPSHOT:
+            os << "CLEAR_SNAPSHOT";
+            break;
+        case OP_ITERATOR_SEEK_TO_FIRST:
+            os << "ITERATOR_SEEK_TO_FIRST";
+            break;
+        case OP_ITERATOR_GET_KEY:
+            os << "ITERATOR_GET_KEY";
+            break;
+        case OP_ITERATOR_GET_VALUE:
+            os << "ITERATOR_GET_VALUE";
+            break;
+        case OP_ITERATOR_NEXT:
+            os << "ITERATOR_NEXT";
+            break;
+        case OP_BEGIN_TRANSACTION:
+            os << "BEGIN_TRANSACTION";
+            break;
+        case OP_COMMIT_TRANSACTION:
+            os << "COMMIT_TRANSACTION";
+            break;
+        case OP_ROLLBACK_TRANSACTION:
+            os << "ROLLBACK_TRANSACTION";
+            break;
+        default:
+            os << "UNKNWON";
+    }
+    return os;
+}
+
+rocksdb::PerfLevel RocksDBPerfGuard::ToPerfLevel(uint32_t level) {
+    switch (level) {
+        case 0:
+            return rocksdb::PerfLevel::kDisable;
+        case 1:
+            return rocksdb::PerfLevel::kEnableCount;
+        case 2:
+            return rocksdb::PerfLevel::kEnableTimeExceptForMutex;
+        case 3:
+            return rocksdb::PerfLevel::kEnableTimeAndCPUTimeExceptForMutex;
+        case 4:
+            return rocksdb::PerfLevel::kEnableTime;
+    }
+    return rocksdb::PerfLevel::kDisable;
+}
+
+RocksDBPerfGuard::RocksDBPerfGuard(OPERATOR_TYPE opType) {
+    rocksdb::PerfLevel level = ToPerfLevel(FLAGS_rocksdb_perf_level);
+    if (level == rocksdb::PerfLevel::kDisable) {
+        return;
+    }
+
+    rocksdb::SetPerfLevel(level);
+    rocksdb::get_perf_context()->Reset();
+    rocksdb::get_iostats_context()->Reset();
+    opType_ = opType;
+    startTimeUs_ = TimeUtility::GetTimeofDayUs();
+}
+
+RocksDBPerfGuard::~RocksDBPerfGuard() {
+    rocksdb::PerfLevel level = ToPerfLevel(FLAGS_rocksdb_perf_level);
+    if (level == rocksdb::PerfLevel::kDisable) {
+        return;
+    }
+
+    uint64_t now = TimeUtility::GetTimeofDayUs();
+    uint64_t latencyUs = now - startTimeUs_;
+    rocksdb::SetPerfLevel(rocksdb::PerfLevel::kDisable);
+    if (latencyUs <= FLAGS_rocksdb_perf_slow_us &&
+        FLAGS_rocksdb_perf_sampling_ratio <= butil::fast_rand_double()) {
+        return;
+    }
+
+    std::ostringstream oss;
+    oss << "latencyUs(" << latencyUs << ")"
+        << ", slowUs(" << FLAGS_rocksdb_perf_slow_us << ")"
+        << ", perf context(" << rocksdb::get_perf_context()->ToString() << ")"
+        << ", iostat context(" << rocksdb::get_iostats_context()->ToString()
+        << ")";
+
+    if (latencyUs > FLAGS_rocksdb_perf_slow_us) {
+        LOG(WARNING) << "[RockDBPerf] slow operation"
+                     << ", opType(" << opType_ << "), " << oss.str();
+    } else {
+        LOG(INFO) << "[RockDBPerf] sampling operation"
+                  << ", opType(" << opType_ << "), " << oss.str();
+    }
+}
+
+}  // namespace storage
+}  // namespace metaserver
+}  // namespace curvefs

--- a/curvefs/src/metaserver/storage/rocksdb_perf.h
+++ b/curvefs/src/metaserver/storage/rocksdb_perf.h
@@ -1,0 +1,92 @@
+
+/*
+ *  Copyright (c) 2022 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * Project: Curve
+ * Date: 2022-06-10
+ * Author: Jingli Chen (Wine93)
+ */
+
+#ifndef CURVEFS_SRC_METASERVER_STORAGE_ROCKSDB_PERF_H_
+#define CURVEFS_SRC_METASERVER_STORAGE_ROCKSDB_PERF_H_
+
+#include <string>
+#include <random>
+
+#include "rocksdb/perf_context.h"
+#include "rocksdb/iostats_context.h"
+#include "curvefs/src/metaserver/storage/storage.h"
+
+/*
+ *   0: kDisable                             // disable perf start
+ *   1: kEnableCount                         // enable only count stats
+ *   2: kEnableTimeAndCPUTimeExceptForMutex  // Other than count stats, also enable time
+ *                                           // stats except for mutexes
+ *                                           // Other than time, also measure CPU time counters. Still don't measure
+ *                                           // time (neither wall time nor CPU time) for mutexes.
+ *   3: kEnableTimeExceptForMutex
+ *   4: kEnableTime                          // enable count and time stats
+ * see also: https://github.com/facebook/rocksdb/wiki/Perf-Context-and-IO-Stats-Context#profile-levels-and-costs
+ *
+ * You can also modify rocksdb perf level to 1 on the fly:
+ * curl -s http://127.0.0.1:9000/flags/rocksdb_perf_level?setvalue=1
+ */
+DECLARE_uint32(rocksdb_perf_level);
+DECLARE_uint64(rocksdb_perf_slow_us);
+DECLARE_double(rocksdb_perf_sampling_ratio);
+
+namespace curvefs {
+namespace metaserver {
+namespace storage {
+
+enum OPERATOR_TYPE : unsigned char {
+    OP_GET = 1,
+    OP_PUT = 2,
+    OP_DELETE = 3,
+    OP_DELETE_RANGE = 4,
+    OP_GET_ITERATOR = 5,
+    OP_GET_SNAPSHOT = 6,
+    OP_CLEAR_SNAPSHOT = 7,
+    OP_ITERATOR_SEEK_TO_FIRST = 8,
+    OP_ITERATOR_GET_KEY = 9,
+    OP_ITERATOR_GET_VALUE = 10,
+    OP_ITERATOR_NEXT = 11,
+    OP_BEGIN_TRANSACTION = 12,
+    OP_COMMIT_TRANSACTION = 13,
+    OP_ROLLBACK_TRANSACTION = 14,
+};
+
+class RocksDBPerfGuard {
+ public:
+    explicit RocksDBPerfGuard(OPERATOR_TYPE opType);
+
+    ~RocksDBPerfGuard();
+
+ private:
+    rocksdb::PerfLevel ToPerfLevel(uint32_t level);
+
+ private:
+    OPERATOR_TYPE opType_;
+    uint64_t startTimeUs_;
+    static const uint32_t kPerfLevelOutOfBounds_;
+};
+
+}  // namespace storage
+}  // namespace metaserver
+}  // namespace curvefs
+
+#endif  //  CURVEFS_SRC_METASERVER_STORAGE_ROCKSDB_PERF_H_

--- a/curvefs/src/metaserver/storage/rocksdb_storage.cpp
+++ b/curvefs/src/metaserver/storage/rocksdb_storage.cpp
@@ -23,22 +23,29 @@
 
 #include <glog/logging.h>
 
-#include <sstream>
+#include <ostream>
+#include <iostream>
 #include <unordered_map>
 
 #include "rocksdb/slice_transform.h"
+#include "src/common/timeutility.h"
 #include "curvefs/src/metaserver/storage/utils.h"
 #include "curvefs/src/metaserver/storage/storage.h"
+#include "curvefs/src/metaserver/storage/converter.h"
+#include "curvefs/src/metaserver/storage/rocksdb_perf.h"
 #include "curvefs/src/metaserver/storage/rocksdb_storage.h"
 
 namespace curvefs {
 namespace metaserver {
 namespace storage {
 
-using KeyPair = RocksDBStorage::KeyPair;
+using ::curve::common::TimeUtility;
 
+// RocksDBOptions
 const std::string RocksDBOptions::kOrderedColumnFamilyName_ =  // NOLINT
     "ordered_column_familiy";
+
+const std::string RocksDBStorage::kDelimiter_ = ":";  // NOLINT
 
 RocksDBOptions::RocksDBOptions(StorageOptions options) {
     // db options
@@ -48,17 +55,21 @@ RocksDBOptions::RocksDBOptions(StorageOptions options) {
     dbOptions_.create_missing_column_families = true;
     // maximum number of concurrent background memtable flush jobs,
     // submitted by default to the HIGH priority thread pool
-    dbOptions_.max_background_flushes = 2;
+    dbOptions_.max_background_flushes = 4;
     // maximum number of concurrent background compaction jobs,
     // submitted to the default LOW priority thread pool.
     dbOptions_.max_background_compactions = 4;
     // allows OS to incrementally sync files to disk while they are being
     // written, asynchronously, in the background.
     dbOptions_.bytes_per_sync = 1048576;
+    // collect metrics about database operations
+    dbOptions_.statistics = rocksdb::CreateDBStatistics();
+    // dump rocksdb.stats to LOG every stats_dump_period_sec
+    dbOptions_.stats_dump_period_sec = options.statsDumpPeriodSec;
 
     // table options
     std::shared_ptr<ROCKSDB_NAMESPACE::Cache> cache =
-        NewLRUCache(options.blockCacheCapacity);
+        NewLRUCache(options.blockCacheCapacity, 1, false, 0.9);
     BlockBasedTableOptions tableOptions;
     tableOptions.block_size = 16 * 1024;  // 16KB
     // default: an 8MB internal cache
@@ -71,10 +82,7 @@ RocksDBOptions::RocksDBOptions(StorageOptions options) {
     tableOptions.filter_policy.reset(NewBloomFilterPolicy(10, false));
 
     // column failmy options
-    comparator_ = std::make_shared<RocksDBStorageComparator>();
     ColumnFamilyOptions cfOptions = ColumnFamilyOptions();
-    // user-defined key comparator
-    cfOptions.comparator = comparator_.get();
     // large values (blobs) are written to separate blob files, and
     // only pointers to them are stored in SST files
     cfOptions.enable_blob_files = true;
@@ -82,7 +90,8 @@ RocksDBOptions::RocksDBOptions(StorageOptions options) {
     cfOptions.level_compaction_dynamic_level_bytes = true;
     cfOptions.compaction_pri = ROCKSDB_NAMESPACE::kMinOverlappingRatio;
     // use the specified function to determine the prefixes for keys
-    cfOptions.prefix_extractor.reset(NewFixedPrefixTransform(sizeof(size_t)));
+    cfOptions.prefix_extractor.reset(
+        NewFixedPrefixTransform(options.keyPrefixLength));
     // The size in bytes of the filter for memtable is
     // write_buffer_size * memtable_prefix_bloom_size_ratio
     cfOptions.memtable_prefix_bloom_size_ratio =
@@ -133,15 +142,20 @@ inline ROCKSDB_NAMESPACE::WriteOptions RocksDBOptions::WriteOptions() {
     return options;
 }
 
+//  RocksDBStorage
 RocksDBStorage::RocksDBStorage()
     : InTransaction_(false) {}
 
 RocksDBStorage::RocksDBStorage(StorageOptions options)
     : inited_(false),
       options_(options),
-      rocksdbOptions_(RocksDBOptions(options)),
-      counter_(std::make_shared<Counter>()),
-      InTransaction_(false) {}
+      InTransaction_(false) {
+    // we fake a table name and invoke ToInternale() to get key prefix length
+    std::string tablename = std::string(NameGenerator::GetFixedLength(), '0');
+    std::string iname = ToInternalName(tablename, true, true);
+    options_.keyPrefixLength = iname.size();
+    rocksdbOptions_ = RocksDBOptions(options_);
+}
 
 RocksDBStorage::RocksDBStorage(const RocksDBStorage& storage,
                                ROCKSDB_NAMESPACE::Transaction* txn)
@@ -151,7 +165,6 @@ RocksDBStorage::RocksDBStorage(const RocksDBStorage& storage,
       db_(storage.db_),
       txnDB_(storage.txnDB_),
       handles_(storage.handles_),
-      counter_(storage.counter_),
       InTransaction_(true),
       txn_(txn) {}
 
@@ -237,74 +250,36 @@ Status RocksDBStorage::ToStorageStatus(const ROCKSDB_NAMESPACE::Status& s) {
     return Status::InternalError();
 }
 
-// "ordered:name"
+/* NOTE:
+ * 1. we use suffix 0/1 to determine the key range:
+ *    [ordered:name:0, ordered:name:1)
+ * 2. please gurantee the length of name is fixed for
+ *    we can determine the rocksdb's prefix key
+ */
 std::string RocksDBStorage::ToInternalName(const std::string& name,
-                                           bool ordered) {
+                                           bool ordered,
+                                           bool start) {
     std::ostringstream oss;
-    oss << ordered << ":" << name;
+    oss << ordered << kDelimiter_ << name << kDelimiter_ << (start ? "0" : "1");
     return oss.str();
 }
 
-std::string RocksDBStorage::FormatInternalKey(size_t num4name,
-                                              const std::string& key) {
+std::string RocksDBStorage::ToInternalKey(const std::string& name,
+                                          const std::string& key,
+                                          bool ordered) {
+    std::string iname = ToInternalName(name, ordered, true);
     std::ostringstream oss;
-    oss << Number2BinaryString(num4name) << ":" << key;
-    return oss.str();
+    oss << iname << kDelimiter_ << key;
+    std::string ikey = oss.str();
+    VLOG(9) << "ikey = " << ikey << " (ordered = " << ordered
+            << ", name = " << name << ", key = " << key << ")"
+            << ", size = " << ikey.size();
+    return ikey;
 }
 
-// NOTE: we will convert name to number for compare prefix
-// eg: Hash(iname):key
-std::string RocksDBStorage::ToInternalKey(const std::string& iname,
-                                          const std::string& key) {
-    size_t num4name = Hash(iname);
-    return FormatInternalKey(num4name, key);
-}
-
+// extract user key from internal key: prefix:key => key
 std::string RocksDBStorage::ToUserKey(const std::string& ikey) {
-    size_t length = sizeof(size_t);
-    return ikey.substr(length + 1);  // trim prefix "name:"
-}
-
-inline bool RocksDBStorage::FindKey(std::string name, std::string key) {
-    ReadLockGuard readLockGuard(rwLock_);
-    return counter_->Find(name, key);
-}
-
-inline void RocksDBStorage::InsertKey(std::string name, std::string key) {
-    WriteLockGuard writeLockGuard(rwLock_);
-    counter_->Insert(name, key);
-}
-
-inline void RocksDBStorage::EraseKey(std::string name, std::string key) {
-    WriteLockGuard writeLockGuard(rwLock_);
-    counter_->Erase(name, key);
-}
-
-inline size_t RocksDBStorage::TableSize(std::string name) {
-    ReadLockGuard readLockGuard(rwLock_);
-    return counter_->Size(name);
-}
-
-inline void RocksDBStorage::ClearTable(std::string name) {
-    WriteLockGuard writeLockGuard(rwLock_);
-    counter_->Clear(name);
-}
-
-inline void RocksDBStorage::CommitKeys() {
-    WriteLockGuard writeLockGuard(rwLock_);
-    for (const auto& pair : pending4set_) {
-        counter_->Insert(pair.first, pair.second);
-    }
-    for (const auto& pair : pending4del_) {
-        counter_->Erase(pair.first, pair.second);
-    }
-    pending4set_.clear();
-    pending4del_.clear();
-}
-
-inline void RocksDBStorage::RollbackKeys() {
-    pending4set_.clear();
-    pending4del_.clear();
+    return ikey.substr(options_.keyPrefixLength + kDelimiter_.size());
 }
 
 Status RocksDBStorage::Get(const std::string& name,
@@ -315,17 +290,15 @@ Status RocksDBStorage::Get(const std::string& name,
         return Status::DBClosed();
     }
 
-    std::string iname = ToInternalName(name, ordered);
-    std::string ikey = ToInternalKey(iname, key);
-    if (!InTransaction_ && !FindKey(iname, ikey)) {
-        return Status::NotFound();
-    }
-
+    ROCKSDB_NAMESPACE::Status s;
     std::string svalue;
+    std::string ikey = ToInternalKey(name, key, ordered);
     auto handle = GetColumnFamilyHandle(ordered);
-    ROCKSDB_NAMESPACE::Status s = InTransaction_ ?
-        txn_->Get(ReadOptions(), handle, ikey, &svalue) :
-        db_->Get(ReadOptions(), handle, ikey, &svalue);
+    {
+        RocksDBPerfGuard guard(OP_GET);
+        s = InTransaction_ ? txn_->Get(ReadOptions(), handle, ikey, &svalue) :
+                             db_->Get(ReadOptions(), handle, ikey, &svalue);
+    }
     if (s.ok() && !value->ParseFromString(svalue)) {
         return Status::ParsedFailed();
     }
@@ -344,18 +317,11 @@ Status RocksDBStorage::Set(const std::string& name,
     }
 
     auto handle = GetColumnFamilyHandle(ordered);
-    std::string iname = ToInternalName(name, ordered);
-    std::string ikey = ToInternalKey(iname, key);
+    std::string ikey = ToInternalKey(name, key, ordered);
+    RocksDBPerfGuard guard(OP_PUT);
     ROCKSDB_NAMESPACE::Status s = InTransaction_ ?
         txn_->Put(handle, ikey, svalue) :
         db_->Put(WriteOptions(), handle, ikey, svalue);
-    if (s.ok()) {
-        if (InTransaction_) {
-            pending4set_.push_back(KeyPair(iname, ikey));
-        } else {
-            InsertKey(iname, ikey);
-        }
-    }
     return ToStorageStatus(s);
 }
 
@@ -366,49 +332,42 @@ Status RocksDBStorage::Del(const std::string& name,
         return Status::DBClosed();
     }
 
-    std::string iname = ToInternalName(name, ordered);
-    std::string ikey = ToInternalKey(iname, key);
-    if (!InTransaction_ && !counter_->Find(iname, ikey)) {
-        return Status::NotFound();
-    }
-
+    std::string ikey = ToInternalKey(name, key, ordered);
     auto handle = GetColumnFamilyHandle(ordered);
+    RocksDBPerfGuard guard(OP_DELETE);
     ROCKSDB_NAMESPACE::Status s = InTransaction_ ?
         txn_->Delete(handle, ikey) :
         db_->Delete(WriteOptions(), handle, ikey);
-    if (s.ok()) {
-        if (InTransaction_) {
-            pending4del_.push_back(KeyPair(iname, ikey));
-        } else {
-            EraseKey(iname, ikey);
-        }
-    }
     return ToStorageStatus(s);
 }
 
 std::shared_ptr<Iterator> RocksDBStorage::Seek(const std::string& name,
                                                const std::string& prefix) {
-    size_t size = 0;
     int status = inited_ ? 0 : -1;
-    std::string iname = ToInternalName(name, true);
-    std::string ikey = ToInternalKey(iname, prefix);
+    std::string ikey = ToInternalKey(name, prefix, true);
     return std::make_shared<RocksDBStorageIterator>(
-        this, ikey, size, status, true);
+        this, ikey, 0, status, true);
 }
 
 std::shared_ptr<Iterator> RocksDBStorage::GetAll(const std::string& name,
                                                  bool ordered) {
     int status = inited_ ? 0 : -1;
-    std::string iname = ToInternalName(name, ordered);
-    std::string ikey = ToInternalKey(iname, "");
-    size_t size = TableSize(iname);
+    std::string ikey = ToInternalKey(name, "", ordered);
     return std::make_shared<RocksDBStorageIterator>(
-        this, ikey, size, status, ordered);
+        this, ikey, 0, status, ordered);
 }
 
 size_t RocksDBStorage::Size(const std::string& name, bool ordered) {
-    std::string iname = ToInternalName(name, ordered);
-    return TableSize(iname);
+    auto iterator = GetAll(name, ordered);
+    if (iterator->Status() != 0) {
+        return 0;
+    }
+
+    size_t size = 0;
+    for (iterator->SeekToFirst(); iterator->Valid(); iterator->Next()) {
+        size++;
+    }
+    return size;
 }
 
 Status RocksDBStorage::Clear(const std::string& name, bool ordered) {
@@ -419,26 +378,23 @@ Status RocksDBStorage::Clear(const std::string& name, bool ordered) {
     }
 
     auto handle = GetColumnFamilyHandle(ordered);
-    std::string iname = ToInternalName(name, ordered);  // "1:name"
-    std::string beginKey = ToInternalKey(iname, "");  // "Hash(iname):"
-    size_t beginNum = BinrayString2Number(beginKey);
-    std::string endKey = FormatInternalKey(beginNum + 1, "");
+    std::string lower = ToInternalName(name, ordered, true);
+    std::string upper = ToInternalName(name, ordered, false);
+    RocksDBPerfGuard guard(OP_DELETE_RANGE);
     ROCKSDB_NAMESPACE::Status s = db_->DeleteRange(
-        WriteOptions(), handle, beginKey, endKey);
-    if (s.ok()) {
-        ClearTable(iname);
-    }
+        WriteOptions(), handle, lower, upper);
+    LOG(INFO) << "Clear(), tablename = " << name << ", ordered = " << ordered
+              << ", lower key = " << lower << ", upper key = " << upper;
     return ToStorageStatus(s);
 }
 
 std::shared_ptr<StorageTransaction> RocksDBStorage::BeginTransaction() {
+    RocksDBPerfGuard guard(OP_BEGIN_TRANSACTION);
     ROCKSDB_NAMESPACE::Transaction* txn =
         txnDB_->BeginTransaction(WriteOptions());
     if (nullptr == txn) {
         return nullptr;
     }
-    pending4set_.clear();
-    pending4del_.clear();
     return std::make_shared<RocksDBStorage>(*this, txn);
 }
 
@@ -447,12 +403,11 @@ Status RocksDBStorage::Commit() {
         return Status::NotSupported();
     }
 
+    RocksDBPerfGuard guard(OP_COMMIT_TRANSACTION);
     ROCKSDB_NAMESPACE::Status s = txn_->Commit();
     if (!s.ok()) {
         LOG(ERROR) << "RocksDBStorage commit transaction failed"
                    << ", status=" << s.ToString();
-    } else {
-        CommitKeys();
     }
     delete txn_;
     return ToStorageStatus(s);
@@ -462,12 +417,12 @@ Status RocksDBStorage::Rollback()  {
     if (!InTransaction_ || nullptr == txn_) {
         return Status::NotSupported();
     }
+
+    RocksDBPerfGuard guard(OP_ROLLBACK_TRANSACTION);
     ROCKSDB_NAMESPACE::Status s = txn_->Rollback();
     if (!s.ok()) {
         LOG(ERROR) << "RocksDBStorage rollback transaction failed"
                    << ", status=" << s.ToString();
-    } else {
-        RollbackKeys();
     }
     delete txn_;
     return ToStorageStatus(s);

--- a/curvefs/src/metaserver/storage/utils.h
+++ b/curvefs/src/metaserver/storage/utils.h
@@ -36,45 +36,11 @@ namespace storage {
 
 using ::curve::common::RWLock;
 
-size_t Hash(const std::string& key);
-
-std::string Number2BinaryString(size_t num);
-
-size_t BinrayString2Number(const std::string& value);
-
 bool GetFileSystemSpaces(const std::string& path,
                          uint64_t* capacity,
                          uint64_t* available);
 
 bool GetProcMemory(uint64_t* vmRSS);
-
-class Counter {
- public:
-    using ContainerType = absl::btree_set<size_t>;
-
- public:
-    Counter() = default;
-
-    void Insert(const std::string& name, const std::string& key);
-
-    void Erase(const std::string& name, const std::string& key);
-
-    bool Find(const std::string& name, const std::string& key);
-
-    size_t Size(const std::string& name);
-
-    void Clear(const std::string& name);
-
- private:
-    std::shared_ptr<ContainerType> GetContainer(const std::string& name);
-
-    size_t ToInternalKey(const std::string& key);
-
- private:
-    RWLock rwLock_;
-    std::unordered_map<std::string,
-                       std::shared_ptr<ContainerType>> containerDict_;
-};
 
 }  // namespace storage
 }  // namespace metaserver

--- a/curvefs/src/metaserver/transaction.cpp
+++ b/curvefs/src/metaserver/transaction.cpp
@@ -27,6 +27,7 @@ namespace curvefs {
 namespace metaserver {
 
 using curve::common::ReadLockGuard;
+using curve::common::WriteLockGuard;
 
 #define FOR_EACH_DENTRY(action) \
 do { \
@@ -143,7 +144,7 @@ MetaStatusCode TxManager::HandleRenameTx(const std::vector<Dentry>& dentrys) {
 }
 
 bool TxManager::InsertPendingTx(const RenameTx& tx) {
-    ReadLockGuard w(rwLock_);
+    WriteLockGuard w(rwLock_);
     if (pendingTx_ == EMPTY_TX) {
         pendingTx_ = tx;
         return true;
@@ -152,7 +153,7 @@ bool TxManager::InsertPendingTx(const RenameTx& tx) {
 }
 
 void TxManager::DeletePendingTx() {
-    ReadLockGuard w(rwLock_);
+    WriteLockGuard w(rwLock_);
     pendingTx_ = EMPTY_TX;
 }
 

--- a/curvefs/test/metaserver/dentry_storage_test.cpp
+++ b/curvefs/test/metaserver/dentry_storage_test.cpp
@@ -35,13 +35,14 @@ namespace metaserver {
 using ::curvefs::metaserver::storage::KVStorage;
 using ::curvefs::metaserver::storage::StorageOptions;
 using ::curvefs::metaserver::storage::RocksDBStorage;
+using ::curvefs::metaserver::storage::NameGenerator;
 using ::curvefs::metaserver::storage::RandomStoragePath;
 using TX_OP_TYPE = DentryStorage::TX_OP_TYPE;
 
 class DentryStorageTest : public ::testing::Test {
  protected:
     void SetUp() override {
-        tablename_ = "partition:1";
+        nameGenerator_ = std::make_shared<NameGenerator>(1);
         dataDir_ = RandomStoragePath();;
         StorageOptions options;
         options.dataDir = dataDir_;
@@ -103,12 +104,12 @@ class DentryStorageTest : public ::testing::Test {
 
  protected:
     std::string dataDir_;
-    std::string tablename_;
+    std::shared_ptr<NameGenerator> nameGenerator_;
     std::shared_ptr<KVStorage> kvStorage_;
 };
 
 TEST_F(DentryStorageTest, Insert) {
-    DentryStorage storage(kvStorage_, tablename_);
+    DentryStorage storage(kvStorage_, nameGenerator_, 0);
 
     Dentry dentry;
     dentry.set_fsid(1);
@@ -147,7 +148,7 @@ TEST_F(DentryStorageTest, Insert) {
 }
 
 TEST_F(DentryStorageTest, Delete) {
-    DentryStorage storage(kvStorage_, tablename_);
+    DentryStorage storage(kvStorage_, nameGenerator_, 0);
 
     Dentry dentry;
     dentry.set_fsid(1);
@@ -206,13 +207,14 @@ TEST_F(DentryStorageTest, Delete) {
     dentry.set_flag(DentryFlag::DELETE_MARK_FLAG);
     rc = storage.HandleTx(TX_OP_TYPE::PREPARE, dentry);
     ASSERT_EQ(rc, MetaStatusCode::OK);
+    ASSERT_EQ(storage.Size(), 2);
 
     ASSERT_EQ(storage.Delete(dentry), MetaStatusCode::NOT_FOUND);
     ASSERT_EQ(storage.Size(), 0);
 }
 
 TEST_F(DentryStorageTest, Get) {
-    DentryStorage storage(kvStorage_, tablename_);
+    DentryStorage storage(kvStorage_, nameGenerator_, 0);
     Dentry dentry;
 
     // CASE 1: dentry not found
@@ -264,11 +266,10 @@ TEST_F(DentryStorageTest, Get) {
 }
 
 TEST_F(DentryStorageTest, List) {
-    DentryStorage storage(kvStorage_, tablename_);
+    DentryStorage storage(kvStorage_, nameGenerator_, 0);
     std::vector<Dentry> dentrys;
     Dentry dentry;
 
-    /*
     // CASE 1: basic list
     InsertDentrys(&storage, std::vector<Dentry>{
         // { fsId, parentId, name, txId, inodeId, deleteMarkFlag }
@@ -419,7 +420,6 @@ TEST_F(DentryStorageTest, List) {
     dentry = GenDentry(2, 0, "", 0, 0, false);
     ASSERT_EQ(storage.List(dentry, &dentrys, 0), MetaStatusCode::NOT_FOUND);
     ASSERT_EQ(dentrys.size(), 0);
-    */
 
     // CASE 9: list directory only
     storage.Clear();
@@ -438,7 +438,7 @@ TEST_F(DentryStorageTest, List) {
 }
 
 TEST_F(DentryStorageTest, HandleTx) {
-    DentryStorage storage(kvStorage_, tablename_);
+    DentryStorage storage(kvStorage_, nameGenerator_, 0);
     std::vector<Dentry> dentrys;
     Dentry dentry;
 
@@ -488,7 +488,9 @@ TEST_F(DentryStorageTest, HandleTx) {
         GenDentry(1, 0, "A", 0, 1, false),
         GenDentry(1, 0, "A", 1, 2, false),
     });
+    ASSERT_EQ(storage.Size(), 2);
 
+    dentry = GenDentry(1, 0, "A", 1, 2, false);
     rc = storage.HandleTx(TX_OP_TYPE::ROLLBACK, dentry);
     ASSERT_EQ(rc, MetaStatusCode::OK);
     ASSERT_EQ(storage.Size(), 1);

--- a/curvefs/test/metaserver/inode_manager_test.cpp
+++ b/curvefs/test/metaserver/inode_manager_test.cpp
@@ -45,6 +45,7 @@ using ::testing::StrEq;
 using ::curvefs::metaserver::storage::KVStorage;
 using ::curvefs::metaserver::storage::StorageOptions;
 using ::curvefs::metaserver::storage::RocksDBStorage;
+using ::curvefs::metaserver::storage::NameGenerator;
 using ::curvefs::metaserver::storage::Key4S3ChunkInfoList;
 using ::curvefs::metaserver::storage::RandomStoragePath;
 
@@ -60,8 +61,9 @@ class InodeManagerTest : public ::testing::Test {
         kvStorage_ = std::make_shared<RocksDBStorage>(options);
         ASSERT_TRUE(kvStorage_->Open());
 
+        auto nameGenerator = std::make_shared<NameGenerator>(1);
         auto inodeStorage = std::make_shared<InodeStorage>(
-            kvStorage_, tablename);
+            kvStorage_, nameGenerator, 0);
         auto trash = std::make_shared<TrashImpl>(inodeStorage);
         manager = std::make_shared<InodeManager>(inodeStorage, trash);
 
@@ -230,7 +232,7 @@ TEST_F(InodeManagerTest, test1) {
     // DELETE
     ASSERT_EQ(manager->DeleteInode(fsId, inode1.inodeid()), MetaStatusCode::OK);
     ASSERT_EQ(manager->DeleteInode(fsId, inode1.inodeid()),
-              MetaStatusCode::NOT_FOUND);
+              MetaStatusCode::OK);
     ASSERT_EQ(manager->GetInode(fsId, inode1.inodeid(), &temp1),
               MetaStatusCode::NOT_FOUND);
 

--- a/curvefs/test/metaserver/inode_storage_test.cpp
+++ b/curvefs/test/metaserver/inode_storage_test.cpp
@@ -63,8 +63,8 @@ namespace metaserver {
 class InodeStorageTest : public ::testing::Test {
  protected:
     void SetUp() override {
-        tablename_ = "partition:1";
-        dataDir_ = RandomStoragePath();;
+        nameGenerator_ = std::make_shared<NameGenerator>(1);
+        dataDir_ = RandomStoragePath();
         StorageOptions options;
         options.dataDir = dataDir_;
         kvStorage_ = std::make_shared<RocksDBStorage>(options);
@@ -180,13 +180,13 @@ class InodeStorageTest : public ::testing::Test {
 
  protected:
     std::string dataDir_;
-    std::string tablename_;
+    std::shared_ptr<NameGenerator> nameGenerator_;
     std::shared_ptr<KVStorage> kvStorage_;
     std::shared_ptr<Converter> conv_;
 };
 
 TEST_F(InodeStorageTest, test1) {
-    InodeStorage storage(kvStorage_, tablename_);
+    InodeStorage storage(kvStorage_, nameGenerator_, 0);
     Inode inode1 = GenInode(1, 1);
     Inode inode2 = GenInode(2, 2);
     Inode inode3 = GenInode(3, 3);
@@ -214,7 +214,7 @@ TEST_F(InodeStorageTest, test1) {
     ASSERT_EQ(storage.Size(), 2);
     ASSERT_EQ(storage.Get(Key4Inode(inode1), &temp),
         MetaStatusCode::NOT_FOUND);
-    ASSERT_EQ(storage.Delete(Key4Inode(inode1)), MetaStatusCode::NOT_FOUND);
+    ASSERT_EQ(storage.Delete(Key4Inode(inode1)), MetaStatusCode::OK);
 
     // update
     ASSERT_EQ(storage.Update(inode1), MetaStatusCode::NOT_FOUND);
@@ -230,12 +230,12 @@ TEST_F(InodeStorageTest, test1) {
 
     // GetInodeIdList
     std::list<uint64_t> inodeIdList;
-    ASSERT_TRUE(storage.GetInodeIdList(&inodeIdList));
+    ASSERT_TRUE(storage.GetAllInodeId(&inodeIdList));
     ASSERT_EQ(inodeIdList.size(), 2);
 }
 
 TEST_F(InodeStorageTest, testGetAttrNotFound) {
-    InodeStorage storage(kvStorage_, tablename_);
+    InodeStorage storage(kvStorage_, nameGenerator_, 0);
     Inode inode;
     inode.set_fsid(1);
     inode.set_inodeid(1);
@@ -259,7 +259,7 @@ TEST_F(InodeStorageTest, testGetAttrNotFound) {
 }
 
 TEST_F(InodeStorageTest, testGetAttr) {
-    InodeStorage storage(kvStorage_, tablename_);
+    InodeStorage storage(kvStorage_, nameGenerator_, 0);
     Inode inode;
     inode.set_fsid(1);
     inode.set_inodeid(1);
@@ -286,7 +286,7 @@ TEST_F(InodeStorageTest, testGetAttr) {
 }
 
 TEST_F(InodeStorageTest, testGetXAttr) {
-    InodeStorage storage(kvStorage_, tablename_);
+    InodeStorage storage(kvStorage_, nameGenerator_, 0);
     Inode inode;
     inode.set_fsid(1);
     inode.set_inodeid(1);
@@ -331,7 +331,7 @@ TEST_F(InodeStorageTest, testGetXAttr) {
 TEST_F(InodeStorageTest, ModifyInodeS3ChunkInfoList) {
     uint32_t fsId = 1;
     uint64_t inodeId = 1;
-    InodeStorage storage(kvStorage_, tablename_);
+    InodeStorage storage(kvStorage_, nameGenerator_, 0);
 
     // CASE 1: get empty s3chunkinfo
     {
@@ -620,7 +620,7 @@ TEST_F(InodeStorageTest, ModifyInodeS3ChunkInfoList) {
 TEST_F(InodeStorageTest, PaddingInodeS3ChunkInfo) {
     uint32_t fsId = 1;
     uint64_t inodeId = 1;
-    InodeStorage storage(kvStorage_, tablename_);
+    InodeStorage storage(kvStorage_, nameGenerator_, 0);
     S3ChunkInfoList list2del;
 
     // step1: insert inode
@@ -688,7 +688,7 @@ TEST_F(InodeStorageTest, PaddingInodeS3ChunkInfo) {
 }
 
 TEST_F(InodeStorageTest, GetAllS3ChunkInfoList) {
-    InodeStorage storage(kvStorage_, tablename_);
+    InodeStorage storage(kvStorage_, nameGenerator_, 0);
     uint64_t chunkIndex = 1;
     S3ChunkInfoList list2add = GenS3ChunkInfoList(1, 10);
 
@@ -733,16 +733,16 @@ TEST_F(InodeStorageTest, TestUpdateVolumeExtentSlice) {
     };
 
     for (const auto& test : cases) {
-        const std::string tablename = "hello";
         auto kvStorage = std::make_shared<storage::MockKVStorage>();
-        InodeStorage storage(kvStorage, tablename);
+        InodeStorage storage(kvStorage, nameGenerator_, 0);
 
         uint32_t fsId = 1;
         uint64_t inodeId = 1;
         VolumeExtentSlice slice;
         slice.set_offset(1ULL * 1024 * 1024 * 1024);
 
-        const std::string expectTableName = "3:" + tablename;
+        const std::string expectTableName =
+            nameGenerator_->GetVolumnExtentTableName();
         const std::string expectKey = "4:1:1:" + std::to_string(slice.offset());
         EXPECT_CALL(*kvStorage, SSet(expectTableName, expectKey, _))
             .WillOnce(Return(test.second));
@@ -820,7 +820,7 @@ TEST_F(InodeStorageTest, TestGetAllVolumeExtent) {
     std::shared_ptr<KVStorage> kvStore = kvStorage_;
 
     for (auto& store : {memStore, kvStore}) {
-        InodeStorage storage(memStore, "TestGetAllVolumeExtent");
+        InodeStorage storage(memStore, nameGenerator_, 0);
         const uint32_t fsId = 1;
         const uint64_t inodeId = 2;
 
@@ -856,7 +856,7 @@ TEST_F(InodeStorageTest, TestGetVolumeExtentByOffset) {
     std::shared_ptr<KVStorage> kvStore = kvStorage_;
 
     for (auto& store : {kvStorage_, memStore}) {
-        InodeStorage storage(store, "TestGetVolumeExtentByOffset");
+        InodeStorage storage(store, nameGenerator_, 0);
         const uint32_t fsId = 1;
         const uint64_t inodeId = 2;
 

--- a/curvefs/test/metaserver/metaserver_test.cpp
+++ b/curvefs/test/metaserver/metaserver_test.cpp
@@ -27,6 +27,7 @@
 #include "curvefs/src/metaserver/metaserver.h"
 #include "curvefs/test/metaserver/mock_topology_service.h"
 #include "curvefs/test/metaserver/mock_heartbeat_service.h"
+#include "curvefs/test/metaserver/storage/utils.h"
 
 using ::curvefs::mds::heartbeat::HeartbeatStatusCode;
 using ::curvefs::mds::heartbeat::MetaServerHeartbeatRequest;
@@ -36,6 +37,7 @@ using ::curvefs::mds::topology::MetaServerRegistRequest;
 using ::curvefs::mds::topology::MetaServerRegistResponse;
 using ::curvefs::mds::topology::MockTopologyService;
 using ::curvefs::mds::topology::TopoStatusCode;
+using ::curvefs::metaserver::storage::RandomStoragePath;
 using ::testing::_;
 using ::testing::AtLeast;
 using ::testing::DoAll;
@@ -54,6 +56,7 @@ class MetaserverTest : public ::testing::Test {
  protected:
     void SetUp() override {
         // run mds server
+        dataDir_ = RandomStoragePath();
         metaPath_ = "./meta.dat";
         ASSERT_EQ(0, server_.AddService(&mockTopologyService_,
                                         brpc::SERVER_DOESNT_OWN_SERVICE));
@@ -81,6 +84,8 @@ class MetaserverTest : public ::testing::Test {
     void TearDown() override {
         server_.Stop(0);
         server_.Join();
+        auto output = execShell("rm -rf " + dataDir_);
+        ASSERT_EQ(output.size(), 0);
         return;
     }
 
@@ -98,6 +103,7 @@ class MetaserverTest : public ::testing::Test {
         return result;
     }
 
+    std::string dataDir_;
     std::string metaserverIp_;
     std::string metaserverPort_;
     std::string metaserverExternalPort_;
@@ -130,6 +136,7 @@ TEST_F(MetaserverTest, register_to_mds_success) {
     conf->SetStringValue("global.ip", metaserverIp_);
     conf->SetStringValue("global.port", metaserverPort_);
     conf->SetStringValue("metaserver.meta_file_path", metaPath_);
+    conf->SetStringValue("storage.data_dir", dataDir_);
 
     // initialize MDS options
     metaserver.InitOptions(conf);
@@ -181,6 +188,7 @@ TEST_F(MetaserverTest, register_to_mds_enable_external_success) {
     conf->SetStringValue("global.enable_external_server", "true");
     conf->SetStringValue("global.external_port", metaserverExternalPort_);
     conf->SetStringValue("global.external_ip", metaserverIp_);
+    conf->SetStringValue("storage.data_dir", dataDir_);
 
     // initialize MDS options
     metaserver.InitOptions(conf);
@@ -230,6 +238,7 @@ TEST_F(MetaserverTest, test2) {
     conf->SetStringValue("global.ip", metaserverIp_);
     conf->SetStringValue("global.port", metaserverPort_);
     conf->SetStringValue("metaserver.meta_file_path", metaPath_);
+    conf->SetStringValue("storage.data_dir", dataDir_);
 
     // mock RegistMetaServer
     MetaServerRegistResponse response;
@@ -285,6 +294,7 @@ TEST_F(MetaserverTest, load_from_local) {
     conf->SetStringValue("global.ip", metaserverIp_);
     conf->SetStringValue("global.port", metaserverPort_);
     conf->SetStringValue("metaserver.meta_file_path", metaPath_);
+    conf->SetStringValue("storage.data_dir", dataDir_);
 
     // initialize MDS options
     metaserver.InitOptions(conf);

--- a/curvefs/test/metaserver/metastore_test.cpp
+++ b/curvefs/test/metaserver/metastore_test.cpp
@@ -574,7 +574,7 @@ TEST_F(MetastoreTest, test_inode) {
     ASSERT_EQ(deleteResponse.statuscode(), ret);
 
     ret = metastore.DeleteInode(&deleteRequest, &deleteResponse);
-    ASSERT_EQ(deleteResponse.statuscode(), MetaStatusCode::NOT_FOUND);
+    ASSERT_EQ(deleteResponse.statuscode(), MetaStatusCode::OK);
     ASSERT_EQ(deleteResponse.statuscode(), ret);
 }
 
@@ -743,8 +743,8 @@ TEST_F(MetastoreTest, test_dentry) {
     ASSERT_EQ(listResponse.dentrys_size(), 3);
 
     ASSERT_TRUE(CompareDentry(listResponse.dentrys(0), dentry1));
-    ASSERT_TRUE(CompareDentry(listResponse.dentrys(1), dentry3));
-    ASSERT_TRUE(CompareDentry(listResponse.dentrys(2), dentry2));
+    ASSERT_TRUE(CompareDentry(listResponse.dentrys(1), dentry2));
+    ASSERT_TRUE(CompareDentry(listResponse.dentrys(2), dentry3));
 
     listRequest.set_fsid(fsId);
     listRequest.set_dirinodeid(parentId);
@@ -756,8 +756,8 @@ TEST_F(MetastoreTest, test_dentry) {
     ASSERT_EQ(listResponse.statuscode(), MetaStatusCode::OK);
     ASSERT_EQ(listResponse.statuscode(), MetaStatusCode::OK);
     ASSERT_EQ(listResponse.dentrys_size(), 2);
-    ASSERT_TRUE(CompareDentry(listResponse.dentrys(0), dentry3));
-    ASSERT_TRUE(CompareDentry(listResponse.dentrys(1), dentry2));
+    ASSERT_TRUE(CompareDentry(listResponse.dentrys(0), dentry2));
+    ASSERT_TRUE(CompareDentry(listResponse.dentrys(1), dentry3));
 
     listRequest.set_fsid(fsId);
     listRequest.set_dirinodeid(parentId);
@@ -802,7 +802,6 @@ TEST_F(MetastoreTest, test_dentry) {
     ASSERT_EQ(listResponse.dentrys_size(), 2);
     ASSERT_TRUE(CompareDentry(listResponse.dentrys(0), dentry1));
     ASSERT_TRUE(CompareDentry(listResponse.dentrys(1), dentry3));
-    // ASSERT_TRUE(CompareDentry(listResponse.dentrys(2), dentry3));
 
     ret = metastore.DeleteDentry(&deleteRequest, &deleteResponse);
     ASSERT_EQ(deleteResponse.statuscode(), MetaStatusCode::NOT_FOUND);

--- a/curvefs/test/metaserver/s3compactwq_test.cpp
+++ b/curvefs/test/metaserver/s3compactwq_test.cpp
@@ -50,6 +50,7 @@ using ::curvefs::metaserver::storage::KVStorage;
 using ::curvefs::metaserver::storage::RandomStoragePath;
 using ::curvefs::metaserver::storage::RocksDBStorage;
 using ::curvefs::metaserver::storage::StorageOptions;
+using ::curvefs::metaserver::storage::NameGenerator;
 
 namespace curvefs {
 namespace metaserver {
@@ -80,8 +81,9 @@ class S3CompactWorkQueueImplTest : public ::testing::Test {
         kvStorage_ = std::make_shared<RocksDBStorage>(options);
         ASSERT_TRUE(kvStorage_->Open());
 
+        auto nameGenerator = std::make_shared<NameGenerator>(1);
         inodeStorage_ =
-            std::make_shared<InodeStorage>(kvStorage_, "partition:1");
+            std::make_shared<InodeStorage>(kvStorage_, nameGenerator, 0);
         trash_ = std::make_shared<TrashImpl>(inodeStorage_);
         inodeManager_ = std::make_shared<InodeManager>(inodeStorage_, trash_);
         impl_ = std::make_shared<S3CompactWorkQueueImpl>(

--- a/curvefs/test/metaserver/storage/converter_test.cpp
+++ b/curvefs/test/metaserver/storage/converter_test.cpp
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2021 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * Project: Curve
+ * Created Date: 2022-06-08
+ * Author: Jingli Chen (Wine93)
+ */
+
+#include <gtest/gtest.h>
+#include <glog/logging.h>
+
+#include <unordered_map>
+
+#include "curvefs/src/metaserver/storage/converter.h"
+
+namespace curvefs {
+namespace metaserver {
+namespace storage {
+
+class ConverterTest : public testing::Test {
+ protected:
+    void SetUp() override {}
+
+    void TearDown() override {}
+
+ protected:
+    Converter conv_;
+};
+
+TEST_F(ConverterTest, Key4Dentry) {
+    std::vector<std::string> paths {
+        "/a",
+        "/a/b/cdefg",
+        "/a:/b:/c",
+        "/a:",
+        "/a::",
+        "/a:::",
+        "/a::/b",
+        "/a:/b:",
+        ":/a",
+        "::/a",
+        ":",
+        "::",
+        ":::::::::",
+        ":/a:",
+        "/::::::",
+        "/::::/::/",
+        "/012,::2,:2211",
+    };
+
+    for (const auto& path : paths) {
+        LOG(INFO) << "TEST " << path;
+        Key4Dentry key(1, 1, path);
+        std::string skey = conv_.SerializeToString(key);
+        ASSERT_EQ(skey, "3:1:1:" + path);
+
+        Key4Dentry out;
+        ASSERT_TRUE(conv_.ParseFromString(skey, &out));
+        ASSERT_EQ(out.fsId, 1);
+        ASSERT_EQ(out.parentInodeId, 1);
+        ASSERT_EQ(out.name, path);
+    }
+
+    for (const auto& path : paths) {
+        LOG(INFO) << "TEST " << path;
+        Key4Dentry key(100, 1001, path);
+        std::string skey = conv_.SerializeToString(key);
+        ASSERT_EQ(skey, "3:100:1001:" + path);
+
+        Key4Dentry out;
+        ASSERT_TRUE(conv_.ParseFromString(skey, &out));
+        ASSERT_EQ(out.fsId, 100);
+        ASSERT_EQ(out.parentInodeId, 1001);
+        ASSERT_EQ(out.name, path);
+    }
+}
+
+TEST_F(ConverterTest, Prefix4SameParentDentry) {
+    Prefix4SameParentDentry prefix(1, 100);
+    std::string sprefix = conv_.SerializeToString(prefix);
+    ASSERT_EQ(sprefix, "3:1:100:");
+
+    Prefix4SameParentDentry out;
+    ASSERT_TRUE(conv_.ParseFromString(sprefix, &out));
+    ASSERT_EQ(out.fsId, 1);
+    ASSERT_EQ(out.parentInodeId, 100);
+}
+
+TEST_F(ConverterTest, Key4InodeAuxInfo) {
+    Key4InodeAuxInfo key(1, 1);
+    std::string skey = conv_.SerializeToString(key);
+    ASSERT_EQ(skey, "5:1:1");
+
+    Key4InodeAuxInfo out;
+    ASSERT_TRUE(conv_.ParseFromString(skey, &out));
+    ASSERT_EQ(out.fsId, 1);
+    ASSERT_EQ(out.inodeId, 1);
+}
+
+TEST_F(ConverterTest, NameGenerator) {
+    NameGenerator ng(1);
+    ASSERT_EQ(ng.GetFixedLength(), 6);
+    ASSERT_EQ(ng.GetInodeTableName().size(), ng.GetFixedLength());
+    ASSERT_EQ(ng.GetS3ChunkInfoTableName().size(), ng.GetFixedLength());
+    ASSERT_EQ(ng.GetDentryTableName().size(), ng.GetFixedLength());
+    ASSERT_EQ(ng.GetVolumnExtentTableName().size(), ng.GetFixedLength());
+    ASSERT_EQ(ng.GetInodeAuxInfoTableName().size(), ng.GetFixedLength());
+}
+
+}  // namespace storage
+}  // namespace metaserver
+}  // namespace curvefs

--- a/curvefs/test/metaserver/storage/memory_storage_test.cpp
+++ b/curvefs/test/metaserver/storage/memory_storage_test.cpp
@@ -108,8 +108,8 @@ TEST_F(MemoryStorageTest, SSizeTest) { TestSSize(kvStorage_);
                                        TestSSize(kvStorage2_); }
 TEST_F(MemoryStorageTest, SClearTest) { TestSClear(kvStorage_);
                                         TestSClear(kvStorage2_); }
-TEST_F(MemoryStorageTest, SMixOperator) { TestMixOperator(kvStorage_);
-                                          TestMixOperator(kvStorage2_); }
+TEST_F(MemoryStorageTest, MixOperatorTest) { TestMixOperator(kvStorage_);
+                                             TestMixOperator(kvStorage2_); }
 
 }  // namespace storage
 }  // namespace metaserver

--- a/curvefs/test/metaserver/storage/rocksdb_storage_test.cpp
+++ b/curvefs/test/metaserver/storage/rocksdb_storage_test.cpp
@@ -39,7 +39,6 @@ using ::curvefs::metaserver::storage::KVStorage;
 using ::curvefs::metaserver::storage::RocksDBStorage;
 using ::curvefs::metaserver::storage::StorageOptions;
 using ::curvefs::metaserver::storage::StorageStatistics;
-using ::curvefs::metaserver::storage::RocksDBStorageComparator;
 using ROCKSDB_STATUS = ROCKSDB_NAMESPACE::Status;
 
 using STORAGE_TYPE = ::curvefs::metaserver::storage::KVStorage::STORAGE_TYPE;
@@ -155,21 +154,6 @@ TEST_F(RocksDBStorageTest, GetStatisticsTest) {
     ASSERT_GT(statistics.diskUsageBytes, 0);
 }
 
-TEST_F(RocksDBStorageTest, ComparatorTest) {
-    RocksDBStorageComparator cmp;
-    std::string str4num1 = Number2BinaryString(1);
-    std::string str4num2 = Number2BinaryString(2);
-    std::string key1 = str4num1 + ":/a";
-    std::string key2 = str4num1 + ":/b";
-
-    ASSERT_EQ(cmp.Compare(str4num1, str4num2), -1);
-    ASSERT_EQ(cmp.Compare(str4num2, str4num1), 1);
-    ASSERT_EQ(cmp.Compare(str4num2, str4num1), 1);
-    ASSERT_EQ(cmp.Compare(key1, key2), -1);
-    ASSERT_EQ(cmp.Compare(key2, key1), 1);
-    ASSERT_EQ(cmp.Compare(key1, key1), 0);
-}
-
 TEST_F(RocksDBStorageTest, MiscTest) {
     // CASE 1: storage type
     ASSERT_EQ(kvStorage_->Type(), STORAGE_TYPE::ROCKSDB_STORAGE);
@@ -205,8 +189,8 @@ TEST_F(RocksDBStorageTest, SSeekTest) { TestSSeek(kvStorage_); }
 TEST_F(RocksDBStorageTest, SGetAllTest) { TestSGetAll(kvStorage_); }
 TEST_F(RocksDBStorageTest, SSizeTest) { TestSSize(kvStorage_); }
 TEST_F(RocksDBStorageTest, SClearTest) { TestSClear(kvStorage_); }
-TEST_F(RocksDBStorageTest, SMixOperator) { TestMixOperator(kvStorage_); }
-TEST_F(RocksDBStorageTest, Transaction) { TestTransaction(kvStorage_); }
+TEST_F(RocksDBStorageTest, MixOperatorTest) { TestMixOperator(kvStorage_); }
+TEST_F(RocksDBStorageTest, TransactionTest) { TestTransaction(kvStorage_); }
 
 }  // namespace storage
 }  // namespace metaserver

--- a/curvefs/test/metaserver/trash_test.cpp
+++ b/curvefs/test/metaserver/trash_test.cpp
@@ -54,8 +54,9 @@ class TestTrash : public ::testing::Test {
         kvStorage_ = std::make_shared<RocksDBStorage>(options);
         ASSERT_TRUE(kvStorage_->Open());
 
-        tablename_ = "partition:1";
-        inodeStorage_ = std::make_shared<InodeStorage>(kvStorage_, tablename_);
+        auto nameGenerator = std::make_shared<NameGenerator>(1);
+        inodeStorage_ = std::make_shared<InodeStorage>(
+            kvStorage_, nameGenerator, 0);
         trashManager_ = std::make_shared<TrashManager>();
     }
 
@@ -102,7 +103,6 @@ class TestTrash : public ::testing::Test {
 
  protected:
     std::string dataDir_;
-    std::string tablename_;
     std::shared_ptr<KVStorage> kvStorage_;
     std::shared_ptr<InodeStorage> inodeStorage_;
     std::shared_ptr<TrashManager> trashManager_;


### PR DESCRIPTION
…ot of memory and optimized some implementations:

1. use dentry vector instead of seek operation, it can speed up getting latest version dentry.
2. use rocksdb default BytewiseComparator instead of RocksDBStorageComparator, it can speed up lookup key.
3. support dumpfile v2 which not require the number of dentrys.

(#1528) (#1516)

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #1528 #1516

Problem Summary: 

* metaserver takes a lot of memory
* snapshot CRC check failed

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
