### PR TITLE
fix topology metric inaccurate when metaserver offline

### DIFF
--- a/curvefs/src/mds/topology/topology_metric.cpp
+++ b/curvefs/src/mds/topology/topology_metric.cpp
@@ -161,6 +161,17 @@ void TopologyMetricService::UpdateTopologyMetrics() {
             totalDiskUsed += ix->second->diskUsed.get_value();
             totalMemoryThreshold += ix->second->memoryThreshold.get_value();
             totalMemoryUsed += ix->second->memoryUsed.get_value();
+
+            // process the metric of metaserver which has no copyset
+            if (metaServerMetricInfo.find(msId) == metaServerMetricInfo.end()) {
+                auto ix = gMetaServerMetrics.find(msId);
+                if (ix != gMetaServerMetrics.end()) {
+                    ix->second->scatterWidth.set_value(0);
+                    ix->second->copysetNum.set_value(0);
+                    ix->second->leaderNum.set_value(0);
+                    ix->second->partitionNum.set_value(0);
+                }
+            }
         }
 
         it->second->metaServerNum.set_value(msIdInPool.size());


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #1805 

Problem Summary:
if metaserver offlines, the metirc is inaccurate on copyset_num, partition_num of it.

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
