### PR TITLE
curvefs: fix utest at concurrent scenarios

### DIFF
--- a/curvefs/test/client/test_fuse_client.cpp
+++ b/curvefs/test/client/test_fuse_client.cpp
@@ -2296,6 +2296,7 @@ TEST_F(TestFuseS3Client, FuseOpGetXattr_EnableSumInDir_Failed) {
     InodeAttr inode;
     inode.set_inodeid(ino);
     inode.set_nlink(3);
+    inode.set_length(4096);
     inode.set_type(FsFileType::TYPE_DIRECTORY);
     inode.mutable_xattr()->insert({XATTRFILES, "1"});
     inode.mutable_xattr()->insert({XATTRSUBDIRS, "1"});
@@ -2330,7 +2331,7 @@ TEST_F(TestFuseS3Client, FuseOpGetXattr_EnableSumInDir_Failed) {
     ASSERT_EQ(CURVEFS_ERROR::INTERNAL, ret);
 
     // BatchGetInodeAttr failed
-    EXPECT_CALL(*inodeManager_, GetInodeAttr(ino, _))
+    EXPECT_CALL(*inodeManager_, GetInodeAttr(_, _))
         .Times(AtLeast(2))
         .WillRepeatedly(
             DoAll(SetArgPointee<1>(inode), Return(CURVEFS_ERROR::OK)));
@@ -2347,7 +2348,7 @@ TEST_F(TestFuseS3Client, FuseOpGetXattr_EnableSumInDir_Failed) {
 
     // AddUllStringToFirst  XATTRFILES failed
     inode.mutable_xattr()->find(XATTRFILES)->second = "aaa";
-    EXPECT_CALL(*inodeManager_, GetInodeAttr(ino, _))
+    EXPECT_CALL(*inodeManager_, GetInodeAttr(_, _))
         .Times(AtLeast(2))
         .WillRepeatedly(
             DoAll(SetArgPointee<1>(inode), Return(CURVEFS_ERROR::OK)));
@@ -2366,7 +2367,7 @@ TEST_F(TestFuseS3Client, FuseOpGetXattr_EnableSumInDir_Failed) {
     // AddUllStringToFirst  XATTRSUBDIRS failed
     inode.mutable_xattr()->find(XATTRFILES)->second = "0";
     inode.mutable_xattr()->find(XATTRSUBDIRS)->second = "aaa";
-    EXPECT_CALL(*inodeManager_, GetInodeAttr(ino, _))
+    EXPECT_CALL(*inodeManager_, GetInodeAttr(_, _))
         .Times(AtLeast(2))
         .WillRepeatedly(
             DoAll(SetArgPointee<1>(inode), Return(CURVEFS_ERROR::OK)));
@@ -2385,7 +2386,7 @@ TEST_F(TestFuseS3Client, FuseOpGetXattr_EnableSumInDir_Failed) {
     // AddUllStringToFirst  XATTRENTRIES failed
     inode.mutable_xattr()->find(XATTRSUBDIRS)->second = "0";
     inode.mutable_xattr()->find(XATTRENTRIES)->second = "aaa";
-    EXPECT_CALL(*inodeManager_, GetInodeAttr(ino, _))
+    EXPECT_CALL(*inodeManager_, GetInodeAttr(_, _))
         .Times(AtLeast(2))
         .WillRepeatedly(
             DoAll(SetArgPointee<1>(inode), Return(CURVEFS_ERROR::OK)));


### PR DESCRIPTION
Signed-off-by: wanghai01 <seanhaizi@163.com>

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?
The first param of GetInodeAttr in FuseOpGetXattr_EnableSumInDir_Failed utest is changing at concurrent scenarios, it depends witch thread run faster.


Issue Number: #xxx <!-- replace xxx with issue number -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
