### PR TITLE
avoid deadlock when calling s3async callback, issue #1854

### DIFF
--- a/conf/s3.conf
+++ b/conf/s3.conf
@@ -19,7 +19,7 @@ s3.request_timeout=10000
 # Off = 0,Fatal = 1,Error = 2,Warn = 3,Info = 4,Debug = 5,Trace = 6
 s3.loglevel=4
 s3.logPrefix=/data/log/curve/aws_
-s3.async_thread_num=64
+s3.async_thread_num=1
 # throttle
 s3.throttle.iopsTotalLimit=5000
 s3.throttle.iopsReadLimit=5000

--- a/curvefs/conf/client.conf
+++ b/curvefs/conf/client.conf
@@ -153,7 +153,7 @@ s3.request_timeout=10000
 # Off = 0,Fatal = 1,Error = 2,Warn = 3,Info = 4,Debug = 5,Trace = 6
 s3.loglevel=4
 s3.logPrefix=/data/logs/curvefs/aws_ # __CURVEADM_TEMPLATE__ /curvefs/client/logs/aws_ __CURVEADM_TEMPLATE__
-s3.async_thread_num=30
+s3.async_thread_num=1
 # limit all inflight async requests' bytes, |0| means not limited
 s3.max_async_request_inflight_bytes=104857600
 s3.chunkFlushThreads=5

--- a/curvefs/conf/mds.conf
+++ b/curvefs/conf/mds.conf
@@ -122,7 +122,7 @@ s3.request_timeout=10000
 # Off = 0,Fatal = 1,Error = 2,Warn = 3,Info = 4,Debug = 5,Trace = 6
 s3.loglevel=4
 s3.logPrefix=/data/logs/curvefs/aws_  # __CURVEADM_TEMPLATE__ /curvefs/client/logs/aws_ __CURVEADM_TEMPLATE__
-s3.async_thread_num=30
+s3.async_thread_num=1
 # limit all inflight async requests' bytes, |0| means not limited
 s3.max_async_request_inflight_bytes=104857600
 # throttle

--- a/curvefs/conf/metaserver.conf
+++ b/curvefs/conf/metaserver.conf
@@ -18,7 +18,7 @@ s3.request_timeout=10000
 # Off = 0,Fatal = 1,Error = 2,Warn = 3,Info = 4,Debug = 5,Trace = 6
 s3.loglevel=4
 s3.logPrefix=/tmp/curvefs/metaserver/aws_
-s3.async_thread_num=10
+s3.async_thread_num=1
 # throttle
 s3.throttle.iopsTotalLimit=0
 s3.throttle.iopsReadLimit=0

--- a/src/common/concurrent/task_thread_pool.h
+++ b/src/common/concurrent/task_thread_pool.h
@@ -73,6 +73,7 @@ class TaskThreadPool : public Uncopyable {
         }
 
         if (!running_.exchange(true, std::memory_order_acq_rel)) {
+            threads_.clear();
             threads_.reserve(numThreads);
             for (int i = 0; i < numThreads; ++i) {
                 threads_.emplace_back(new std::thread(


### PR DESCRIPTION
Signed-off-by: h0hmj <h0hmjcn@gmail.com>

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #1854 

Problem Summary:

### What is changed and how it works?

What's Changed:

add a work queue and a thread to handle async s3 request

How it Works:

move throttle check outside main loop, async s3 request will not block main loop

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
