### PR TITLE
curvefs/client: fixed GetLatestTxId rpc request without fsid which le…

### DIFF
--- a/curvefs/src/client/client_operator.h
+++ b/curvefs/src/client/client_operator.h
@@ -68,9 +68,9 @@ class RenameOperator {
         *oldInodeType = oldInodeType_;
     }
 
- private:
     std::string DebugString();
 
+ private:
     CURVEFS_ERROR CheckOverwrite();
 
     CURVEFS_ERROR GetLatestTxIdWithLock();

--- a/curvefs/src/client/fuse_client.cpp
+++ b/curvefs/src/client/fuse_client.cpp
@@ -747,6 +747,7 @@ CURVEFS_ERROR FuseClient::FuseOpRename(fuse_req_t req, fuse_ino_t parent,
 
     curve::common::LockGuard lg(renameMutex_);
     CURVEFS_ERROR rc = CURVEFS_ERROR::OK;
+    VLOG(3) << "FuseOpRename [start]: " << renameOp.DebugString();
     RETURN_IF_UNSUCCESS(GetTxId);
     RETURN_IF_UNSUCCESS(Precheck);
     RETURN_IF_UNSUCCESS(RecordOldInodeInfo);
@@ -755,6 +756,7 @@ CURVEFS_ERROR FuseClient::FuseOpRename(fuse_req_t req, fuse_ino_t parent,
     RETURN_IF_UNSUCCESS(LinkDestParentInode);
     RETURN_IF_UNSUCCESS(PrepareTx);
     RETURN_IF_UNSUCCESS(CommitTx);
+    VLOG(3) << "FuseOpRename [success]: " << renameOp.DebugString();
     // Do not check UnlinkSrcParentInode, beause rename is already success
     renameOp.UnlinkSrcParentInode();
     renameOp.UnlinkOldInode();

--- a/curvefs/src/client/rpcclient/mds_client.cpp
+++ b/curvefs/src/client/rpcclient/mds_client.cpp
@@ -485,6 +485,7 @@ MdsClientImpl::RefreshSession(const std::vector<PartitionTxId> &txIds,
 FSStatusCode MdsClientImpl::GetLatestTxId(const GetLatestTxIdRequest& request,
                                           GetLatestTxIdResponse* response) {
     auto task = RPCTask {
+        VLOG(3) << "GetLatestTxId [request]: " << request.DebugString();
         mdsClientMetric_.getLatestTxId.qps.count << 1;
         LatencyUpdater updater(&mdsClientMetric_.getLatestTxId.latency);
         mdsbasecli_->GetLatestTxId(request, response, cntl, channel);
@@ -508,6 +509,8 @@ FSStatusCode MdsClientImpl::GetLatestTxId(const GetLatestTxIdRequest& request,
             LOG(WARNING) << "GetLatestTxId fail, errcode = " << rc
                          << ", errmsg = " << FSStatusCode_Name(rc);
         }
+
+        VLOG(3) << "GetLatestTxId [response]: " << response->DebugString();
         return rc;
     };
 
@@ -517,6 +520,7 @@ FSStatusCode MdsClientImpl::GetLatestTxId(const GetLatestTxIdRequest& request,
 
 FSStatusCode MdsClientImpl::CommitTx(const CommitTxRequest& request) {
     auto task = RPCTask {
+        VLOG(3) << "CommitTx [request]: " << request.DebugString();
         mdsClientMetric_.commitTx.qps.count << 1;
         LatencyUpdater updater(&mdsClientMetric_.commitTx.latency);
         CommitTxResponse response;
@@ -541,15 +545,18 @@ FSStatusCode MdsClientImpl::CommitTx(const CommitTxRequest& request) {
             LOG(WARNING) << "CommitTx: retCode = " << rc
                          << ", message = " << FSStatusCode_Name(rc);
         }
+        VLOG(3) << "CommitTx [response]: " << response.DebugString();
         return rc;
     };
     // for rpc error or get lock failed/timeout, we will retry until success
     return ReturnError(rpcexcutor_.DoRPCTask(task, 0));
 }
 
-FSStatusCode MdsClientImpl::GetLatestTxId(std::vector<PartitionTxId>* txIds) {
+FSStatusCode MdsClientImpl::GetLatestTxId(uint32_t fsId,
+                                          std::vector<PartitionTxId>* txIds) {
     GetLatestTxIdRequest request;
     GetLatestTxIdResponse response;
+    request.set_fsid(fsId);
     FSStatusCode rc = GetLatestTxId(request, &response);
     if (rc == FSStatusCode::OK) {
         *txIds = { response.txids().begin(), response.txids().end() };

--- a/curvefs/src/client/rpcclient/mds_client.h
+++ b/curvefs/src/client/rpcclient/mds_client.h
@@ -111,7 +111,8 @@ class MdsClient {
                    const std::string& fsName,
                    const Mountpoint& mountpoint) = 0;
 
-    virtual FSStatusCode GetLatestTxId(std::vector<PartitionTxId>* txIds) = 0;
+    virtual FSStatusCode GetLatestTxId(uint32_t fsId,
+                                       std::vector<PartitionTxId>* txIds) = 0;
 
     virtual FSStatusCode
     GetLatestTxIdWithLock(uint32_t fsId,
@@ -194,7 +195,8 @@ class MdsClientImpl : public MdsClient {
                                 const std::string& fsName,
                                 const Mountpoint& mountpoint) override;
 
-    FSStatusCode GetLatestTxId(std::vector<PartitionTxId>* txIds) override;
+    FSStatusCode GetLatestTxId(uint32_t fsId,
+                               std::vector<PartitionTxId>* txIds) override;
 
     FSStatusCode
     GetLatestTxIdWithLock(uint32_t fsId,

--- a/curvefs/src/client/rpcclient/metacache.cpp
+++ b/curvefs/src/client/rpcclient/metacache.cpp
@@ -79,7 +79,7 @@ void MetaCache::GetAllTxIds(std::vector<PartitionTxId> *txIds) {
 
 bool MetaCache::RefreshTxId() {
     std::vector<PartitionTxId> txIds;
-    FSStatusCode rc = mdsClient_->GetLatestTxId(&txIds);
+    FSStatusCode rc = mdsClient_->GetLatestTxId(fsID_, &txIds);
     if (rc != FSStatusCode::OK) {
         LOG(ERROR) << "Get latest txid failed, retCode=" << rc;
         return false;

--- a/curvefs/src/mds/fs_manager.cpp
+++ b/curvefs/src/mds/fs_manager.cpp
@@ -758,6 +758,13 @@ FSStatusCode FsManager::GetFsTxSequence(const std::string& fsName,
 void FsManager::GetLatestTxId(const GetLatestTxIdRequest* request,
                               GetLatestTxIdResponse* response) {
     std::vector<PartitionTxId> txIds;
+    if (!request->has_fsid()) {
+        response->set_statuscode(FSStatusCode::PARAM_ERROR);
+        LOG(ERROR) << "Bad GetLatestTxId request which missing fsid"
+                   << ", request=" << request->DebugString();
+        return;
+    }
+
     uint32_t fsId = request->fsid();
     if (!request->lock()) {
         GetLatestTxId(fsId, &txIds);

--- a/curvefs/src/mds/mds_service.cpp
+++ b/curvefs/src/mds/mds_service.cpp
@@ -327,7 +327,9 @@ void MdsServiceImpl::GetLatestTxId(
     GetLatestTxIdResponse* response,
     ::google::protobuf::Closure* done) {
     brpc::ClosureGuard guard(done);
+    VLOG(3) << "GetLatestTxId [request]: " << request->DebugString();
     fsManager_->GetLatestTxId(request, response);
+    VLOG(3) << "GetLatestTxId [response]: " << response->DebugString();
 }
 
 void MdsServiceImpl::CommitTx(::google::protobuf::RpcController* controller,
@@ -335,7 +337,9 @@ void MdsServiceImpl::CommitTx(::google::protobuf::RpcController* controller,
                               CommitTxResponse* response,
                               ::google::protobuf::Closure* done) {
     brpc::ClosureGuard guard(done);
+    VLOG(3) << "CommitTx [request]: " << request->DebugString();
     fsManager_->CommitTx(request, response);
+    VLOG(3) << "CommitTx [response]: " << request->DebugString();
 }
 
 }  // namespace mds

--- a/curvefs/test/client/rpcclient/mock_mds_client.h
+++ b/curvefs/test/client/rpcclient/mock_mds_client.h
@@ -63,8 +63,9 @@ class MockMdsClient : public MdsClient {
     MOCK_METHOD2(AllocS3ChunkId,
                  FSStatusCode(uint32_t fsId, uint64_t* chunkId));
 
-    MOCK_METHOD1(GetLatestTxId,
-                 FSStatusCode(std::vector<PartitionTxId>* txIds));
+    MOCK_METHOD2(GetLatestTxId,
+                 FSStatusCode(uint32_t fsId,
+                              std::vector<PartitionTxId>* txIds));
 
     MOCK_METHOD5(GetLatestTxIdWithLock,
                  FSStatusCode(uint32_t fsId,


### PR DESCRIPTION
…ads to some mountpoints use stale txid to find dentry and not found.

Signed-off-by: Wine93 <wine93.info@gmail.com>

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #xxx <!-- replace xxx with issue number -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
