### PR TITLE
curvefs/client: fixed GetLatestTxId rpc request without fsid which le…

### DIFF
--- a/curvefs/src/client/client_operator.h
+++ b/curvefs/src/client/client_operator.h
@@ -68,9 +68,9 @@ class RenameOperator {
         *oldInodeType = oldInodeType_;
     }
 
- private:
     std::string DebugString();
 
+ private:
     CURVEFS_ERROR CheckOverwrite();
 
     CURVEFS_ERROR GetLatestTxIdWithLock();

--- a/curvefs/src/client/fuse_client.cpp
+++ b/curvefs/src/client/fuse_client.cpp
@@ -935,6 +935,7 @@ CURVEFS_ERROR FuseClient::FuseOpRename(fuse_req_t req, fuse_ino_t parent,
 
     curve::common::LockGuard lg(renameMutex_);
     CURVEFS_ERROR rc = CURVEFS_ERROR::OK;
+    VLOG(3) << "FuseOpRename [start]: " << renameOp.DebugString();
     RETURN_IF_UNSUCCESS(GetTxId);
     RETURN_IF_UNSUCCESS(Precheck);
     RETURN_IF_UNSUCCESS(RecordOldInodeInfo);
@@ -943,6 +944,7 @@ CURVEFS_ERROR FuseClient::FuseOpRename(fuse_req_t req, fuse_ino_t parent,
     RETURN_IF_UNSUCCESS(LinkDestParentInode);
     RETURN_IF_UNSUCCESS(PrepareTx);
     RETURN_IF_UNSUCCESS(CommitTx);
+    VLOG(3) << "FuseOpRename [success]: " << renameOp.DebugString();
     // Do not check UnlinkSrcParentInode, beause rename is already success
     renameOp.UnlinkSrcParentInode();
     renameOp.UnlinkOldInode();

--- a/curvefs/src/client/rpcclient/mds_client.h
+++ b/curvefs/src/client/rpcclient/mds_client.h
@@ -112,7 +112,8 @@ class MdsClient {
                    const std::string& fsName,
                    const Mountpoint& mountpoint) = 0;
 
-    virtual FSStatusCode GetLatestTxId(std::vector<PartitionTxId>* txIds) = 0;
+    virtual FSStatusCode GetLatestTxId(uint32_t fsId,
+                                       std::vector<PartitionTxId>* txIds) = 0;
 
     virtual FSStatusCode
     GetLatestTxIdWithLock(uint32_t fsId,
@@ -196,7 +197,8 @@ class MdsClientImpl : public MdsClient {
                                 const std::string& fsName,
                                 const Mountpoint& mountpoint) override;
 
-    FSStatusCode GetLatestTxId(std::vector<PartitionTxId>* txIds) override;
+    FSStatusCode GetLatestTxId(uint32_t fsId,
+                               std::vector<PartitionTxId>* txIds) override;
 
     FSStatusCode
     GetLatestTxIdWithLock(uint32_t fsId,

--- a/curvefs/src/client/rpcclient/metacache.cpp
+++ b/curvefs/src/client/rpcclient/metacache.cpp
@@ -79,7 +79,7 @@ void MetaCache::GetAllTxIds(std::vector<PartitionTxId> *txIds) {
 
 bool MetaCache::RefreshTxId() {
     std::vector<PartitionTxId> txIds;
-    FSStatusCode rc = mdsClient_->GetLatestTxId(&txIds);
+    FSStatusCode rc = mdsClient_->GetLatestTxId(fsID_, &txIds);
     if (rc != FSStatusCode::OK) {
         LOG(ERROR) << "Get latest txid failed, retCode=" << rc;
         return false;

--- a/curvefs/src/mds/fs_manager.cpp
+++ b/curvefs/src/mds/fs_manager.cpp
@@ -808,6 +808,13 @@ FSStatusCode FsManager::GetFsTxSequence(const std::string& fsName,
 void FsManager::GetLatestTxId(const GetLatestTxIdRequest* request,
                               GetLatestTxIdResponse* response) {
     std::vector<PartitionTxId> txIds;
+    if (!request->has_fsid()) {
+        response->set_statuscode(FSStatusCode::PARAM_ERROR);
+        LOG(ERROR) << "Bad GetLatestTxId request which missing fsid"
+                   << ", request=" << request->DebugString();
+        return;
+    }
+
     uint32_t fsId = request->fsid();
     if (!request->lock()) {
         GetLatestTxId(fsId, &txIds);

--- a/curvefs/src/mds/mds_service.cpp
+++ b/curvefs/src/mds/mds_service.cpp
@@ -325,7 +325,9 @@ void MdsServiceImpl::GetLatestTxId(
     GetLatestTxIdResponse* response,
     ::google::protobuf::Closure* done) {
     brpc::ClosureGuard guard(done);
+    VLOG(3) << "GetLatestTxId [request]: " << request->DebugString();
     fsManager_->GetLatestTxId(request, response);
+    VLOG(3) << "GetLatestTxId [response]: " << response->DebugString();
 }
 
 void MdsServiceImpl::CommitTx(::google::protobuf::RpcController* controller,
@@ -333,7 +335,9 @@ void MdsServiceImpl::CommitTx(::google::protobuf::RpcController* controller,
                               CommitTxResponse* response,
                               ::google::protobuf::Closure* done) {
     brpc::ClosureGuard guard(done);
+    VLOG(3) << "CommitTx [request]: " << request->DebugString();
     fsManager_->CommitTx(request, response);
+    VLOG(3) << "CommitTx [response]: " << request->DebugString();
 }
 
 }  // namespace mds

--- a/curvefs/test/client/rpcclient/mock_mds_client.h
+++ b/curvefs/test/client/rpcclient/mock_mds_client.h
@@ -63,8 +63,9 @@ class MockMdsClient : public MdsClient {
     MOCK_METHOD3(AllocS3ChunkId, FSStatusCode(uint32_t fsId, uint32_t idNum,
                                               uint64_t *chunkId));
 
-    MOCK_METHOD1(GetLatestTxId,
-                 FSStatusCode(std::vector<PartitionTxId>* txIds));
+    MOCK_METHOD2(GetLatestTxId,
+                 FSStatusCode(uint32_t fsId,
+                              std::vector<PartitionTxId>* txIds));
 
     MOCK_METHOD5(GetLatestTxIdWithLock,
                  FSStatusCode(uint32_t fsId,

--- a/curvefs/test/mds/fs_manager_test.cpp
+++ b/curvefs/test/mds/fs_manager_test.cpp
@@ -71,6 +71,7 @@ using ::curvefs::mds::topology::TopologyImpl;
 using ::curvefs::mds::topology::CreatePartitionRequest;
 using ::curvefs::mds::topology::CreatePartitionResponse;
 using ::curvefs::mds::topology::TopoStatusCode;
+using ::curvefs::mds::topology::FsIdType;
 using ::curvefs::metaserver::copyset::MockCliService2;
 using ::curvefs::metaserver::copyset::GetLeaderResponse2;
 using ::curve::common::MockS3Adapter;
@@ -732,6 +733,42 @@ TEST_F(FSManagerTest, test_refreshSession) {
         *request.mutable_mountpoint() = mountpoint;
         fsManager_->RefreshSession(&request, &response);
         ASSERT_EQ(0, response.latesttxidlist_size());
+    }
+}
+
+TEST_F(FSManagerTest, GetLatestTxId_ParamFsId) {
+    // CASE 1: GetLatestTxId without fsid param
+    {
+        GetLatestTxIdRequest request;
+        GetLatestTxIdResponse response;
+        fsManager_->GetLatestTxId(&request, &response);
+        ASSERT_EQ(response.statuscode(), FSStatusCode::PARAM_ERROR);
+    }
+
+    // CASE 2: GetLatestTxId with fsid
+    {
+        GetLatestTxIdRequest request;
+        GetLatestTxIdResponse response;
+        request.set_fsid(1);
+        EXPECT_CALL(*topoManager_, ListPartitionOfFs(_, _))
+            .WillOnce(Invoke([&](FsIdType fsId,
+                                 std::list<PartitionInfo>* list) {
+                if (fsId != 1) {
+                    return;
+                }
+                PartitionInfo partition;
+                partition.set_fsid(0);
+                partition.set_poolid(0);
+                partition.set_copysetid(0);
+                partition.set_partitionid(0);
+                partition.set_start(0);
+                partition.set_end(0);
+                partition.set_txid(0);
+                list->push_back(partition);
+            }));
+        fsManager_->GetLatestTxId(&request, &response);
+        ASSERT_EQ(response.statuscode(), FSStatusCode::OK);
+        ASSERT_EQ(response.txids_size(), 1);
     }
 }
 


### PR DESCRIPTION
…ads to some mountpoints use stale txid to find dentry and not found.

Signed-off-by: Wine93 <wine93.info@gmail.com>

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #xxx <!-- replace xxx with issue number -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
