### PR TITLE
curve: fix curve_ops_tool without snapshotserver

### DIFF
--- a/conf/tools.conf
+++ b/conf/tools.conf
@@ -11,8 +11,8 @@ rpcConcurrentNum=10
 # etcd地址
 etcdAddr=127.0.0.1:2379  # __CURVEADM_TEMPLATE__ ${cluster_etcd_addr} __CURVEADM_TEMPLATE__
 # snapshot clone server 地址
-snapshotCloneAddr=127.0.0.1:5555  # __CURVEADM_TEMPLATE__ ${cluster_snapshotclone_addr} __CURVEADM_TEMPLATE__
+snapshotCloneAddr=  # __CURVEADM_TEMPLATE__ ${cluster_snapshotclone_addr} __CURVEADM_TEMPLATE__
 # snapshot clone server dummy port
-snapshotCloneDummyPort=8081  # __CURVEADM_TEMPLATE__ ${cluster_snapshotclone_dummy_port} __CURVEADM_TEMPLATE__
+snapshotCloneDummyPort=  # __CURVEADM_TEMPLATE__ ${cluster_snapshotclone_dummy_port} __CURVEADM_TEMPLATE__
 rootUserName=root
 rootUserPassword=root_password

--- a/src/tools/curve_tool_define.cpp
+++ b/src/tools/curve_tool_define.cpp
@@ -32,8 +32,8 @@ DEFINE_string(etcdAddr, "127.0.0.1:2379", "etcd addr");
 DEFINE_uint64(rpcTimeout, 3000, "millisecond for rpc timeout");
 DEFINE_uint64(rpcRetryTimes, 5, "rpc retry times");
 DEFINE_uint64(rpcConcurrentNum, 10, "rpc concurrent number to chunkserver");
-DEFINE_string(snapshotCloneAddr, "127.0.0.1:5555", "snapshot clone addr");
-DEFINE_string(snapshotCloneDummyPort, "8081", "dummy port of snapshot clone, "
+DEFINE_string(snapshotCloneAddr, "", "snapshot clone addr");
+DEFINE_string(snapshotCloneDummyPort, "", "dummy port of snapshot clone, "
                                     "can specify one or several. "
                                     "if specify several, the order should "
                                     "be the same as snapshot clone addr");

--- a/src/tools/snapshot_clone_client.cpp
+++ b/src/tools/snapshot_clone_client.cpp
@@ -29,8 +29,8 @@ int SnapshotCloneClient::Init(const std::string& serverAddr,
                               const std::string& dummyPort) {
     curve::common::SplitString(serverAddr, ",", &serverAddrVec_);
     if (serverAddrVec_.empty()) {
-        std::cout << "Split snapshot clone server address fail!" << std::endl;
-        return -1;
+        // no snapshot clone server
+        return 1;
     }
 
     int res = InitDummyServerMap(dummyPort);

--- a/src/tools/snapshot_clone_client.h
+++ b/src/tools/snapshot_clone_client.h
@@ -46,7 +46,11 @@ class SnapshotCloneClient {
      *  @param dummyPort dummy port列表，只输入一个的话
      *         所有server用同样的dummy port，用字符串分隔有多个的话
      *         为每个server设置不同的dummy port
-     *  @return 成功返回0，失败返回-1
+     *  @return
+     * success: 0
+     * failed: -1
+     * no snapshot server: 1
+     *
      */
     virtual int Init(const std::string& serverAddr,
                      const std::string& dummyPort);

--- a/src/tools/status_tool.h
+++ b/src/tools/status_tool.h
@@ -93,7 +93,8 @@ class StatusTool : public CurveTool {
                   versionTool_(versionTool),
                   metricClient_(metricClient),
                   snapshotClient_(snapshotClient),
-                  mdsInited_(false), etcdInited_(false) {}
+                  mdsInited_(false), etcdInited_(false),
+                  noSnapshotServer_(false) {}
     ~StatusTool() = default;
 
     /**
@@ -203,6 +204,8 @@ class StatusTool : public CurveTool {
     bool mdsInited_;
     // etcd是否初始化过
     bool etcdInited_;
+    // Is there a snapshot service or not
+    bool noSnapshotServer_;
 };
 }  // namespace tool
 }  // namespace curve

--- a/test/tools/snapshot_clone_client_test.cpp
+++ b/test/tools/snapshot_clone_client_test.cpp
@@ -47,7 +47,8 @@ class SnapshotCloneClientTest : public ::testing::Test {
 
 TEST_F(SnapshotCloneClientTest, Init) {
     SnapshotCloneClient client(metricClient_);
-    ASSERT_EQ(-1, client.Init("", "8081"));
+    // no snapshot clone server
+    ASSERT_EQ(1, client.Init("", ""));
     ASSERT_EQ(-1, client.Init("127.0.0.1:5555", ""));
     // dummy server与mds不匹配
     ASSERT_EQ(-1, client.Init("127.0.0.1:5555", "8081,8082,8083"));


### PR DESCRIPTION
1. rm the default snapshot server addr
2. If there is no SnapshotServer address, it can be considered that
there is no snapshot service
3. add Add noSnapshotServer_ to StatusTool to mark if a SnapshotServer
exists

Signed-off-by: Cyber-SiKu <Cyber-SiKu@outlook.com>

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: [curveadm#112](https://github.com/opencurve/curveadm/issues/112)
Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
