### PR TITLE
curvefs/client: fix update nlink error

### DIFF
--- a/curvefs/src/client/common/common.h
+++ b/curvefs/src/client/common/common.h
@@ -87,6 +87,11 @@ enum class FileHandle : uint64_t {
     kKeepCache = 1,
 };
 
+enum class NlinkChange : int32_t {
+    kAddOne = 1,
+    kSubOne = -1,
+};
+
 }  // namespace common
 }  // namespace client
 }  // namespace curvefs

--- a/curvefs/src/client/fuse_client.h
+++ b/curvefs/src/client/fuse_client.h
@@ -348,8 +348,8 @@ class FuseClient {
 
     virtual void FlushData() = 0;
 
-    CURVEFS_ERROR UpdateParentInodeMCTimeAndInvalidNlink(
-        fuse_ino_t parent, FsFileType type);
+    CURVEFS_ERROR UpdateParentMCTimeAndNlink(
+        fuse_ino_t parent, FsFileType type,  NlinkChange nlink);
 
     void WarmUpTask();
 

--- a/curvefs/src/metaserver/inode_manager.cpp
+++ b/curvefs/src/metaserver/inode_manager.cpp
@@ -460,13 +460,6 @@ MetaStatusCode InodeManager::UpdateInodeWhenCreateOrRemoveSubNode(
         }
     }
 
-    struct timespec now;
-    clock_gettime(CLOCK_REALTIME, &now);
-    inode.set_ctime(now.tv_sec);
-    inode.set_ctime_ns(now.tv_nsec);
-    inode.set_mtime(now.tv_sec);
-    inode.set_mtime_ns(now.tv_nsec);
-
     ret = inodeStorage_->Update(inode);
     if (ret != MetaStatusCode::OK) {
         LOG(ERROR) << "UpdateInode fail, " << inode.ShortDebugString()


### PR DESCRIPTION
Signed-off-by: wanghai01 <seanhaizi@163.com>

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?
fix the update inode nlink logic, the previous logic will update nlink incorrect at:
![未命名绘图](https://user-images.githubusercontent.com/13496900/188802915-600cd62b-3d9b-4183-91e9-90492a74d700.png)

The fixed logic is every update of nlink to metaserver should refresh from metaserver first.


Issue Number: #1904  <!-- replace xxx with issue number -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
