### PR TITLE
filter offline metaserver when regist

### DIFF
--- a/curvefs/src/mds/topology/topology_manager.cpp
+++ b/curvefs/src/mds/topology/topology_manager.cpp
@@ -57,7 +57,8 @@ void TopologyManager::RegistMetaServer(const MetaServerRegistRequest *request,
     std::vector<MetaServerIdType> list = topology_->GetMetaServerInCluster(
         [&hostIp, &port](const MetaServer &ms) {
             return (ms.GetInternalIp() == hostIp) &&
-                   (ms.GetInternalPort() == port);
+                   (ms.GetInternalPort() == port) &&
+                   (ms.GetOnlineState() != OnlineState::OFFLINE);
         });
     if (1 == list.size()) {
         // report duplicated register (already a metaserver with same ip and


### PR DESCRIPTION
Signed-off-by: chenwei <461432360@qq.com>

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #1672 

Problem Summary: If a metaserver disk is broken, the new disk can not add to cluster to replace the old one. Now I change the logic. If the old metaserver is in offline status, the new metaserver can add to cluster use the old ip and old port.

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [x] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license
