### PR TITLE
Curve/tool fs create topology

### DIFF
--- a/tools-v2/internal/error/error.go
+++ b/tools-v2/internal/error/error.go
@@ -275,6 +275,9 @@ var (
 	ErrMetaserverOffline = func() *CmdError {
 		return NewInternalCmdError(25, "metaserver[%s] is offline!")
 	}
+	ErrCheckPoolTopology = func() *CmdError {
+		return NewInternalCmdError(26, "pool[%s] is not in cluster nor in json file")
+	}
 
 	// http error
 	ErrHttpUnreadableResult = func() *CmdError {
@@ -359,6 +362,61 @@ var (
 			message = "ok"
 		default:
 			message = fmt.Sprintf("op status: %s in %s", statusCode.String(), addr)
+		}
+		return NewRpcReultCmdError(code, message)
+	}
+	ErrListPool = func(statusCode topology.TopoStatusCode) *CmdError {
+		var message string
+		code := int(statusCode)
+		switch statusCode {
+		case topology.TopoStatusCode_TOPO_OK:
+			message = "ok"
+		default:
+			message = fmt.Sprintf("list topology err: %s", statusCode.String())
+		}
+		return NewRpcReultCmdError(code, message)
+	}
+	ErrListZone = func(statusCode topology.TopoStatusCode) *CmdError {
+		var message string
+		code := int(statusCode)
+		switch statusCode {
+		case topology.TopoStatusCode_TOPO_OK:
+			message = "ok"
+		default:
+			message = fmt.Sprintf("list Zone err: %s", statusCode.String())
+		}
+		return NewRpcReultCmdError(code, message)
+	}
+	ErrListServer = func(statusCode topology.TopoStatusCode) *CmdError {
+		var message string
+		code := int(statusCode)
+		switch statusCode {
+		case topology.TopoStatusCode_TOPO_OK:
+			message = "ok"
+		default:
+			message = fmt.Sprintf("list Server err: %s", statusCode.String())
+		}
+		return NewRpcReultCmdError(code, message)
+	}
+	ErrDeleteTopology = func(statusCode topology.TopoStatusCode, topoType string) *CmdError {
+		var message string
+		code := int(statusCode)
+		switch statusCode {
+		case topology.TopoStatusCode_TOPO_OK:
+			message = "ok"
+		default:
+			message = fmt.Sprintf("delete %s err: %s", topoType, statusCode.String())
+		}
+		return NewRpcReultCmdError(code, message)
+	}
+	ErrCreateTopology = func(statusCode topology.TopoStatusCode, topoType string) *CmdError {
+		var message string
+		code := int(statusCode)
+		switch statusCode {
+		case topology.TopoStatusCode_TOPO_OK:
+			message = "ok"
+		default:
+			message = fmt.Sprintf("create %s err: %s", topoType, statusCode.String())
 		}
 		return NewRpcReultCmdError(code, message)
 	}

--- a/tools-v2/pkg/cli/command/curvefs/create/create.go
+++ b/tools-v2/pkg/cli/command/curvefs/create/create.go
@@ -25,6 +25,7 @@ package create
 import (
 	basecmd "github.com/opencurve/curve/tools-v2/pkg/cli/command"
 	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvefs/create/fs"
+	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvefs/create/topology"
 	"github.com/spf13/cobra"
 )
 
@@ -37,6 +38,7 @@ var _ basecmd.MidCurveCmdFunc = (*CreateCommand)(nil) // check interface
 func (createCmd *CreateCommand) AddSubCommands() {
 	createCmd.Cmd.AddCommand(
 		fs.NewFsCommand(),
+		topology.NewTopologyCommand(),
 	)
 }
 

--- a/tools-v2/pkg/cli/command/curvefs/create/topology/pool.go
+++ b/tools-v2/pkg/cli/command/curvefs/create/topology/pool.go
@@ -1,0 +1,227 @@
+/*
+ *  Copyright (c) 2022 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * Project: CurveCli
+ * Created Date: 2022-06-30
+ * Author: chengyi (Cyber-SiKu)
+ */
+
+package topology
+
+import (
+	"context"
+	"encoding/json"
+
+	cmderror "github.com/opencurve/curve/tools-v2/internal/error"
+	basecmd "github.com/opencurve/curve/tools-v2/pkg/cli/command"
+	"github.com/opencurve/curve/tools-v2/proto/curvefs/proto/topology"
+	"golang.org/x/exp/slices"
+	"google.golang.org/grpc"
+)
+
+const (
+	TYPE_POOL = "pool"
+)
+
+
+type Pool struct {
+	Name         string `json:"name"`
+	ReplicasNum  uint32 `json:"replicasnum"`
+	ZoneNum      uint32 `json:"zonenum"`
+	CopysetNum   uint64 `json:"copysetnum"`
+	PoolType     uint64 `json:"type"`
+	ScatterWidth uint64 `json:"scatterwidth"`
+	PhysicalPool string `json:"physicalpool"`
+}
+
+type Policy struct {
+	ReplicaNum uint32 `json:"replicaNum"`
+	CopysetNum uint64 `json:"copysetNum"`
+	ZoneNum    uint32 `json:"zoneNum"`
+}
+
+type DeletePoolRpc struct {
+	Info           *basecmd.Rpc
+	Request        *topology.DeletePoolRequest
+	topologyClient topology.TopologyServiceClient
+}
+
+func (dpRpc *DeletePoolRpc) NewRpcClient(cc grpc.ClientConnInterface) {
+	dpRpc.topologyClient = topology.NewTopologyServiceClient(cc)
+}
+
+func (dpRpc *DeletePoolRpc) Stub_Func(ctx context.Context) (interface{}, error) {
+	return dpRpc.topologyClient.DeletePool(ctx, dpRpc.Request)
+}
+
+var _ basecmd.RpcFunc = (*DeletePoolRpc)(nil) // check interface
+
+type CreatePoolRpc struct {
+	Info           *basecmd.Rpc
+	Request        *topology.CreatePoolRequest
+	topologyClient topology.TopologyServiceClient
+}
+
+func (cpRpc *CreatePoolRpc) NewRpcClient(cc grpc.ClientConnInterface) {
+	cpRpc.topologyClient = topology.NewTopologyServiceClient(cc)
+}
+
+func (cpRpc *CreatePoolRpc) Stub_Func(ctx context.Context) (interface{}, error) {
+	return cpRpc.topologyClient.CreatePool(ctx, cpRpc.Request)
+}
+
+var _ basecmd.RpcFunc = (*CreatePoolRpc)(nil) // check interface
+
+type ListPoolRpc struct {
+	Info           *basecmd.Rpc
+	Request        *topology.ListPoolRequest
+	topologyClient topology.TopologyServiceClient
+}
+
+func (lpRpc *ListPoolRpc) NewRpcClient(cc grpc.ClientConnInterface) {
+	lpRpc.topologyClient = topology.NewTopologyServiceClient(cc)
+}
+
+func (lpRpc *ListPoolRpc) Stub_Func(ctx context.Context) (interface{}, error) {
+	return lpRpc.topologyClient.ListPool(ctx, lpRpc.Request)
+}
+
+func (tCmd *TopologyCommand) listPool() (*topology.ListPoolResponse, *cmderror.CmdError) {
+	tCmd.listPoolRpc = &ListPoolRpc{}
+	tCmd.listPoolRpc.Request = &topology.ListPoolRequest{}
+	tCmd. listPoolRpc.Info = basecmd.NewRpc(tCmd.addrs, tCmd.timeout, tCmd.retryTimes, "ListPool")
+	result, err := basecmd.GetRpcResponse(tCmd.listPoolRpc.Info, tCmd.listPoolRpc)
+	if err.TypeCode() != cmderror.CODE_SUCCESS {
+		return nil, err
+	}
+	response := result.(*topology.ListPoolResponse)
+	return response, cmderror.ErrSuccess()
+}
+
+func (tCmd *TopologyCommand) scanPools() *cmderror.CmdError {
+	// scan pool
+	response, err := tCmd.listPool()
+	if err.TypeCode() != cmderror.CODE_SUCCESS {
+		return err
+	}
+	if response.GetStatusCode() != topology.TopoStatusCode_TOPO_OK {
+		return cmderror.ErrListPool(response.GetStatusCode())
+	}
+	tCmd.clusterPoolsInfo = response.GetPoolInfos()
+	// update delete pool
+	compare := func(pool Pool, poolInfo *topology.PoolInfo) bool {
+		return pool.Name == poolInfo.GetPoolName()
+	}
+	for _, poolInfo := range tCmd.clusterPoolsInfo {
+		index := slices.IndexFunc(tCmd.topology.Pools, func(pool Pool) bool {
+			return compare(pool, poolInfo)
+		})
+		if index == -1 {
+			id := poolInfo.GetPoolID()
+			request := &topology.DeletePoolRequest{
+				PoolID: &id,
+			}
+			tCmd.deletePool = append(tCmd.deletePool, request)
+			row := make(map[string]string)
+			row[ROW_NAME] = poolInfo.GetPoolName()
+			row[ROW_TYPE] = TYPE_POOL
+			row[ROW_OPERATION] = ROW_VALUE_DEL
+			row[ROW_PARENT] = ""
+			tCmd.Table.AddRow(row)
+		}
+	}
+
+	// update create pool
+	for _, pool := range tCmd.topology.Pools {
+		index := slices.IndexFunc(tCmd.clusterPoolsInfo, func(poolInfo *topology.PoolInfo) bool {
+			return compare(pool, poolInfo)
+		})
+		if index == -1 {
+			policy := Policy{
+				ReplicaNum: pool.ReplicasNum,
+				CopysetNum: pool.CopysetNum,
+				ZoneNum:    pool.ZoneNum,
+			}
+			policyByte, _ := json.Marshal(policy)
+			request := &topology.CreatePoolRequest{
+				PoolName:                     &pool.Name,
+				RedundanceAndPlaceMentPolicy: policyByte,
+			}
+			tCmd.createPool = append(tCmd.createPool, request)
+			row := make(map[string]string)
+			row[ROW_NAME] = pool.Name
+			row[ROW_TYPE] = TYPE_POOL
+			row[ROW_OPERATION] = ROW_VALUE_ADD
+			row[ROW_PARENT] = ""
+			tCmd.Table.AddRow(row)
+		}
+	}
+
+	return err
+}
+
+func (tCmd *TopologyCommand) removePools() *cmderror.CmdError {
+	tCmd.deletePoolRpc = &DeletePoolRpc{}
+	tCmd.deletePoolRpc.Info = basecmd.NewRpc(tCmd.addrs, tCmd.timeout, tCmd.retryTimes, "DeleteServer")
+	for _, delReuest := range tCmd.deletePool {
+		tCmd.deletePoolRpc.Request = delReuest
+		result, err := basecmd.GetRpcResponse(tCmd.deletePoolRpc.Info, tCmd.deletePoolRpc)
+		if err.TypeCode() != cmderror.CODE_SUCCESS {
+			return err
+		}
+		response := result.(*topology.DeletePoolResponse)
+		if response.GetStatusCode() != topology.TopoStatusCode_TOPO_OK {
+			return cmderror.ErrDeleteTopology(response.GetStatusCode(), TYPE_POOL)
+		}
+	}
+	return cmderror.ErrSuccess()
+}
+
+func (tCmd *TopologyCommand) createPools() *cmderror.CmdError {
+	tCmd.createPoolRpc = &CreatePoolRpc{}
+	tCmd.createPoolRpc.Info = basecmd.NewRpc(tCmd.addrs, tCmd.timeout, tCmd.retryTimes, "CreatePool")
+	for _, crtReuest := range tCmd.createPool {
+		tCmd.createPoolRpc.Request = crtReuest
+		result, err := basecmd.GetRpcResponse(tCmd.createPoolRpc.Info, tCmd.createPoolRpc)
+		if err.TypeCode() != cmderror.CODE_SUCCESS {
+			return err
+		}
+		response := result.(*topology.CreatePoolResponse)
+		if response.GetStatusCode() != topology.TopoStatusCode_TOPO_OK {
+			return cmderror.ErrCreateTopology(response.GetStatusCode(), TYPE_POOL)
+		}
+	}
+	return cmderror.ErrSuccess()
+}
+
+// Check if the pool in the server exists in the cluster and json.
+// if not exist return error
+func (tCmd *TopologyCommand) checkPool(poolName string) *cmderror.CmdError {
+	indexPool := slices.IndexFunc(tCmd.topology.Pools, func(pool Pool) bool {
+		return pool.Name == poolName
+	})
+	indexCluster := slices.IndexFunc(tCmd.clusterPoolsInfo, func(poolInfo *topology.PoolInfo) bool {
+		return poolInfo.GetPoolName() == poolName
+	})
+	if indexPool == -1 && indexCluster == -1 {
+		err := cmderror.ErrCheckPoolTopology()
+		err.Format(poolName)
+	}
+	return cmderror.ErrSuccess()
+}
+
+

--- a/tools-v2/pkg/cli/command/curvefs/create/topology/server.go
+++ b/tools-v2/pkg/cli/command/curvefs/create/topology/server.go
@@ -1,0 +1,208 @@
+/*
+ *  Copyright (c) 2022 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * Project: CurveCli
+ * Created Date: 2022-06-30
+ * Author: chengyi (Cyber-SiKu)
+ */
+
+package topology
+
+import (
+	"context"
+
+	cmderror "github.com/opencurve/curve/tools-v2/internal/error"
+	basecmd "github.com/opencurve/curve/tools-v2/pkg/cli/command"
+	"github.com/opencurve/curve/tools-v2/proto/curvefs/proto/topology"
+	"golang.org/x/exp/slices"
+	"google.golang.org/grpc"
+)
+
+type Server struct {
+	Name         string `json:"name"`
+	InternalIp   string `json:"internalip"`
+	InternalPort uint32 `json:"internalport"`
+	ExternalIp   string `json:"externalip"`
+	ExternalPort uint32 `json:"externalport"`
+	ZoneName     string `json:"zone"`
+	PoolName     string `json:"pool"`
+}
+
+const (
+	TYPE_SERVER = "server"
+)
+
+type DeleteServerRpc struct {
+	Info           *basecmd.Rpc
+	Request        *topology.DeleteServerRequest
+	topologyClient topology.TopologyServiceClient
+}
+
+func (dsRpc *DeleteServerRpc) NewRpcClient(cc grpc.ClientConnInterface) {
+	dsRpc.topologyClient = topology.NewTopologyServiceClient(cc)
+}
+
+func (dsRpc *DeleteServerRpc) Stub_Func(ctx context.Context) (interface{}, error) {
+	return dsRpc.topologyClient.DeleteServer(ctx, dsRpc.Request)
+}
+
+var _ basecmd.RpcFunc = (*DeleteServerRpc)(nil) // check interface
+
+type CreateServerRpc struct {
+	Info           *basecmd.Rpc
+	Request        *topology.ServerRegistRequest
+	topologyClient topology.TopologyServiceClient
+}
+
+func (csRpc *CreateServerRpc) NewRpcClient(cc grpc.ClientConnInterface) {
+	csRpc.topologyClient = topology.NewTopologyServiceClient(cc)
+}
+
+func (csRpc *CreateServerRpc) Stub_Func(ctx context.Context) (interface{}, error) {
+	return csRpc.topologyClient.RegistServer(ctx, csRpc.Request)
+}
+
+var _ basecmd.RpcFunc = (*CreateServerRpc)(nil) // check interface
+
+type ListZoneServerRpc struct {
+	Info           *basecmd.Rpc
+	Request        *topology.ListZoneServerRequest
+	topologyClient topology.TopologyServiceClient
+}
+
+func (lzsRpc *ListZoneServerRpc) NewRpcClient(cc grpc.ClientConnInterface) {
+	lzsRpc.topologyClient = topology.NewTopologyServiceClient(cc)
+}
+
+func (lzsRpc *ListZoneServerRpc) Stub_Func(ctx context.Context) (interface{}, error) {
+	return lzsRpc.topologyClient.ListZoneServer(ctx, lzsRpc.Request)
+}
+
+var _ basecmd.RpcFunc = (*ListZoneServerRpc)(nil) // check interface
+
+func (tCmd *TopologyCommand) listZoneServer(zoneId uint32) (*topology.ListZoneServerResponse, *cmderror.CmdError) {
+	request := &topology.ListZoneServerRequest{
+		ZoneID: &zoneId,
+	}
+	tCmd.listZoneServerRpc = &ListZoneServerRpc{
+		Request: request,
+	}
+	tCmd.listZoneServerRpc.Info = basecmd.NewRpc(tCmd.addrs, tCmd.timeout, tCmd.retryTimes, "ListPoolZone")
+	result, err := basecmd.GetRpcResponse(tCmd.listZoneServerRpc.Info, tCmd.listZoneServerRpc)
+	if err.TypeCode() != cmderror.CODE_SUCCESS {
+		return nil, err
+	}
+	response := result.(*topology.ListZoneServerResponse)
+	return response, cmderror.ErrSuccess()
+}
+
+func (tCmd *TopologyCommand) scanServers() *cmderror.CmdError {
+	// scan server
+	for _, zone := range tCmd.clusterZonesInfo {
+		response, err := tCmd.listZoneServer(zone.GetZoneID())
+		if err.TypeCode() != cmderror.CODE_SUCCESS {
+			return err
+		}
+		if response.GetStatusCode() != topology.TopoStatusCode_TOPO_OK {
+			return cmderror.ErrListPool(response.GetStatusCode())
+		}
+		tCmd.clusterServersInfo = append(tCmd.clusterServersInfo, response.GetServerInfo()...)
+	}
+	// update delete server
+	compare := func(server Server, serverInfo *topology.ServerInfo) bool {
+		return server.Name == serverInfo.GetHostName() && server.ZoneName == serverInfo.GetZoneName() && server.PoolName == serverInfo.GetPoolName()
+	}
+	for _, serverInfo := range tCmd.clusterServersInfo {
+		index := slices.IndexFunc(tCmd.topology.Servers, func(server Server) bool {
+			return compare(server, serverInfo)
+		})
+		if index == -1 {
+			id := serverInfo.GetServerID()
+			request := &topology.DeleteServerRequest{
+				ServerID: &id,
+			}
+			tCmd.deleteServer = append(tCmd.deleteServer, request)
+			row := make(map[string]string)
+			row[ROW_NAME] = serverInfo.GetHostName()
+			row[ROW_TYPE] = TYPE_SERVER
+			row[ROW_OPERATION] = ROW_VALUE_DEL
+			row[ROW_PARENT] = serverInfo.GetZoneName()
+			tCmd.Table.AddRow(row)
+		}
+	}
+
+	// update create server
+	for _, server := range tCmd.topology.Servers {
+		index := slices.IndexFunc(tCmd.clusterServersInfo, func(serverInfo *topology.ServerInfo) bool {
+			return compare(server, serverInfo)
+		})
+		if index == -1 {
+			request := &topology.ServerRegistRequest{
+				HostName:     &server.Name,
+				InternalIp:   &server.InternalIp,
+				InternalPort: &server.InternalPort,
+				ExternalIp:   &server.ExternalIp,
+				ExternalPort: &server.ExternalPort,
+				ZoneName:     &server.ZoneName,
+				PoolName:     &server.PoolName,
+			}
+			tCmd.createServer = append(tCmd.createServer, request)
+			row := make(map[string]string)
+			row[ROW_NAME] = server.Name
+			row[ROW_TYPE] = TYPE_SERVER
+			row[ROW_OPERATION] = ROW_VALUE_ADD
+			row[ROW_PARENT] = server.ZoneName
+			tCmd.Table.AddRow(row)
+		}
+	}
+
+	return cmderror.ErrSuccess()
+}
+
+func (tCmd *TopologyCommand) removeServers() *cmderror.CmdError {
+	tCmd.deleteServerRpc = &DeleteServerRpc{}
+	tCmd.deleteServerRpc.Info = basecmd.NewRpc(tCmd.addrs, tCmd.timeout, tCmd.retryTimes, "DeleteServer")
+	for _, delReuest := range tCmd.deleteServer {
+		tCmd.deleteServerRpc.Request = delReuest
+		result, err := basecmd.GetRpcResponse(tCmd.deleteServerRpc.Info, tCmd.deleteServerRpc)
+		if err.TypeCode() != cmderror.CODE_SUCCESS {
+			return err
+		}
+		response := result.(*topology.DeleteServerResponse)
+		if response.GetStatusCode() != topology.TopoStatusCode_TOPO_OK {
+			return cmderror.ErrDeleteTopology(response.GetStatusCode(), TYPE_SERVER)
+		}
+	}
+	return cmderror.ErrSuccess()
+}
+
+func (tCmd *TopologyCommand) createServers() *cmderror.CmdError {
+	tCmd.createServerRpc = &CreateServerRpc{}
+	tCmd.createServerRpc.Info = basecmd.NewRpc(tCmd.addrs, tCmd.timeout, tCmd.retryTimes, "RegisterServer")
+	for _, crtReuest := range tCmd.createServer {
+		tCmd.createServerRpc.Request = crtReuest
+		result, err := basecmd.GetRpcResponse(tCmd.createServerRpc.Info, tCmd.createServerRpc)
+		if err.TypeCode() != cmderror.CODE_SUCCESS {
+			return err
+		}
+		response := result.(*topology.ServerRegistResponse)
+		if response.GetStatusCode() != topology.TopoStatusCode_TOPO_OK {
+			return cmderror.ErrCreateTopology(response.GetStatusCode(), TYPE_SERVER)
+		}
+	}
+	return cmderror.ErrSuccess()
+}

--- a/tools-v2/pkg/cli/command/curvefs/create/topology/topology.go
+++ b/tools-v2/pkg/cli/command/curvefs/create/topology/topology.go
@@ -1,0 +1,229 @@
+/*
+ *  Copyright (c) 2022 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * Project: CurveCli
+ * Created Date: 2022-06-29
+ * Author: chengyi (Cyber-SiKu)
+ */
+
+package topology
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"time"
+
+	"github.com/liushuochen/gotable"
+	cmderror "github.com/opencurve/curve/tools-v2/internal/error"
+	cobrautil "github.com/opencurve/curve/tools-v2/internal/utils"
+	basecmd "github.com/opencurve/curve/tools-v2/pkg/cli/command"
+	"github.com/opencurve/curve/tools-v2/pkg/config"
+	"github.com/opencurve/curve/tools-v2/pkg/output"
+	"github.com/opencurve/curve/tools-v2/proto/curvefs/proto/topology"
+	"github.com/spf13/cobra"
+)
+
+const (
+	ROW_OPERATION = "operation"
+	ROW_VALUE_ADD = "add"
+	ROW_VALUE_DEL = "del"
+	ROW_TYPE      = "Type"
+	ROW_NAME      = "Name"
+	ROW_PARENT	  = "parent"
+)
+
+type Topology struct {
+	Servers []Server `json:"servers"`
+	Zones   []Zone   `json:"-"`
+	Pools   []Pool   `json:"pools"`
+	PoolNum uint64   `json:"npools"`
+}
+
+type TopologyCommand struct {
+	basecmd.FinalCurveCmd
+	topology   Topology
+	timeout    time.Duration
+	retryTimes int32
+	addrs      []string
+	// pool
+	clusterPoolsInfo []*topology.PoolInfo
+	createPoolRpc    *CreatePoolRpc
+	deletePoolRpc    *DeletePoolRpc
+	listPoolRpc      *ListPoolRpc
+	createPool       []*topology.CreatePoolRequest
+	deletePool       []*topology.DeletePoolRequest
+	// zone
+	clusterZonesInfo []*topology.ZoneInfo
+	deleteZoneRpc    *DeleteZoneRpc
+	createZoneRpc    *CreateZoneRpc
+	listPoolZoneRpc  *ListPoolZoneRpc
+	createZone       []*topology.CreateZoneRequest
+	deleteZone       []*topology.DeleteZoneRequest
+	// server
+	clusterServersInfo []*topology.ServerInfo
+	deleteServerRpc    *DeleteServerRpc
+	createServerRpc    *CreateServerRpc
+	listZoneServerRpc  *ListZoneServerRpc
+	createServer       []*topology.ServerRegistRequest
+	deleteServer       []*topology.DeleteServerRequest
+}
+
+var _ basecmd.FinalCurveCmdFunc = (*TopologyCommand)(nil) // check interface
+
+func NewTopologyCommand() *cobra.Command {
+	topologyCmd := &TopologyCommand{
+		FinalCurveCmd: basecmd.FinalCurveCmd{
+			Use:   "topology",
+			Short: "create curvefs topology",
+		},
+	}
+	basecmd.NewFinalCurveCli(&topologyCmd.FinalCurveCmd, topologyCmd)
+	return topologyCmd.Cmd
+}
+
+func (tCmd *TopologyCommand) AddFlags() {
+	config.AddRpcRetryTimesFlag(tCmd.Cmd)
+	config.AddRpcTimeoutFlag(tCmd.Cmd)
+	config.AddFsMdsAddrFlag(tCmd.Cmd)
+	config.AddClusterMapRequiredFlag(tCmd.Cmd)
+}
+
+func (tCmd *TopologyCommand) Init(cmd *cobra.Command, args []string) error {
+	addrs, addrErr := config.GetFsMdsAddrSlice(tCmd.Cmd)
+	if addrErr.TypeCode() != cmderror.CODE_SUCCESS {
+		return fmt.Errorf(addrErr.Message)
+	}
+	tCmd.addrs = addrs
+	tCmd.timeout = config.GetFlagDuration(tCmd.Cmd, config.RPCTIMEOUT)
+	tCmd.retryTimes = config.GetFlagInt32(tCmd.Cmd, config.RPCRETRYTIMES)
+
+	filePath := config.GetFlagString(tCmd.Cmd, config.CURVEFS_CLUSTERMAP)
+	jsonFile, err := os.Open(filePath)
+	if err != nil {
+		return err
+	}
+	defer jsonFile.Close()
+	byteValue, err := ioutil.ReadAll(jsonFile)
+	if err != nil {
+		return err
+	}
+	err = json.Unmarshal(byteValue, &tCmd.topology)
+	if err != nil {
+		return err
+	}
+
+	updateZoneErr := tCmd.updateZone()
+	if updateZoneErr.TypeCode() != cmderror.CODE_SUCCESS {
+		return fmt.Errorf(updateZoneErr.Message)
+	}
+
+	table, err := gotable.Create(ROW_NAME, ROW_TYPE, ROW_OPERATION, ROW_PARENT)
+	if err != nil {
+		return err
+	}
+	tCmd.Table = table
+
+	tCmd.scanCluster()
+
+	return nil
+}
+
+func (tCmd *TopologyCommand) updateTopology() *cmderror.CmdError {
+	// update cluster topology
+	// remove
+	// server
+	err := tCmd.removeServers()
+	if err.TypeCode() != cmderror.CODE_SUCCESS {
+		return err
+	}
+	// zone
+	err = tCmd.removeZones()
+	if err.TypeCode() != cmderror.CODE_SUCCESS {
+		return err
+	}
+	// pool
+	err = tCmd.removePools()
+	if err.TypeCode() != cmderror.CODE_SUCCESS {
+		return err
+	}
+
+	// create
+	// pool
+	err = tCmd.createPools()
+	if err.TypeCode() != cmderror.CODE_SUCCESS {
+		return err
+	}
+	// zone
+	err = tCmd.createZones()
+	if err.TypeCode() != cmderror.CODE_SUCCESS {
+		return err
+	}
+	// zerver
+	err = tCmd.createServers()
+	if err.TypeCode() != cmderror.CODE_SUCCESS {
+		return err
+	}
+	return cmderror.ErrSuccess()
+}
+
+func (tCmd *TopologyCommand) RunCommand(cmd *cobra.Command, args []string) error {
+	err := tCmd.updateTopology()
+	if err.TypeCode() != cmderror.CODE_SUCCESS {
+		return fmt.Errorf(err.Message)
+	}
+	result, resultErr := cobrautil.TableToResult(tCmd.Table)
+	if resultErr != nil {
+		return resultErr
+	}
+	tCmd.Result = result
+	tCmd.Error = err
+	return nil
+}
+
+func (tCmd *TopologyCommand) Print(cmd *cobra.Command, args []string) error {
+	return output.FinalCmdOutput(&tCmd.FinalCurveCmd, tCmd)
+}
+
+func (tCmd *TopologyCommand) ResultPlainOutput() error {
+	if len(tCmd.createPool) == 0 && len(tCmd.deletePool) == 0 && len(tCmd.createZone) == 0 && len(tCmd.deleteZone) == 0 && len(tCmd.createServer) == 0 && len(tCmd.deleteServer) == 0 {
+		fmt.Println("no change")
+	}
+	return output.FinalCmdOutputPlain(&tCmd.FinalCurveCmd, tCmd)
+}
+
+// Compare the topology in the cluster with json,
+// delete in the cluster not in json,
+// create in json not in the topology.
+func (tCmd *TopologyCommand) scanCluster() *cmderror.CmdError {
+	err := tCmd.scanPools()
+	if err.TypeCode() != cmderror.CODE_SUCCESS {
+		return err
+	}
+	err = tCmd.scanZones()
+	if err.TypeCode() != cmderror.CODE_SUCCESS {
+		return err
+	}
+
+	err = tCmd.scanServers()
+	if err.TypeCode() != cmderror.CODE_SUCCESS {
+		return err
+	}
+
+	return err
+}

--- a/tools-v2/pkg/cli/command/curvefs/create/topology/zone.go
+++ b/tools-v2/pkg/cli/command/curvefs/create/topology/zone.go
@@ -1,0 +1,220 @@
+/*
+ *  Copyright (c) 2022 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * Project: CurveCli
+ * Created Date: 2022-06-30
+ * Author: chengyi (Cyber-SiKu)
+ */
+
+package topology
+
+import (
+	"context"
+
+	cmderror "github.com/opencurve/curve/tools-v2/internal/error"
+	basecmd "github.com/opencurve/curve/tools-v2/pkg/cli/command"
+	"github.com/opencurve/curve/tools-v2/proto/curvefs/proto/topology"
+	"golang.org/x/exp/slices"
+	"google.golang.org/grpc"
+)
+
+const (
+	TYPE_ZONE = "zone"
+)
+
+type Zone struct {
+	Name     string
+	PoolName string
+}
+
+type DeleteZoneRpc struct {
+	Info           *basecmd.Rpc
+	Request        *topology.DeleteZoneRequest
+	topologyClient topology.TopologyServiceClient
+}
+
+func (dzRpc *DeleteZoneRpc) NewRpcClient(cc grpc.ClientConnInterface) {
+	dzRpc.topologyClient = topology.NewTopologyServiceClient(cc)
+}
+
+func (dzRpc *DeleteZoneRpc) Stub_Func(ctx context.Context) (interface{}, error) {
+	return dzRpc.topologyClient.DeleteZone(ctx, dzRpc.Request)
+}
+
+var _ basecmd.RpcFunc = (*DeleteZoneRpc)(nil) // check interface
+
+type CreateZoneRpc struct {
+	Info           *basecmd.Rpc
+	Request        *topology.CreateZoneRequest
+	topologyClient topology.TopologyServiceClient
+}
+
+func (czRpc *CreateZoneRpc) NewRpcClient(cc grpc.ClientConnInterface) {
+	czRpc.topologyClient = topology.NewTopologyServiceClient(cc)
+}
+
+func (czRpc *CreateZoneRpc) Stub_Func(ctx context.Context) (interface{}, error) {
+	return czRpc.topologyClient.CreateZone(ctx, czRpc.Request)
+}
+
+var _ basecmd.RpcFunc = (*CreateZoneRpc)(nil) // check interface
+
+type ListPoolZoneRpc struct {
+	Info           *basecmd.Rpc
+	Request        *topology.ListPoolZoneRequest
+	topologyClient topology.TopologyServiceClient
+}
+
+func (lpzRpc *ListPoolZoneRpc) NewRpcClient(cc grpc.ClientConnInterface) {
+	lpzRpc.topologyClient = topology.NewTopologyServiceClient(cc)
+}
+
+func (lpzRpc *ListPoolZoneRpc) Stub_Func(ctx context.Context) (interface{}, error) {
+	return lpzRpc.topologyClient.ListPoolZone(ctx, lpzRpc.Request)
+}
+
+var _ basecmd.RpcFunc = (*ListPoolZoneRpc)(nil) // check interface
+
+func (tCmd *TopologyCommand) listPoolZone(poolId uint32) (*topology.ListPoolZoneResponse, *cmderror.CmdError) {
+	request := &topology.ListPoolZoneRequest{
+		PoolID: &poolId,
+	}
+	tCmd.listPoolZoneRpc = &ListPoolZoneRpc{
+		Request: request,
+	}
+	tCmd.listPoolZoneRpc.Info = basecmd.NewRpc(tCmd.addrs, tCmd.timeout, tCmd.retryTimes, "ListPoolZone")
+	result, err := basecmd.GetRpcResponse(tCmd.listPoolZoneRpc.Info, tCmd.listPoolZoneRpc)
+	if err.TypeCode() != cmderror.CODE_SUCCESS {
+		return nil, err
+	}
+	response := result.(*topology.ListPoolZoneResponse)
+	return response, cmderror.ErrSuccess()
+}
+
+func (tCmd *TopologyCommand) scanZones() *cmderror.CmdError {
+	// scan zone
+	for _, pool := range tCmd.clusterPoolsInfo {
+		response, err := tCmd.listPoolZone(pool.GetPoolID())
+		if err.TypeCode() != cmderror.CODE_SUCCESS {
+			return err
+		}
+		if response.GetStatusCode() != topology.TopoStatusCode_TOPO_OK {
+			return cmderror.ErrListPool(response.GetStatusCode())
+		}
+		tCmd.clusterZonesInfo = append(tCmd.clusterZonesInfo, response.GetZones()...)
+	}
+
+	// update delete zone
+	compare := func(zone Zone, zoneInfo *topology.ZoneInfo) bool {
+		return zone.Name == zoneInfo.GetZoneName() && zone.PoolName == zoneInfo.GetPoolName()
+	}
+	for _, zoneInfo := range tCmd.clusterZonesInfo  {
+		index := slices.IndexFunc(tCmd.topology.Zones, func(zone Zone) bool {
+			return compare(zone, zoneInfo)
+		})
+		if index == -1 {
+			id := zoneInfo.GetZoneID()
+			request := &topology.DeleteZoneRequest{
+				ZoneID: &id,
+			}
+			tCmd.deleteZone = append(tCmd.deleteZone, request)
+			row := make(map[string]string)
+			row[ROW_NAME] = zoneInfo.GetZoneName()
+			row[ROW_TYPE] = TYPE_ZONE
+			row[ROW_OPERATION] = ROW_VALUE_DEL
+			row[ROW_PARENT] = zoneInfo.GetPoolName()
+			tCmd.Table.AddRow(row)
+		}
+	}
+
+	// update create zone
+	for _, zone := range tCmd.topology.Zones {
+		index := slices.IndexFunc(tCmd.clusterZonesInfo , func(zoneInfo *topology.ZoneInfo) bool {
+			return compare(zone, zoneInfo)
+		})
+		if index == -1 {
+			request := &topology.CreateZoneRequest{
+				ZoneName: &zone.Name,
+				PoolName: &zone.PoolName,
+			}
+			tCmd.createZone = append(tCmd.createZone, request)
+			row := make(map[string]string)
+			row[ROW_NAME] = zone.Name
+			row[ROW_TYPE] = TYPE_ZONE
+			row[ROW_OPERATION] = ROW_VALUE_ADD
+			row[ROW_PARENT] = zone.PoolName
+			tCmd.Table.AddRow(row)
+		}
+	}
+
+	return cmderror.ErrSuccess()
+}
+
+func (tCmd *TopologyCommand) removeZones() *cmderror.CmdError {
+	tCmd.deleteZoneRpc = &DeleteZoneRpc{}
+	tCmd.deleteZoneRpc.Info = basecmd.NewRpc(tCmd.addrs, tCmd.timeout, tCmd.retryTimes, "DeleteServer")
+	for _, delReuest := range tCmd.deleteZone {
+		tCmd.deleteZoneRpc.Request = delReuest
+		result, err := basecmd.GetRpcResponse(tCmd.deleteZoneRpc.Info, tCmd.deleteZoneRpc)
+		if err.TypeCode() != cmderror.CODE_SUCCESS {
+			return err
+		}
+		response := result.(*topology.DeleteZoneResponse)
+		if response.GetStatusCode() != topology.TopoStatusCode_TOPO_OK {
+			return cmderror.ErrDeleteTopology(response.GetStatusCode(), TYPE_ZONE)
+		}
+	}
+	return cmderror.ErrSuccess()
+}
+
+func (tCmd *TopologyCommand) createZones() *cmderror.CmdError {
+	tCmd.createZoneRpc = &CreateZoneRpc{}
+	tCmd.createZoneRpc.Info = basecmd.NewRpc(tCmd.addrs, tCmd.timeout, tCmd.retryTimes, "CreateZone")
+	for _, crtReuest := range tCmd.createZone {
+		tCmd.createZoneRpc.Request = crtReuest
+		result, err := basecmd.GetRpcResponse(tCmd.createZoneRpc.Info, tCmd.createZoneRpc)
+		if err.TypeCode() != cmderror.CODE_SUCCESS {
+			return err
+		}
+		response := result.(*topology.CreateZoneResponse)
+		if response.GetStatusCode() != topology.TopoStatusCode_TOPO_OK {
+			return cmderror.ErrCreateTopology(response.GetStatusCode(), TYPE_ZONE)
+		}
+	}
+	return cmderror.ErrSuccess()
+}
+
+// The zone is not marked separately
+// so it needs to be read and created from the servers
+func (tCmd *TopologyCommand) updateZone() *cmderror.CmdError {
+	// update zone
+	for _, server := range tCmd.topology.Servers {
+		err := tCmd.checkPool(server.PoolName)
+		if err.TypeCode() != cmderror.CODE_SUCCESS {
+			return err
+		}
+		zone := Zone{
+			Name:     server.ZoneName,
+			PoolName: server.PoolName,
+		}
+		index := slices.Index(tCmd.topology.Zones, zone)
+		if index == -1 {
+			tCmd.topology.Zones = append(tCmd.topology.Zones, zone)
+		}
+	}
+	return cmderror.ErrSuccess()
+}

--- a/tools-v2/pkg/cli/command/curvefs/list/topology/topology.go
+++ b/tools-v2/pkg/cli/command/curvefs/list/topology/topology.go
@@ -44,6 +44,7 @@ type ListTopologyRpc struct {
 	Info           *basecmd.Rpc
 	Request        *topology.ListTopologyRequest
 	topologyClient topology.TopologyServiceClient
+	Response       *topology.ListTopologyResponse
 }
 
 var _ basecmd.RpcFunc = (*ListTopologyRpc)(nil) // check interface
@@ -86,6 +87,18 @@ func GetMetaserverAddrs() ([]string, []string, *cmderror.CmdError) {
 		return nil, nil, retErr
 	}
 	return listTopo.externalAddr, listTopo.internalAddr, cmderror.ErrSuccess()
+}
+
+func GetTopology() (*topology.ListTopologyResponse, *cmderror.CmdError) {
+	listTopo := NewListTopologyCommand()
+	listTopo.Cmd.SetArgs([]string{"--format", "noout"})
+	err := listTopo.Cmd.Execute()
+	if err != nil {
+		retErr := cmderror.ErrGetMetaserverAddr()
+		retErr.Format(err.Error())
+		return nil, retErr
+	}
+	return listTopo.Rpc.Response, cmderror.ErrSuccess()
 }
 
 func NewListTopologyCommand() *TopologyCommand {
@@ -131,6 +144,7 @@ func (tCmd *TopologyCommand) RunCommand(cmd *cobra.Command, args []string) error
 	}
 	tCmd.Error = errCmd
 	topologyResponse := response.(*topology.ListTopologyResponse)
+	tCmd.Rpc.Response = topologyResponse
 	res, err := output.MarshalProtoJson(topologyResponse)
 	if err != nil {
 		return err

--- a/tools-v2/pkg/config/config.go
+++ b/tools-v2/pkg/config/config.go
@@ -92,6 +92,9 @@ const (
 	CURVEFS_DEFAULT_DETAIL       = false
 	CURVEFS_INODEID              = "inodeid"
 	VIPER_CURVEFS_INODEID        = "curvefs.inodeid"
+	CURVEFS_CLUSTERMAP           = "clustermap"
+	VIPER_CURVEFS_CLUSTERMAP     = "curvefs.clustermap"
+	CURVEFS_DEFAULT_CLUSTERMAP   = "topo_example.json"
 	// S3
 	CURVEFS_S3_AK                 = "s3.ak"
 	VIPER_CURVEFS_S3_AK           = "curvefs.s3.ak"
@@ -161,6 +164,7 @@ var (
 		CURVEFS_POOLID:         VIPER_CURVEFS_POOLID,
 		CURVEFS_DETAIL:         VIPER_CURVEFS_DETAIL,
 		CURVEFS_INODEID:        VIPER_CURVEFS_INODEID,
+		CURVEFS_CLUSTERMAP:     VIPER_CURVEFS_CLUSTERMAP,
 		// S3
 		CURVEFS_S3_AK:         VIPER_CURVEFS_S3_AK,
 		CURVEFS_S3_SK:         VIPER_CURVEFS_S3_SK,
@@ -180,10 +184,11 @@ var (
 	}
 
 	FLAG2DEFAULT = map[string]interface{}{
-		RPCTIMEOUT:       DEFAULT_RPCTIMEOUT,
-		RPCRETRYTIMES:    DEFAULT_RPCRETRYTIMES,
-		CURVEFS_SUMINDIR: CURVEFS_DEFAULT_SUMINDIR,
-		CURVEFS_DETAIL:   CURVEFS_DEFAULT_DETAIL,
+		RPCTIMEOUT:         DEFAULT_RPCTIMEOUT,
+		RPCRETRYTIMES:      DEFAULT_RPCRETRYTIMES,
+		CURVEFS_SUMINDIR:   CURVEFS_DEFAULT_SUMINDIR,
+		CURVEFS_DETAIL:     CURVEFS_DEFAULT_DETAIL,
+		CURVEFS_CLUSTERMAP: CURVEFS_DEFAULT_CLUSTERMAP,
 		// S3
 		CURVEFS_S3_AK:         CURVEFS_DEFAULT_S3_AK,
 		CURVEFS_S3_SK:         CURVEFS_DEFAULT_S3_SK,
@@ -486,6 +491,26 @@ func GetFlagStringSlice(cmd *cobra.Command, flagName string) []string {
 	return value
 }
 
+func GetFlagDuration(cmd *cobra.Command, flagName string) time.Duration {
+	var value time.Duration
+	if cmd.Flag(flagName).Changed {
+		value, _ = cmd.Flags().GetDuration(flagName)
+	} else {
+		value = viper.GetDuration(FLAG2VIPER[flagName])
+	}
+	return value
+}
+
+func GetFlagInt32(cmd *cobra.Command, flagName string) int32 {
+	var value int32
+	if cmd.Flag(flagName).Changed {
+		value, _ = cmd.Flags().GetInt32(flagName)
+	} else {
+		value = viper.GetInt32(FLAG2VIPER[flagName])
+	}
+	return value
+}
+
 func GetFsMdsAddrSlice(cmd *cobra.Command) ([]string, *cmderror.CmdError) {
 	return GetAddrSlice(cmd, CURVEFS_MDSADDR)
 }
@@ -760,4 +785,9 @@ func AddInodeIdRequiredFlag(cmd *cobra.Command) {
 // fsid [required]
 func AddFsIdRequiredFlag(cmd *cobra.Command) {
 	AddUint32RequiredFlag(cmd, CURVEFS_FSID, "fsid")
+}
+
+// cluserMap [required]
+func AddClusterMapRequiredFlag(cmd *cobra.Command) {
+	AddStringRequiredFlag(cmd, CURVEFS_CLUSTERMAP, "clusterMap")
 }

--- a/tools-v2/pkg/config/topology.json
+++ b/tools-v2/pkg/config/topology.json
@@ -1,0 +1,1 @@
+{{ curvefs_topology | to_nice_json }}


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #xxx <!-- replace xxx with issue number -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

before:
```
+----+------------+--------------------+------------+-----------------------+
| id |    type    |        name        | child type |      child list       |
+----+------------+--------------------+------------+-----------------------+
| 1  |    pool    |       pool1        |    zone    |  zone3 zone2 zone1    |
| 3  |    zone    |       zone3        |   server   |  10.219.192.50_2_0    |
| 2  |    zone    |       zone2        |   server   |  10.219.192.50_1_0    |
| 1  |    zone    |       zone1        |   server   |  10.219.192.50_0_0    |
| 3  |   server   | 10.219.192.50_2_0  | metaserver | curvefs-metaserver.2  |
| 2  |   server   | 10.219.192.50_1_0  | metaserver | curvefs-metaserver.3  |
| 1  |   server   | 10.219.192.50_0_0  | metaserver | curvefs-metaserver.1  |
| 3  | metaserver | curvefs-metaserver |            |                       |
| 2  | metaserver | curvefs-metaserver |            |                       |
| 1  | metaserver | curvefs-metaserver |            |                       |
+----+------------+--------------------+------------+-----------------------+
```
create topology json file:
```json 
{
    "servers": [
        {
            "name": "10.219.192.50_0_0",
            "internalip": "10.219.192.50",
            "internalport": 6800,
            "externalip": "10.219.192.50",
            "externalport": 6800,
            "zone": "zone1",
            "pool": "pool1"
        },
        {
            "name": "10.219.192.50_1_0",
            "internalip": "10.219.192.50",
            "internalport": 6801,
            "externalip": "10.219.192.50",
            "externalport": 6801,
            "zone": "zone2",
            "pool": "pool1"
        },
        {
            "name": "10.219.192.50_2_0",
            "internalip": "10.219.192.50",
            "internalport": 6802,
            "externalip": "10.219.192.50",
            "externalport": 6802,
            "zone": "zone3",
            "pool": "pool1"
        },
        {
            "name": "10.219.192.50_3_0",
            "internalip": "10.219.192.50",
            "internalport": 6803,
            "externalip": "10.219.192.50",
            "externalport": 6803,
            "zone": "zone4",
            "pool": "pool2"
        }
    ],
    "pools": [
        {
            "name": "pool1",
            "replicasnum": 3,
            "zonenum": 3,
            "copysetnum": 100,
            "type": 0,
            "scatterwidth": 0,
            "physicalpool": ""
        },
        {
            "name": "pool2",
            "replicasnum": 3,
            "zonenum": 3,
            "copysetnum": 100,
            "type": 0,
            "scatterwidth": 0,
            "physicalpool": ""
        }
    ],
    "npools": 1
}
```
Newly added pool: polo2 zone:zon4 server:10.219.192.50_3_0

run it:
```bash 
curve fs create topology --clustermap topology.json
+-------------------+--------+-----------+
|       Name        |  Type  | operation |
+-------------------+--------+-----------+
|       pool2       |  pool  |    add    |
|       zone4       |  zone  |    add    |
| 10.219.192.50_3_0 | server |    add    |
+-------------------+--------+-----------+
```
topology:
```
+----+------------+--------------------+------------+-----------------------+
| id |    type    |        name        | child type |      child list       |
+----+------------+--------------------+------------+-----------------------+
| 2  |    pool    |       pool2        |    zone    |        zone4          |
| 1  |    pool    |       pool1        |    zone    |  zone3 zone2 zone1    |
| 4  |    zone    |       zone4        |   server   |  10.219.192.50_3_0    |
| 3  |    zone    |       zone3        |   server   |  10.219.192.50_2_0    |
| 2  |    zone    |       zone2        |   server   |  10.219.192.50_1_0    |
| 1  |    zone    |       zone1        |   server   |  10.219.192.50_0_0    |
| 4  |   server   | 10.219.192.50_3_0  | metaserver |                       |
| 3  |   server   | 10.219.192.50_2_0  | metaserver | curvefs-metaserver.2  |
| 2  |   server   | 10.219.192.50_1_0  | metaserver | curvefs-metaserver.3  |
| 1  |   server   | 10.219.192.50_0_0  | metaserver | curvefs-metaserver.1  |
| 3  | metaserver | curvefs-metaserver |            |                       |
| 2  | metaserver | curvefs-metaserver |            |                       |
| 1  | metaserver | curvefs-metaserver |            |                       |
+----+------------+--------------------+------------+-----------------------+
```

recovery:

```json
{
    "servers": [
        {
            "name": "10.219.192.50_0_0",
            "internalip": "10.219.192.50",
            "internalport": 6800,
            "externalip": "10.219.192.50",
            "externalport": 6800,
            "zone": "zone1",
            "pool": "pool1"
        },
        {
            "name": "10.219.192.50_1_0",
            "internalip": "10.219.192.50",
            "internalport": 6801,
            "externalip": "10.219.192.50",
            "externalport": 6801,
            "zone": "zone2",
            "pool": "pool1"
        },
        {
            "name": "10.219.192.50_2_0",
            "internalip": "10.219.192.50",
            "internalport": 6802,
            "externalip": "10.219.192.50",
            "externalport": 6802,
            "zone": "zone3",
            "pool": "pool1"
        }
    ],
    "pools": [
        {
            "name": "pool1",
            "replicasnum": 3,
            "zonenum": 3,
            "copysetnum": 100,
            "type": 0,
            "scatterwidth": 0,
            "physicalpool": ""
        }
    ],
    "npools": 1
}
```

run command:
```bash 
curve fs create topology --clustermap topology.json -f json | jq
{
"error": {
"code": 0,
"message": "success"
},
"result": [
{
"Name": "pool2",
"Type": "pool",
"operation": "del"
},
{
"Name": "zone4",
"Type": "zone",
"operation": "del"
},
{
"Name": "10.219.192.50_3_0",
"Type": "server",
"operation": "del"
}
]
}
```

topology:
```
curve fs list topology
+----+------------+--------------------+------------+-----------------------+
| id |    type    |        name        | child type |      child list       |
+----+------------+--------------------+------------+-----------------------+
| 1  |    pool    |       pool1        |    zone    |  zone3 zone2 zone1    |
| 3  |    zone    |       zone3        |   server   |  10.219.192.50_2_0    |
| 2  |    zone    |       zone2        |   server   |  10.219.192.50_1_0    |
| 1  |    zone    |       zone1        |   server   |  10.219.192.50_0_0    |
| 3  |   server   | 10.219.192.50_2_0  | metaserver | curvefs-metaserver.2  |
| 2  |   server   | 10.219.192.50_1_0  | metaserver | curvefs-metaserver.3  |
| 1  |   server   | 10.219.192.50_0_0  | metaserver | curvefs-metaserver.1  |
| 3  | metaserver | curvefs-metaserver |            |                       |
| 2  | metaserver | curvefs-metaserver |            |                       |
| 1  | metaserver | curvefs-metaserver |            |                       |
+----+------------+--------------------+------------+-----------------------+
```

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
