### PR TITLE
curvefs/client: fix bugs after use new aws sdk

### DIFF
--- a/curvefs/src/client/s3/client_s3_cache_manager.cpp
+++ b/curvefs/src/client/s3/client_s3_cache_manager.cpp
@@ -2237,7 +2237,7 @@ CURVEFS_ERROR DataCache::Flush(uint64_t inodeId, bool toS3) {
                 // will be destructed before being accessed
                 if (pendingReq.fetch_sub(
                     1, std::memory_order_seq_cst) == 1) {
-                    VLOG(9) << "pendingReq is over";
+                    VLOG(9) << "pendingReq is over, " << context->key;
                     cond.Signal();
                 }
                 VLOG(9) << "PutObjectAsyncCallBack: " << context->key

--- a/curvefs/src/client/s3/disk_cache_manager_impl.cpp
+++ b/curvefs/src/client/s3/disk_cache_manager_impl.cpp
@@ -80,15 +80,9 @@ int DiskCacheManagerImpl::Write(const std::string name, const char *buf,
     VLOG(9) << "write name = " << name << ", length = " << length;
     int ret = 0;
     ret = WriteDiskFile(name, buf, length);
-    if (ret < 0) {
-        ret = client_->Upload(name, buf, length);
-        if (ret < 0) {
-            LOG(ERROR) << "upload object fail. object: " << name;
-            return -1;
-        }
-    }
-    VLOG(9) << "write success, write name = " << name;
-    return 0;
+    VLOG(9) << "write end, write name: " << name
+            << "ret: " << ret;
+    return ret;
 }
 
 int DiskCacheManagerImpl::WriteDiskFile(const std::string name, const char *buf,

--- a/curvefs/test/client/test_disk_cache_manager_impl.cpp
+++ b/curvefs/test/client/test_disk_cache_manager_impl.cpp
@@ -141,7 +141,6 @@ TEST_F(TestDiskCacheManagerImpl, Write) {
     std::string fileName = "test";
     std::string buf = "test";
     int ret;
-    EXPECT_CALL(*client_, Upload(_, _, _)).WillOnce(Return(-1));
     EXPECT_CALL(*diskCacheManager_, IsDiskCacheFull()).WillOnce(Return(true));
     ret = diskCacheManagerImpl_->Write(fileName,
                                        const_cast<char *>(buf.c_str()), 10);
@@ -150,7 +149,6 @@ TEST_F(TestDiskCacheManagerImpl, Write) {
     EXPECT_CALL(*diskCacheManager_, IsDiskCacheFull()).WillOnce(Return(false));
     EXPECT_CALL(*diskCacheWrite_, WriteDiskFile(_, _, _, _))
         .WillOnce(Return(-1));
-    EXPECT_CALL(*client_, Upload(_, _, _)).WillOnce(Return(-1));
     ret = diskCacheManagerImpl_->Write(fileName,
                                        const_cast<char *>(buf.c_str()), 10);
     ASSERT_EQ(-1, ret);
@@ -161,7 +159,6 @@ TEST_F(TestDiskCacheManagerImpl, Write) {
     EXPECT_CALL(*diskCacheWrite_, GetCacheIoFullDir()).WillOnce(Return(buf));
     EXPECT_CALL(*diskCacheRead_, GetCacheIoFullDir()).WillOnce(Return(buf));
     EXPECT_CALL(*diskCacheRead_, LinkWriteToRead(_, _, _)).WillOnce(Return(-1));
-    EXPECT_CALL(*client_, Upload(_, _, _)).WillOnce(Return(-1));
     ret = diskCacheManagerImpl_->Write(fileName,
                                        const_cast<char *>(buf.c_str()), 10);
     ASSERT_EQ(-1, ret);
@@ -173,12 +170,6 @@ TEST_F(TestDiskCacheManagerImpl, Write) {
     EXPECT_CALL(*diskCacheRead_, GetCacheIoFullDir()).WillOnce(Return(buf));
     EXPECT_CALL(*diskCacheRead_, LinkWriteToRead(_, _, _)).WillOnce(Return(0));
     EXPECT_CALL(*diskCacheWrite_, AsyncUploadEnqueue(_)).WillOnce(Return());
-    ret = diskCacheManagerImpl_->Write(fileName,
-                                       const_cast<char *>(buf.c_str()), 10);
-    ASSERT_EQ(0, ret);
-
-    EXPECT_CALL(*diskCacheManager_, IsDiskCacheFull()).WillOnce(Return(true));
-    EXPECT_CALL(*client_, Upload(_, _, _)).WillOnce(Return(0));
     ret = diskCacheManagerImpl_->Write(fileName,
                                        const_cast<char *>(buf.c_str()), 10);
     ASSERT_EQ(0, ret);


### PR DESCRIPTION
after use new aws sdk, the PutObject will start upload until all the objs in queue have uploaded,
so it may be takes a long time.

so we need move the upload to S3ClientAdaptorImpl when write is failed

signed-off-by: hzwuhongsong hzwuhongsong@corp.netease.com

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #1826  <!-- replace xxx with issue number -->


