### PR TITLE
curvefs/client: fix throttle bug

### DIFF
--- a/src/common/leaky_bucket.h
+++ b/src/common/leaky_bucket.h
@@ -51,7 +51,7 @@ struct ThrottleParams {
     // note: the real burst duration will be longer than burstSeconds
     uint64_t burstSeconds;
 
-    ThrottleParams() : ThrottleParams(0, 0, 1) {}
+    ThrottleParams() : ThrottleParams(0, 0, 0) {}
 
     ThrottleParams(uint64_t limit, uint64_t burst, uint64_t burstSeconds)
         : limit(limit), burst(burst), burstSeconds(burstSeconds) {}


### PR DESCRIPTION
burst is 0 but burstlenth is non-zero,so the function of SetLimit not work default.

signed-off-by: hzwuhongsong hzwuhongsong@corp.netease.com

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #xxx <!-- replace xxx with issue number -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
