### PR TITLE
[skipci] docs: make README.md more pretty and remove old build guides Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,14 @@
-[中文版](README_cn.md)
 
 
-<img src="docs/images/curve-logo1.png"/>
+<div align=center> <img src="docs/images/curve-logo1.png"/>
 
 # CURVE
+  
+**A could-native distributed storage system**
+
+#### English | [简体中文](README_cn.md)
+
+<div align=left>
 
 [![Docs](https://img.shields.io/badge/docs-latest-green.svg)](https://github.com/opencurve/curve/tree/master/docs)
 [![Releases](https://img.shields.io/github/v/release/opencurve/curve?include_prereleases)](https://github.com/opencurve/curve/releases)
@@ -11,7 +16,12 @@
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/6136/badge)](https://bestpractices.coreinfrastructure.org/projects/6136)
 
 
-Curve is a high-performance, lightweight-operation, cloud-native open source distributed storage system. Can be applied to mainstream cloud-native infrastructure platforms: connect to OpenStack platform to provide high-performance block storage services for cloud VM; connect to Kubernetes to provide RWO, RWX and other types of persistent volumes; connect to PolarFS as a high-performance storage for cloud-native databases, perfectly supports the storage-computing separation architecture of cloud-native databases. Curve can also be used as a cloud storage middleware using S3-compatible object storage as a data storage engine, providing cost-effective shared file storage for public cloud users.
+Curve is a high-performance, lightweight-operation, cloud-native open source distributed storage system. It can be applied to mainstream cloud-native infrastructure platforms:
+- connect to OpenStack platform to provide high-performance block storage services for cloud VM;
+- connect to Kubernetes to provide RWO, RWX and other types of persistent volumes;
+- connect to PolarFS as a high-performance storage for cloud-native databases, perfectly supports the storage-computing separation architecture of cloud-native databases.
+
+Curve can also be used as a cloud storage middleware using S3-compatible object storage as a data storage engine, providing cost-effective shared file storage for public cloud users.
 
 Curve has hosted by the Cloud Native Computing Foundation (CNCF) as a sandbox project.
 
@@ -121,7 +131,10 @@ How to participate in the Curve project development is detailed in [Curve Commun
 [test cases compiling and running](docs/en/build_and_run_en.md#test-case-compilation-and-execution)
 
 ### FIO curve block storage engine
-Fio curve engine is added, you can clone https://github.com/opencurve/fio and compile the fio tool with our engine(depend on nebd lib), fio command line example: `./fio --thread --rw=randwrite --bs=4k --ioengine=nebd --nebd=cbd:pool//pfstest_test_ --iodepth=10 --runtime=120 --numjobs=10 --time_based --group_reporting --name=curve-fio-test`
+Fio curve engine is added, you can clone https://github.com/opencurve/fio and compile the fio tool with our engine(depend on nebd lib), fio command line example: 
+```bash
+$ ./fio --thread --rw=randwrite --bs=4k --ioengine=nebd --nebd=cbd:pool//pfstest_test_ --iodepth=10 --runtime=120 --numjobs=10 --time_based --group_reporting --name=curve-fio-test`
+```
 
 ## Release Cycle
 - CURVE release cycle：Half a year for major version, 1~2 months for minor version

--- a/README_cn.md
+++ b/README_cn.md
@@ -1,9 +1,14 @@
-[English version](README.md)
 
 
-<img src="docs/images/curve-logo1.png"/>
+<div align=center> <img src="docs/images/curve-logo1.png"/>
 
-# Curve
+# CURVE
+  
+**A could-native distributed storage system**
+
+#### [English](README.md) | 简体中文
+
+<div align=left>
 
 [![Jenkins Coverage](https://img.shields.io/jenkins/coverage/cobertura?jobUrl=http%3A%2F%2F59.111.91.248%3A8080%2Fjob%2Fcurve_untest_job%2F)](http://59.111.91.248:8080/job/curve_untest_job/HTML_20Report/)
 [![Robot failover](https://img.shields.io/jenkins/build?jobUrl=http%3A%2F%2F59.111.91.248%3A8080%2Fjob%2Fcurve_failover_testjob%2F&label=failover)](http://59.111.91.248:8080/job/curve_failover_testjob/)
@@ -14,7 +19,12 @@
 [![LICENSE](https://img.shields.io/badge/licence-Apache--2.0%2FGPL-blue)](https://github.com/opencurve/curve/blob/master/LICENSE)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/6136/badge)](https://bestpractices.coreinfrastructure.org/projects/6136)
 
-Curve是一款高性能、易运维、云原生的开源分布式存储系统。可应用于主流的云原生基础设施平台：对接 OpenStack 平台为云主机提供高性能块存储服务；对接 Kubernetes 为其提供 RWO、RWX 等类型的持久化存储卷；对接 PolarFS 作为云原生数据库的高性能存储底座，完美支持云原生数据库的存算分离架构。Curve 亦可作为云存储中间件使用 S3 兼容的对象存储作为数据存储引擎，为公有云用户提供高性价比的共享文件存储。
+Curve是一款高性能、易运维、云原生的开源分布式存储系统。可应用于主流的云原生基础设施平台：
+- 对接 OpenStack 平台为云主机提供高性能块存储服务；
+- 对接 Kubernetes 为其提供 RWO、RWX 等类型的持久化存储卷；
+- 对接 PolarFS 作为云原生数据库的高性能存储底座，完美支持云原生数据库的存算分离架构。
+
+Curve 亦可作为云存储中间件使用 S3 兼容的对象存储作为数据存储引擎，为公有云用户提供高性价比的共享文件存储。
 
 Curve已加入云原生计算基金会（CNCF）作为沙箱项目托管。
 
@@ -90,15 +100,6 @@ Ceph: L/N
 ### 部署All-in-one体验环境
 请参考CurveAdm用户手册中[CurveBS集群部署步骤](https://github.com/opencurve/curveadm/wiki/curvebs-cluster-deployment)，单机体验环境请使用“集群拓扑文件-单机部署”模板。
 
-
-[单机部署 - 即将废弃方式](docs/cn/deploy.md#%E5%8D%95%E6%9C%BA%E9%83%A8%E7%BD%B2)
-
-### 部署多机集群
-请参考CurveAdm用户手册中[CurveBS集群部署步骤](https://github.com/opencurve/curveadm/wiki/curvebs-cluster-deployment)，请使用“集群拓扑文件-多机部署”模板。
-
-
-[多机部署 - 即将废弃方式](docs/cn/deploy.md#%E5%A4%9A%E6%9C%BA%E9%83%A8%E7%BD%B2)
-
 ### 命令行工具说明
 
 [命令行工具说明](docs/cn/curve_ops_tool.md)
@@ -126,7 +127,11 @@ Ceph: L/N
 [测试用例编译及运行](docs/cn/build_and_run.md#%E6%B5%8B%E8%AF%95%E7%94%A8%E4%BE%8B%E7%BC%96%E8%AF%91%E5%8F%8A%E6%89%A7%E8%A1%8C)
 
 ### FIO curve块存储引擎
-fio的curve块存储引擎代码已经上传到 https://github.com/opencurve/fio ，请自行编译测试（依赖nebd库），fio命令行示例：`./fio --thread --rw=randwrite --bs=4k --ioengine=nebd --nebd=cbd:pool//pfstest_test_ --iodepth=10 --runtime=120 --numjobs=10 --time_based --group_reporting --name=curve-fio-test`
+fio的curve块存储引擎代码已经上传到 https://github.com/opencurve/fio ，请自行编译测试（依赖nebd库），fio命令行示例：`
+```bash
+$ ./fio --thread --rw=randwrite --bs=4k --ioengine=nebd --nebd=cbd:pool//pfstest_test_ --iodepth=10 --runtime=120 --numjobs=10 --time_based --group_reporting --name=curve-fio-test`
+```
+
 
 ## 版本发布周期
 - CURVE版本发布周期：大版本半年，小版本1~2个月


### PR DESCRIPTION
Signed-off-by: fan <yfan3763@gmail.com>

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: (#1819)

Problem Summary:
1. Some users have problems in our README.md build guide. I think we only maintain the curveadm for users.
2. I change the README.md some styles.
### What is changed and how it works?

What's Changed:
1. Remove some links to the deploy.md.
2. You can easily watch the README.md changes here https://github.com/fansehep/curve/tree/fix_doc
How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
