### PR TITLE
curvefs: optimize directory empty condition

### DIFF
--- a/curvefs/proto/metaserver.proto
+++ b/curvefs/proto/metaserver.proto
@@ -220,6 +220,7 @@ message Inode {
     optional uint32 openmpcount = 20; // openmpcount mount points had the file open
     map<string, string> xattr = 21;
     repeated uint64 parent = 22;
+    optional uint32 nentry = 23;  // one level entries under dir
 }
 
 message GetInodeResponse {
@@ -295,6 +296,7 @@ message UpdateInodeRequest {
     repeated uint64 parent = 21;
     map<uint64, S3ChunkInfoList> s3ChunkInfoAdd = 22;
     optional VolumeExtentList volumeExtents = 23;
+    optional uint32 nentry = 24;
 }
 
 message UpdateInodeResponse {
@@ -386,6 +388,7 @@ message InodeAttr {
     optional uint32 openmpcount = 18;
     map<string, string> xattr = 19;
     repeated uint64 parent = 20;
+    optional uint32 nentry = 21;
 }
 
 message BatchGetInodeAttrRequest {

--- a/curvefs/src/client/client_operator.h
+++ b/curvefs/src/client/client_operator.h
@@ -23,10 +23,12 @@
 #ifndef CURVEFS_SRC_CLIENT_CLIENT_OPERATOR_H_
 #define CURVEFS_SRC_CLIENT_CLIENT_OPERATOR_H_
 
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <memory>
 
+#include "curvefs/src/client/error_code.h"
 #include "curvefs/src/client/inode_cache_manager.h"
 #include "curvefs/src/client/dentry_cache_manager.h"
 #include "curvefs/src/client/rpcclient/mds_client.h"
@@ -87,6 +89,10 @@ class RenameOperator {
     CURVEFS_ERROR LinkInode(uint64_t inodeId, uint64_t parent = 0);
 
     CURVEFS_ERROR UnLinkInode(uint64_t inodeId, uint64_t parent = 0);
+
+    CURVEFS_ERROR AddNentry(uint64_t inodeId);
+
+    CURVEFS_ERROR SubNentry(uint64_t inodeId);
 
     CURVEFS_ERROR UpdateMCTime(uint64_t inodeId);
 

--- a/curvefs/src/client/fuse_client.h
+++ b/curvefs/src/client/fuse_client.h
@@ -348,8 +348,8 @@ class FuseClient {
 
     virtual void FlushData() = 0;
 
-    CURVEFS_ERROR UpdateParentInodeMCTimeAndInvalidNlink(
-        fuse_ino_t parent, FsFileType type);
+    CURVEFS_ERROR UpdateParentMCTimeAndNlink(
+        fuse_ino_t parent, FsFileType type, int32_t nlink);
 
     void WarmUpTask();
 

--- a/curvefs/src/client/inode_cache_manager.cpp
+++ b/curvefs/src/client/inode_cache_manager.cpp
@@ -170,13 +170,14 @@ InodeCacheManagerImpl::RefreshInode(uint64_t inodeId) {
 }
 
 CURVEFS_ERROR InodeCacheManagerImpl::GetInodeAttr(uint64_t inodeId,
-                                                  InodeAttr *out) {
+                                                  InodeAttr *out,
+                                                  bool refreshNlinkAndNentry) {
     NameLockGuard lock(nameLock_, std::to_string(inodeId));
     // 1. find in icache
     std::shared_ptr<InodeWrapper> inodeWrapper;
     bool ok = iCache_->Get(inodeId, &inodeWrapper);
     if (ok) {
-        inodeWrapper->GetInodeAttrLocked(out);
+        inodeWrapper->GetInodeAttrLocked(out, refreshNlinkAndNentry);
         return CURVEFS_ERROR::OK;
     }
 

--- a/curvefs/src/client/inode_cache_manager.h
+++ b/curvefs/src/client/inode_cache_manager.h
@@ -132,7 +132,8 @@ class InodeCacheManager {
 
     virtual CURVEFS_ERROR RefreshInode(uint64_t inodeId) = 0;
 
-    virtual CURVEFS_ERROR GetInodeAttr(uint64_t inodeId, InodeAttr *out) = 0;
+    virtual CURVEFS_ERROR GetInodeAttr(uint64_t inodeId, InodeAttr *out,
+        bool refreshNentry = false) = 0;
 
     virtual CURVEFS_ERROR BatchGetInodeAttr(
         std::set<uint64_t> *inodeIds,
@@ -227,7 +228,8 @@ class InodeCacheManagerImpl : public InodeCacheManager,
 
     CURVEFS_ERROR RefreshInode(uint64_t inodeId) override;
 
-    CURVEFS_ERROR GetInodeAttr(uint64_t inodeId, InodeAttr *out) override;
+    CURVEFS_ERROR GetInodeAttr(uint64_t inodeId, InodeAttr *out,
+        bool refreshNlinkAndNentry = false) override;
 
     CURVEFS_ERROR BatchGetInodeAttr(std::set<uint64_t> *inodeIds,
         std::list<InodeAttr> *attrs) override;

--- a/curvefs/src/client/rpcclient/metaserver_client.h
+++ b/curvefs/src/client/rpcclient/metaserver_client.h
@@ -45,7 +45,6 @@ using ::curvefs::client::metric::MetaServerClientMetric;
 using ::curvefs::metaserver::Dentry;
 using ::curvefs::metaserver::FsFileType;
 using ::curvefs::metaserver::Inode;
-using ::curvefs::metaserver::InodeOpenStatusChange;
 using ::curvefs::metaserver::InodeAttr;
 using ::curvefs::metaserver::XAttr;
 using ::curvefs::metaserver::MetaStatusCode;
@@ -114,25 +113,16 @@ class MetaServerClient {
         const std::set<uint64_t> &inodeIds,
         std::list<XAttr> *xattr) = 0;
 
-    virtual MetaStatusCode UpdateInodeAttr(const Inode &inode,
-        InodeOpenStatusChange statusChange =
-            InodeOpenStatusChange::NOCHANGE) = 0;
+    virtual MetaStatusCode UpdateInodeAttr(const Inode &inode) = 0;
 
     virtual MetaStatusCode UpdateInodeAttrWithOutNlink(
         const Inode &inode,
-        InodeOpenStatusChange statusChange = InodeOpenStatusChange::NOCHANGE,
         S3ChunkInfoMap *s3ChunkInfoAdd = nullptr,
         bool internal = false) = 0;
-
-    virtual void UpdateInodeAttrAsync(const Inode &inode,
-        MetaServerClientDone *done,
-        InodeOpenStatusChange statusChange =
-            InodeOpenStatusChange::NOCHANGE) = 0;
 
     virtual void UpdateInodeWithOutNlinkAsync(
         const Inode& inode,
         MetaServerClientDone* done,
-        InodeOpenStatusChange statusChange = InodeOpenStatusChange::NOCHANGE,
         DataIndices&& indices = {}) = 0;
 
     virtual MetaStatusCode GetOrModifyS3ChunkInfo(
@@ -218,24 +208,16 @@ class MetaServerClientImpl : public MetaServerClient {
         const std::set<uint64_t> &inodeIds,
         std::list<XAttr> *xattr) override;
 
-    MetaStatusCode UpdateInodeAttr(const Inode &inode,
-        InodeOpenStatusChange statusChange =
-            InodeOpenStatusChange::NOCHANGE) override;
+    MetaStatusCode UpdateInodeAttr(const Inode &inode) override;
 
     MetaStatusCode UpdateInodeAttrWithOutNlink(
         const Inode &inode,
-        InodeOpenStatusChange statusChange = InodeOpenStatusChange::NOCHANGE,
         S3ChunkInfoMap *s3ChunkInfoAdd = nullptr,
         bool internal = false) override;
-
-    void UpdateInodeAttrAsync(const Inode &inode, MetaServerClientDone *done,
-                          InodeOpenStatusChange statusChange =
-                              InodeOpenStatusChange::NOCHANGE) override;
 
     void UpdateInodeWithOutNlinkAsync(
         const Inode &inode,
         MetaServerClientDone *done,
-        InodeOpenStatusChange statusChange = InodeOpenStatusChange::NOCHANGE,
         DataIndices &&indices = {}) override;
 
     MetaStatusCode GetOrModifyS3ChunkInfo(

--- a/curvefs/src/metaserver/inode_storage.cpp
+++ b/curvefs/src/metaserver/inode_storage.cpp
@@ -143,6 +143,9 @@ MetaStatusCode InodeStorage::GetAttr(const Key4Inode& key,
     if (inode.xattr_size() > 0) {
         *(attr->mutable_xattr()) = inode.xattr();
     }
+    if (inode.has_nentry()) {
+        attr->set_nentry(inode.nentry());
+    }
     return MetaStatusCode::OK;
 }
 

--- a/curvefs/test/client/mock_inode_cache_manager.h
+++ b/curvefs/test/client/mock_inode_cache_manager.h
@@ -53,8 +53,8 @@ class MockInodeCacheManager : public InodeCacheManager {
                  CURVEFS_ERROR(uint64_t inodeId,
                                std::shared_ptr<InodeWrapper> &out));  // NOLINT
 
-    MOCK_METHOD2(GetInodeAttr, CURVEFS_ERROR(
-        uint64_t inodeId, InodeAttr *out));
+    MOCK_METHOD3(GetInodeAttr, CURVEFS_ERROR(
+        uint64_t inodeId, InodeAttr *out, bool refreshNlinkNentry));
 
     MOCK_METHOD1(RefreshInode, CURVEFS_ERROR(uint64_t inodeId));
 

--- a/curvefs/test/client/mock_metaserver_client.h
+++ b/curvefs/test/client/mock_metaserver_client.h
@@ -95,34 +95,26 @@ class MockMetaServerClient : public MetaServerClient {
         uint32_t fsId, const std::set<uint64_t> &inodeIds,
         std::list<XAttr> *xattr));
 
-    MOCK_METHOD2(UpdateInodeAttr,
-                 MetaStatusCode(const Inode &inode,
-                                InodeOpenStatusChange statusChange));
+    MOCK_METHOD1(UpdateInodeAttr,
+                 MetaStatusCode(const Inode &inode));
 
-    MOCK_METHOD4(UpdateInodeAttrWithOutNlink,
+    MOCK_METHOD3(UpdateInodeAttrWithOutNlink,
                  MetaStatusCode(const Inode &inode,
-                                InodeOpenStatusChange statusChange,
                                 S3ChunkInfoMap *s3ChunkInfoAdd,
                                 bool internal));
-
-    MOCK_METHOD3(UpdateInodeAttrAsync,
-                 void(const Inode &inode, MetaServerClientDone *done,
-                      InodeOpenStatusChange statusChange));
 
     // Workaround for rvalue parameters
     // https://stackoverflow.com/questions/12088537/workaround-for-gmock-to-support-rvalue-reference
     void UpdateInodeWithOutNlinkAsync(const Inode& inode,
                                       MetaServerClientDone* done,
-                                      InodeOpenStatusChange change,
                                       DataIndices&& indices) override {
-        return UpdateInodeWithOutNlinkAsync_rvr(inode, done, change,
+        return UpdateInodeWithOutNlinkAsync_rvr(inode, done,
                                                 std::move(indices));
     }
 
-    MOCK_METHOD4(UpdateInodeWithOutNlinkAsync_rvr,
+    MOCK_METHOD3(UpdateInodeWithOutNlinkAsync_rvr,
                  void(const Inode& inode,
                       MetaServerClientDone* done,
-                      InodeOpenStatusChange statusChange,
                       DataIndices));
 
     MOCK_METHOD2(UpdateXattrAsync, void(const Inode &inode,

--- a/curvefs/test/client/test_inode_cache_manager.cpp
+++ b/curvefs/test/client/test_inode_cache_manager.cpp
@@ -352,9 +352,8 @@ TEST_F(TestInodeCacheManager, ShipToFlushAndFlushAll) {
 
     iCacheManager_->ShipToFlush(inodeWrapper);
 
-    EXPECT_CALL(*metaClient_, UpdateInodeWithOutNlinkAsync_rvr(_, _, _, _))
+    EXPECT_CALL(*metaClient_, UpdateInodeWithOutNlinkAsync_rvr(_, _, _))
         .WillOnce(Invoke([](const Inode &inode, MetaServerClientDone *done,
-                            InodeOpenStatusChange statusChange,
                             DataIndices /*indices*/) {
             done->SetMetaStatusCode(MetaStatusCode::OK);
             done->Run();
@@ -465,10 +464,9 @@ TEST_F(TestInodeCacheManager, TestFlushInodeBackground) {
         inodeMap.emplace(inodeId + i, inodeWrapper);
     }
 
-    EXPECT_CALL(*metaClient_, UpdateInodeWithOutNlinkAsync_rvr(_, _, _, _))
+    EXPECT_CALL(*metaClient_, UpdateInodeWithOutNlinkAsync_rvr(_, _, _))
         .WillRepeatedly(
             Invoke([](const Inode& inode, MetaServerClientDone* done,
-                      InodeOpenStatusChange statusChange,
                       DataIndices /*dataIndices*/) {
                 // run closure in a separate thread
                 std::thread th{[done]() {

--- a/curvefs/test/client/volume/default_volume_storage_test.cpp
+++ b/curvefs/test/client/volume/default_volume_storage_test.cpp
@@ -53,7 +53,7 @@ class DefaultVolumeStorageTest : public ::testing::Test {
           metaServerCli_(std::make_shared<MockMetaServerClient>()) {}
 
     void SetUp() override {
-        ON_CALL(*metaServerCli_, UpdateInodeAttrWithOutNlink(_, _, _, _))
+        ON_CALL(*metaServerCli_, UpdateInodeAttrWithOutNlink(_, _, _))
             .WillByDefault(Return(MetaStatusCode::OK));
     }
 


### PR DESCRIPTION
Signed-off-by: wanghai01 <seanhaizi@163.com>

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?
1. remove the 'InodeOpenStatus' related code, because this status doesn't use anymore.
2. fix the update inode nlink logic, the previous logic will update nlink incorrect at:
![未命名绘图](https://user-images.githubusercontent.com/13496900/187844738-1bff96c0-ec18-4215-8cad-0939953a1bf5.png)

The fixed logic is every update of nlink to metaserver should refresh from metaserver first.

3.  optimize the judgement of dir empty, replace listDentry by add nentry field in inode which record the number of files and dirs under this dir.


Issue Number: #xxx <!-- replace xxx with issue number -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
