### PR TITLE
curvefsd/client: fix bug that read redundant data(#1918)

### DIFF
--- a/curvefs/src/client/s3/client_s3_cache_manager.cpp
+++ b/curvefs/src/client/s3/client_s3_cache_manager.cpp
@@ -616,8 +616,8 @@ class AsyncPrefetchCallback {
 
     void operator()(const S3Adapter *,
                     const std::shared_ptr<GetObjectAsyncContext> &context) {
-        VLOG(9) << "prefetch end: " << context->key << ", len " << context->len;
-
+        VLOG(9) << "prefetch end: " << context->key << ", len " << context->len
+                << "actual len: " <<  context->getActualLen;
         std::unique_ptr<char[]> guard(context->buf);
         auto fileCache =
             s3Client_->GetFsCacheManager()->FindFileCacheManager(inode_);
@@ -635,7 +635,7 @@ class AsyncPrefetchCallback {
         }
 
         int ret = s3Client_->GetDiskCacheManager()->WriteReadDirect(
-            context->key, context->buf, context->len);
+            context->key, context->buf, context->getActualLen);
         if (ret < 0) {
             LOG_EVERY_SECOND(INFO) <<
               "write read directly failed, key: " << context->key;

--- a/src/common/s3_adapter.cpp
+++ b/src/common/s3_adapter.cpp
@@ -469,7 +469,7 @@ void S3Adapter::GetObjectAsync(std::shared_ptr<GetObjectAsyncContext> context) {
                 << "GetObjectAsync error: "
                 << response.GetError().GetExceptionName()
                 << response.GetError().GetMessage();
-
+            ctx->getActualLen = response.GetResult().GetContentLength();
             ctx->retCode = (response.IsSuccess() ? 0 : -1);
             asyncCallbackTP_.Enqueue(ctx->cb, this, ctx);
         };

--- a/src/common/s3_adapter.h
+++ b/src/common/s3_adapter.h
@@ -118,6 +118,7 @@ struct GetObjectAsyncContext : public Aws::Client::AsyncCallerContext {
     size_t len;
     GetObjectAsyncCallBack cb;
     int retCode;
+    size_t getActualLen;
 };
 
 /*
@@ -253,7 +254,6 @@ class S3Adapter {
      * @param context 异步上下文
      */
     virtual void GetObjectAsync(std::shared_ptr<GetObjectAsyncContext> context);
-
     /**
      * 删除对象
      * @param 对象名


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

Issue Number: #1918  <!-- replace xxx with issue number -->

Problem Summary:

when use S3, a block is the most basic units to split the file. so the context->len we will fill is larger than blockSize in the fuction of ReadFromS3. so even when the s3 obj is less than blockSize, the context->len is set to blockSize, and we will pass context->len to the WriteReadDirect

