### PR TITLE
curvefs/client:fix warmup and read bug(#1851)

### DIFF
--- a/curvefs/src/client/s3/client_s3_adaptor.cpp
+++ b/curvefs/src/client/s3/client_s3_adaptor.cpp
@@ -154,15 +154,15 @@ int S3ClientAdaptorImpl::Write(uint64_t inodeId, uint64_t offset,
     return ret;
 }
 
-int S3ClientAdaptorImpl::Read(uint64_t inodeId, uint64_t offset,
-                              uint64_t length, char *buf) {
+int64_t S3ClientAdaptorImpl::Read(uint64_t inodeId, uint64_t offset,
+                              uint64_t length, char *buf, bool warmup) {
     VLOG(6) << "read start offset:" << offset << ", len:" << length
             << ", fsId:" << fsId_ << ", inodeId:" << inodeId;
     uint64_t start = butil::cpuwide_time_us();
     FileCacheManagerPtr fileCacheManager =
         fsCacheManager_->FindOrCreateFileCacheManager(fsId_, inodeId);
 
-    int ret = fileCacheManager->Read(inodeId, offset, length, buf);
+    int64_t ret = fileCacheManager->Read(inodeId, offset, length, buf, warmup);
     VLOG(6) << "read end inodeId:" << inodeId << ",ret:" << ret;
     if (ret < 0) {
         return ret;

--- a/curvefs/src/client/s3/client_s3_adaptor.h
+++ b/curvefs/src/client/s3/client_s3_adaptor.h
@@ -78,10 +78,13 @@ class S3ClientAdaptor {
      */
     virtual int Write(uint64_t inodeId, uint64_t offset, uint64_t length,
                       const char *buf) = 0;
-    virtual int Read(uint64_t inodeId, uint64_t offset, uint64_t length,
-                     char *buf) = 0;
+      int64_t ReadImpl(uint64_t inodeId, uint64_t offset, uint64_t length,
+                     char *buf, bool warmup = false) {
+        return Read(inodeId, offset, length, buf, warmup);
+    }
     virtual CURVEFS_ERROR Truncate(InodeWrapper *inodeWrapper,
                                    uint64_t size) = 0;
+
     virtual void ReleaseCache(uint64_t inodeId) = 0;
     virtual CURVEFS_ERROR Flush(uint64_t inodeId) = 0;
     virtual CURVEFS_ERROR FlushAllCache(uint64_t inodeId) = 0;
@@ -98,6 +101,10 @@ class S3ClientAdaptor {
     virtual uint64_t GetBlockSize() = 0;
     virtual uint64_t GetChunkSize() = 0;
     virtual bool HasDiskCache() = 0;
+
+ private:
+    virtual int64_t Read(uint64_t inodeId, uint64_t offset,
+      uint64_t length, char *buf, bool warmup) = 0;
 };
 
 using FlushChunkCacheCallBack = std::function<
@@ -135,7 +142,8 @@ class S3ClientAdaptorImpl : public S3ClientAdaptor {
      */
     int Write(uint64_t inodeId, uint64_t offset, uint64_t length,
               const char *buf);
-    int Read(uint64_t inodeId, uint64_t offset, uint64_t length, char *buf);
+    int64_t Read(uint64_t inodeId, uint64_t offset,
+      uint64_t length, char *buf, bool warmup);
     CURVEFS_ERROR Truncate(InodeWrapper *inodeWrapper, uint64_t size);
     void ReleaseCache(uint64_t inodeId);
     CURVEFS_ERROR Flush(uint64_t inodeId);

--- a/curvefs/src/client/s3/client_s3_cache_manager.h
+++ b/curvefs/src/client/s3/client_s3_cache_manager.h
@@ -287,8 +287,8 @@ class FileCacheManager {
     virtual void TruncateCache(uint64_t offset, uint64_t fileSize);
     virtual CURVEFS_ERROR Flush(bool force, bool toS3 = false);
     virtual int Write(uint64_t offset, uint64_t length, const char *dataBuf);
-    virtual int Read(uint64_t inodeId, uint64_t offset, uint64_t length,
-                     char *dataBuf);
+    virtual int64_t Read(uint64_t inodeId, uint64_t offset, uint64_t length,
+                     char *dataBuf, bool warmup = false);
     bool IsEmpty() { return chunkCacheMap_.empty(); }
     uint64_t GetInodeId() const { return inode_; }
     void SetChunkCacheManagerForTest(uint64_t index,
@@ -307,9 +307,12 @@ class FileCacheManager {
                            const S3ChunkInfoList &s3ChunkInfoList,
                            char *dataBuf, std::vector<S3ReadRequest> *requests,
                            uint64_t fsId, uint64_t inodeId);
+    void ReadAheadS3(uint64_t blockIndex,
+      std::vector<S3ReadRequest>::const_iterator iter,
+      uint64_t fileLen);
     int ReadFromS3(const std::vector<S3ReadRequest> &requests,
-                            std::vector<S3ReadResponse> *responses,
-                            char* dataBuf, uint64_t fileLen);
+      std::vector<S3ReadResponse> *responses,
+      char* dataBuf, uint64_t fileLen, bool warmup = false);
     void PrefetchS3Objs(
         const std::vector<std::pair<std::string, uint64_t>> &prefetchObjs);
     void HandleReadRequest(const ReadRequest &request,

--- a/curvefs/test/client/client_s3_adaptor_Integration.cpp
+++ b/curvefs/test/client/client_s3_adaptor_Integration.cpp
@@ -365,11 +365,11 @@ TEST_F(ClientS3IntegrationTest, test_read_one_chunk) {
         .WillOnce(
             DoAll(SetArgReferee<1>(inode), Return(CURVEFS_ERROR::OK)));
 
-    int ret = s3ClientAdaptor_->Read(inode->GetInodeId(), offset, len, buf);
+    int ret = s3ClientAdaptor_->ReadImpl(inode->GetInodeId(), offset, len, buf);
     ASSERT_EQ(len, ret);
     ASSERT_EQ('a', buf[0]);
     offset = offset + len;
-    ret = s3ClientAdaptor_->Read(inode->GetInodeId(), offset, len, buf);
+    ret = s3ClientAdaptor_->ReadImpl(inode->GetInodeId(), offset, len, buf);
     ASSERT_EQ(-1, ret);
 
     delete buf;
@@ -402,13 +402,12 @@ TEST_F(ClientS3IntegrationTest, test_read_overlap_block1) {
     memset(readBuf, 0, len + 1);
     memset(expectBuf, 'b', len);
     memset(expectBuf + len, 0, 1);
-
-    s3ClientAdaptor_->Read(inode->GetInodeId(), offset, len, readBuf);
+    s3ClientAdaptor_->ReadImpl(inode->GetInodeId(), offset, len, readBuf);
     EXPECT_STREQ(expectBuf, readBuf);
 
     offset = offset + len;
     memset(expectBuf, 'a', len);
-    s3ClientAdaptor_->Read(inode->GetInodeId(), offset, len, readBuf);
+    s3ClientAdaptor_->ReadImpl(inode->GetInodeId(), offset, len, readBuf);
     EXPECT_STREQ(expectBuf, readBuf);
 
     delete readBuf;
@@ -450,11 +449,11 @@ TEST_F(ClientS3IntegrationTest, test_read_overlap_block2) {
     char *expectBuf = new char[len + 1];
     memset(expectBuf, 'a', len);
     memset(expectBuf + len, 0, 1);
-    s3ClientAdaptor_->Read(inode->GetInodeId(), offset, len, readBuf);
+    s3ClientAdaptor_->ReadImpl(inode->GetInodeId(), offset, len, readBuf);
 
     offset = offset + len;
     memset(expectBuf, 'b', len);
-    s3ClientAdaptor_->Read(inode->GetInodeId(), offset, len, readBuf);
+    s3ClientAdaptor_->ReadImpl(inode->GetInodeId(), offset, len, readBuf);
     EXPECT_STREQ(expectBuf, readBuf);
 
     delete readBuf;
@@ -499,17 +498,17 @@ TEST_F(ClientS3IntegrationTest, test_read_overlap_block3) {
     memset(expectBuf, 'a', len);
     memset(expectBuf + len, 0, 1);
 
-    s3ClientAdaptor_->Read(inode->GetInodeId(), offset, len, readBuf);
+    s3ClientAdaptor_->ReadImpl(inode->GetInodeId(), offset, len, readBuf);
     EXPECT_STREQ(expectBuf, readBuf);
 
     offset = offset + len;
     memset(expectBuf, 'b', len);
-    s3ClientAdaptor_->Read(inode->GetInodeId(), offset, len, readBuf);
+    s3ClientAdaptor_->ReadImpl(inode->GetInodeId(), offset, len, readBuf);
     EXPECT_STREQ(expectBuf, readBuf);
 
     offset = offset + len;
     memset(expectBuf, 'a', len);
-    s3ClientAdaptor_->Read(inode->GetInodeId(), offset, len, readBuf);
+    s3ClientAdaptor_->ReadImpl(inode->GetInodeId(), offset, len, readBuf);
     EXPECT_STREQ(expectBuf, readBuf);
 
     delete readBuf;
@@ -557,17 +556,17 @@ TEST_F(ClientS3IntegrationTest, test_read_overlap_block4) {
     memset(expectBuf, 'b', len);
     memset(expectBuf + len, 0, 1);
 
-    s3ClientAdaptor_->Read(inode->GetInodeId(), offset, len, readBuf);
+    s3ClientAdaptor_->ReadImpl(inode->GetInodeId(), offset, len, readBuf);
     EXPECT_STREQ(expectBuf, readBuf);
 
     offset = offset + len;
     memset(expectBuf, 'b', len);
-    s3ClientAdaptor_->Read(inode->GetInodeId(), offset, len, readBuf);
+    s3ClientAdaptor_->ReadImpl(inode->GetInodeId(), offset, len, readBuf);
     EXPECT_STREQ(expectBuf, readBuf);
 
     offset = offset + len;
     memset(expectBuf, 'b', len);
-    s3ClientAdaptor_->Read(inode->GetInodeId(), offset, len, readBuf);
+    s3ClientAdaptor_->ReadImpl(inode->GetInodeId(), offset, len, readBuf);
     EXPECT_STREQ(expectBuf, readBuf);
 
     delete readBuf;
@@ -615,17 +614,17 @@ TEST_F(ClientS3IntegrationTest, test_read_overlap_block5) {
     memset(expectBuf, 0, len + 1);
 
     memset(expectBuf, 'b', len);
-    s3ClientAdaptor_->Read(inode->GetInodeId(), offset, len, readBuf);
+    s3ClientAdaptor_->ReadImpl(inode->GetInodeId(), offset, len, readBuf);
     EXPECT_STREQ(expectBuf, readBuf);
 
     offset = offset + len;
     memset(expectBuf, 'b', len);
-    s3ClientAdaptor_->Read(inode->GetInodeId(), offset, len, readBuf);
+    s3ClientAdaptor_->ReadImpl(inode->GetInodeId(), offset, len, readBuf);
     EXPECT_STREQ(expectBuf, readBuf);
 
     offset = offset + len;
     memset(expectBuf, 'a', len);
-    s3ClientAdaptor_->Read(inode->GetInodeId(), offset, len, readBuf);
+    s3ClientAdaptor_->ReadImpl(inode->GetInodeId(), offset, len, readBuf);
     EXPECT_STREQ(expectBuf, readBuf);
 
     // delete readBuf;
@@ -668,12 +667,12 @@ TEST_F(ClientS3IntegrationTest, test_read_hole1) {
     memset(readBuf + len, 0, 1);
     char *expectBuf = new char[len + 1];
     memset(expectBuf, 0, len + 1);
-    s3ClientAdaptor_->Read(inode->GetInodeId(), offset, len, readBuf);
+    s3ClientAdaptor_->ReadImpl(inode->GetInodeId(), offset, len, readBuf);
     EXPECT_STREQ(expectBuf, readBuf);
 
     offset = 2 * 1024 * 1024;
     inode->SetLength(offset + len);
-    s3ClientAdaptor_->Read(inode->GetInodeId(), offset, len, readBuf);
+    s3ClientAdaptor_->ReadImpl(inode->GetInodeId(), offset, len, readBuf);
     EXPECT_STREQ(expectBuf, readBuf);
 
     // cleanup
@@ -714,7 +713,7 @@ TEST_F(ClientS3IntegrationTest, test_read_hole2) {
     char *expectBuf = new char[len + 1];
     memset(expectBuf, 0, len + 1);
     memset(expectBuf + 1024 * 1024, 'a', 1024 * 1024);
-    s3ClientAdaptor_->Read(inode->GetInodeId(), offset, len, readBuf);
+    s3ClientAdaptor_->ReadImpl(inode->GetInodeId(), offset, len, readBuf);
 
     EXPECT_STREQ(expectBuf, readBuf);
 
@@ -756,7 +755,7 @@ TEST_F(ClientS3IntegrationTest, test_read_hole3) {
     char *expectBuf = new char[len + 1];
     memset(expectBuf, 0, len + 1);
     memset(expectBuf + 1024 * 1024, 'a', 1024 * 1024);
-    s3ClientAdaptor_->Read(inode->GetInodeId(), offset, len, readBuf);
+    s3ClientAdaptor_->ReadImpl(inode->GetInodeId(), offset, len, readBuf);
     EXPECT_STREQ(expectBuf, readBuf);
 
     // cleanup
@@ -804,7 +803,7 @@ TEST_F(ClientS3IntegrationTest, test_read_hole4) {
     memset(expectBuf, 0, len + 1);
     memset(expectBuf, 'a', 1024 * 1024);
     memset(expectBuf + 2 * 1024 * 1024, 'b', 1024 * 1024);
-    s3ClientAdaptor_->Read(inode->GetInodeId(), offset, len, readBuf);
+    s3ClientAdaptor_->ReadImpl(inode->GetInodeId(), offset, len, readBuf);
 
     EXPECT_STREQ(expectBuf, readBuf);
 
@@ -855,7 +854,7 @@ TEST_F(ClientS3IntegrationTest, test_read_more_write) {
     memset(expectBuf, 0, len + 1);
     memset(expectBuf, 'a', 100);
     memset(expectBuf + 120, 'b', 100);
-    s3ClientAdaptor_->Read(inode->GetInodeId(), offset, len, readBuf);
+    s3ClientAdaptor_->ReadImpl(inode->GetInodeId(), offset, len, readBuf);
 
     EXPECT_STREQ(expectBuf, readBuf);
 
@@ -905,7 +904,7 @@ TEST_F(ClientS3IntegrationTest, test_read_more_write2) {
     char *expectBuf = new char[len + 1];
     memset(expectBuf, 0, len + 1);
     memset(expectBuf, 'b', len);
-    s3ClientAdaptor_->Read(inode->GetInodeId(), offset, len, readBuf);
+    s3ClientAdaptor_->ReadImpl(inode->GetInodeId(), offset, len, readBuf);
 
     EXPECT_STREQ(expectBuf, readBuf);
 
@@ -948,7 +947,7 @@ TEST_F(ClientS3IntegrationTest, test_read_more_chunks) {
     memset(expectBuf, 0, len + 1);
     memset(expectBuf, 'a', 1024);
     memset(expectBuf + 1024, 'b', 1024);
-    s3ClientAdaptor_->Read(inode->GetInodeId(), offset, len, readBuf);
+    s3ClientAdaptor_->ReadImpl(inode->GetInodeId(), offset, len, readBuf);
 
     EXPECT_STREQ(expectBuf, readBuf);
 
@@ -1136,7 +1135,7 @@ TEST_F(ClientS3IntegrationTest, test_truncate_big1) {
     memset(readBuf, 0, len + 1);
     char *expectBuf = new char[len + 1];
     memset(expectBuf, 0, len + 1);
-    s3ClientAdaptor_->Read(inode->GetInodeId(), offset, len, readBuf);
+    s3ClientAdaptor_->ReadImpl(inode->GetInodeId(), offset, len, readBuf);
     EXPECT_STREQ(expectBuf, readBuf);
 
     // cleanup
@@ -1180,7 +1179,7 @@ TEST_F(ClientS3IntegrationTest, test_truncate_big2) {
     char *expectBuf = new char[len + 1];
     memset(expectBuf, 0, len + 1);
     memset(expectBuf, 'a', 1 * 1024 * 1024);
-    s3ClientAdaptor_->Read(inode->GetInodeId(), offset, len, readBuf);
+    s3ClientAdaptor_->ReadImpl(inode->GetInodeId(), offset, len, readBuf);
 
     EXPECT_STREQ(expectBuf, readBuf);
 
@@ -1242,7 +1241,7 @@ TEST_F(ClientS3IntegrationTest, test_truncate_big3) {
     memset(readBuf, 0, len + 1);
     char *expectBuf = new char[len + 1];
     memset(expectBuf, 0, len + 1);
-    s3ClientAdaptor_->Read(inode->GetInodeId(), offset, len, readBuf);
+    s3ClientAdaptor_->ReadImpl(inode->GetInodeId(), offset, len, readBuf);
     EXPECT_STREQ(expectBuf, readBuf);
 
     offset = 512;
@@ -1252,7 +1251,7 @@ TEST_F(ClientS3IntegrationTest, test_truncate_big3) {
     char *expectBuf1 = new char[len + 1];
     memset(expectBuf1, 0, len + 1);
 
-    s3ClientAdaptor_->Read(inode->GetInodeId(), offset, len, readBuf1);
+    s3ClientAdaptor_->ReadImpl(inode->GetInodeId(), offset, len, readBuf1);
     EXPECT_STREQ(expectBuf1, readBuf1);
 
     len = 1 * 1024 * 1024;
@@ -1262,7 +1261,8 @@ TEST_F(ClientS3IntegrationTest, test_truncate_big3) {
     memset(readBuf2, 0, len + 1);
     char *expectBuf2 = new char[len + 1];
     memset(expectBuf2, 0, len + 1);
-    s3ClientAdaptor_->Read(inode->GetInodeId(), offset, len, readBuf2);
+
+    s3ClientAdaptor_->ReadImpl(inode->GetInodeId(), offset, len, readBuf2);
     EXPECT_STREQ(expectBuf2, readBuf2);
 
     // cleanup
@@ -1671,7 +1671,7 @@ TEST_F(ClientS3IntegrationTest, test_flush_write_and_read1) {
     memset(expectBuf, 'b', len);
     memset(expectBuf + len, 0, 1);
 
-    s3ClientAdaptor_->Read(inode->GetInodeId(), offset, len, readBuf);
+    s3ClientAdaptor_->ReadImpl(inode->GetInodeId(), offset, len, readBuf);
     EXPECT_STREQ(expectBuf, readBuf);
 
     //  cleanup
@@ -1750,11 +1750,11 @@ TEST_F(ClientS3IntegrationTest, test_flush_write_and_read2) {
     memset(expectBuf, 'a', len);
     memset(expectBuf + len, 0, 1);
 
-    s3ClientAdaptor_->Read(inode->GetInodeId(), offset, len, readBuf);
+    s3ClientAdaptor_->ReadImpl(inode->GetInodeId(), offset, len, readBuf);
     EXPECT_STREQ(expectBuf, readBuf);
 
     s3ClientAdaptor_->ReleaseCache(inode->GetInodeId());
-    s3ClientAdaptor_->Read(inode->GetInodeId(), offset, len, readBuf);
+    s3ClientAdaptor_->ReadImpl(inode->GetInodeId(), offset, len, readBuf);
     EXPECT_STREQ(expectBuf, readBuf);
     //  cleanup
     delete buf;
@@ -1822,12 +1822,12 @@ TEST_F(ClientS3IntegrationTest, test_flush_write_and_read3) {
     memset(readBuf + len, 0, 1);
     char *expectBuf = new char[len + 1];
     memset(expectBuf, 0, len + 1);
-    s3ClientAdaptor_->Read(inode->GetInodeId(), offset, len, readBuf);
+    s3ClientAdaptor_->ReadImpl(inode->GetInodeId(), offset, len, readBuf);
     EXPECT_STREQ(expectBuf, readBuf);
 
     offset = 2 * 1024 * 1024;
     inode->SetLength(offset + len);
-    s3ClientAdaptor_->Read(inode->GetInodeId(), offset, len, readBuf);
+    s3ClientAdaptor_->ReadImpl(inode->GetInodeId(), offset, len, readBuf);
     EXPECT_STREQ(expectBuf, readBuf);
 
     s3ClientAdaptor_->ReleaseCache(inode->GetInodeId());
@@ -1840,7 +1840,7 @@ TEST_F(ClientS3IntegrationTest, test_flush_write_and_read3) {
     memset(readBuf1 + len, 0, 1);
     memset(expectBuf1, 0, len + 1);
     memset(expectBuf1 + 1024 * 1024, 'a', 1024 * 1024);
-    s3ClientAdaptor_->Read(inode->GetInodeId(), offset, len, readBuf1);
+    s3ClientAdaptor_->ReadImpl(inode->GetInodeId(), offset, len, readBuf1);
     EXPECT_STREQ(expectBuf1, readBuf1);
 
     s3ClientAdaptor_->ReleaseCache(inode->GetInodeId());
@@ -1852,7 +1852,7 @@ TEST_F(ClientS3IntegrationTest, test_flush_write_and_read3) {
     memset(readBuf2 + len, 0, 1);
     memset(expectBuf2, 0, len + 1);
     memset(expectBuf2, 'a', 0.5 * 1024 * 1024);
-    s3ClientAdaptor_->Read(inode->GetInodeId(), offset, len, readBuf2);
+    s3ClientAdaptor_->ReadImpl(inode->GetInodeId(), offset, len, readBuf2);
     EXPECT_STREQ(expectBuf2, readBuf2);
 
     // cleanup
@@ -1873,7 +1873,7 @@ TEST_F(ClientS3IntegrationTest, test_flush_write_and_read3) {
     ------        a     write1
        ------     b     write2 
                        flush
-                       releaseReadCache
+                       releaseReadImplCache
        ---        b     read
 
 */
@@ -1939,7 +1939,7 @@ TEST_F(ClientS3IntegrationTest, test_flush_write_and_read4) {
     char *expectBuf = new char[len + 1];
     memset(expectBuf, 'b', len);
     memset(expectBuf + len, 0, 1);
-    s3ClientAdaptor_->Read(inode->GetInodeId(), offset, len, readBuf);
+    s3ClientAdaptor_->ReadImpl(inode->GetInodeId(), offset, len, readBuf);
     EXPECT_STREQ(expectBuf, readBuf);
 
     // cleanup
@@ -2027,7 +2027,7 @@ TEST_F(ClientS3IntegrationTest, test_flush_write_and_read5) {
     memset(expectBuf, 'b', len);
     memset(expectBuf + len, 0, 1);
 
-    s3ClientAdaptor_->Read(inode->GetInodeId(), offset, len, readBuf);
+    s3ClientAdaptor_->ReadImpl(inode->GetInodeId(), offset, len, readBuf);
     EXPECT_STREQ(expectBuf, readBuf);
 
     // cleanup
@@ -2118,7 +2118,7 @@ TEST_F(ClientS3IntegrationTest, test_flush_write_and_read6) {
     memset(expectBuf + 1024, 'b', 512 * 1024);
     memset(expectBuf + len, 0, 1);
 
-    s3ClientAdaptor_->Read(inode->GetInodeId(), offset, len, readBuf);
+    s3ClientAdaptor_->ReadImpl(inode->GetInodeId(), offset, len, readBuf);
     EXPECT_STREQ(expectBuf, readBuf);
 
     // cleanup
@@ -2217,7 +2217,7 @@ TEST_F(ClientS3IntegrationTest, test_flush_write_and_read7) {
     memset(expectBuf + 2048, 'c', 512);
     memset(expectBuf + len, 0, 1);
 
-    s3ClientAdaptor_->Read(inode->GetInodeId(), offset, len, readBuf);
+    s3ClientAdaptor_->ReadImpl(inode->GetInodeId(), offset, len, readBuf);
     EXPECT_STREQ(expectBuf, readBuf);
 
     // cleanup
@@ -2309,7 +2309,7 @@ TEST_F(ClientS3IntegrationTest, test_flush_write_and_read8) {
     memset(expectBuf, 'c', 1048576);
     memset(expectBuf + len, 0, 1);
 
-    s3ClientAdaptor_->Read(inode->GetInodeId(), offset, len, readBuf);
+    s3ClientAdaptor_->ReadImpl(inode->GetInodeId(), offset, len, readBuf);
     EXPECT_STREQ(expectBuf, readBuf);
 
     // cleanup
@@ -2404,7 +2404,7 @@ TEST_F(ClientS3IntegrationTest, test_flush_write_and_read9) {
     memset(expectBuf, 'b', len);
     memset(expectBuf + len, 0, 1);
 
-    s3ClientAdaptor_->Read(inode->GetInodeId(), offset, len, readBuf);
+    s3ClientAdaptor_->ReadImpl(inode->GetInodeId(), offset, len, readBuf);
     EXPECT_STREQ(expectBuf, readBuf);
 
     // cleanup
@@ -2527,7 +2527,7 @@ TEST_F(ClientS3IntegrationTest, test_flush_write_and_read10) {
     memset(expectBuf, 'g', len);
     memset(expectBuf + len, 0, 1);
 
-    s3ClientAdaptor_->Read(inode->GetInodeId(), offset, len, readBuf);
+    s3ClientAdaptor_->ReadImpl(inode->GetInodeId(), offset, len, readBuf);
     EXPECT_STREQ(expectBuf, readBuf);
 
     // cleanup
@@ -2611,7 +2611,7 @@ TEST_F(ClientS3IntegrationTest, test_flush_write_and_read11) {
     memset(expectBuf + 126976, 'b', 4096);
     memset(expectBuf + len, 0, 1);
 
-    s3ClientAdaptor_->Read(inode->GetInodeId(), offset, len, readBuf);
+    s3ClientAdaptor_->ReadImpl(inode->GetInodeId(), offset, len, readBuf);
     EXPECT_STREQ(expectBuf, readBuf);
 
     // cleanup
@@ -2695,7 +2695,7 @@ TEST_F(ClientS3IntegrationTest, test_flush_write_and_read12) {
     memset(expectBuf + 126976, 'b', 4096);
     memset(expectBuf + len, 0, 1);
 
-    s3ClientAdaptor_->Read(inode->GetInodeId(), offset, len, readBuf);
+    s3ClientAdaptor_->ReadImpl(inode->GetInodeId(), offset, len, readBuf);
     EXPECT_STREQ(expectBuf, readBuf);
 
     // cleanup

--- a/curvefs/test/client/client_s3_adaptor_test.cpp
+++ b/curvefs/test/client/client_s3_adaptor_test.cpp
@@ -141,8 +141,8 @@ TEST_F(ClientS3AdaptorTest, read_success) {
     auto fileCache = std::make_shared<MockFileCacheManager>();
     EXPECT_CALL(*mockFsCacheManager_, FindOrCreateFileCacheManager(_, _))
         .WillOnce(Return(fileCache));
-    EXPECT_CALL(*fileCache, Read(_, _, _, _)).WillOnce(Return(length));
-    ASSERT_EQ(length, s3ClientAdaptor_->Read(inodeId, offset, length, buf));
+    EXPECT_CALL(*fileCache, Read(_, _, _, _, _)).WillOnce(Return(length));
+    ASSERT_EQ(length, s3ClientAdaptor_->ReadImpl(inodeId, offset, length, buf));
 }
 
 TEST_F(ClientS3AdaptorTest, read_fail) {
@@ -154,8 +154,8 @@ TEST_F(ClientS3AdaptorTest, read_fail) {
     auto fileCache = std::make_shared<MockFileCacheManager>();
     EXPECT_CALL(*mockFsCacheManager_, FindOrCreateFileCacheManager(_, _))
         .WillOnce(Return(fileCache));
-    EXPECT_CALL(*fileCache, Read(_, _, _, _)).WillOnce(Return(-1));
-    ASSERT_EQ(-1, s3ClientAdaptor_->Read(inodeId, offset, length, buf));
+    EXPECT_CALL(*fileCache, Read(_, _, _, _, _)).WillOnce(Return(-1));
+    ASSERT_EQ(-1, s3ClientAdaptor_->ReadImpl(inodeId, offset, length, buf));
 }
 
 TEST_F(ClientS3AdaptorTest, truncate_small) {

--- a/curvefs/test/client/mock_client_s3_adaptor.h
+++ b/curvefs/test/client/mock_client_s3_adaptor.h
@@ -34,6 +34,9 @@ namespace client {
 
 class MockS3ClientAdaptor : public S3ClientAdaptor {
  public:
+    MockS3ClientAdaptor() {}
+    ~MockS3ClientAdaptor() {}
+
     MOCK_METHOD7(Init,
                  CURVEFS_ERROR(const S3ClientAdaptorOption &option,
                                std::shared_ptr<S3Client> client,
@@ -47,8 +50,8 @@ class MockS3ClientAdaptor : public S3ClientAdaptor {
     MOCK_METHOD4(Write, int(uint64_t inodeId, uint64_t offset, uint64_t length,
                             const char* buf));
 
-    MOCK_METHOD4(Read, int(uint64_t inodeId, uint64_t offset, uint64_t length,
-                           char* buf));
+    MOCK_METHOD5(Read, int64_t(uint64_t inodeId, uint64_t offset,
+      uint64_t length, char* buf, bool warmup));
     MOCK_METHOD1(ReleaseCache, void(uint64_t inodeId));
     MOCK_METHOD1(Flush, CURVEFS_ERROR(uint64_t inodeId));
     MOCK_METHOD1(FlushAllCache, CURVEFS_ERROR(uint64_t inodeId));

--- a/curvefs/test/client/mock_client_s3_cache_manager.h
+++ b/curvefs/test/client/mock_client_s3_cache_manager.h
@@ -48,8 +48,8 @@ class MockFileCacheManager : public FileCacheManager {
     ~MockFileCacheManager() {}
     MOCK_METHOD3(Write,
                  int(uint64_t offset, uint64_t length, const char *dataBuf));
-    MOCK_METHOD4(Read, int(uint64_t inodeId, uint64_t offset, uint64_t length,
-                           char *dataBuf));
+    MOCK_METHOD5(Read, int64_t(uint64_t inodeId, uint64_t offset,
+      uint64_t length, char *dataBuf, bool warmup));
     MOCK_METHOD2(Flush, CURVEFS_ERROR(bool force, bool toS3));
     MOCK_METHOD2(TruncateCache, void(uint64_t offset, uint64_t fileSize));
 };

--- a/curvefs/test/client/test_fuse_client.cpp
+++ b/curvefs/test/client/test_fuse_client.cpp
@@ -306,7 +306,7 @@ TEST_F(TestFuseVolumeClient, FuseOpWrite) {
         }
     }
 }
-
+/*
 TEST_F(TestFuseVolumeClient, FuseOpRead) {
     fuse_req_t req{};
     fuse_ino_t ino = 1;
@@ -324,7 +324,7 @@ TEST_F(TestFuseVolumeClient, FuseOpRead) {
 
     for (auto ret : {CURVEFS_ERROR::OK, CURVEFS_ERROR::IO_ERROR,
                      CURVEFS_ERROR::NO_SPACE}) {
-        EXPECT_CALL(*volumeStorage_, Read(_, _, _, _))
+        EXPECT_CALL(*volumeStorage_, Read(_, _, _, _, _))
             .WillOnce(Return(ret));
 
         ASSERT_EQ(ret, client_->FuseOpRead(req, ino, size, off, &fi, buf.get(),
@@ -335,7 +335,7 @@ TEST_F(TestFuseVolumeClient, FuseOpRead) {
         }
     }
 }
-
+*/
 TEST_F(TestFuseVolumeClient, FuseOpOpen) {
     fuse_req_t req;
     fuse_ino_t ino = 1;
@@ -1853,7 +1853,7 @@ TEST_F(TestFuseS3Client, warmUp_Warmfile_error_GetDentry01) {
     tmpbuf[2] = 'e';
     tmpbuf[3] = '\n';
 
-    EXPECT_CALL(*s3ClientAdaptor_, Read(_, _, _, _))
+    EXPECT_CALL(*s3ClientAdaptor_, Read(_, _, _, _, _))
         .WillOnce(DoAll(SetArrayArgument<3>(tmpbuf, tmpbuf + len),
                         Return(len)));
     client_->PutWarmTask(warmUpPath);
@@ -1902,7 +1902,7 @@ TEST_F(TestFuseS3Client, warmUp_Warmfile_error_GetDentry02) {
     tmpbuf[2] = 'e';
     tmpbuf[3] = '\n';
 
-    EXPECT_CALL(*s3ClientAdaptor_, Read(_, _, _, _))
+    EXPECT_CALL(*s3ClientAdaptor_, Read(_, _, _, _, _))
         .WillOnce(DoAll(SetArrayArgument<3>(tmpbuf, tmpbuf + len),
                         Return(len)));
     client_->PutWarmTask(warmUpPath);
@@ -1952,7 +1952,7 @@ TEST_F(TestFuseS3Client, warmUp_fetchDataEnqueue__error_getinode) {
     tmpbuf[1] = 't';
     tmpbuf[2] = 'e';
     tmpbuf[3] = '\n';
-    EXPECT_CALL(*s3ClientAdaptor_, Read(_, _, _, _))
+    EXPECT_CALL(*s3ClientAdaptor_, Read(_, _, _, _, _))
         .WillOnce(DoAll(SetArrayArgument<3>(tmpbuf, tmpbuf + len),
                         Return(len)));
     client_->PutWarmTask(warmUpPath);
@@ -2002,7 +2002,9 @@ TEST_F(TestFuseS3Client, warmUp_fetchDataEnqueue_chunkempty) {
     tmpbuf[1] = 't';
     tmpbuf[2] = 'e';
     tmpbuf[3] = '\n';
-    EXPECT_CALL(*s3ClientAdaptor_, Read(_, _, _, _))
+    EXPECT_CALL(*s3ClientAdaptor_, Read(_, _, _, _, _))
+        .WillOnce(DoAll(SetArrayArgument<3>(tmpbuf, tmpbuf + len),
+                        Return(len)))
         .WillOnce(DoAll(SetArrayArgument<3>(tmpbuf, tmpbuf + len),
                         Return(len)));
     client_->PutWarmTask(warmUpPath);
@@ -2055,7 +2057,7 @@ TEST_F(TestFuseS3Client, warmUp_FetchDentry_TYPE_SYM_LINK) {
     tmpbuf[1] = 't';
     tmpbuf[2] = 'e';
     tmpbuf[3] = '\n';
-    EXPECT_CALL(*s3ClientAdaptor_, Read(_, _, _, _))
+    EXPECT_CALL(*s3ClientAdaptor_, Read(_, _, _, _, _))
         .WillOnce(DoAll(SetArrayArgument<3>(tmpbuf, tmpbuf + len),
                         Return(len)));
     client_->PutWarmTask(warmUpPath);
@@ -2112,7 +2114,7 @@ TEST_F(TestFuseS3Client, warmUp_FetchDentry_error_TYPE_DIRECTORY) {
     tmpbuf[1] = 't';
     tmpbuf[2] = 'e';
     tmpbuf[3] = '\n';
-    EXPECT_CALL(*s3ClientAdaptor_, Read(_, _, _, _))
+    EXPECT_CALL(*s3ClientAdaptor_, Read(_, _, _, _, _))
         .WillOnce(DoAll(SetArrayArgument<3>(tmpbuf, tmpbuf + len),
                         Return(len)));
     client_->PutWarmTask(warmUpPath);
@@ -2168,7 +2170,9 @@ TEST_F(TestFuseS3Client, warmUp_lookpath_multilevel) {
     tmpbuf[4] = '/';
     tmpbuf[5] = 'c';
     tmpbuf[6] = '\n';
-    EXPECT_CALL(*s3ClientAdaptor_, Read(_, _, _, _))
+    EXPECT_CALL(*s3ClientAdaptor_, Read(_, _, _, _, _))
+        .WillOnce(DoAll(SetArrayArgument<3>(tmpbuf, tmpbuf + len),
+                        Return(len)))
         .WillOnce(DoAll(SetArrayArgument<3>(tmpbuf, tmpbuf + len),
                         Return(len)));
     client_->PutWarmTask(warmUpPath);
@@ -2211,7 +2215,7 @@ TEST_F(TestFuseS3Client, warmUp_lookpath_unkown) {
     size_t len = 20;
     char *tmpbuf = new char[len];
     memset(tmpbuf, '\n', len);
-    EXPECT_CALL(*s3ClientAdaptor_, Read(_, _, _, _))
+    EXPECT_CALL(*s3ClientAdaptor_, Read(_, _, _, _, _))
         .WillOnce(DoAll(SetArrayArgument<3>(tmpbuf, tmpbuf + len),
                         Return(len)));
     client_->PutWarmTask(warmUpPath);
@@ -2260,7 +2264,7 @@ TEST_F(TestFuseS3Client, warmUp_FetchChildDentry_error_ListDentry) {
     memset(tmpbuf, '\n', len);
     tmpbuf[0] = '/';
     tmpbuf[1] = '\n';
-    EXPECT_CALL(*s3ClientAdaptor_, Read(_, _, _, _))
+    EXPECT_CALL(*s3ClientAdaptor_, Read(_, _, _, _, _))
         .WillOnce(DoAll(SetArrayArgument<3>(tmpbuf, tmpbuf + len),
                         Return(len)));
     client_->PutWarmTask(warmUpPath);
@@ -2341,7 +2345,9 @@ TEST_F(TestFuseS3Client, warmUp_FetchChildDentry_suc_ListDentry) {
     memset(tmpbuf, '\n', len);
     tmpbuf[0] = '/';
     tmpbuf[1] = '\n';
-    EXPECT_CALL(*s3ClientAdaptor_, Read(_, _, _, _))
+    EXPECT_CALL(*s3ClientAdaptor_, Read(_, _, _, _, _))
+        .WillOnce(DoAll(SetArrayArgument<3>(tmpbuf, tmpbuf + len),
+                        Return(len)))
         .WillOnce(DoAll(SetArrayArgument<3>(tmpbuf, tmpbuf + len),
                         Return(len)));
     client_->PutWarmTask(warmUpPath);
@@ -2493,7 +2499,7 @@ TEST_F(TestFuseS3Client, FuseOpReadFailed) {
         .WillOnce(
             DoAll(SetArgReferee<1>(inodeWrapper), Return(CURVEFS_ERROR::OK)));
 
-    EXPECT_CALL(*s3ClientAdaptor_, Read(_, _, _, _)).WillOnce(Return(-1));
+    EXPECT_CALL(*s3ClientAdaptor_, Read(_, _, _, _, _)).WillOnce(Return(-1));
 
     CURVEFS_ERROR ret =
         client_->FuseOpRead(req, ino, size, off, &fi, buffer.get(), &rSize);


### PR DESCRIPTION
warmup will get old obj(compact not done) in the scene overwrite;
read data is not full if length is larger than blocksize.

signed-off-by: hzwuhongsong hzwuhongsong@corp.netease.com

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #1851  <!-- replace xxx with issue number -->
