### PR TITLE
curvefs/metaserver: fix inode create time inconsistent

### DIFF
--- a/curvefs/proto/metaserver.proto
+++ b/curvefs/proto/metaserver.proto
@@ -242,6 +242,12 @@ message CreateInodeRequest {
     required uint64 parent = 10;
     optional uint64 rdev = 11;
     optional string symlink = 12;   // TYPE_SYM_LINK only
+    optional Time create = 13;
+}
+
+message Time {
+    required uint64 sec = 1;
+    required int64 nsec = 2;
 }
 
 message CreateInodeResponse {
@@ -258,6 +264,7 @@ message CreateRootInodeRequest {
     required uint32 uid = 5;
     required uint32 gid = 6;
     required uint32 mode = 7;
+    optional Time create = 8;
 }
 
 message CreateRootInodeResponse {

--- a/curvefs/src/client/rpcclient/metaserver_client.cpp
+++ b/curvefs/src/client/rpcclient/metaserver_client.cpp
@@ -24,6 +24,7 @@
 #include <brpc/closure_guard.h>
 #include <butil/iobuf.h>
 #include <glog/logging.h>
+#include <time.h>
 
 #include <cstddef>
 #include <memory>
@@ -1228,6 +1229,12 @@ MetaStatusCode MetaServerClientImpl::CreateInode(const InodeParam &param,
         request.set_rdev(param.rdev);
         request.set_symlink(param.symlink);
         request.set_parent(param.parent);
+        struct timespec now;
+        clock_gettime(CLOCK_REALTIME, &now);
+        Time* tm = new Time();
+        tm->set_sec(now.tv_sec);
+        tm->set_nsec(now.tv_nsec);
+        request.set_allocated_create(tm);
         curvefs::metaserver::MetaServerService_Stub stub(channel);
         stub.CreateInode(cntl, &request, &response, nullptr);
 

--- a/curvefs/src/client/rpcclient/metaserver_client.h
+++ b/curvefs/src/client/rpcclient/metaserver_client.h
@@ -53,6 +53,7 @@ using ::curvefs::metaserver::S3ChunkInfoList;
 using ::curvefs::common::StreamStatus;
 using ::curvefs::common::StreamClient;
 using S3ChunkInfoMap = google::protobuf::Map<uint64_t, S3ChunkInfoList>;
+using ::curvefs::metaserver::Time;
 
 namespace curvefs {
 namespace client {

--- a/curvefs/src/mds/metaserverclient/metaserver_client.cpp
+++ b/curvefs/src/mds/metaserverclient/metaserver_client.cpp
@@ -23,9 +23,12 @@
 #include "curvefs/src/mds/metaserverclient/metaserver_client.h"
 #include <bthread/bthread.h>
 
+#include <ctime>
+
 namespace curvefs {
 namespace mds {
 
+using curvefs::metaserver::Time;
 using curvefs::metaserver::CreateRootInodeRequest;
 using curvefs::metaserver::CreateRootInodeResponse;
 using curvefs::metaserver::DeleteInodeRequest;
@@ -162,7 +165,12 @@ FSStatusCode MetaserverClient::CreateRootInode(
     request.set_uid(uid);
     request.set_gid(gid);
     request.set_mode(mode);
-
+    struct timespec now;
+    clock_gettime(CLOCK_REALTIME, &now);
+    Time* tm = new Time();
+    tm->set_sec(now.tv_sec);
+    tm->set_nsec(now.tv_nsec);
+    request.set_allocated_create(tm);
     auto fp = &MetaServerService_Stub::CreateRootInode;
     LeaderCtx ctx;
     ctx.addrs = addrs;

--- a/curvefs/src/metaserver/inode_manager.cpp
+++ b/curvefs/src/metaserver/inode_manager.cpp
@@ -27,6 +27,7 @@
 #include <list>
 #include <unordered_set>
 #include <utility>
+#include <ctime>
 
 #include "curvefs/proto/metaserver.pb.h"
 #include "curvefs/src/common/define.h"
@@ -112,14 +113,23 @@ void InodeManager::GenerateInodeInternal(uint64_t inodeId,
     inode->set_rdev(param.rdev);
     inode->add_parent(param.parent);
 
-    struct timespec now;
-    clock_gettime(CLOCK_REALTIME, &now);
-    inode->set_mtime(now.tv_sec);
-    inode->set_mtime_ns(now.tv_nsec);
-    inode->set_atime(now.tv_sec);
-    inode->set_atime_ns(now.tv_nsec);
-    inode->set_ctime(now.tv_sec);
-    inode->set_ctime_ns(now.tv_nsec);
+    if (param.timestamp.has_value()) {
+        inode->set_mtime(param.timestamp->tv_sec);
+        inode->set_mtime_ns(param.timestamp->tv_nsec);
+        inode->set_atime(param.timestamp->tv_sec);
+        inode->set_atime_ns(param.timestamp->tv_nsec);
+        inode->set_ctime(param.timestamp->tv_sec);
+        inode->set_ctime_ns(param.timestamp->tv_nsec);
+    } else {
+        struct timespec now;
+        clock_gettime(CLOCK_REALTIME, &now);
+        inode->set_mtime(now.tv_sec);
+        inode->set_mtime_ns(now.tv_nsec);
+        inode->set_atime(now.tv_sec);
+        inode->set_atime_ns(now.tv_nsec);
+        inode->set_ctime(now.tv_sec);
+        inode->set_ctime_ns(now.tv_nsec);
+    }
 
     if (FsFileType::TYPE_DIRECTORY == param.type) {
         inode->set_nlink(2);

--- a/curvefs/src/metaserver/inode_manager.h
+++ b/curvefs/src/metaserver/inode_manager.h
@@ -23,6 +23,8 @@
 #ifndef CURVEFS_SRC_METASERVER_INODE_MANAGER_H_
 #define CURVEFS_SRC_METASERVER_INODE_MANAGER_H_
 
+#include <time.h>
+
 #include <atomic>
 #include <memory>
 #include <string>
@@ -32,6 +34,7 @@
 #include "curvefs/src/metaserver/inode_storage.h"
 #include "curvefs/src/metaserver/trash.h"
 #include "src/common/concurrent/name_lock.h"
+
 
 using ::curve::common::NameLock;
 using ::curvefs::metaserver::S3ChunkInfoList;
@@ -53,6 +56,7 @@ struct InodeParam {
     std::string symlink;
     uint64_t rdev;
     uint64_t parent;
+    absl::optional<struct timespec> timestamp;
 };
 
 class InodeManager {

--- a/curvefs/test/metaserver/BUILD
+++ b/curvefs/test/metaserver/BUILD
@@ -45,6 +45,7 @@ cc_test(
             "//curvefs/src/metaserver:metaserver_s3_lib",
             "//curvefs/test/metaserver/storage:metaserver_storage_test_utils",
             "//curvefs/test/metaserver/mock:metaserver_test_mock",
+            "@com_google_absl//absl/types:optional",
     ],
 )
 

--- a/curvefs/test/metaserver/inode_manager_test.cpp
+++ b/curvefs/test/metaserver/inode_manager_test.cpp
@@ -20,6 +20,7 @@
  * @Author: chenwei
  */
 
+#include <time.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <google/protobuf/util/message_differencer.h>
@@ -33,6 +34,7 @@
 #include "curvefs/src/metaserver/storage/rocksdb_storage.h"
 #include "curvefs/test/metaserver/storage/utils.h"
 #include "src/fs/ext4_filesystem_impl.h"
+#include "absl/types/optional.h"
 
 using ::google::protobuf::util::MessageDifferencer;
 using ::testing::_;
@@ -219,6 +221,14 @@ TEST_F(InodeManagerTest, test1) {
     ASSERT_EQ(inode4.inodeid(), 5);
     ASSERT_EQ(inode4.type(), FsFileType::TYPE_S3);
 
+    // test struct timespec
+    Inode inode5;
+    struct timespec now;
+    clock_gettime(CLOCK_REALTIME, &now);
+    param_.timestamp = absl::make_optional<struct timespec>(now);
+    ASSERT_EQ(manager->CreateInode(6, param_, &inode5),
+              MetaStatusCode::OK);
+
     // GET
     Inode temp1;
     ASSERT_EQ(manager->GetInode(fsId, inode1.inodeid(), &temp1),
@@ -258,6 +268,11 @@ TEST_F(InodeManagerTest, test1) {
               MetaStatusCode::OK);
     ASSERT_TRUE(CompareInode(temp5, temp2));
     ASSERT_FALSE(CompareInode(inode2, temp2));
+
+    Inode temp6;
+    ASSERT_EQ(manager->GetInode(fsId, inode5.inodeid(), &temp6),
+              MetaStatusCode::OK);
+    ASSERT_TRUE(CompareInode(inode5, temp6));
 }
 
 TEST_F(InodeManagerTest, GetOrModifyS3ChunkInfo) {

--- a/curvefs/test/metaserver/metastore_test.cpp
+++ b/curvefs/test/metaserver/metastore_test.cpp
@@ -410,6 +410,11 @@ TEST_F(MetastoreTest, test_inode) {
     uint32_t gid = 200;
     uint32_t mode = 777;
     FsFileType type = FsFileType::TYPE_DIRECTORY;
+    struct timespec now;
+    clock_gettime(CLOCK_REALTIME, &now);
+    Time* tm = new Time();
+    tm->set_sec(now.tv_sec);
+    tm->set_nsec(now.tv_nsec);
 
     createRequest.set_poolid(poolId);
     createRequest.set_copysetid(copysetId);
@@ -420,7 +425,7 @@ TEST_F(MetastoreTest, test_inode) {
     createRequest.set_gid(gid);
     createRequest.set_mode(mode);
     createRequest.set_type(type);
-
+    createRequest.set_allocated_create(tm);
     // CreateInde wrong partitionid
     ret = metastore.CreateInode(&createRequest, &createResponse);
     ASSERT_EQ(createResponse.statuscode(), ret);
@@ -450,6 +455,12 @@ TEST_F(MetastoreTest, test_inode) {
     ASSERT_EQ(createResponse2.inode().gid(), gid);
     ASSERT_EQ(createResponse2.inode().mode(), mode);
     ASSERT_EQ(createResponse2.inode().type(), FsFileType::TYPE_S3);
+    ASSERT_EQ(createResponse2.inode().ctime(), now.tv_sec);
+    ASSERT_EQ(createResponse2.inode().ctime_ns(), now.tv_nsec);
+    ASSERT_EQ(createResponse2.inode().mtime(), now.tv_sec);
+    ASSERT_EQ(createResponse2.inode().mtime_ns(), now.tv_nsec);
+    ASSERT_EQ(createResponse2.inode().atime(), now.tv_sec);
+    ASSERT_EQ(createResponse2.inode().atime_ns(), now.tv_nsec);
 
     // type symlink
     createRequest.set_type(FsFileType::TYPE_SYM_LINK);


### PR DESCRIPTION
Signed-off-by: fan <yfan3763@gmail.com>

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #1850 

Problem Summary: see issue

### What is changed and how it works?

What's Changed: add fuse client rpc to the three replicas tv_sec(sec) and tv_nsec(ns).

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
