### PR TITLE
curvefs/client: fix umount bug(#1841)

### DIFF
--- a/curvefs/src/client/fuse_s3_client.cpp
+++ b/curvefs/src/client/fuse_s3_client.cpp
@@ -326,8 +326,8 @@ void FuseS3Client::travelChunks(fuse_ino_t ino, google::protobuf::Map<uint64_t,
 void FuseS3Client::UnInit() {
     bgFetchStop_.store(true, std::memory_order_release);
     bgFetchThread_.join();
-    s3Adaptor_->Stop();
     FuseClient::UnInit();
+    s3Adaptor_->Stop();
     curve::common::S3Adapter::Shutdown();
 }
 


### PR DESCRIPTION
stop s3 when where are download because of warmup, so umount will block

signed-off-by: hzwuhongsong hzwuhongsong@corp.netease.com

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #1841  <!-- replace xxx with issue number -->