### PR TITLE
curvebs/chunkserver: optimize sync chunk when write in bulk

### DIFF
--- a/conf/chunkserver.conf
+++ b/conf/chunkserver.conf
@@ -88,6 +88,8 @@ copyset.raft_snapshot_uri=curve://./0/copysets  # __CURVEADM_TEMPLATE__ curve://
 copyset.recycler_uri=local://./0/recycler  # __CURVEADM_TEMPLATE__ local://${prefix}/data/recycler __CURVEADM_TEMPLATE__
 # chunkserver启动时，copyset并发加载的阈值,为0则表示不做限制
 copyset.load_concurrency=10
+# chunkserver use how many threads to use copyset complete sync. 
+copyset.sync_concurrency=20
 # 检查copyset是否加载完成出现异常时的最大重试次数
 copyset.check_retrytimes=3
 # 当前peer的applied_index与leader上的committed_index差距小于该值
@@ -107,8 +109,12 @@ copyset.scan_rpc_retry_times=3
 copyset.scan_rpc_retry_interval_us=100000
 # enable O_DSYNC when open chunkfile
 copyset.enable_odsync_when_open_chunkfile=false
-# sync timer timeout interval
-copyset.synctimer_interval_ms=30000
+# sync trigger seconds
+copyset.sync_trigger_seconds=25
+# sync chunk limit default = 2MB
+copyset.sync_chunk_limits=2097152
+# 30s if the sum of write > sync_threshold, let the sync_chunk_limits doubled.
+copyset.sync_threshold=65536
 # check syncing interval
 copyset.check_syncing_interval_ms=500
 

--- a/conf/chunkserver.conf.example
+++ b/conf/chunkserver.conf.example
@@ -88,6 +88,8 @@ copyset.raft_snapshot_uri=curve://./0/copysets
 copyset.recycler_uri=local://./0/recycler
 # chunkserver启动时，copyset并发加载的阈值,为0则表示不做限制
 copyset.load_concurrency=10
+# chunkserver use how many threads to use copyset complete sync. 
+copyset.sync_concurrency=20
 # 检查copyset是否加载完成出现异常时的最大重试次数
 copyset.check_retrytimes=3
 # 当前peer的applied_index与leader上的committed_index差距小于该值
@@ -107,8 +109,12 @@ copyset.scan_rpc_retry_times=3
 copyset.scan_rpc_retry_interval_us=100000
 # enable O_DSYNC when open chunkfile
 copyset.enable_odsync_when_open_chunkfile=false
-# sync timer timeout interval
-copyset.synctimer_interval_ms=30000
+# sync trigger seconds
+copyset.sync_trigger_seconds=25
+# sync chunk limit default = 2MB
+copyset.sync_chunk_limits=2097152
+# 30s if the sum of write > sync_threshold, let the sync_chunk_limits doubled.
+copyset.sync_threshold=65536
 # check syncing interval
 copyset.check_syncing_interval_ms=500
 

--- a/src/chunkserver/chunkserver.cpp
+++ b/src/chunkserver/chunkserver.cpp
@@ -37,6 +37,7 @@
 #include "src/chunkserver/braft_cli_service.h"
 #include "src/chunkserver/braft_cli_service2.h"
 #include "src/chunkserver/chunkserver_helper.h"
+#include "src/common/concurrent/task_thread_pool.h"
 #include "src/common/uri_parser.h"
 #include "src/chunkserver/raftsnapshot/curve_snapshot_attachment.h"
 #include "src/chunkserver/raftsnapshot/curve_file_service.h"
@@ -587,15 +588,21 @@ void ChunkServer::InitCopysetNodeOptions(
         &copysetNodeOptions->finishLoadMargin));
     LOG_IF(FATAL, !conf->GetUInt32Value("copyset.check_loadmargin_interval_ms",
         &copysetNodeOptions->checkLoadMarginIntervalMs));
+    LOG_IF(FATAL, !conf->GetUInt32Value("copyset.sync_concurrency",
+            &copysetNodeOptions->syncConcurrency));
 
     LOG_IF(FATAL, !conf->GetBoolValue(
         "copyset.enable_odsync_when_open_chunkfile",
         &copysetNodeOptions->enableOdsyncWhenOpenChunkFile));
     if (!copysetNodeOptions->enableOdsyncWhenOpenChunkFile) {
-        LOG_IF(FATAL, !conf->GetUInt32Value("copyset.synctimer_interval_ms",
-            &copysetNodeOptions->syncTimerIntervalMs));
+        LOG_IF(FATAL, !conf->GetUInt64Value("copyset.sync_chunk_limits",
+            &copysetNodeOptions->syncChunkLimit));
+        LOG_IF(FATAL, !conf->GetUInt64Value("copyset.sync_threshold",
+            &copysetNodeOptions->syncThreshold));
         LOG_IF(FATAL, !conf->GetUInt32Value("copyset.check_syncing_interval_ms",
             &copysetNodeOptions->checkSyncingIntervalMs));
+        LOG_IF(FATAL, !conf->GetUInt32Value("copyset.sync_trigger_seconds",
+                &copysetNodeOptions->syncTriggerSeconds));
     }
 }
 

--- a/src/chunkserver/config_info.h
+++ b/src/chunkserver/config_info.h
@@ -111,6 +111,10 @@ struct CopysetNodeOptions {
 
     // 限制chunkserver启动时copyset并发恢复加载的数量,为0表示不限制
     uint32_t loadConcurrency = 0;
+    // chunkserver sync_thread_pool number of threads.
+    uint32_t syncConcurrency = 20;
+    // copyset trigger sync timeout
+    uint32_t syncTriggerSeconds = 25;
     // 检查copyset是否加载完成出现异常时的最大重试次数
     // 可能的异常：1.当前大多数副本还没起来；2.网络问题等导致无法获取leader
     // 3.其他的原因导致无法获取到leader的committed index
@@ -123,8 +127,10 @@ struct CopysetNodeOptions {
 
     // enable O_DSYNC when open chunkfile
     bool enableOdsyncWhenOpenChunkFile = false;
-    // sync timer timeout interval
-    uint32_t syncTimerIntervalMs = 30000u;
+    // syncChunkLimit default limit
+    uint64_t syncChunkLimit = 2 * 1024 * 1024;
+    // syncHighChunkLimit default limit = 64k
+    uint64_t syncThreshold = 64 * 1024;
     // check syncing interval
     uint32_t checkSyncingIntervalMs = 500u;
 

--- a/src/chunkserver/copyset_node.cpp
+++ b/src/chunkserver/copyset_node.cpp
@@ -35,10 +35,13 @@
 #include <future>
 #include <deque>
 #include <set>
+#include <chrono>
+#include <condition_variable>
 
 #include "src/chunkserver/raftsnapshot/curve_filesystem_adaptor.h"
 #include "src/chunkserver/chunk_closure.h"
 #include "src/chunkserver/op_request.h"
+#include "src/common/concurrent/task_thread_pool.h"
 #include "src/fs/fs_common.h"
 #include "src/chunkserver/copyset_node_manager.h"
 #include "src/chunkserver/datastore/define.h"
@@ -53,6 +56,10 @@ namespace chunkserver {
 using curve::fs::FileSystemInfo;
 
 const char *kCurveConfEpochFilename = "conf.epoch";
+
+uint32_t CopysetNode::syncTriggerSeconds_ = 25;
+std::shared_ptr<common::TaskThreadPool<>>
+    CopysetNode::copysetSyncPool_ = nullptr;
 
 CopysetNode::CopysetNode(const LogicPoolID &logicPoolId,
                          const CopysetID &copysetId,
@@ -73,7 +80,6 @@ CopysetNode::CopysetNode(const LogicPoolID &logicPoolId,
     lastSnapshotIndex_(0),
     configChange_(std::make_shared<ConfigurationChange>()),
     enableOdsyncWhenOpenChunkFile_(false),
-    syncTimerIntervalMs_(30000),
     isSyncing_(false),
     checkSyncingIntervalMs_(500) {
 }
@@ -134,6 +140,16 @@ int CopysetNode::Init(const CopysetNodeOptions &options) {
                    << "Copyset: " << GroupIdString();
         return -1;
     }
+    enableOdsyncWhenOpenChunkFile_ = options.enableOdsyncWhenOpenChunkFile;
+    if (!enableOdsyncWhenOpenChunkFile_) {
+        syncThread_.Init(this);
+        dataStore_->SetCacheCondPtr(syncThread_.cond_);
+        dataStore_->SetCacheLimits(options.syncChunkLimit,
+            options.syncThreshold);
+        LOG(INFO) << "init sync thread success limit = "
+                  << options.syncChunkLimit <<
+                  "syncthreshold = " << options.syncThreshold;
+    }
 
     recyclerUri_ = options.recyclerUri;
 
@@ -180,9 +196,7 @@ int CopysetNode::Init(const CopysetNodeOptions &options) {
     // without using global variables.
     StoreOptForCurveSegmentLogStorage(lsOptions);
 
-    syncTimerIntervalMs_ = options.syncTimerIntervalMs;
     checkSyncingIntervalMs_ = options.checkSyncingIntervalMs;
-    enableOdsyncWhenOpenChunkFile_ = options.enableOdsyncWhenOpenChunkFile;
 
     return 0;
 }
@@ -194,14 +208,7 @@ int CopysetNode::Run() {
                    << "Copyset: " << GroupIdString();
         return -1;
     }
-
-    if (!enableOdsyncWhenOpenChunkFile_) {
-        CHECK_EQ(0, syncTimer_.init(this, syncTimerIntervalMs_));
-        LOG(INFO) << "Init sync timer success, interval = "
-                  << syncTimerIntervalMs_;
-
-        syncTimer_.start();
-    }
+    syncThread_.Run();
 
     LOG(INFO) << "Run copyset success."
               << "Copyset: " << GroupIdString();
@@ -210,7 +217,7 @@ int CopysetNode::Run() {
 
 void CopysetNode::Fini() {
     if (!enableOdsyncWhenOpenChunkFile_) {
-        syncTimer_.destroy();
+        syncThread_.Stop();
     }
 
     WaitSnapshotDone();
@@ -1007,32 +1014,50 @@ void CopysetNode::SyncAllChunks() {
         curve::common::LockGuard lg(chunkIdsLock_);
         temp.swap(chunkIdsToSync_);
     }
-    size_t total = temp.size();
     std::set<ChunkID> chunkIds;
     for (auto chunkId : temp) {
         chunkIds.insert(chunkId);
     }
     for (ChunkID chunk : chunkIds) {
-        CSErrorCode r = dataStore_->SyncChunk(chunk);
-        if (r != CSErrorCode::Success) {
-            LOG(FATAL) << "Sync Chunk failed in Copyset: "
+        copysetSyncPool_->Enqueue([=]() {
+            CSErrorCode r = dataStore_->SyncChunk(chunk);
+            if (r != CSErrorCode::Success) {
+                LOG(FATAL) << "Sync Chunk failed in Copyset: "
                        << GroupIdString()
                        << ", chunkid: " << chunk
                        << " data store return: " << r;
-        }
+            }
+        });
     }
 }
 
-int SyncTimer::init(CopysetNode *node, int timeoutMs) {
-    if (RepeatedTimerTask::init(timeoutMs) != 0) {
-        return -1;
-    }
+void SyncChunkThread::Init(CopysetNode* node) {
+    running_ = true;
     node_ = node;
-    return 0;
+    cond_ = std::make_shared<std::condition_variable>();
 }
 
-void SyncTimer::run() {
-    node_->HandleSyncTimerOut();
+void SyncChunkThread::Run() {
+    syncThread_ = std::thread([this](){
+        while (running_) {
+            std::unique_lock<std::mutex> lock(mtx_);
+            cond_->wait_for(lock,
+                std::chrono::seconds(CopysetNode::syncTriggerSeconds_));
+            node_->SyncAllChunks();
+        }
+    });
+}
+
+void SyncChunkThread::Stop() {
+    running_ = false;
+    if (syncThread_.joinable()) {
+        cond_->notify_one();
+        syncThread_.join();
+    }
+}
+
+SyncChunkThread::~SyncChunkThread() {
+    Stop();
 }
 
 }  // namespace chunkserver

--- a/src/chunkserver/copyset_node.h
+++ b/src/chunkserver/copyset_node.h
@@ -25,7 +25,9 @@
 
 #include <butil/memory/ref_counted.h>
 #include <braft/repeated_timer_task.h>
+#include <bthread/condition_variable.h>
 
+#include <condition_variable>
 #include <string>
 #include <vector>
 #include <climits>
@@ -41,6 +43,7 @@
 #include "src/chunkserver/raftsnapshot/define.h"
 #include "src/chunkserver/raftsnapshot/curve_snapshot_writer.h"
 #include "src/common/string_util.h"
+#include "src/common/concurrent/task_thread_pool.h"
 #include "src/chunkserver/raft_node.h"
 #include "proto/heartbeat.pb.h"
 #include "proto/chunk.pb.h"
@@ -54,6 +57,7 @@ using ::google::protobuf::RpcController;
 using ::google::protobuf::Closure;
 using ::curve::mds::heartbeat::ConfigChangeType;
 using ::curve::common::Peer;
+using ::curve::common::TaskThreadPool;
 
 class CopysetNodeManager;
 
@@ -104,18 +108,20 @@ class ConfigurationChangeDone : public braft::Closure {
 
 class CopysetNode;
 
-class SyncTimer : public braft::RepeatedTimerTask {
+class SyncChunkThread : public curve::common::Uncopyable {
  public:
-    SyncTimer() : node_(nullptr) {}
-    virtual ~SyncTimer() {}
-
-    int init(CopysetNode *node, int timeoutMs);
-
-    void run() override;
-
- protected:
-    void on_destroy() override {}
-    CopysetNode *node_;
+    friend class CopysetNode;
+    SyncChunkThread() = default;
+    ~SyncChunkThread();
+    void Run();
+    void Init(CopysetNode* node);
+    void Stop();
+ private:
+    bool running_;
+    std::mutex mtx_;
+    std::shared_ptr<std::condition_variable> cond_;
+    std::thread syncThread_;
+    CopysetNode* node_;
 };
 
 /**
@@ -406,6 +412,10 @@ class CopysetNode : public braft::StateMachine,
      * better for test
      */
  public:
+    // sync trigger seconds
+    static uint32_t syncTriggerSeconds_;
+    // shared to sync pool
+    static std::shared_ptr<TaskThreadPool<>> copysetSyncPool_;
     /**
      * 从文件中解析copyset配置版本信息
      * @param filePath:文件路径
@@ -501,10 +511,8 @@ class CopysetNode : public braft::StateMachine,
 
     // enable O_DSYNC when open file
     bool enableOdsyncWhenOpenChunkFile_;
-    // sync chunk timer
-    SyncTimer syncTimer_;
-    // sync timer timeout interval
-    uint32_t syncTimerIntervalMs_;
+    // sync chunk thread
+    SyncChunkThread syncThread_;
     // chunkIds need to sync
     std::deque<ChunkID> chunkIdsToSync_;
     // lock for chunkIdsToSync_

--- a/src/chunkserver/datastore/chunkserver_chunkfile.h
+++ b/src/chunkserver/datastore/chunkserver_chunkfile.h
@@ -30,11 +30,13 @@
 #include <atomic>
 #include <functional>
 #include <memory>
+#include <condition_variable>
 
 #include "include/curve_compiler_specific.h"
 #include "include/chunkserver/chunkserver_common.h"
 #include "src/common/concurrent/rw_lock.h"
 #include "src/common/crc32.h"
+#include "src/common/timeutility.h"
 #include "src/fs/local_filesystem.h"
 #include "src/chunkserver/datastore/filename_operator.h"
 #include "src/chunkserver/datastore/chunkserver_snapshot.h"
@@ -51,6 +53,7 @@ using curve::common::RWLock;
 using curve::common::WriteLockGuard;
 using curve::common::ReadLockGuard;
 using curve::common::BitRange;
+using curve::common::TimeUtility;
 
 class FilePool;
 class CSSnapshot;
@@ -261,6 +264,17 @@ class CSChunkFile {
         metaPage_ = metaPage;
     }
 
+    void SetSyncInfo(std::shared_ptr<std::atomic<uint64_t>> rate,
+        std::shared_ptr<std::condition_variable> cond) {
+        chunkrate_ = rate;
+        cvar_ = cond;
+    }
+
+    // default synclimit
+    static uint64_t syncChunkLimits_;
+    // high threshold limit
+    static uint64_t syncThreshold_;
+
  private:
     /**
      * Determine whether you need to create a new snapshot
@@ -377,7 +391,18 @@ class CSChunkFile {
                common::is_aligned(len, align);
     }
 
+    uint64_t MayUpdateWriteLimits(uint64_t write_len) {
+        if (write_len > syncThreshold_) {
+            return syncChunkLimits_ * 2;
+        }
+        return syncChunkLimits_;
+    }
+
  private:
+    // to notify syncThread
+    std::shared_ptr<std::condition_variable> cvar_;
+    // the sum of every chunkfile length
+    std::shared_ptr<std::atomic<uint64_t>> chunkrate_;
     // file descriptor of chunk file
     int fd_;
     // The logical size of the chunk, not including metapage

--- a/test/chunkserver/chunkserver_test_util.cpp
+++ b/test/chunkserver/chunkserver_test_util.cpp
@@ -35,6 +35,7 @@
 #include <string>
 #include <utility>
 
+#include "src/common/concurrent/task_thread_pool.h"
 #include "src/common/crc32.h"
 #include "src/chunkserver/copyset_node.h"
 #include "src/chunkserver/copyset_node_manager.h"
@@ -286,7 +287,6 @@ int TestCluster::StartPeer(const PeerId &peerId,
     options.snapshotIntervalS = snapshotIntervalS_;
     options.electionTimeoutMs = electionTimeoutMs_;
     options.catchupMargin = catchupMargin_;
-
     peer->options = options;
 
     pid_t pid = ::fork();

--- a/test/chunkserver/copyset_node_manager_test.cpp
+++ b/test/chunkserver/copyset_node_manager_test.cpp
@@ -63,6 +63,7 @@ class CopysetNodeManagerTest : public ::testing::Test {
         defaultOptions_.raftMetaUri = copysetUri;
         defaultOptions_.raftSnapshotUri = copysetUri;
         defaultOptions_.loadConcurrency = 5;
+        defaultOptions_.syncConcurrency = 10;
         defaultOptions_.checkRetryTimes = 3;
         defaultOptions_.finishLoadMargin = 1000;
 

--- a/test/chunkserver/copyset_node_test.cpp
+++ b/test/chunkserver/copyset_node_test.cpp
@@ -131,6 +131,7 @@ class CopysetNodeTest : public ::testing::Test {
         defaultOptions_.raftMetaUri = copysetUri;
         defaultOptions_.raftSnapshotUri = copysetUri;
         defaultOptions_.loadConcurrency = 5;
+        defaultOptions_.syncConcurrency = 20;
         defaultOptions_.checkRetryTimes = 3;
         defaultOptions_.finishLoadMargin = 1000;
 
@@ -274,7 +275,9 @@ TEST_F(CopysetNodeTest, error_test) {
 
         CopysetNode copysetNode(logicPoolID, copysetID, conf);
         defaultOptions_.enableOdsyncWhenOpenChunkFile = false;
-        defaultOptions_.syncTimerIntervalMs = 1000;
+        defaultOptions_.syncConcurrency = 20;
+        defaultOptions_.syncChunkLimit = 2 * 1024 * 1024;
+        defaultOptions_.syncThreshold = 65536;
         ASSERT_EQ(0, copysetNode.Init(defaultOptions_));
         FakeClosure closure;
         FakeSnapshotWriter writer;
@@ -304,7 +307,9 @@ TEST_F(CopysetNodeTest, error_test) {
         CopysetNode copysetNode(logicPoolID, copysetID, conf);
 
         defaultOptions_.enableOdsyncWhenOpenChunkFile = false;
-        defaultOptions_.syncTimerIntervalMs = 1000;
+        defaultOptions_.syncConcurrency = 20;
+        defaultOptions_.syncChunkLimit = 2 * 1024 * 1024;
+        defaultOptions_.syncThreshold = 65536;
         ASSERT_EQ(0, copysetNode.Init(defaultOptions_));
 
         ChunkID id1 = 100;


### PR DESCRIPTION
Signed-off-by: fan <yfan3763@gmail.com>

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #1887 

Problem Summary: see issue.

### What is changed and how it works?

What's Changed:
I use SyncChunkThread instread of the synctimer, Let each write determine on its own whether to notify. and the sumWrite is shared. Default 30s or sum of write >= 4 MB(maybe 4MB is not better) will force sync.
We need **some tests or benchmarks** for this changes to verify this design is better than old synctimer design.

---
And i think 4 MB as the default threshold is not accurate, Maybe we can use ```binary search``` to find the best thredhold for most machines.
