### PR TITLE
curvefs/client: fix cto bugs

### DIFF
--- a/curvefs/proto/mds.proto
+++ b/curvefs/proto/mds.proto
@@ -54,6 +54,7 @@ enum FSStatusCode {
     LOCK_TIMEOUT = 29;
     COMMIT_TX_SEQUENCE_MISMATCH = 30;
     VOLUME_INFO_ERROR = 31;
+    MOUNT_POINT_CONFLICT = 32;
 }
 
 // fs interface
@@ -77,6 +78,7 @@ message Mountpoint {
     required string hostname = 1;
     required uint32 port = 2;
     required string path = 3;
+    optional bool cto = 4;
 }
 
 message FsInfo {

--- a/curvefs/src/client/common/config.cpp
+++ b/curvefs/src/client/common/config.cpp
@@ -272,18 +272,24 @@ void InitFuseClientOption(Configuration *conf, FuseClientOption *clientOption) {
                               &clientOption->enableICacheMetrics);
     conf->GetValueFatalIfFail("fuseClient.enableDCacheMetrics",
                               &clientOption->enableDCacheMetrics);
-    conf->GetValueFatalIfFail("fuseClient.cto", &FLAGS_enableCto);
     conf->GetValueFatalIfFail("client.dummyserver.startport",
                               &clientOption->dummyServerStartPort);
     conf->GetValueFatalIfFail("fuseClient.enableMultiMountPointRename",
                               &clientOption->enableMultiMountPointRename);
     conf->GetValueFatalIfFail("fuseClient.disableXattr",
                               &clientOption->disableXattr);
+    conf->GetValueFatalIfFail("fuseClient.cto", &FLAGS_enableCto);
 
     LOG_IF(WARNING, conf->GetBoolValue("fuseClient.enableSplice",
                                        &clientOption->enableFuseSplice))
         << "Not found `fuseClient.enableSplice` in conf, use default value `"
         << std::boolalpha << clientOption->enableFuseSplice << '`';
+
+    // if enableCto, attr and entry cache must invalid
+    if (FLAGS_enableCto) {
+        clientOption->attrTimeOut = 0;
+        clientOption->entryTimeOut = 0;
+    }
 
     SetBrpcOpt(conf);
 }

--- a/curvefs/src/client/inode_cache_manager.cpp
+++ b/curvefs/src/client/inode_cache_manager.cpp
@@ -107,107 +107,120 @@ class TrimICacheAsyncDone : public MetaServerClientDone {
     std::shared_ptr<InodeCacheManagerImpl> inodeCacheManager_;
 };
 
-CURVEFS_ERROR InodeCacheManagerImpl::GetInode(uint64_t inodeId,
-    std::shared_ptr<InodeWrapper> &out) {
+#define GET_INODE_REMOTE(FSID, INODEID, OUT, STREAMING)                        \
+    MetaStatusCode ret = metaClient_->GetInode(FSID, INODEID, OUT, STREAMING); \
+    if (ret != MetaStatusCode::OK) {                                           \
+        LOG_IF(ERROR, ret != MetaStatusCode::NOT_FOUND)                        \
+            << "metaClient_ GetInode failed, MetaStatusCode = " << ret         \
+            << ", MetaStatusCode_Name = " << MetaStatusCode_Name(ret)          \
+            << ", inodeid = " << INODEID;                                      \
+        return MetaStatusCodeToCurvefsErrCode(ret);                            \
+    }
+
+#define PUT_INODE_CACHE(INODEID, INODEWRAPPER)                                 \
+    std::shared_ptr<InodeWrapper> eliminatedOne;                               \
+    bool eliminated = iCache_->Put(INODEID, INODEWRAPPER, &eliminatedOne);     \
+    if (eliminated) {                                                          \
+        VLOG(3) << "GetInode eliminate one inode, ino: "                       \
+                << eliminatedOne->GetInodeId()                                 \
+                << ", iCache does not evict inodes via put interface ";        \
+        assert(0);                                                             \
+    }
+
+#define REFRESH_DATA_REMOTE(OUT, STREAMING)                                    \
+    CURVEFS_ERROR rc = RefreshData(OUT, STREAMING);                            \
+    if (rc != CURVEFS_ERROR::OK) {                                             \
+        return rc;                                                             \
+    }
+
+CURVEFS_ERROR
+InodeCacheManagerImpl::GetInode(uint64_t inodeId,
+                                std::shared_ptr<InodeWrapper> &out) {
     NameLockGuard lock(nameLock_, std::to_string(inodeId));
+    // get inode from cache
     bool ok = iCache_->Get(inodeId, &out);
     if (ok) {
-        // if enableCto, we need and is unopen, we need reload from metaserver
-        if (curvefs::client::common::FLAGS_enableCto && !out->IsOpen()) {
-            VLOG(6) << "InodeCacheManagerImpl, GetInode: enableCto and inode: "
-                    << inodeId << " opencount is 0";
-            iCache_->Remove(inodeId);
-        } else {
-            curve::common::UniqueLock lgGuard = out->GetUniqueLock();
-            if (out->NeedRefreshData()) {
-                CURVEFS_ERROR rc = out->RefreshS3ChunkInfo();
-                if (rc != CURVEFS_ERROR::OK) {
-                    LOG(ERROR) << "RefreshS3ChunkInfo failed, retCode = " << rc;
-                    return rc;
-                }
-            }
-            return CURVEFS_ERROR::OK;
-        }
+        curve::common::UniqueLock lgGuard = out->GetUniqueLock();
+        REFRESH_DATA_REMOTE(out, out->NeedRefreshData());
+        return CURVEFS_ERROR::OK;
     }
 
+    // get inode from metaserver
     Inode inode;
-    bool streaming;
-
-    MetaStatusCode ret2 = metaClient_->GetInode(
-        fsId_, inodeId, &inode, &streaming);
-
-    if (ret2 != MetaStatusCode::OK) {
-        LOG_IF(ERROR, ret2 != MetaStatusCode::NOT_FOUND)
-            << "metaClient_ GetInode failed, MetaStatusCode = " << ret2
-            << ", MetaStatusCode_Name = " << MetaStatusCode_Name(ret2)
-            << ", inodeid = " << inodeId;
-        return MetaStatusCodeToCurvefsErrCode(ret2);
-    }
-
-    auto type = inode.type();
-    out = std::make_shared<InodeWrapper>(std::move(inode), metaClient_,
-        s3ChunkInfoMetric_, option_.maxDataSize,
+    bool streaming = false;
+    GET_INODE_REMOTE(fsId_, inodeId, &inode, &streaming);
+    out = std::make_shared<InodeWrapper>(
+        std::move(inode), metaClient_, s3ChunkInfoMetric_, option_.maxDataSize,
         option_.refreshDataIntervalSec);
 
-    // NOTE: if the s3chunkinfo inside inode is too large,
-    // we should invoke RefreshS3ChunkInfo() to receive s3chunkinfo
-    // by streaming and padding its into inode.
-    if (type == FsFileType::TYPE_S3 && streaming) {
-        CURVEFS_ERROR rc = out->RefreshS3ChunkInfo();
-        if (rc != CURVEFS_ERROR::OK) {
-            LOG(ERROR) << "RefreshS3ChunkInfo() failed, retCode = " << rc;
-            return rc;
-        }
-    } else if (type == FsFileType::TYPE_FILE) {
-        auto rc = out->RefreshVolumeExtent();
-        if (rc != CURVEFS_ERROR::OK) {
-            LOG(ERROR) << "RefreshVolumeExtent failed, error: " << rc;
-            return rc;
-        }
+    // refresh data
+    REFRESH_DATA_REMOTE(out, streaming);
+
+    // put to cache
+    PUT_INODE_CACHE(inodeId, out);
+
+    return CURVEFS_ERROR::OK;
+}
+
+CURVEFS_ERROR
+InodeCacheManagerImpl::RefreshInode(uint64_t inodeId) {
+    NameLockGuard lock(nameLock_, std::to_string(inodeId));
+
+    // get inode from metaserver
+    Inode inode;
+    bool streaming = false;
+    GET_INODE_REMOTE(fsId_, inodeId, &inode, &streaming);
+
+    // get inode from cache
+    std::shared_ptr<InodeWrapper> out;
+    bool ok = iCache_->Get(inodeId, &out);
+    curve::common::UniqueLock lgGuard;
+    if (!ok) {
+        out = std::make_shared<InodeWrapper>(
+            std::move(inode), metaClient_, s3ChunkInfoMetric_,
+            option_.maxDataSize, option_.refreshDataIntervalSec);
+    } else {
+        lgGuard = out->GetUniqueLock();
     }
 
-    std::shared_ptr<InodeWrapper> eliminatedOne;
-    bool eliminated = iCache_->Put(inodeId, out, &eliminatedOne);
-    if (eliminated) {
-        VLOG(3) << "GetInode eliminate one inode, ino: "
-                << eliminatedOne->GetInodeId();
-        /* iCache does not evict inodes via put interface */
-        assert(0);
+    // refresh data
+    REFRESH_DATA_REMOTE(out, streaming);
+
+    // put to cache or refresh length
+    if (!ok) {
+        PUT_INODE_CACHE(inodeId, out);
+    } else {
+        out->SetLength(inode.length());
     }
+
     return CURVEFS_ERROR::OK;
 }
 
 CURVEFS_ERROR InodeCacheManagerImpl::GetInodeAttr(uint64_t inodeId,
-    InodeAttr *out) {
+                                                  InodeAttr *out) {
     NameLockGuard lock(nameLock_, std::to_string(inodeId));
     // 1. find in icache
     std::shared_ptr<InodeWrapper> inodeWrapper;
     bool ok = iCache_->Get(inodeId, &inodeWrapper);
     if (ok) {
-        if (curvefs::client::common::FLAGS_enableCto &&
-            !inodeWrapper->IsOpen()) {
-            iCache_->Remove(inodeId);
-        } else {
-            inodeWrapper->GetInodeAttrLocked(out);
-            return CURVEFS_ERROR::OK;
-        }
+        inodeWrapper->GetInodeAttrLocked(out);
+        return CURVEFS_ERROR::OK;
     }
 
     // 2. get form metaserver
     std::set<uint64_t> inodeIds;
     std::list<InodeAttr> attrs;
     inodeIds.emplace(inodeId);
-    MetaStatusCode ret = metaClient_->BatchGetInodeAttr(
-        fsId_, inodeIds, &attrs);
+    MetaStatusCode ret =
+        metaClient_->BatchGetInodeAttr(fsId_, inodeIds, &attrs);
     if (MetaStatusCode::OK != ret) {
         LOG(ERROR) << "metaClient BatchGetInodeAttr failed"
-                   << ", inodeId = " << inodeId
-                   << ", MetaStatusCode = " << ret
+                   << ", inodeId = " << inodeId << ", MetaStatusCode = " << ret
                    << ", MetaStatusCode_Name = " << MetaStatusCode_Name(ret);
         return MetaStatusCodeToCurvefsErrCode(ret);
     }
 
-    if (attrs.size() !=  1) {
+    if (attrs.size() != 1) {
         LOG(ERROR) << "metaClient BatchGetInodeAttr error,"
                    << " getSize is 1, inodeId = " << inodeId
                    << "but real size = " << attrs.size();
@@ -466,6 +479,37 @@ void InodeCacheManagerImpl::TrimIcache(uint64_t trimSize) {
             assert(0);
         }
     }
+}
+
+CURVEFS_ERROR
+InodeCacheManagerImpl::RefreshData(std::shared_ptr<InodeWrapper> &inode,
+                                   bool streaming) {
+    auto type = inode->GetType();
+    CURVEFS_ERROR rc = CURVEFS_ERROR::OK;
+
+    switch (type) {
+    case FsFileType::TYPE_S3:
+        if (streaming) {
+            // NOTE: if the s3chunkinfo inside inode is too large,
+            // we should invoke RefreshS3ChunkInfo() to receive s3chunkinfo
+            // by streaming and padding its into inode.
+            rc = inode->RefreshS3ChunkInfo();
+            LOG_IF(ERROR, rc != CURVEFS_ERROR::OK)
+                << "RefreshS3ChunkInfo() failed, retCode = " << rc;
+        }
+        break;
+
+    case FsFileType::TYPE_FILE:
+        rc = inode->RefreshVolumeExtent();
+        LOG_IF(ERROR, rc != CURVEFS_ERROR::OK)
+            << "RefreshVolumeExtent failed, error: " << rc;
+        break;
+
+    default:
+        rc = CURVEFS_ERROR::OK;
+    }
+
+    return rc;
 }
 
 }  // namespace client

--- a/curvefs/src/client/inode_cache_manager.h
+++ b/curvefs/src/client/inode_cache_manager.h
@@ -126,8 +126,11 @@ class InodeCacheManager {
 
     virtual void Stop() = 0;
 
-    virtual CURVEFS_ERROR GetInode(uint64_t inodeId,
-        std::shared_ptr<InodeWrapper> &out) = 0;   // NOLINT
+    virtual CURVEFS_ERROR
+    GetInode(uint64_t inodeId,
+             std::shared_ptr<InodeWrapper> &out) = 0;  // NOLINT
+
+    virtual CURVEFS_ERROR RefreshInode(uint64_t inodeId) = 0;
 
     virtual CURVEFS_ERROR GetInodeAttr(uint64_t inodeId, InodeAttr *out) = 0;
 
@@ -220,7 +223,9 @@ class InodeCacheManagerImpl : public InodeCacheManager,
     }
 
     CURVEFS_ERROR GetInode(uint64_t inodeId,
-        std::shared_ptr<InodeWrapper> &out) override;
+                           std::shared_ptr<InodeWrapper> &out) override;
+
+    CURVEFS_ERROR RefreshInode(uint64_t inodeId) override;
 
     CURVEFS_ERROR GetInodeAttr(uint64_t inodeId, InodeAttr *out) override;
 
@@ -258,6 +263,8 @@ class InodeCacheManagerImpl : public InodeCacheManager,
  private:
     virtual void FlushInodeBackground();
     void TrimIcache(uint64_t trimSize);
+    CURVEFS_ERROR RefreshData(std::shared_ptr<InodeWrapper> &inode,  // NOLINT
+                              bool streaming = true);
 
  private:
     std::shared_ptr<MetaServerClient> metaClient_;

--- a/curvefs/src/client/inode_wrapper.cpp
+++ b/curvefs/src/client/inode_wrapper.cpp
@@ -336,33 +336,6 @@ CURVEFS_ERROR InodeWrapper::UnLinkLocked(uint64_t parent) {
     return CURVEFS_ERROR::INTERNAL;
 }
 
-CURVEFS_ERROR InodeWrapper::Open() {
-    CURVEFS_ERROR ret = CURVEFS_ERROR::OK;
-    if (0 == openCount_) {
-        ret = UpdateInodeStatus(InodeOpenStatusChange::OPEN);
-        if (ret != CURVEFS_ERROR::OK) {
-            return ret;
-        }
-    }
-    openCount_++;
-
-    return CURVEFS_ERROR::OK;
-}
-
-bool InodeWrapper::IsOpen() { return openCount_ > 0; }
-
-CURVEFS_ERROR InodeWrapper::Release() {
-    CURVEFS_ERROR ret = CURVEFS_ERROR::OK;
-    if (1 == openCount_) {
-        ret = UpdateInodeStatus(InodeOpenStatusChange::CLOSE);
-        if (ret != CURVEFS_ERROR::OK) {
-            return ret;
-        }
-    }
-    openCount_--;
-    return CURVEFS_ERROR::OK;
-}
-
 CURVEFS_ERROR
 InodeWrapper::UpdateInodeStatus(InodeOpenStatusChange statusChange) {
     MetaStatusCode ret =
@@ -403,7 +376,6 @@ CURVEFS_ERROR InodeWrapper::UpdateParentLocked(
 }
 
 CURVEFS_ERROR InodeWrapper::Sync(bool internal) {
-    VLOG(9) << "sync inode: " << inode_.ShortDebugString();
     CURVEFS_ERROR ret = CURVEFS_ERROR::OK;
     switch (inode_.type()) {
         case FsFileType::TYPE_S3:
@@ -426,8 +398,6 @@ CURVEFS_ERROR InodeWrapper::Sync(bool internal) {
 }
 
 void InodeWrapper::Async(MetaServerClientDone *done, bool internal) {
-    VLOG(9) << "async inode: " << inode_.ShortDebugString();
-
     switch (inode_.type()) {
         case FsFileType::TYPE_S3:
             AsyncS3(done, internal);

--- a/curvefs/src/client/s3/disk_cache_base.cpp
+++ b/curvefs/src/client/s3/disk_cache_base.cpp
@@ -93,7 +93,7 @@ int DiskCacheBase::LoadAllCacheFile(std::set<std::string> *cachedObj) {
         return -1;
     }
 
-    LOG(INFO) << "LoadAllCacheFile start, dir: " << cachePath;
+    VLOG(3) << "LoadAllCacheFile start, dir: " << cachePath;
     DIR *cacheDir = NULL;
     struct dirent *cacheDirent = NULL;
     cacheDir = posixWrapper_->opendir(cachePath.c_str());
@@ -115,7 +115,7 @@ int DiskCacheBase::LoadAllCacheFile(std::set<std::string> *cachedObj) {
         LOG(ERROR) << "LoadAllCacheFile, opendir error, errno = " << errno;
         return rc;
     }
-    LOG(INFO) << "LoadAllCacheReadFile end, dir: " << cachePath;
+    VLOG(3) << "LoadAllCacheReadFile end, dir: " << cachePath;
     return 0;
 }
 

--- a/curvefs/src/client/s3/disk_cache_write.cpp
+++ b/curvefs/src/client/s3/disk_cache_write.cpp
@@ -260,7 +260,7 @@ int DiskCacheWrite::UploadFileByInode(const std::string &inode) {
         if (ret <= 0) {
             return ret;
         }
-        LOG(INFO) << "UploadFileByInode, need wait file on disk uopload ok";
+        VLOG(3) << "UploadFileByInode, need wait file on disk upload ok";
         sleeper_.wait_for(std::chrono::milliseconds(asyncLoadPeriodMs_));
     }
 

--- a/curvefs/src/mds/fs_info_wrapper.h
+++ b/curvefs/src/mds/fs_info_wrapper.h
@@ -112,6 +112,8 @@ class FsInfoWrapper {
 
     bool IsMountPointExist(const Mountpoint& mp) const;
 
+    bool IsMountPointConflict(const Mountpoint &mp) const;
+
     void AddMountPoint(const Mountpoint& mp);
 
     FSStatusCode DeleteMountPoint(const Mountpoint& mp);

--- a/curvefs/src/mds/fs_manager.cpp
+++ b/curvefs/src/mds/fs_manager.cpp
@@ -463,7 +463,7 @@ FSStatusCode FsManager::MountFs(const std::string& fsName,
                                 const Mountpoint& mountpoint, FsInfo* fsInfo) {
     NameLockGuard lock(nameLock_, fsName);
 
-    // 1. query fs
+    // query fs
     FsInfoWrapper wrapper;
     FSStatusCode ret = fsStorage_->Get(fsName, &wrapper);
     if (ret != FSStatusCode::OK) {
@@ -472,7 +472,7 @@ FSStatusCode FsManager::MountFs(const std::string& fsName,
         return ret;
     }
 
-    // 2. check fs status
+    // check fs status
     FsStatus status = wrapper.GetStatus();
     switch (status) {
         case FsStatus::NEW:
@@ -490,14 +490,22 @@ FSStatusCode FsManager::MountFs(const std::string& fsName,
             return FSStatusCode::UNKNOWN_ERROR;
     }
 
-    // 3. if mount point exist, return MOUNT_POINT_EXIST
-    if (wrapper.IsMountPointExist(mountpoint)) {
-        LOG(WARNING) << "MountFs fail, mount point exist, fsName = " << fsName
-                     << ", mountpoint = " << mountpoint.ShortDebugString();
-        return FSStatusCode::MOUNT_POINT_EXIST;
+    // check param
+    if (!mountpoint.has_cto()) {
+        LOG(WARNING) << "MountFs fail, mount point miss cto param, fsName = "
+                     << fsName << ", fs status = " << FsStatus_Name(status);
+        return FSStatusCode::PARAM_ERROR;
     }
 
-    // 4. If this is the first mountpoint, init space,
+    // mount point conflict
+    if (wrapper.IsMountPointConflict(mountpoint)) {
+        LOG(WARNING) << "MountFs fail, mount point conflict, fsName = "
+                     << fsName
+                     << ", mountpoint = " << mountpoint.ShortDebugString();
+        return FSStatusCode::MOUNT_POINT_CONFLICT;
+    }
+
+    // If this is the first mountpoint, init space,
     if (wrapper.GetFsType() == FSType::TYPE_VOLUME &&
         wrapper.IsMountPointEmpty()) {
         const auto& tempFsInfo = wrapper.ProtoFsInfo();
@@ -510,7 +518,7 @@ FSStatusCode FsManager::MountFs(const std::string& fsName,
         }
     }
 
-    // 5. insert mountpoint
+    // insert mountpoint
     wrapper.AddMountPoint(mountpoint);
     // for persistence consider
     ret = fsStorage_->Update(wrapper);
@@ -523,7 +531,7 @@ FSStatusCode FsManager::MountFs(const std::string& fsName,
     // update client alive time
     UpdateClientAliveTime(mountpoint, fsName, false);
 
-    // 6. convert fs info
+    // convert fs info
     FsMetric::GetInstance().OnMount(wrapper.GetFsName(), mountpoint);
     *fsInfo = std::move(wrapper).ProtoFsInfo();
 

--- a/curvefs/src/mds/fs_manager.h
+++ b/curvefs/src/mds/fs_manager.h
@@ -134,8 +134,8 @@ class FsManager {
      * @param[out] fsInfo: return the fsInfo
      *
      * @return If success return OK;
-     *         if fs has same mount point, return MOUNT_POINT_EXIST;
-     *         else return error code
+     *         if fs has same mount point or cto not consistent, return
+     *         MOUNT_POINT_CONFLICT; else return error code
      */
     FSStatusCode MountFs(const std::string& fsName,
                          const Mountpoint& mountpoint, FsInfo* fsInfo);

--- a/curvefs/src/metaserver/inode_storage.cpp
+++ b/curvefs/src/metaserver/inode_storage.cpp
@@ -140,9 +140,6 @@ MetaStatusCode InodeStorage::GetAttr(const Key4Inode& key,
     if (inode.has_dtime()) {
         attr->set_dtime(inode.dtime());
     }
-    if (inode.has_openmpcount()) {
-        attr->set_openmpcount(inode.openmpcount());
-    }
     if (inode.xattr_size() > 0) {
         *(attr->mutable_xattr()) = inode.xattr();
     }

--- a/curvefs/src/metaserver/trash.cpp
+++ b/curvefs/src/metaserver/trash.cpp
@@ -123,11 +123,7 @@ bool TrashImpl::NeedDelete(const TrashItem &item) {
                      << ", ret = " << MetaStatusCode_Name(ret);
         return false;
     }
-    if (inode.has_openmpcount() && inode.openmpcount() > 0) {
-            return false;
-    } else {
-        return ((now - item.dtime) >= options_.expiredAfterSec);
-    }
+    return ((now - item.dtime) >= options_.expiredAfterSec);
 }
 
 MetaStatusCode TrashImpl::DeleteInodeAndData(const TrashItem &item) {

--- a/curvefs/test/client/mock_inode_cache_manager.h
+++ b/curvefs/test/client/mock_inode_cache_manager.h
@@ -56,6 +56,8 @@ class MockInodeCacheManager : public InodeCacheManager {
     MOCK_METHOD2(GetInodeAttr, CURVEFS_ERROR(
         uint64_t inodeId, InodeAttr *out));
 
+    MOCK_METHOD1(RefreshInode, CURVEFS_ERROR(uint64_t inodeId));
+
     MOCK_METHOD2(BatchGetInodeAttr, CURVEFS_ERROR(
         std::set<uint64_t> *inodeIds, std::list<InodeAttr> *attrs));
 

--- a/curvefs/test/client/test_fuse_client.cpp
+++ b/curvefs/test/client/test_fuse_client.cpp
@@ -349,13 +349,8 @@ TEST_F(TestFuseVolumeClient, FuseOpOpen) {
         .WillOnce(
             DoAll(SetArgReferee<1>(inodeWrapper), Return(CURVEFS_ERROR::OK)));
 
-    EXPECT_CALL(*metaClient_, UpdateInodeAttrWithOutNlink(_, _, _, _))
-        .WillOnce(Return(MetaStatusCode::OK));
-
     CURVEFS_ERROR ret = client_->FuseOpOpen(req, ino, &fi);
     ASSERT_EQ(CURVEFS_ERROR::OK, ret);
-
-    ASSERT_TRUE(inodeWrapper->IsOpen());
 }
 
 TEST_F(TestFuseVolumeClient, FuseOpOpenFailed) {
@@ -372,18 +367,10 @@ TEST_F(TestFuseVolumeClient, FuseOpOpenFailed) {
     auto inodeWrapper = std::make_shared<InodeWrapper>(inode, metaClient_);
 
     EXPECT_CALL(*inodeManager_, GetInode(ino, _))
-        .WillOnce(Return(CURVEFS_ERROR::INTERNAL))
-        .WillOnce(
-            DoAll(SetArgReferee<1>(inodeWrapper), Return(CURVEFS_ERROR::OK)));
-
-    EXPECT_CALL(*metaClient_, UpdateInodeAttrWithOutNlink(_, _, _, _))
-        .WillOnce(Return(MetaStatusCode::UNKNOWN_ERROR));
+        .WillOnce(Return(CURVEFS_ERROR::INTERNAL));
 
     CURVEFS_ERROR ret = client_->FuseOpOpen(req, ino, &fi);
     ASSERT_EQ(CURVEFS_ERROR::INTERNAL, ret);
-
-    ret = client_->FuseOpOpen(req, ino, &fi);
-    ASSERT_EQ(CURVEFS_ERROR::UNKNOWN, ret);
 }
 
 TEST_F(TestFuseVolumeClient, FuseOpCreate) {
@@ -425,14 +412,9 @@ TEST_F(TestFuseVolumeClient, FuseOpCreate) {
         .WillOnce(
             DoAll(SetArgReferee<1>(inodeWrapper), Return(CURVEFS_ERROR::OK)));
 
-    EXPECT_CALL(*metaClient_, UpdateInodeAttrWithOutNlink(_, _, _, _))
-        .WillOnce(Return(MetaStatusCode::OK));
-
     fuse_entry_param e;
     CURVEFS_ERROR ret = client_->FuseOpCreate(req, parent, name, mode, &fi, &e);
     ASSERT_EQ(CURVEFS_ERROR::OK, ret);
-
-    ASSERT_TRUE(inodeWrapper->IsOpen());
 }
 
 TEST_F(TestFuseVolumeClient, FuseOpMkDir) {
@@ -1297,6 +1279,35 @@ TEST_F(TestFuseVolumeClient, FuseOpGetAttrFailed) {
     ASSERT_EQ(CURVEFS_ERROR::INTERNAL, ret);
 }
 
+TEST_F(TestFuseVolumeClient, FuseOpGetAttrEnableCto) {
+    curvefs::client::common::FLAGS_enableCto = true;
+
+    fuse_req_t req;
+    fuse_ino_t ino = 1;
+    struct fuse_file_info fi;
+    memset(&fi, 0, sizeof(fi));
+    struct stat attr;
+
+    InodeAttr inode;
+    inode.set_inodeid(ino);
+    inode.set_length(0);
+
+    // RefreshInode OK
+    EXPECT_CALL(*inodeManager_, RefreshInode(ino))
+        .WillOnce(Return(CURVEFS_ERROR::OK));
+    EXPECT_CALL(*inodeManager_, GetInodeAttr(ino, _))
+        .WillOnce(DoAll(SetArgPointee<1>(inode), Return(CURVEFS_ERROR::OK)));
+
+    ASSERT_EQ(CURVEFS_ERROR::OK, client_->FuseOpGetAttr(req, ino, &fi, &attr));
+
+    // RefreshInode Fail
+    EXPECT_CALL(*inodeManager_, RefreshInode(ino))
+        .WillOnce(Return(CURVEFS_ERROR::INTERNAL));
+
+    ASSERT_EQ(CURVEFS_ERROR::INTERNAL,
+              client_->FuseOpGetAttr(req, ino, &fi, &attr));
+}
+
 TEST_F(TestFuseVolumeClient, FuseOpSetAttr) {
     fuse_req_t req;
     fuse_ino_t ino = 1;
@@ -1639,13 +1650,6 @@ TEST_F(TestFuseVolumeClient, FuseOpRelease) {
     inode.set_inodeid(ino);
 
     auto inodeWrapper = std::make_shared<InodeWrapper>(inode, metaClient_);
-    inodeWrapper->SetOpenCount(1);
-    EXPECT_CALL(*inodeManager_, GetInode(ino, _))
-        .WillOnce(
-            DoAll(SetArgReferee<1>(inodeWrapper), Return(CURVEFS_ERROR::OK)));
-    EXPECT_CALL(*metaClient_, UpdateInodeAttrWithOutNlink(
-        _, InodeOpenStatusChange::CLOSE, _, _))
-        .WillOnce(Return(MetaStatusCode::OK));
     ASSERT_EQ(CURVEFS_ERROR::OK, client_->FuseOpRelease(req, ino, &fi));
 }
 
@@ -1899,7 +1903,6 @@ TEST_F(TestFuseS3Client, FuseOpFlush) {
 
     auto inodeWrapper = std::make_shared<InodeWrapper>(inode, metaClient_);
     inodeWrapper->SetUid(32);
-    inodeWrapper->SetOpenCount(1);
 
     LOG(INFO) << "############ case1: test disable cto and s3 flush fail";
     curvefs::client::common::FLAGS_enableCto = false;
@@ -2459,7 +2462,6 @@ TEST_F(TestFuseS3Client, FuseOpCreate_EnableSummary) {
     fuse_entry_param e;
     CURVEFS_ERROR ret = client_->FuseOpCreate(req, parent, name, mode, &fi, &e);
     ASSERT_EQ(CURVEFS_ERROR::OK, ret);
-    ASSERT_TRUE(inodeWrapper->IsOpen());
 
     auto p = parentInodeWrapper->GetInodeLocked();
     ASSERT_EQ(p.xattr().find(XATTRFILES)->second, "2");
@@ -2692,7 +2694,6 @@ TEST_F(TestFuseS3Client, FuseOpOpen_Trunc_EnableSummary) {
 
     CURVEFS_ERROR ret = client_->FuseOpOpen(req, ino, &fi);
     ASSERT_EQ(CURVEFS_ERROR::OK, ret);
-    ASSERT_TRUE(inodeWrapper->IsOpen());
 
     auto p = parentInodeWrapper->GetInodeLocked();
     ASSERT_EQ(p.xattr().find(XATTRFILES)->second, "1");

--- a/curvefs/test/client/test_inode_cache_manager.cpp
+++ b/curvefs/test/client/test_inode_cache_manager.cpp
@@ -86,6 +86,7 @@ TEST_F(TestInodeCacheManager, GetInode) {
     inode.set_inodeid(inodeId);
     inode.set_fsid(fsId_);
     inode.set_length(fileLength);
+    inode.set_type(FsFileType::TYPE_S3);
     auto s3ChunkInfoMap = inode.mutable_s3chunkinfomap();
     S3ChunkInfoList *s3ChunkInfoList = new S3ChunkInfoList();
     S3ChunkInfo *s3ChunkInfo = s3ChunkInfoList->add_s3chunks();
@@ -97,16 +98,32 @@ TEST_F(TestInodeCacheManager, GetInode) {
     s3ChunkInfo->set_zero(true);
     s3ChunkInfoMap->insert({1, *s3ChunkInfoList});
 
+    // miss cache and get inode failed
     EXPECT_CALL(*metaClient_, GetInode(fsId_, inodeId, _, _))
-        .WillOnce(Return(MetaStatusCode::NOT_FOUND))
-        .WillOnce(DoAll(SetArgPointee<2>(inode), Return(MetaStatusCode::OK)));
-
+        .WillOnce(Return(MetaStatusCode::NOT_FOUND));
     std::shared_ptr<InodeWrapper> inodeWrapper;
     CURVEFS_ERROR ret = iCacheManager_->GetInode(inodeId, inodeWrapper);
     ASSERT_EQ(CURVEFS_ERROR::NOTEXIST, ret);
 
+    // miss cache and get inode ok, do not need streaming
+    EXPECT_CALL(*metaClient_, GetInode(fsId_, inodeId, _, _))
+        .WillOnce(DoAll(SetArgPointee<2>(inode), SetArgPointee<3>(false),
+                        Return(MetaStatusCode::OK)));
     ret = iCacheManager_->GetInode(inodeId, inodeWrapper);
     ASSERT_EQ(CURVEFS_ERROR::OK, ret);
+
+    // miss cache and get inode ok, need streaming
+    uint64_t inodeId2 = 200;
+    Inode inode2 = inode;
+    inode2.set_inodeid(inodeId2);
+    EXPECT_CALL(*metaClient_, GetInode(fsId_, inodeId2, _, _))
+        .WillOnce(DoAll(SetArgPointee<2>(inode2), SetArgPointee<3>(true),
+                        Return(MetaStatusCode::OK)));
+    EXPECT_CALL(*metaClient_,
+                GetOrModifyS3ChunkInfo(fsId_, inodeId2, _, true, _, _))
+        .WillOnce(Return(MetaStatusCode::OK));
+    ASSERT_EQ(CURVEFS_ERROR::OK,
+              iCacheManager_->GetInode(inodeId2, inodeWrapper));
 
     // hit cache and need refresh s3info
     EXPECT_CALL(*metaClient_,
@@ -127,22 +144,78 @@ TEST_F(TestInodeCacheManager, GetInode) {
     ASSERT_EQ(inodeId, out.inodeid());
     ASSERT_EQ(fsId_, out.fsid());
     ASSERT_EQ(fileLength, out.length());
+}
 
-    curvefs::client::common::FLAGS_enableCto = true;
-    inodeWrapper->SetOpenCount(0);
+TEST_F(TestInodeCacheManager, RefreshInode) {
+    uint64_t inodeId = 100;
+    uint64_t fileLength = 100;
+
+    Inode inode;
+    inode.set_inodeid(inodeId);
+    inode.set_fsid(fsId_);
+    inode.set_length(fileLength);
+    inode.set_type(FsFileType::TYPE_S3);
+    auto s3ChunkInfoMap = inode.mutable_s3chunkinfomap();
+    S3ChunkInfoList *s3ChunkInfoList = new S3ChunkInfoList();
+    S3ChunkInfo *s3ChunkInfo = s3ChunkInfoList->add_s3chunks();
+    s3ChunkInfo->set_chunkid(1);
+    s3ChunkInfo->set_compaction(1);
+    s3ChunkInfo->set_offset(0);
+    s3ChunkInfo->set_len(1024);
+    s3ChunkInfo->set_size(65536);
+    s3ChunkInfo->set_zero(true);
+    s3ChunkInfoMap->insert({1, *s3ChunkInfoList});
+
+    // cache miss, get s3-inode from metaserver failed
     EXPECT_CALL(*metaClient_, GetInode(fsId_, inodeId, _, _))
         .WillOnce(Return(MetaStatusCode::NOT_FOUND));
-    ret = iCacheManager_->GetInode(inodeId, inodeWrapper);
-    ASSERT_EQ(CURVEFS_ERROR::NOTEXIST, ret);
-    ASSERT_EQ(inodeId, out.inodeid());
-    ASSERT_EQ(fsId_, out.fsid());
-    ASSERT_EQ(fileLength, out.length());
+    ASSERT_EQ(CURVEFS_ERROR::NOTEXIST, iCacheManager_->RefreshInode(inodeId));
 
-    inodeWrapper->SetOpenCount(1);
+    // cache miss, get s3-inode from metaserver ok, do not need streaming
     EXPECT_CALL(*metaClient_, GetInode(fsId_, inodeId, _, _))
-        .WillOnce(Return(MetaStatusCode::NOT_FOUND));
-    ret = iCacheManager_->GetInode(inodeId, inodeWrapper);
-    ASSERT_EQ(CURVEFS_ERROR::NOTEXIST, ret);
+        .WillOnce(DoAll(SetArgPointee<2>(inode), SetArgPointee<3>(false),
+                        Return(MetaStatusCode::OK)));
+    ASSERT_EQ(CURVEFS_ERROR::OK, iCacheManager_->RefreshInode(inodeId));
+
+    // cache miss, get s3-inode from metaserver, need streaming
+    uint64_t inodeId2 = 200;
+    Inode inode2 = inode;
+    inode2.set_inodeid(inodeId2);
+    EXPECT_CALL(*metaClient_, GetInode(fsId_, inodeId2, _, _))
+        .WillOnce(DoAll(SetArgPointee<2>(inode2), SetArgPointee<3>(true),
+                        Return(MetaStatusCode::OK)));
+    EXPECT_CALL(*metaClient_,
+                GetOrModifyS3ChunkInfo(fsId_, inodeId2, _, true, _, _))
+        .WillOnce(Return(MetaStatusCode::OK));
+    ASSERT_EQ(CURVEFS_ERROR::OK, iCacheManager_->RefreshInode(inodeId2));
+
+    // cache hit, refresh s3-inode from metaserver, do not need streaming
+    Inode inodenew = inode;
+    inodenew.set_length(fileLength * 3);
+    EXPECT_CALL(*metaClient_, GetInode(fsId_, inodeId, _, _))
+        .WillOnce(DoAll(SetArgPointee<2>(inodenew), SetArgPointee<3>(false),
+                        Return(MetaStatusCode::OK)));
+    EXPECT_CALL(*metaClient_,
+                GetOrModifyS3ChunkInfo(fsId_, inodeId, _, true, _, _))
+        .WillOnce(Return(MetaStatusCode::OK));
+    ASSERT_EQ(CURVEFS_ERROR::OK, iCacheManager_->RefreshInode(inodeId));
+    std::shared_ptr<InodeWrapper> inodeWrapper;
+    ASSERT_EQ(CURVEFS_ERROR::OK,
+              iCacheManager_->GetInode(inodeId, inodeWrapper));
+    ASSERT_EQ(inodenew.length(), inodeWrapper->GetLength());
+
+    // cache miss, get file-inode from metaserver
+    Inode inodefile;
+    uint64_t inodefileid = 300;
+    inodefile.set_inodeid(inodefileid);
+    inodefile.set_fsid(fsId_);
+    inodefile.set_type(FsFileType::TYPE_FILE);
+    EXPECT_CALL(*metaClient_, GetInode(fsId_, inodefileid, _, _))
+        .WillOnce(DoAll(SetArgPointee<2>(inodefile), SetArgPointee<3>(false),
+                        Return(MetaStatusCode::OK)));
+    EXPECT_CALL(*metaClient_, GetVolumeExtent(fsId_, inodefileid, _, _))
+        .WillOnce(Return(MetaStatusCode::OK));
+    ASSERT_EQ(CURVEFS_ERROR::OK, iCacheManager_->RefreshInode(inodefileid));
 }
 
 TEST_F(TestInodeCacheManager, GetInodeAttr) {

--- a/curvefs/test/mds/fs_info_wrapper_test.cpp
+++ b/curvefs/test/mds/fs_info_wrapper_test.cpp
@@ -85,5 +85,69 @@ TEST(FsInfoWrapperTest, hybridTest) {
     EXPECT_TRUE(MessageDifferencer::Equals(wrapper.ProtoFsInfo(), fsinfo));
 }
 
+TEST(FsInfoWrapperTest, mpconflictTest_disablecto) {
+    FsInfo fsinfo;
+
+    fsinfo.set_fsid(3);
+    fsinfo.set_fsname("hello");
+    fsinfo.set_status(mds::FsStatus::INITED);
+    fsinfo.set_rootinodeid(1);
+    fsinfo.set_capacity(8192);
+    fsinfo.set_blocksize(4096);
+    fsinfo.set_mountnum(0);
+    fsinfo.set_fstype(mds::FSType::TYPE_S3);
+    Mountpoint mp;
+    mp.set_hostname("0.0.0.0");
+    mp.set_port(9000);
+    mp.set_path("/data");
+    *fsinfo.add_mountpoints() = mp;
+    FsInfoWrapper wrapper(fsinfo);
+
+    // mount point exsit
+    Mountpoint testmp = mp;
+    ASSERT_TRUE(wrapper.IsMountPointConflict(mp));
+
+    // mount point has cto=false, no conflict
+    testmp.set_hostname("127.0.0.1");
+    testmp.set_cto(false);
+    ASSERT_FALSE(wrapper.IsMountPointConflict(testmp));
+
+    // mount point has cto=true, conflict
+    testmp.set_hostname("127.0.0.1");
+    testmp.set_cto(true);
+    ASSERT_TRUE(wrapper.IsMountPointConflict(testmp));
+}
+
+TEST(FsInfoWrapperTest, mpconflictTest_enablecto) {
+    FsInfo fsinfo;
+
+    fsinfo.set_fsid(3);
+    fsinfo.set_fsname("hello");
+    fsinfo.set_status(mds::FsStatus::INITED);
+    fsinfo.set_rootinodeid(1);
+    fsinfo.set_capacity(8192);
+    fsinfo.set_blocksize(4096);
+    fsinfo.set_mountnum(0);
+    fsinfo.set_fstype(mds::FSType::TYPE_S3);
+    Mountpoint mp;
+    mp.set_hostname("0.0.0.0");
+    mp.set_port(9000);
+    mp.set_path("/data");
+    mp.set_cto(true);
+    *fsinfo.add_mountpoints() = mp;
+    FsInfoWrapper wrapper(fsinfo);
+
+    // mount point has cto=false, conflict
+    Mountpoint testmp = mp;
+    testmp.set_hostname("127.0.0.1");
+    testmp.set_cto(false);
+    ASSERT_TRUE(wrapper.IsMountPointConflict(testmp));
+
+    // mount point has cto=true, no conflict
+    testmp.set_hostname("127.0.0.1");
+    testmp.set_cto(true);
+    ASSERT_FALSE(wrapper.IsMountPointConflict(testmp));
+}
+
 }  // namespace mds
 }  // namespace curvefs

--- a/curvefs/test/mds/fs_manager_test.cpp
+++ b/curvefs/test/mds/fs_manager_test.cpp
@@ -393,6 +393,7 @@ TEST_F(FSManagerTest, test1) {
     mountPoint.set_hostname("host");
     mountPoint.set_port(90000);
     mountPoint.set_path("/a/b/c");
+    mountPoint.set_cto(false);
     FsInfo fsInfo3;
 
     // mount volumefs initspace fail
@@ -438,7 +439,7 @@ TEST_F(FSManagerTest, test1) {
 
     // mount volumefs mountpoint exist
     ret = fsManager_->MountFs(fsName1, mountPoint, &fsInfo3);
-    ASSERT_EQ(ret, FSStatusCode::MOUNT_POINT_EXIST);
+    ASSERT_EQ(ret, FSStatusCode::MOUNT_POINT_CONFLICT);
 
     // mount s3 fs success
     FsInfo fsInfo4;
@@ -450,7 +451,7 @@ TEST_F(FSManagerTest, test1) {
 
     // mount s3 fs mount point exist
     ret = fsManager_->MountFs(fsName2, mountPoint, &fsInfo4);
-    ASSERT_EQ(ret, FSStatusCode::MOUNT_POINT_EXIST);
+    ASSERT_EQ(ret, FSStatusCode::MOUNT_POINT_CONFLICT);
 
     // TEST UmountFs
     // umount UnInitSpace fail

--- a/curvefs/test/mds/mds_service_test.cpp
+++ b/curvefs/test/mds/mds_service_test.cpp
@@ -357,6 +357,7 @@ TEST_F(MdsServiceTest, test1) {
     mountPoint.set_hostname("host1");
     mountPoint.set_port(9000);
     mountPoint.set_path("/a/b/c");
+    mountPoint.set_cto(false);
     MountFsRequest mountRequest;
     MountFsResponse mountResponse;
     mountRequest.set_fsname("fs1");
@@ -378,7 +379,8 @@ TEST_F(MdsServiceTest, test1) {
     cntl.Reset();
     stub.MountFs(&cntl, &mountRequest, &mountResponse, NULL);
     if (!cntl.Failed()) {
-        ASSERT_EQ(mountResponse.statuscode(), FSStatusCode::MOUNT_POINT_EXIST);
+        ASSERT_EQ(mountResponse.statuscode(),
+                  FSStatusCode::MOUNT_POINT_CONFLICT);
     } else {
         LOG(ERROR) << "error = " << cntl.ErrorText();
         ASSERT_TRUE(false);
@@ -389,6 +391,7 @@ TEST_F(MdsServiceTest, test1) {
     mountPoint2.set_hostname("host1");
     mountPoint2.set_port(9000);
     mountPoint2.set_path("/a/b/d");
+    mountPoint2.set_cto(false);
     mountRequest.set_allocated_mountpoint(new Mountpoint(mountPoint2));
     stub.MountFs(&cntl, &mountRequest, &mountResponse, NULL);
     if (!cntl.Failed()) {
@@ -407,6 +410,7 @@ TEST_F(MdsServiceTest, test1) {
     mountPoint3.set_hostname("host2");
     mountPoint3.set_port(9000);
     mountPoint3.set_path("/a/b/d");
+    mountPoint3.set_cto(false);
     mountRequest.set_allocated_mountpoint(new Mountpoint(mountPoint3));
     stub.MountFs(&cntl, &mountRequest, &mountResponse, NULL);
     if (!cntl.Failed()) {
@@ -424,6 +428,7 @@ TEST_F(MdsServiceTest, test1) {
     mountPoint.set_hostname("host2");
     mountPoint.set_port(9000);
     mountPoint.set_path("/a/b/c");
+    mountPoint.set_cto(false);
     mountRequest.set_allocated_mountpoint(new Mountpoint(mountPoint));
     stub.MountFs(&cntl, &mountRequest, &mountResponse, NULL);
     if (!cntl.Failed()) {

--- a/curvefs/test/metaserver/inode_manager_test.cpp
+++ b/curvefs/test/metaserver/inode_manager_test.cpp
@@ -404,40 +404,18 @@ TEST_F(InodeManagerTest, UpdateInode) {
     uint64_t ino = 2;
 
     Inode inode;
-    ASSERT_EQ(MetaStatusCode::OK,
-              manager->CreateInode(ino, param_, &inode));
+    ASSERT_EQ(MetaStatusCode::OK, manager->CreateInode(ino, param_, &inode));
 
-    // 1. test add openmpcount
+    // test update ok
     Inode old;
     int32_t deletedNum = 0;
     UpdateInodeRequest request = MakeUpdateInodeRequestFromInode(inode);
-    request.set_inodeopenstatuschange(InodeOpenStatusChange::OPEN);
     ASSERT_EQ(MetaStatusCode::OK,
               manager->UpdateInode(request, &old, &deletedNum));
-    Inode updateOne;
-    ASSERT_EQ(MetaStatusCode::OK, manager->GetInode(fsId, ino, &updateOne));
-    ASSERT_EQ(1, updateOne.openmpcount());
 
-    // 2. test openmpcount nochange
-    request.set_inodeopenstatuschange(InodeOpenStatusChange::NOCHANGE);
+    // test update fail
     ASSERT_EQ(MetaStatusCode::OK,
               manager->UpdateInode(request, &old, &deletedNum));
-    ASSERT_EQ(MetaStatusCode::OK, manager->GetInode(fsId, ino, &updateOne));
-    ASSERT_EQ(1, updateOne.openmpcount());
-
-    // 3. test sub openmpcount
-    request.set_inodeopenstatuschange(InodeOpenStatusChange::CLOSE);
-    ASSERT_EQ(MetaStatusCode::OK,
-              manager->UpdateInode(request, &old, &deletedNum));
-    ASSERT_EQ(MetaStatusCode::OK, manager->GetInode(fsId, ino, &updateOne));
-    ASSERT_EQ(0, updateOne.openmpcount());
-
-    // 4. test update fail
-    request.set_inodeopenstatuschange(InodeOpenStatusChange::CLOSE);
-    ASSERT_EQ(MetaStatusCode::OK,
-              manager->UpdateInode(request, &old, &deletedNum));
-    ASSERT_EQ(MetaStatusCode::OK, manager->GetInode(fsId, ino, &updateOne));
-    ASSERT_EQ(0, updateOne.openmpcount());
 }
 
 


### PR DESCRIPTION
Signed-off-by: ilixiaocui <ilixiaocui@163.com>

related to issue: 1213/1582/1463
1. All mount points on the same file system are either enableCto, or they do not guarantee consistency.
2. If enableCto, attr and dentry cache will auto set invalid.
3. Consistency of multi-mount nodes under delete operation is not guaranteed. If one mount point deletes a file,
the behavior of the other mount point for all operations on that file is unknown.

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #1213 #1582 #1463 <!-- replace xxx with issue number -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
