### PR TITLE
curvefs/metaserver: remove the unnecessary get process in inodeStore

### DIFF
--- a/curvefs/src/metaserver/inode_storage.cpp
+++ b/curvefs/src/metaserver/inode_storage.cpp
@@ -188,17 +188,7 @@ MetaStatusCode InodeStorage::Update(const Inode& inode) {
     Key4Inode key(inode.fsid(), inode.inodeid());
     std::string skey = conv_.SerializeToString(key);
 
-    // FIXME: we need't to HGet() before HSet(), because every time
-    // we try to update inode we will get inode first in inode manager.
-    Inode out;
-    Status s = kvStorage_->HGet(table4Inode_, skey, &out);
-    if (s.IsNotFound()) {
-        return MetaStatusCode::NOT_FOUND;
-    } else if (!s.ok()) {
-        return MetaStatusCode::STORAGE_INTERNAL_ERROR;
-    }
-
-    s = kvStorage_->HSet(table4Inode_, skey, inode);
+    Status s = kvStorage_->HSet(table4Inode_, skey, inode);
     if (s.ok()) {
         return MetaStatusCode::OK;
     }

--- a/curvefs/test/metaserver/inode_storage_test.cpp
+++ b/curvefs/test/metaserver/inode_storage_test.cpp
@@ -224,7 +224,6 @@ TEST_F(InodeStorageTest, test1) {
     ASSERT_EQ(storage.Delete(Key4Inode(inode1)), MetaStatusCode::OK);
 
     // update
-    ASSERT_EQ(storage.Update(inode1), MetaStatusCode::NOT_FOUND);
     Inode oldInode;
     ASSERT_EQ(storage.Get(Key4Inode(inode2), &oldInode), MetaStatusCode::OK);
     inode2.set_atime(400);


### PR DESCRIPTION
Signed-off-by: wanghai01 <seanhaizi@163.com>

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

The inode have been getted in inodeManager before updateInode.

Issue Number: #xxx <!-- replace xxx with issue number -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
