### PR TITLE
curvefs/metaserver: fixed WriteBufferManager doesn't have the capabil…

### DIFF
--- a/curvefs/conf/metaserver.conf
+++ b/curvefs/conf/metaserver.conf
@@ -236,6 +236,8 @@ storage.rocksdb.ordered_write_buffer_size=67108864
 # rocksdb column family's max_write_buffer_number
 # for store dentry and inode's s3chunkinfo list (default: 3)
 storage.rocksdb.ordered_max_write_buffer_number=3
+# The target number of write history bytes to hold in memory (default: 20MB)
+storage.rocksdb.max_write_buffer_size_to_maintain=20971520
 # rocksdb memtable prefix bloom size ratio (size=write_buffer_size*memtable_prefix_bloom_size_ratio)
 storage.rocksdb.memtable_prefix_bloom_size_ratio=0.1
 # dump rocksdb.stats to LOG every stats_dump_period_sec

--- a/curvefs/src/metaserver/storage/rocksdb_options.cpp
+++ b/curvefs/src/metaserver/storage/rocksdb_options.cpp
@@ -78,6 +78,10 @@ DEFINE_int32(rocksdb_ordered_cf_max_write_buffer_number,
              2,
              "Number of writer buffer for ordered column family");
 
+DEFINE_int32(rocksdb_max_write_buffer_size_to_maintain,
+             20 << 20,
+             "The target number of write history bytes to hold in memory");
+
 DEFINE_int32(rocksdb_stats_dump_period_sec,
              180,
              "Dump rocksdb.stats to LOG every stats_dump_period_sec");
@@ -149,6 +153,8 @@ void InitRocksdbOptions(
     tableOptions.filter_policy.reset(rocksdb::NewBloomFilterPolicy(10, false));
 
     rocksdb::ColumnFamilyOptions defaultCfOptions;
+    defaultCfOptions.max_write_buffer_size_to_maintain =
+        FLAGS_rocksdb_max_write_buffer_size_to_maintain;
     defaultCfOptions.enable_blob_files = true;
     defaultCfOptions.level_compaction_dynamic_level_bytes = true;
     defaultCfOptions.compaction_pri = rocksdb::kMinOverlappingRatio;
@@ -211,6 +217,10 @@ void ParseRocksdbOptions(curve::common::Configuration* conf) {
     dummy.Load(conf, "rocksdb_ordered_cf_max_write_buffer_number",
                "storage.rocksdb.ordered_max_write_buffer_number",
                &FLAGS_rocksdb_ordered_cf_max_write_buffer_number,
+               /*fatalIfMissing*/ false);
+    dummy.Load(conf, "rocksdb_max_write_buffer_size_to_maintain",
+               "storage.rocksdb.max_write_buffer_size_to_maintain",
+               &FLAGS_rocksdb_max_write_buffer_size_to_maintain,
                /*fatalIfMissing*/ false);
     dummy.Load(conf, "rocksdb_stats_dump_period_sec",
                "storage.rocksdb.stats_dump_period_sec",


### PR DESCRIPTION
…ity to trim the history

leads the total memory size exceed the limit (#1643).

Signed-off-by: Wine93 <wine93.info@gmail.com>

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #xxx <!-- replace xxx with issue number -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
