### PR TITLE
metaserver: set apply queue and bthread worker thread name

### DIFF
--- a/curvefs/src/common/BUILD
+++ b/curvefs/src/common/BUILD
@@ -20,13 +20,14 @@ cc_library(
     name = "curvefs_common",
     srcs = glob(
         ["*.cpp"],
-        exclude = ["dynamic_vlog.cpp"],
+        exclude = ["dynamic_vlog.cpp", "threading.cpp"],
     ),
     hdrs = glob(
         ["*.h"],
         exclude = [
             "metric_utils.h",
             "dynamic_vlog.h",
+            "threading.h",
         ],
     ),
     copts = CURVE_DEFAULT_COPTS,
@@ -64,6 +65,21 @@ cc_library(
     deps = [
         "//external:brpc",
         "//external:gflags",
+        "//external:glog",
+    ],
+)
+
+cc_library(
+    name = "threading",
+    srcs = [
+        "threading.cpp",
+    ],
+    hdrs = [
+        "threading.h",
+    ],
+    copts = CURVE_DEFAULT_COPTS,
+    visibility = ["//visibility:public"],
+    deps = [
         "//external:glog",
     ],
 )

--- a/curvefs/src/common/threading.cpp
+++ b/curvefs/src/common/threading.cpp
@@ -1,0 +1,55 @@
+/*
+ *  Copyright (c) 2022 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * Project: curve
+ * Date: Thursday Jun 02 17:32:58 CST 2022
+ * Author: wuhanqing
+ */
+
+#include "curvefs/src/common/threading.h"
+
+#include <glog/logging.h>
+#include <sys/prctl.h>
+#include <sys/syscall.h>
+
+namespace curvefs {
+namespace common {
+
+namespace {
+
+pid_t gettid() {
+    return syscall(SYS_gettid);
+}
+
+}  // namespace
+
+void SetThreadName(const char* name) {
+    // skip main thread
+    if (getpid() == gettid()) {
+        return;
+    }
+
+    int ret = prctl(PR_SET_NAME, name);
+
+    if (ret != 0) {
+        LOG(WARNING) << "Failed to set thread name, tid: " << gettid()
+                     << ", error: " << errno;
+    }
+}
+
+}  // namespace common
+}  // namespace curvefs

--- a/curvefs/src/common/threading.h
+++ b/curvefs/src/common/threading.h
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2022 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * Project: curve
+ * Date: Thursday Jun 02 17:31:28 CST 2022
+ * Author: wuhanqing
+ */
+
+#ifndef CURVEFS_SRC_COMMON_THREADING_H_
+#define CURVEFS_SRC_COMMON_THREADING_H_
+
+namespace curvefs {
+namespace common {
+
+// Set current thread's name
+void SetThreadName(const char* name);
+
+}  // namespace common
+}  // namespace curvefs
+
+#endif  // CURVEFS_SRC_COMMON_THREADING_H_

--- a/curvefs/src/metaserver/BUILD
+++ b/curvefs/src/metaserver/BUILD
@@ -55,6 +55,7 @@ cc_library(
         "//src/common:curve_common",
         "//src/fs:lfs",
         "//curvefs/src/common:dynamic_vlog",
+        "//curvefs/src/common:threading",
         "@rocksdb//:rocksdb_lib",
         "@com_google_absl//absl/cleanup",
         "@com_google_absl//absl/container:btree",

--- a/curvefs/src/metaserver/copyset/apply_queue.h
+++ b/curvefs/src/metaserver/copyset/apply_queue.h
@@ -26,6 +26,7 @@
 #include <atomic>
 #include <cstdint>
 #include <memory>
+#include <string>
 #include <thread>
 #include <utility>
 #include <vector>
@@ -38,9 +39,12 @@ namespace curvefs {
 namespace metaserver {
 namespace copyset {
 
+class CopysetNode;
+
 struct ApplyQueueOption {
     uint32_t workerCount = 1;
     uint32_t queueDepth = 1;
+    CopysetNode* copysetNode = nullptr;
 };
 
 class CURVE_CACHELINE_ALIGNMENT ApplyQueue {
@@ -63,8 +67,11 @@ class CURVE_CACHELINE_ALIGNMENT ApplyQueue {
     void StartWorkers();
 
     struct TaskWorker {
-        explicit TaskWorker(size_t cap)
-            : running(false), worker(), tasks(cap) {}
+        TaskWorker(size_t cap, std::string workerName)
+            : running(false),
+              worker(),
+              tasks(cap),
+              workerName_(std::move(workerName)) {}
 
         void Start();
 
@@ -75,6 +82,7 @@ class CURVE_CACHELINE_ALIGNMENT ApplyQueue {
         std::atomic<bool> running;
         std::thread worker;
         curve::common::TaskQueue tasks;
+        std::string workerName_;
     };
 
  private:

--- a/curvefs/src/metaserver/copyset/copyset_node.cpp
+++ b/curvefs/src/metaserver/copyset/copyset_node.cpp
@@ -120,6 +120,7 @@ bool CopysetNode::Init(const CopysetNodeOptions& options) {
 
     // init apply queue
     applyQueue_ = absl::make_unique<ApplyQueue>();
+    options_.applyQueueOption.copysetNode = this;
     if (!applyQueue_->Start(options_.applyQueueOption)) {
         LOG(ERROR) << "Start apply queue failed";
         return false;

--- a/curvefs/src/metaserver/main.cpp
+++ b/curvefs/src/metaserver/main.cpp
@@ -28,6 +28,7 @@
 #include "curvefs/src/metaserver/metaserver.h"
 #include "src/common/configuration.h"
 #include "curvefs/src/common/dynamic_vlog.h"
+#include "curvefs/src/common/threading.h"
 
 DEFINE_string(confPath, "curvefs/conf/metaserver.conf", "metaserver confPath");
 DEFINE_string(ip, "127.0.0.1", "metasetver listen ip");
@@ -46,7 +47,22 @@ DECLARE_int32(v);
 using ::curve::common::Configuration;
 using ::curvefs::common::FLAGS_vlog_level;
 
+namespace bthread {
+extern void (*g_worker_startfn)();
+}
+
 namespace {
+
+void SetBthreadWorkerName() {
+    static std::atomic<int> counter(0);
+
+    char buffer[16] = {0};
+    snprintf(buffer, sizeof(buffer), "bthread:%d",
+             counter.fetch_add(1, std::memory_order_relaxed));
+
+    curvefs::common::SetThreadName(buffer);
+}
+
 void LoadConfigFromCmdline(Configuration *conf) {
     google::CommandLineFlagInfo info;
     if (GetCommandLineFlagInfo("ip", &info) && !info.is_default) {
@@ -88,6 +104,7 @@ void LoadConfigFromCmdline(Configuration *conf) {
         conf->SetIntValue("metaserver.loglevel", FLAGS_v);
     }
 }
+
 }  // namespace
 
 int main(int argc, char **argv) {
@@ -96,6 +113,8 @@ int main(int argc, char **argv) {
 
     ::curvefs::common::Process::InitSetProcTitle(argc, argv);
     butil::AtExitManager atExit;
+
+    bthread::g_worker_startfn = SetBthreadWorkerName;
 
     std::string confPath = FLAGS_confPath;
     auto conf = std::make_shared<Configuration>();


### PR DESCRIPTION
Support set thread name which will display by `pstree` and `top`, and also set apply queue and bthread worker name in metaserver.

Here is some illustration,

<img width="745" alt="image" src="https://user-images.githubusercontent.com/10327590/176086529-6396bde7-8471-4314-98a0-2f97a6f0ddba.png">

`top` command will show the process's resource usage, and `top -H -p ${pid}` will display every threads' resource usage.

If thread's name is not specified, we will see this

<img width="757" alt="image" src="https://user-images.githubusercontent.com/10327590/176086782-fdfa9e5c-e91c-4712-9149-d9488809d0ca.png">

, every thread has the same name, so we can't distinguish them.

After this patch, bthread worker and apply queue's thread name is specified, so we can get more information from `top -H -p ${pid}`

<img width="980" alt="image" src="https://user-images.githubusercontent.com/10327590/176101815-3a4e40ba-214c-4e4e-a136-04bea89d5a4f.png">
