### PR TITLE
curvefs/client: use separate thread to call SetDiskInitUsedBytes(#1842)

### DIFF
--- a/curvefs/src/client/fuse_client.cpp
+++ b/curvefs/src/client/fuse_client.cpp
@@ -154,7 +154,7 @@ void FuseClient::WarmUpTask() {
             pToken = strtok_r(const_cast<char*>(warmUpTask.c_str()),
               const_cast<char*>(pDelimiter.c_str()), &pSave);
             if (nullptr == pToken) {
-                VLOG(3) << "warmUpTask nullptr";
+                VLOG(6) << "warmUpTask nullptr";
                 continue;
             }
             Dentry dentry;

--- a/curvefs/src/client/fuse_client.h
+++ b/curvefs/src/client/fuse_client.h
@@ -326,7 +326,7 @@ class FuseClient {
         pToken = strtok_r(const_cast<char*>(srcStr.c_str()),
           const_cast<char*>(delimiter.c_str()), &pSave);
         if (nullptr == pToken) {
-            VLOG(3) << "whsdel lookpath end";
+            VLOG(6) << "del lookpath end";
             return;
         }
         splitPath->push_back(pToken);
@@ -334,10 +334,10 @@ class FuseClient {
             pToken = strtok_r(NULL, const_cast<char*>(
               delimiter.c_str()), &pSave);
             if (nullptr == pToken) {
-                VLOG(3) << "whsdel lookpath end";
+                VLOG(6) << "del lookpath end";
                 break;
             }
-            VLOG(9) << "whsdel pToken is:" << pToken
+            VLOG(9) << "del pToken is:" << pToken
                     << "pSave:" << pSave;
             splitPath->push_back(pToken);
         }

--- a/curvefs/src/client/s3/disk_cache_manager.h
+++ b/curvefs/src/client/s3/disk_cache_manager.h
@@ -108,7 +108,15 @@ class DiskCacheManager {
      * @brief: stop trim thread.
      */
     int TrimStop();
+
     void InitMetrics(const std::string &fsName);
+
+    /**
+     * @brief: has geted the origin used size or not.
+     */
+    virtual bool IsDiskUsedInited() {
+        return diskUsedInit_.load();
+    }
 
  private:
     /**
@@ -179,6 +187,10 @@ class DiskCacheManager {
     Throttle diskCacheThrottle_;
 
     S3ClientAdaptorOption option_;
+
+    // has geted the origin used size or not
+    std::atomic<bool> diskUsedInit_;
+    curve::common::Thread diskInitThread_;
 };
 
 

--- a/curvefs/src/client/s3/disk_cache_manager_impl.cpp
+++ b/curvefs/src/client/s3/disk_cache_manager_impl.cpp
@@ -89,7 +89,8 @@ int DiskCacheManagerImpl::WriteDiskFile(const std::string name, const char *buf,
                                         uint64_t length) {
     VLOG(9) << "write name = " << name << ", length = " << length;
     // if cache disk is full
-    if (diskCacheManager_->IsDiskCacheFull()) {
+    if (!diskCacheManager_->IsDiskUsedInited() ||
+      diskCacheManager_->IsDiskCacheFull()) {
         VLOG(6) << "write disk file fail, disk full.";
         return -1;
     }
@@ -115,12 +116,13 @@ int DiskCacheManagerImpl::WriteDiskFile(const std::string name, const char *buf,
 
     // notify async load to s3
     diskCacheManager_->AsyncUploadEnqueue(name);
-    return writeRet;
+    return 0;
 }
 
 int DiskCacheManagerImpl::WriteReadDirect(const std::string fileName,
                                           const char *buf, uint64_t length) {
-    if (diskCacheManager_->IsDiskCacheFull()) {
+    if (!diskCacheManager_->IsDiskUsedInited() ||
+      diskCacheManager_->IsDiskCacheFull()) {
         VLOG(6) << "write disk file fail, disk full.";
         return -1;
     }

--- a/curvefs/test/client/mock_disk_cache_manager.h
+++ b/curvefs/test/client/mock_disk_cache_manager.h
@@ -54,6 +54,8 @@ class MockDiskCacheManager : public DiskCacheManager {
     MOCK_METHOD3(WriteReadDirect,
                   int(const std::string fileName,
                       const char* buf, uint64_t length));
+    MOCK_METHOD0(IsDiskUsedInited,
+                 bool());
 };
 
 class MockDiskCacheManager2 : public DiskCacheManager {


### PR DESCRIPTION
SetDiskInitUsedBytes may takes a long time, so use a separate thread to do this.
otherwise it will block FuseOpInit

signed-off-by: hzwuhongsong hzwuhongsong@corp.netease.com

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #1842  <!-- replace xxx with issue number -->


