### PR TITLE
curvefs/metaserver: enable rocksdb write buffer manager allow_stall t…

### DIFF
--- a/curvefs/src/metaserver/storage/rocksdb_options.cpp
+++ b/curvefs/src/metaserver/storage/rocksdb_options.cpp
@@ -103,7 +103,8 @@ void CreateBlockCacheAndWriterBufferManager() {
             std::make_shared<rocksdb::WriteBufferManager>(
                 FLAGS_rocksdb_write_buffer_manager_capacity,
                 FLAGS_rocksdb_WBM_cost_block_cache ? rocksdbBlockCache
-                                                   : nullptr);
+                                                   : nullptr,
+                true);
     });
 }
 


### PR DESCRIPTION
…o limit memory usage by strictly (#1643).

Signed-off-by: Wine93 <wine93.info@gmail.com>

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #1643

Problem Summary: curvefs metaserver's memory exceed the limit

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
