### PR TITLE
fix the last line of s3 conf not copied when make image

### DIFF
--- a/conf/s3.conf
+++ b/conf/s3.conf
@@ -28,3 +28,4 @@ s3.throttle.bpsTotalMB=1280
 s3.throttle.bpsReadMB=1280
 s3.throttle.bpsWriteMB=1280
 s3.useVirtualAddressing=false
+


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue: the last line of conf/s3.conf will not be copied when make image

Problem Summary: this issue will chunkserver failed to start, errors as below
```
I 2022-07-21T10:55:07.117681+0800     7 chunkserver_main.cpp:28] ChunkServer starting.
I 2022-07-21T10:55:07.117946+0800     7 chunkserver.cpp:89] Loading Configuration.
F 2022-07-21T10:55:07.176982+0800     7 s3_adapter.cpp:106] 
*** Check failure stack trace: ***
*** Aborted at 1658372107 (unix time) try "date -d @1658372107" if you are using GNU date ***
PC: @                0x0 (unknown)
*** SIGABRT (@0x7) received by PID 7 (TID 0x7fab8ed9c240) from PID 7; stack trace: ***
    @     0x7fab8e1aa0e0 (unknown)
    @     0x7fab8c6defff gsignal
    @     0x7fab8c6e042a abort
    @     0x560c77042e0e google::FlushAndAbort()
    @     0x560c77040eca google::LogMessage::Fail()
    @     0x560c77042987 google::LogMessage::SendToLog()
    @     0x560c77040b60 google::LogMessage::Flush()
    @     0x560c770429f9 google::LogMessageFatal::~LogMessageFatal()
    @     0x560c76bb2be8 curve::common::InitS3AdaptorOptionExceptS3InfoOption()
    @     0x560c76bb2eeb curve::common::InitS3AdaptorOption()
    @     0x560c76bb32ce curve::common::S3Adapter::Init()
    @     0x560c769f0006 curve::chunkserver::OriginCopyer::Init()
    @     0x560c7699b4d2 curve::chunkserver::ChunkServer::Run()
    @     0x560c7697153f main
    @     0x7fab8c6cc2e1 __libc_start_main
    @     0x560c769912ba _start
    @                0x0 (unknown)
```

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
