### PR TITLE
fuse: fix extent slice merge coredump

### DIFF
--- a/curvefs/src/client/volume/extent_cache.cpp
+++ b/curvefs/src/client/volume/extent_cache.cpp
@@ -52,7 +52,7 @@ using ::curvefs::metaserver::VolumeExtent;
 namespace {
 
 bvar::LatencyRecorder g_write_divide_latency("extent_cache_write_divide");
-bvar::LatencyRecorder g_read_divide_latency_("extent_cache_read_divide");
+bvar::LatencyRecorder g_read_divide_latency("extent_cache_read_divide");
 bvar::LatencyRecorder g_merge_latency("extent_cache_merge");
 bvar::LatencyRecorder g_mark_written_latency("extent_cache_mark_written");
 
@@ -72,7 +72,7 @@ ExtentCacheOption ExtentCache::option_;
 void ExtentCache::Merge(uint64_t loffset, const PExtent& pExt) {
     VLOG(9) << "merge extent, loffset: " << loffset
             << ", physical offset: " << pExt.pOffset << ", len: " << pExt.len
-            << ", writtern: " << !pExt.UnWritten;
+            << ", written: " << !pExt.UnWritten;
     assert(is_aligned(loffset, option_.blockSize));
     assert(is_aligned(pExt.pOffset, option_.blockSize));
     assert(is_aligned(pExt.len, option_.blockSize));
@@ -192,7 +192,7 @@ void ExtentCache::DivideForRead(uint64_t offset,
                                 char* data,
                                 std::vector<ReadPart>* reads,
                                 std::vector<ReadPart>* holes) {
-    LatencyUpdater updater(&g_read_divide_latency_);
+    LatencyUpdater updater(&g_read_divide_latency);
     ReadLockGuard lk(lock_);
 
     const auto end = offset + len;

--- a/curvefs/src/client/volume/extent_slice.cpp
+++ b/curvefs/src/client/volume/extent_slice.cpp
@@ -380,6 +380,9 @@ void ExtentSlice::Merge(uint64_t loffset, const PExtent &extent) {
     // try merge with rightside
     const auto endOff = inserted->first + inserted->second.len;
     it = extents_.lower_bound(endOff);
+    if (it == extents_.end()) {
+        return;
+    }
 
     if (!it->second.UnWritten && it != extents_.end() && it->first == endOff &&
         inserted->second.pOffset + inserted->second.len == it->second.pOffset) {

--- a/curvefs/test/client/volume/extent_cache_merge_test.cpp
+++ b/curvefs/test/client/volume/extent_cache_merge_test.cpp
@@ -208,10 +208,6 @@ TEST(ExtentCacheMergeTest, MergeCase4_PhysicalOffsetContinuous) {
     ASSERT_EQ(96 * kMiB, range[16 * kMiB].pOffset);
     ASSERT_EQ(8 * kMiB, range[16 * kMiB].len);
     ASSERT_FALSE(range[16 * kMiB].UnWritten);
-
-    // ASSERT_EQ(104 * kMiB, range[20 * kMiB].pOffset);
-    // ASSERT_EQ(4 * kMiB, range[20 * kMiB].len);
-    // ASSERT_TRUE(range[20 * kMiB].UnWritten);
 }
 
 // adding extent             |----|


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #1461

Problem Summary: missing check whether the iterator is equals to end before reading

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [x] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license
