### PR TITLE
update: use modern style rewrite the uncopyable and fix its' destructor be normal

### DIFF
--- a/nebd/src/common/uncopyable.h
+++ b/nebd/src/common/uncopyable.h
@@ -28,10 +28,10 @@ namespace common {
 
 class Uncopyable {
  protected:
-    Uncopyable() = default;
-    virtual ~Uncopyable() = default;
+    constexpr Uncopyable() = default;
+    ~Uncopyable() = default;
 
- private:
+ public:
     Uncopyable(const Uncopyable &) = delete;
     Uncopyable &operator=(const Uncopyable &) = delete;
 };

--- a/src/chunkserver/copyset_node_manager.h
+++ b/src/chunkserver/copyset_node_manager.h
@@ -55,7 +55,7 @@ class CopysetNodeManager : public curve::common::Uncopyable {
         static CopysetNodeManager instance;
         return instance;
     }
-
+    virtual ~CopysetNodeManager() = default;
     int Init(const CopysetNodeOptions &copysetNodeOptions);
     int Run();
     int Fini();

--- a/src/common/uncopyable.h
+++ b/src/common/uncopyable.h
@@ -28,10 +28,10 @@ namespace common {
 
 class Uncopyable {
  protected:
-    Uncopyable() = default;
-    virtual ~Uncopyable() = default;
+    constexpr Uncopyable() = default;
+    ~Uncopyable() = default;
 
- private:
+ public:
     Uncopyable(const Uncopyable &) = delete;
     Uncopyable &operator=(const Uncopyable &) = delete;
 };


### PR DESCRIPTION
Signed-off-by: fan <yfan3763@gmail.com>

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #xxx <!-- replace xxx with issue number -->

Problem Summary: The class of Uncopyable is not mordern style and bad.
The old design make this class disconstruct function be virtual 😮‍💨 . 
There are about **20+ class** extends this class in our project. 
So there is a big virtual table in this uncopybale class.

### What is changed and how it works?

What's Changed:
1. remove the uncopyable class disconstruct func virtual.

How it Works: 

1. I think some coding needs re-review. 😢 

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
