### PR TITLE
update aws-sdk-cpp: fix s3 range get compatibility issue

### DIFF
--- a/thirdparties/aws/Makefile
+++ b/thirdparties/aws/Makefile
@@ -8,7 +8,7 @@ build: clean download
 
 download: clean
 ifeq ($(tarball), 1)
-	@wget https://curve-build.nos-eastchina1.126.net/aws-sdk-cpp-a2c1674.tar.gz && tar -zxf aws-sdk-cpp-a2c1674.tar.gz
+	@wget https://curve-build.nos-eastchina1.126.net/aws-sdk-cpp-e5be3a1.tar.gz && tar -zxf aws-sdk-cpp-e5be3a1.tar.gz
 else
 	@git submodule update --init --recursive --recommend-shallow --progress -- aws-sdk-cpp
 endif


### PR DESCRIPTION
Signed-off-by: h0hmj <h0hmjcn@gmail.com>

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #xxx <!-- replace xxx with issue number -->

Problem Summary:

aws sdk sdk s3 range get 
1. head -> parse content-length and content-range header
2. split object to to multi part downloads

some s3 backends do not support return content-range when do head request, so request will fail.

### What is changed and how it works?

What's Changed:

remove content-range check, content-length is enough.

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
