### PR TITLE
curvefs: fix refresh inode will overwrite data in cache when enabel cto.

### DIFF
--- a/curvefs/conf/client.conf
+++ b/curvefs/conf/client.conf
@@ -90,7 +90,7 @@ fuseClient.iCacheLruSize=65536
 fuseClient.dCacheLruSize=65536
 fuseClient.enableICacheMetrics=true
 fuseClient.enableDCacheMetrics=true
-fuseClient.cto=false
+fuseClient.cto=true
 # you shoudle enable it when mount one filesystem to multi mountpoints,
 # it gurantee the consistent of file after rename, otherwise you should
 # disable it for performance.

--- a/curvefs/src/client/curve_fuse_op.cpp
+++ b/curvefs/src/client/curve_fuse_op.cpp
@@ -359,8 +359,6 @@ void FuseOpOpen(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi) {
         FuseReplyErrByErrCode(req, ret);
         return;
     }
-    // set fh to 1 to indicate needn't refresh inode when file is still opened
-    fi->fh = static_cast<uint64_t>(FileHandle::kKeepCache);
     fuse_reply_open(req, fi);
 }
 

--- a/curvefs/src/client/inode_cache_manager.h
+++ b/curvefs/src/client/inode_cache_manager.h
@@ -130,11 +130,9 @@ class InodeCacheManager {
 
     virtual void Stop() = 0;
 
-    virtual CURVEFS_ERROR
-    GetInode(uint64_t inodeId,
-             std::shared_ptr<InodeWrapper> &out) = 0;  // NOLINT
-
-    virtual CURVEFS_ERROR RefreshInode(uint64_t inodeId) = 0;
+    virtual CURVEFS_ERROR GetInode(uint64_t inodeId,
+             std::shared_ptr<InodeWrapper> &out,  // NOLINT
+             bool ctoCached = false) = 0;
 
     virtual CURVEFS_ERROR GetInodeAttr(uint64_t inodeId, InodeAttr *out) = 0;
 
@@ -224,9 +222,8 @@ class InodeCacheManagerImpl : public InodeCacheManager,
     }
 
     CURVEFS_ERROR GetInode(uint64_t inodeId,
-                           std::shared_ptr<InodeWrapper> &out) override;
-
-    CURVEFS_ERROR RefreshInode(uint64_t inodeId) override;
+                           std::shared_ptr<InodeWrapper> &out,
+                           bool ctoCached = false) override;
 
     CURVEFS_ERROR GetInodeAttr(uint64_t inodeId, InodeAttr *out) override;
 

--- a/curvefs/test/client/client_s3_adaptor_Integration.cpp
+++ b/curvefs/test/client/client_s3_adaptor_Integration.cpp
@@ -359,7 +359,7 @@ TEST_F(ClientS3IntegrationTest, test_read_one_chunk) {
     EXPECT_CALL(mockS3Client_, Download(_, _, _, _))
         .WillOnce(DoAll(SetArgPointee<1>(*tmpbuf), Return(1 * 1024 * 1024)))
         .WillOnce(Return(-1));
-    EXPECT_CALL(mockInodeManager_, GetInode(_, _))
+    EXPECT_CALL(mockInodeManager_, GetInode(_, _, _))
         .WillOnce(
             DoAll(SetArgReferee<1>(inode), Return(CURVEFS_ERROR::OK)))
         .WillOnce(
@@ -653,7 +653,7 @@ TEST_F(ClientS3IntegrationTest, test_read_hole1) {
         .WillRepeatedly(Invoke(S3Upload));
     EXPECT_CALL(mockS3Client_, Download(_, _, _, _))
         .WillRepeatedly(Invoke(S3Download));
-    EXPECT_CALL(mockInodeManager_, GetInode(_, _))
+    EXPECT_CALL(mockInodeManager_, GetInode(_, _, _))
         .WillOnce(
             DoAll(SetArgReferee<1>(inode), Return(CURVEFS_ERROR::OK)))
         .WillOnce(
@@ -701,7 +701,7 @@ TEST_F(ClientS3IntegrationTest, test_read_hole2) {
         .WillRepeatedly(Invoke(S3Upload));
     EXPECT_CALL(mockS3Client_, Download(_, _, _, _))
         .WillRepeatedly(Invoke(S3Download));
-    EXPECT_CALL(mockInodeManager_, GetInode(_, _))
+    EXPECT_CALL(mockInodeManager_, GetInode(_, _, _))
         .WillOnce(
             DoAll(SetArgReferee<1>(inode), Return(CURVEFS_ERROR::OK)));
     s3ClientAdaptor_->Write(inode->GetInodeId(), offset, len, buf);
@@ -743,7 +743,7 @@ TEST_F(ClientS3IntegrationTest, test_read_hole3) {
         .WillRepeatedly(Invoke(S3Upload));
     EXPECT_CALL(mockS3Client_, Download(_, _, _, _))
         .WillRepeatedly(Invoke(S3Download));
-    EXPECT_CALL(mockInodeManager_, GetInode(_, _))
+    EXPECT_CALL(mockInodeManager_, GetInode(_, _, _))
         .WillOnce(
             DoAll(SetArgReferee<1>(inode), Return(CURVEFS_ERROR::OK)));
     s3ClientAdaptor_->Write(inode->GetInodeId(), offset, len, buf);
@@ -785,7 +785,7 @@ TEST_F(ClientS3IntegrationTest, test_read_hole4) {
         .WillRepeatedly(Invoke(S3Upload));
     EXPECT_CALL(mockS3Client_, Download(_, _, _, _))
         .WillRepeatedly(Invoke(S3Download));
-    EXPECT_CALL(mockInodeManager_, GetInode(_, _))
+    EXPECT_CALL(mockInodeManager_, GetInode(_, _, _))
         .WillOnce(
             DoAll(SetArgReferee<1>(inode), Return(CURVEFS_ERROR::OK)));
     s3ClientAdaptor_->Write(inode->GetInodeId(), offset, len, buf);
@@ -835,7 +835,7 @@ TEST_F(ClientS3IntegrationTest, test_read_more_write) {
         .WillRepeatedly(Invoke(S3Upload));
     EXPECT_CALL(mockS3Client_, Download(_, _, _, _))
         .WillRepeatedly(Invoke(S3Download));
-    EXPECT_CALL(mockInodeManager_, GetInode(_, _))
+    EXPECT_CALL(mockInodeManager_, GetInode(_, _, _))
         .WillOnce(
             DoAll(SetArgReferee<1>(inode), Return(CURVEFS_ERROR::OK)));
     s3ClientAdaptor_->Write(inode->GetInodeId(), offset, len, buf);
@@ -1057,7 +1057,7 @@ TEST_F(ClientS3IntegrationTest, test_truncate_small3) {
         .WillRepeatedly(Invoke(S3Upload));
     EXPECT_CALL(mockS3Client_, Download(_, _, _, _))
         .WillRepeatedly(Invoke(S3Download));
-    EXPECT_CALL(mockInodeManager_, GetInode(_, _))
+    EXPECT_CALL(mockInodeManager_, GetInode(_, _, _))
         .WillRepeatedly(
             DoAll(SetArgReferee<1>(inode), Return(CURVEFS_ERROR::OK)));
     EXPECT_CALL(mockS3Client_, UploadAsync(_))
@@ -1117,7 +1117,7 @@ TEST_F(ClientS3IntegrationTest, test_truncate_big1) {
     CURVEFS_ERROR ret;
     uint64_t chunkIndex = offset / s3ClientAdaptor_->GetChunkSize();
     //  mock
-    EXPECT_CALL(mockInodeManager_, GetInode(_, _))
+    EXPECT_CALL(mockInodeManager_, GetInode(_, _, _))
         .WillOnce(
             DoAll(SetArgReferee<1>(inode), Return(CURVEFS_ERROR::OK)));
     ret = s3ClientAdaptor_->Truncate(inode.get(), len);
@@ -1162,7 +1162,7 @@ TEST_F(ClientS3IntegrationTest, test_truncate_big2) {
     memset(buf, 'a', len);
     uint64_t chunkIndex = offset / s3ClientAdaptor_->GetChunkSize();
 
-    EXPECT_CALL(mockInodeManager_, GetInode(_, _))
+    EXPECT_CALL(mockInodeManager_, GetInode(_, _, _))
         .WillOnce(
             DoAll(SetArgReferee<1>(inode), Return(CURVEFS_ERROR::OK)));
     s3ClientAdaptor_->Write(inode->GetInodeId(), offset, len, buf);
@@ -1210,7 +1210,7 @@ TEST_F(ClientS3IntegrationTest, test_truncate_big3) {
     CURVEFS_ERROR ret;
     uint64_t chunkIndex = offset / s3ClientAdaptor_->GetChunkSize();
     //  mock
-    EXPECT_CALL(mockInodeManager_, GetInode(_, _))
+    EXPECT_CALL(mockInodeManager_, GetInode(_, _, _))
         .WillRepeatedly(
             DoAll(SetArgReferee<1>(inode), Return(CURVEFS_ERROR::OK)));
 
@@ -1333,7 +1333,7 @@ TEST_F(ClientS3IntegrationTest, test_flush_first_write) {
                 context->retCode = 0;
                 context->cb(context);
             }));
-    EXPECT_CALL(mockInodeManager_, GetInode(_, _))
+    EXPECT_CALL(mockInodeManager_, GetInode(_, _, _))
         .WillRepeatedly(
             DoAll(SetArgReferee<1>(inode), Return(CURVEFS_ERROR::OK)));
     CURVEFS_ERROR ret = s3ClientAdaptor_->Flush(inode->GetInodeId());
@@ -1385,7 +1385,7 @@ TEST_F(ClientS3IntegrationTest, test_flush_overlap_write) {
             DoAll(SetArgPointee<1>(chunkId), Return(FSStatusCode::OK)));
     EXPECT_CALL(mockS3Client_, Upload(_, _, _))
         .WillRepeatedly(Return(1 * 1024 * 1024));
-    EXPECT_CALL(mockInodeManager_, GetInode(_, _))
+    EXPECT_CALL(mockInodeManager_, GetInode(_, _, _))
         .WillRepeatedly(
             DoAll(SetArgReferee<1>(inode), Return(CURVEFS_ERROR::OK)));
     EXPECT_CALL(mockS3Client_, UploadAsync(_))
@@ -1439,7 +1439,7 @@ TEST_F(ClientS3IntegrationTest, test_flush_overlap_write2) {
     EXPECT_CALL(mockMdsClient_, AllocS3ChunkId(_, _))
         .WillRepeatedly(
             DoAll(SetArgPointee<1>(chunkId), Return(FSStatusCode::OK)));
-    EXPECT_CALL(mockInodeManager_, GetInode(_, _))
+    EXPECT_CALL(mockInodeManager_, GetInode(_, _, _))
         .WillRepeatedly(
             DoAll(SetArgReferee<1>(inode), Return(CURVEFS_ERROR::OK)));
     EXPECT_CALL(mockS3Client_, UploadAsync(_))
@@ -1498,7 +1498,7 @@ TEST_F(ClientS3IntegrationTest, test_flush_hole_write) {
             DoAll(SetArgPointee<1>(chunkId), Return(FSStatusCode::OK)));
     EXPECT_CALL(mockS3Client_, Upload(_, _, _))
         .WillRepeatedly(Return(1 * 1024 * 1024));
-    EXPECT_CALL(mockInodeManager_, GetInode(_, _))
+    EXPECT_CALL(mockInodeManager_, GetInode(_, _, _))
         .WillRepeatedly(
             DoAll(SetArgReferee<1>(inode), Return(CURVEFS_ERROR::OK)));
     EXPECT_CALL(mockS3Client_, UploadAsync(_))
@@ -1557,7 +1557,7 @@ TEST_F(ClientS3IntegrationTest, test_flush_write_more_chunk) {
             DoAll(SetArgPointee<1>(chunkId), Return(FSStatusCode::OK)));
     EXPECT_CALL(mockS3Client_, Upload(_, _, _))
         .WillRepeatedly(Return(1 * 1024 * 1024));
-    EXPECT_CALL(mockInodeManager_, GetInode(_, _))
+    EXPECT_CALL(mockInodeManager_, GetInode(_, _, _))
         .WillRepeatedly(
             DoAll(SetArgReferee<1>(inode), Return(CURVEFS_ERROR::OK)));
     EXPECT_CALL(mockS3Client_, UploadAsync(_))
@@ -1625,7 +1625,7 @@ TEST_F(ClientS3IntegrationTest, test_flush_write_and_read1) {
         .WillRepeatedly(Invoke(S3Upload));
     EXPECT_CALL(mockS3Client_, Download(_, _, _, _))
         .WillRepeatedly(Invoke(S3Download));
-    EXPECT_CALL(mockInodeManager_, GetInode(_, _))
+    EXPECT_CALL(mockInodeManager_, GetInode(_, _, _))
         .WillRepeatedly(
             DoAll(SetArgReferee<1>(inode), Return(CURVEFS_ERROR::OK)));
     EXPECT_CALL(mockS3Client_, UploadAsync(_))
@@ -1705,7 +1705,7 @@ TEST_F(ClientS3IntegrationTest, test_flush_write_and_read2) {
         .WillRepeatedly(Invoke(S3Upload));
     EXPECT_CALL(mockS3Client_, Download(_, _, _, _))
         .WillRepeatedly(Invoke(S3Download));
-    EXPECT_CALL(mockInodeManager_, GetInode(_, _))
+    EXPECT_CALL(mockInodeManager_, GetInode(_, _, _))
         .WillRepeatedly(
             DoAll(SetArgReferee<1>(inode), Return(CURVEFS_ERROR::OK)));
     EXPECT_CALL(mockS3Client_, UploadAsync(_))
@@ -1788,7 +1788,7 @@ TEST_F(ClientS3IntegrationTest, test_flush_write_and_read3) {
         .WillRepeatedly(Invoke(S3Upload));
     EXPECT_CALL(mockS3Client_, Download(_, _, _, _))
         .WillRepeatedly(Invoke(S3Download));
-    EXPECT_CALL(mockInodeManager_, GetInode(_, _))
+    EXPECT_CALL(mockInodeManager_, GetInode(_, _, _))
         .WillRepeatedly(
             DoAll(SetArgReferee<1>(inode), Return(CURVEFS_ERROR::OK)));
     EXPECT_CALL(mockS3Client_, UploadAsync(_))
@@ -1892,7 +1892,7 @@ TEST_F(ClientS3IntegrationTest, test_flush_write_and_read4) {
         .WillRepeatedly(Invoke(S3Upload));
     EXPECT_CALL(mockS3Client_, Download(_, _, _, _))
         .WillRepeatedly(Invoke(S3Download));
-    EXPECT_CALL(mockInodeManager_, GetInode(_, _))
+    EXPECT_CALL(mockInodeManager_, GetInode(_, _, _))
         .WillRepeatedly(
             DoAll(SetArgReferee<1>(inode), Return(CURVEFS_ERROR::OK)));
     EXPECT_CALL(mockS3Client_, UploadAsync(_))
@@ -1971,7 +1971,7 @@ TEST_F(ClientS3IntegrationTest, test_flush_write_and_read5) {
         .WillRepeatedly(Invoke(S3Upload));
     EXPECT_CALL(mockS3Client_, Download(_, _, _, _))
         .WillRepeatedly(Invoke(S3Download));
-    EXPECT_CALL(mockInodeManager_, GetInode(_, _))
+    EXPECT_CALL(mockInodeManager_, GetInode(_, _, _))
         .WillRepeatedly(
             DoAll(SetArgReferee<1>(inode), Return(CURVEFS_ERROR::OK)));
     EXPECT_CALL(mockS3Client_, UploadAsync(_))
@@ -2064,7 +2064,7 @@ TEST_F(ClientS3IntegrationTest, test_flush_write_and_read6) {
         .WillRepeatedly(Invoke(S3Upload));
     EXPECT_CALL(mockS3Client_, Download(_, _, _, _))
         .WillRepeatedly(Invoke(S3Download));
-    EXPECT_CALL(mockInodeManager_, GetInode(_, _))
+    EXPECT_CALL(mockInodeManager_, GetInode(_, _, _))
         .WillRepeatedly(
             DoAll(SetArgReferee<1>(inode), Return(CURVEFS_ERROR::OK)));
     EXPECT_CALL(mockS3Client_, UploadAsync(_))
@@ -2156,7 +2156,7 @@ TEST_F(ClientS3IntegrationTest, test_flush_write_and_read7) {
         .WillRepeatedly(Invoke(S3Upload));
     EXPECT_CALL(mockS3Client_, Download(_, _, _, _))
         .WillRepeatedly(Invoke(S3Download));
-    EXPECT_CALL(mockInodeManager_, GetInode(_, _))
+    EXPECT_CALL(mockInodeManager_, GetInode(_, _, _))
         .WillRepeatedly(
             DoAll(SetArgReferee<1>(inode), Return(CURVEFS_ERROR::OK)));
     EXPECT_CALL(mockS3Client_, UploadAsync(_))
@@ -2251,7 +2251,7 @@ TEST_F(ClientS3IntegrationTest, test_flush_write_and_read8) {
         .WillRepeatedly(Invoke(S3Upload));
     EXPECT_CALL(mockS3Client_, Download(_, _, _, _))
         .WillRepeatedly(Invoke(S3Download));
-    EXPECT_CALL(mockInodeManager_, GetInode(_, _))
+    EXPECT_CALL(mockInodeManager_, GetInode(_, _, _))
         .WillRepeatedly(
             DoAll(SetArgReferee<1>(inode), Return(CURVEFS_ERROR::OK)));
     EXPECT_CALL(mockS3Client_, UploadAsync(_))
@@ -2344,7 +2344,7 @@ TEST_F(ClientS3IntegrationTest, test_flush_write_and_read9) {
         .WillRepeatedly(Invoke(S3Upload));
     EXPECT_CALL(mockS3Client_, Download(_, _, _, _))
         .WillRepeatedly(Invoke(S3Download));
-    EXPECT_CALL(mockInodeManager_, GetInode(_, _))
+    EXPECT_CALL(mockInodeManager_, GetInode(_, _, _))
         .WillRepeatedly(
             DoAll(SetArgReferee<1>(inode), Return(CURVEFS_ERROR::OK)));
     EXPECT_CALL(mockS3Client_, UploadAsync(_))
@@ -2446,7 +2446,7 @@ TEST_F(ClientS3IntegrationTest, test_flush_write_and_read10) {
         .WillRepeatedly(Invoke(S3Upload));
     EXPECT_CALL(mockS3Client_, Download(_, _, _, _))
         .WillRepeatedly(Invoke(S3Download));
-    EXPECT_CALL(mockInodeManager_, GetInode(_, _))
+    EXPECT_CALL(mockInodeManager_, GetInode(_, _, _))
         .WillRepeatedly(
             DoAll(SetArgReferee<1>(inode), Return(CURVEFS_ERROR::OK)));
     EXPECT_CALL(mockS3Client_, UploadAsync(_))
@@ -2560,7 +2560,7 @@ TEST_F(ClientS3IntegrationTest, test_flush_write_and_read11) {
         .WillRepeatedly(Invoke(S3Upload));
     EXPECT_CALL(mockS3Client_, Download(_, _, _, _))
         .WillRepeatedly(Invoke(S3Download));
-    EXPECT_CALL(mockInodeManager_, GetInode(_, _))
+    EXPECT_CALL(mockInodeManager_, GetInode(_, _, _))
         .WillRepeatedly(
             DoAll(SetArgReferee<1>(inode), Return(CURVEFS_ERROR::OK)));
     EXPECT_CALL(mockS3Client_, UploadAsync(_))
@@ -2644,7 +2644,7 @@ TEST_F(ClientS3IntegrationTest, test_flush_write_and_read12) {
         .WillRepeatedly(Invoke(S3Upload));
     EXPECT_CALL(mockS3Client_, Download(_, _, _, _))
         .WillRepeatedly(Invoke(S3Download));
-    EXPECT_CALL(mockInodeManager_, GetInode(_, _))
+    EXPECT_CALL(mockInodeManager_, GetInode(_, _, _))
         .WillRepeatedly(
             DoAll(SetArgReferee<1>(inode), Return(CURVEFS_ERROR::OK)));
     EXPECT_CALL(mockS3Client_, UploadAsync(_))
@@ -2722,7 +2722,7 @@ TEST_F(ClientS3IntegrationTest, test_fssync_success_and_fail) {
         .WillRepeatedly(
             DoAll(SetArgPointee<1>(chunkId), Return(FSStatusCode::OK)));
 
-    EXPECT_CALL(mockInodeManager_, GetInode(_, _))
+    EXPECT_CALL(mockInodeManager_, GetInode(_, _, _))
         .WillOnce(
             DoAll(SetArgReferee<1>(inode), Return(CURVEFS_ERROR::OK)))
         .WillOnce(DoAll(SetArgReferee<1>(inode),
@@ -2784,7 +2784,7 @@ TEST_F(ClientS3IntegrationTest, test_fssync_overlap_write) {
         .WillOnce(DoAll(SetArgPointee<1>(chunkId), Return(FSStatusCode::OK)));
     EXPECT_CALL(mockS3Client_, Upload(_, _, _))
         .WillRepeatedly(Return(1 * 1024 * 1024));
-    EXPECT_CALL(mockInodeManager_, GetInode(_, _))
+    EXPECT_CALL(mockInodeManager_, GetInode(_, _, _))
         .WillOnce(
             DoAll(SetArgReferee<1>(inode), Return(CURVEFS_ERROR::OK)));
     EXPECT_CALL(mockS3Client_, UploadAsync(_))

--- a/curvefs/test/client/file_cache_manager_test.cpp
+++ b/curvefs/test/client/file_cache_manager_test.cpp
@@ -196,7 +196,7 @@ TEST_F(FileCacheManagerTest, test_read_getinode_fail) {
     EXPECT_CALL(*mockChunkCacheManager_, ReadByReadCache(_, _, _, _, _))
         .WillOnce(DoAll(SetArgPointee<4>(requests), Return()));
     fileCacheManager_->SetChunkCacheManagerForTest(0, mockChunkCacheManager_);
-    EXPECT_CALL(*mockInodeManager_, GetInode(_, _))
+    EXPECT_CALL(*mockInodeManager_, GetInode(_, _, _))
         .WillOnce(Return(CURVEFS_ERROR::NOTEXIST));
     ASSERT_EQ(-1, fileCacheManager_->Read(inodeId, offset, len, buf));
 }
@@ -239,7 +239,7 @@ TEST_F(FileCacheManagerTest, test_read_s3) {
     s3ChunkInfo->set_zero(false);
     s3ChunkInfoMap->insert({0, *s3ChunkInfoList});
     auto inodeWrapper = std::make_shared<InodeWrapper>(inode, nullptr);
-    EXPECT_CALL(*mockInodeManager_, GetInode(_, _))
+    EXPECT_CALL(*mockInodeManager_, GetInode(_, _, _))
         .WillOnce(
             DoAll(SetArgReferee<1>(inodeWrapper), Return(CURVEFS_ERROR::OK)))
         .WillOnce(

--- a/curvefs/test/client/mock_inode_cache_manager.h
+++ b/curvefs/test/client/mock_inode_cache_manager.h
@@ -47,14 +47,12 @@ class MockInodeCacheManager : public InodeCacheManager {
 
     MOCK_METHOD0(Stop, void());
 
-    MOCK_METHOD2(GetInode,
-                 CURVEFS_ERROR(uint64_t inodeId,
-                               std::shared_ptr<InodeWrapper> &out));  // NOLINT
+    MOCK_METHOD3(GetInode, CURVEFS_ERROR(
+        uint64_t inodeId, std::shared_ptr<InodeWrapper> &out,  // NOLINT
+        bool ctoCached));
 
     MOCK_METHOD2(GetInodeAttr, CURVEFS_ERROR(
         uint64_t inodeId, InodeAttr *out));
-
-    MOCK_METHOD1(RefreshInode, CURVEFS_ERROR(uint64_t inodeId));
 
     MOCK_METHOD2(BatchGetInodeAttr, CURVEFS_ERROR(
         std::set<uint64_t> *inodeIds, std::list<InodeAttr> *attrs));

--- a/curvefs/test/client/test_fuse_client.cpp
+++ b/curvefs/test/client/test_fuse_client.cpp
@@ -348,7 +348,7 @@ TEST_F(TestFuseVolumeClient, FuseOpOpen) {
     inode.set_type(FsFileType::TYPE_FILE);
     auto inodeWrapper = std::make_shared<InodeWrapper>(inode, metaClient_);
 
-    EXPECT_CALL(*inodeManager_, GetInode(ino, _))
+    EXPECT_CALL(*inodeManager_, GetInode(ino, _, _))
         .WillOnce(
             DoAll(SetArgReferee<1>(inodeWrapper), Return(CURVEFS_ERROR::OK)));
 
@@ -369,7 +369,7 @@ TEST_F(TestFuseVolumeClient, FuseOpOpenFailed) {
     inode.set_type(FsFileType::TYPE_FILE);
     auto inodeWrapper = std::make_shared<InodeWrapper>(inode, metaClient_);
 
-    EXPECT_CALL(*inodeManager_, GetInode(ino, _))
+    EXPECT_CALL(*inodeManager_, GetInode(ino, _, _))
         .WillOnce(Return(CURVEFS_ERROR::INTERNAL));
 
     CURVEFS_ERROR ret = client_->FuseOpOpen(req, ino, &fi);
@@ -409,7 +409,7 @@ TEST_F(TestFuseVolumeClient, FuseOpCreate) {
     parentInode.set_nlink(2);
     auto parentInodeWrapper =
         std::make_shared<InodeWrapper>(parentInode, metaClient_);
-    EXPECT_CALL(*inodeManager_, GetInode(_, _))
+    EXPECT_CALL(*inodeManager_, GetInode(_, _, _))
         .WillOnce(DoAll(SetArgReferee<1>(parentInodeWrapper),
                         Return(CURVEFS_ERROR::OK)))
         .WillOnce(
@@ -453,7 +453,7 @@ TEST_F(TestFuseVolumeClient, FuseOpMkDir) {
     parentInode.set_nlink(2);
     auto parentInodeWrapper =
         std::make_shared<InodeWrapper>(parentInode, metaClient_);
-    EXPECT_CALL(*inodeManager_, GetInode(_, _))
+    EXPECT_CALL(*inodeManager_, GetInode(_, _, _))
         .WillOnce(DoAll(SetArgReferee<1>(parentInodeWrapper),
                         Return(CURVEFS_ERROR::OK)));
 
@@ -550,7 +550,7 @@ TEST_F(TestFuseVolumeClient, FuseOpUnlink) {
     auto parentInodeWrapper =
         std::make_shared<InodeWrapper>(parentInode, metaClient_);
 
-    EXPECT_CALL(*inodeManager_, GetInode(_, _))
+    EXPECT_CALL(*inodeManager_, GetInode(_, _, _))
         .WillOnce(DoAll(SetArgReferee<1>(parentInodeWrapper),
                         Return(CURVEFS_ERROR::OK)))
         .WillOnce(
@@ -604,7 +604,7 @@ TEST_F(TestFuseVolumeClient, FuseOpRmDir) {
     auto parentInodeWrapper =
         std::make_shared<InodeWrapper>(parentInode, metaClient_);
 
-    EXPECT_CALL(*inodeManager_, GetInode(_, _))
+    EXPECT_CALL(*inodeManager_, GetInode(_, _, _))
         .WillOnce(DoAll(SetArgReferee<1>(parentInodeWrapper),
                         Return(CURVEFS_ERROR::OK)))
         .WillOnce(
@@ -665,7 +665,7 @@ TEST_F(TestFuseVolumeClient, FuseOpUnlinkFailed) {
     auto parentInodeWrapper =
         std::make_shared<InodeWrapper>(parentInode, metaClient_);
 
-    EXPECT_CALL(*inodeManager_, GetInode(_, _))
+    EXPECT_CALL(*inodeManager_, GetInode(_, _, _))
         .WillOnce(DoAll(SetArgReferee<1>(parentInodeWrapper),
                         Return(CURVEFS_ERROR::OK)))
         .WillOnce(Return(CURVEFS_ERROR::INTERNAL))
@@ -713,7 +713,7 @@ TEST_F(TestFuseVolumeClient, FuseOpOpenDir) {
     inode.set_type(FsFileType::TYPE_DIRECTORY);
     auto inodeWrapper = std::make_shared<InodeWrapper>(inode, metaClient_);
 
-    EXPECT_CALL(*inodeManager_, GetInode(ino, _))
+    EXPECT_CALL(*inodeManager_, GetInode(ino, _, _))
         .WillOnce(
             DoAll(SetArgReferee<1>(inodeWrapper), Return(CURVEFS_ERROR::OK)));
 
@@ -733,7 +733,7 @@ TEST_F(TestFuseVolumeClient, FuseOpOpenDirFaild) {
     inode.set_type(FsFileType::TYPE_DIRECTORY);
     auto inodeWrapper = std::make_shared<InodeWrapper>(inode, metaClient_);
 
-    EXPECT_CALL(*inodeManager_, GetInode(ino, _))
+    EXPECT_CALL(*inodeManager_, GetInode(ino, _, _))
         .WillOnce(DoAll(SetArgReferee<1>(inodeWrapper),
                         Return(CURVEFS_ERROR::INTERNAL)));
 
@@ -759,7 +759,7 @@ TEST_F(TestFuseVolumeClient, FuseOpOpenAndFuseOpReadDir) {
     inode.set_type(FsFileType::TYPE_DIRECTORY);
     auto inodeWrapper = std::make_shared<InodeWrapper>(inode, metaClient_);
 
-    EXPECT_CALL(*inodeManager_, GetInode(ino, _))
+    EXPECT_CALL(*inodeManager_, GetInode(ino, _, _))
         .Times(2)
         .WillRepeatedly(
             DoAll(SetArgReferee<1>(inodeWrapper), Return(CURVEFS_ERROR::OK)));
@@ -805,7 +805,7 @@ TEST_F(TestFuseVolumeClient, FuseOpOpenAndFuseOpReadDirFailed) {
     inode.set_type(FsFileType::TYPE_DIRECTORY);
     auto inodeWrapper = std::make_shared<InodeWrapper>(inode, metaClient_);
 
-    EXPECT_CALL(*inodeManager_, GetInode(ino, _))
+    EXPECT_CALL(*inodeManager_, GetInode(ino, _, _))
         .Times(2)
         .WillRepeatedly(
             DoAll(SetArgReferee<1>(inodeWrapper), Return(CURVEFS_ERROR::OK)));
@@ -856,7 +856,7 @@ TEST_F(TestFuseVolumeClient, FuseOpRenameBasic) {
     destParentInode.set_nlink(2);
     auto inodeWrapper =
         std::make_shared<InodeWrapper>(destParentInode, metaClient_);
-    EXPECT_CALL(*inodeManager_, GetInode(newparent, _))
+    EXPECT_CALL(*inodeManager_, GetInode(newparent, _, _))
         .WillOnce(DoAll(SetArgReferee<1>(inodeWrapper),
                   Return(CURVEFS_ERROR::OK)));
     // include below unlink operate and update inode parent
@@ -914,7 +914,7 @@ TEST_F(TestFuseVolumeClient, FuseOpRenameBasic) {
     srcParentInode.set_inodeid(parent);
     srcParentInode.set_nlink(3);
     inodeWrapper = std::make_shared<InodeWrapper>(srcParentInode, metaClient_);
-    EXPECT_CALL(*inodeManager_, GetInode(parent, _))
+    EXPECT_CALL(*inodeManager_, GetInode(parent, _, _))
         .WillOnce(DoAll(SetArgReferee<1>(inodeWrapper),
                   Return(CURVEFS_ERROR::OK)));
 
@@ -923,7 +923,7 @@ TEST_F(TestFuseVolumeClient, FuseOpRenameBasic) {
     InodeInfo.set_inodeid(inodeId);
     InodeInfo.add_parent(parent);
     inodeWrapper = std::make_shared<InodeWrapper>(InodeInfo, metaClient_);
-    EXPECT_CALL(*inodeManager_, GetInode(inodeId, _))
+    EXPECT_CALL(*inodeManager_, GetInode(inodeId, _, _))
         .WillOnce(DoAll(SetArgReferee<1>(inodeWrapper),
                   Return(CURVEFS_ERROR::OK)));
 
@@ -970,7 +970,7 @@ TEST_F(TestFuseVolumeClient, FuseOpRenameOverwrite) {
     destParentInode.set_nlink(2);
     auto inodeWrapper =
         std::make_shared<InodeWrapper>(destParentInode, metaClient_);
-    EXPECT_CALL(*inodeManager_, GetInode(newparent, _))
+    EXPECT_CALL(*inodeManager_, GetInode(newparent, _, _))
         .WillOnce(DoAll(SetArgReferee<1>(inodeWrapper),
                   Return(CURVEFS_ERROR::OK)));
 
@@ -1018,7 +1018,7 @@ TEST_F(TestFuseVolumeClient, FuseOpRenameOverwrite) {
     srcParentInode.set_nlink(3);
     inodeWrapper =
         std::make_shared<InodeWrapper>(srcParentInode, metaClient_);
-    EXPECT_CALL(*inodeManager_, GetInode(parent, _))
+    EXPECT_CALL(*inodeManager_, GetInode(parent, _, _))
         .WillOnce(DoAll(SetArgReferee<1>(inodeWrapper),
                   Return(CURVEFS_ERROR::OK)));
     // include below unlink old inode and update inode parent
@@ -1038,7 +1038,7 @@ TEST_F(TestFuseVolumeClient, FuseOpRenameOverwrite) {
     inode.set_inodeid(oldInodeId);
     inode.set_nlink(1);
     inodeWrapper = std::make_shared<InodeWrapper>(inode, metaClient_);
-    EXPECT_CALL(*inodeManager_, GetInode(oldInodeId, _))
+    EXPECT_CALL(*inodeManager_, GetInode(oldInodeId, _, _))
         .Times(2)
         .WillRepeatedly(DoAll(SetArgReferee<1>(inodeWrapper),
                   Return(CURVEFS_ERROR::OK)));
@@ -1048,7 +1048,7 @@ TEST_F(TestFuseVolumeClient, FuseOpRenameOverwrite) {
     InodeInfo.set_inodeid(inodeId);
     InodeInfo.add_parent(parent);
     inodeWrapper = std::make_shared<InodeWrapper>(InodeInfo, metaClient_);
-    EXPECT_CALL(*inodeManager_, GetInode(inodeId, _))
+    EXPECT_CALL(*inodeManager_, GetInode(inodeId, _, _))
         .WillOnce(DoAll(SetArgReferee<1>(inodeWrapper),
                   Return(CURVEFS_ERROR::OK)));
 
@@ -1173,7 +1173,7 @@ TEST_F(TestFuseVolumeClient, FuseOpRenameParallel) {
     srcParentInode.set_nlink(times + 2);
     auto srcParentInodeWrapper =
         std::make_shared<InodeWrapper>(srcParentInode, metaClient_);
-    EXPECT_CALL(*inodeManager_, GetInode(srcParentInode.inodeid(), _))
+    EXPECT_CALL(*inodeManager_, GetInode(srcParentInode.inodeid(), _, _))
         .Times(times * 2)
         .WillRepeatedly(DoAll(SetArgReferee<1>(srcParentInodeWrapper),
                               Return(CURVEFS_ERROR::OK)));
@@ -1191,7 +1191,7 @@ TEST_F(TestFuseVolumeClient, FuseOpRenameParallel) {
     inode.set_nlink(times);
     inode.set_type(FsFileType::TYPE_FILE);
     auto inodeWrapper = std::make_shared<InodeWrapper>(inode, metaClient_);
-    EXPECT_CALL(*inodeManager_, GetInode(inode.inodeid(), _))
+    EXPECT_CALL(*inodeManager_, GetInode(inode.inodeid(), _, _))
         .Times(3 * times)
         .WillRepeatedly(DoAll(SetArgReferee<1>(inodeWrapper),
                               Return(CURVEFS_ERROR::OK)));
@@ -1272,42 +1272,6 @@ TEST_F(TestFuseVolumeClient, FuseOpGetAttrFailed) {
     ASSERT_EQ(CURVEFS_ERROR::INTERNAL, ret);
 }
 
-TEST_F(TestFuseVolumeClient, FuseOpGetAttrEnableCto) {
-    curvefs::client::common::FLAGS_enableCto = true;
-
-    fuse_req_t req;
-    fuse_ino_t ino = 1;
-    struct fuse_file_info fi;
-    memset(&fi, 0, sizeof(fi));
-    struct stat attr;
-
-    InodeAttr inode;
-    inode.set_inodeid(ino);
-    inode.set_length(0);
-
-    // RefreshInode OK
-    EXPECT_CALL(*inodeManager_, RefreshInode(ino))
-        .WillOnce(Return(CURVEFS_ERROR::OK));
-    EXPECT_CALL(*inodeManager_, GetInodeAttr(ino, _))
-        .WillOnce(DoAll(SetArgPointee<1>(inode), Return(CURVEFS_ERROR::OK)));
-
-    ASSERT_EQ(CURVEFS_ERROR::OK, client_->FuseOpGetAttr(req, ino, &fi, &attr));
-
-    // RefreshInode Fail
-    EXPECT_CALL(*inodeManager_, RefreshInode(ino))
-        .WillOnce(Return(CURVEFS_ERROR::INTERNAL));
-
-    ASSERT_EQ(CURVEFS_ERROR::INTERNAL,
-              client_->FuseOpGetAttr(req, ino, &fi, &attr));
-
-    // need not refresh inode
-    fi.fh = static_cast<uint64_t>(FileHandle::kKeepCache);
-    EXPECT_CALL(*inodeManager_, GetInodeAttr(ino, _))
-        .WillOnce(DoAll(SetArgPointee<1>(inode), Return(CURVEFS_ERROR::OK)));
-
-    ASSERT_EQ(CURVEFS_ERROR::OK, client_->FuseOpGetAttr(req, ino, &fi, &attr));
-}
-
 TEST_F(TestFuseVolumeClient, FuseOpSetAttr) {
     fuse_req_t req;
     fuse_ino_t ino = 1;
@@ -1323,7 +1287,7 @@ TEST_F(TestFuseVolumeClient, FuseOpSetAttr) {
     inode.set_type(FsFileType::TYPE_FILE);
     auto inodeWrapper = std::make_shared<InodeWrapper>(inode, metaClient_);
 
-    EXPECT_CALL(*inodeManager_, GetInode(ino, _))
+    EXPECT_CALL(*inodeManager_, GetInode(ino, _, _))
         .WillOnce(
             DoAll(SetArgReferee<1>(inodeWrapper), Return(CURVEFS_ERROR::OK)));
 
@@ -1369,7 +1333,7 @@ TEST_F(TestFuseVolumeClient, FuseOpSetAttrFailed) {
     inode.set_type(FsFileType::TYPE_FILE);
     auto inodeWrapper = std::make_shared<InodeWrapper>(inode, metaClient_);
 
-    EXPECT_CALL(*inodeManager_, GetInode(ino, _))
+    EXPECT_CALL(*inodeManager_, GetInode(ino, _, _))
         .WillOnce(Return(CURVEFS_ERROR::INTERNAL))
         .WillOnce(
             DoAll(SetArgReferee<1>(inodeWrapper), Return(CURVEFS_ERROR::OK)));
@@ -1431,7 +1395,7 @@ TEST_F(TestFuseVolumeClient, FuseOpSymlink) {
     auto parentInodeWrapper =
         std::make_shared<InodeWrapper>(parentInode, metaClient_);
 
-    EXPECT_CALL(*inodeManager_, GetInode(parent, _))
+    EXPECT_CALL(*inodeManager_, GetInode(parent, _, _))
         .WillOnce(DoAll(SetArgReferee<1>(parentInodeWrapper),
                         Return(CURVEFS_ERROR::OK)));
 
@@ -1524,7 +1488,7 @@ TEST_F(TestFuseVolumeClient, FuseOpLink) {
     auto parentInodeWrapper =
         std::make_shared<InodeWrapper>(parentInode, metaClient_);
 
-    EXPECT_CALL(*inodeManager_, GetInode(_, _))
+    EXPECT_CALL(*inodeManager_, GetInode(_, _, _))
         .WillOnce(
             DoAll(SetArgReferee<1>(inodeWrapper), Return(CURVEFS_ERROR::OK)))
         .WillOnce(DoAll(SetArgReferee<1>(parentInodeWrapper),
@@ -1557,7 +1521,7 @@ TEST_F(TestFuseVolumeClient, FuseOpLinkFailed) {
     inode.set_nlink(nlink);
     auto inodeWrapper = std::make_shared<InodeWrapper>(inode, metaClient_);
 
-    EXPECT_CALL(*inodeManager_, GetInode(ino, _))
+    EXPECT_CALL(*inodeManager_, GetInode(ino, _, _))
         .WillOnce(Return(CURVEFS_ERROR::INTERNAL))
         .WillOnce(
             DoAll(SetArgReferee<1>(inodeWrapper), Return(CURVEFS_ERROR::OK)))
@@ -1617,7 +1581,7 @@ TEST_F(TestFuseVolumeClient, FuseOpReadLink) {
     inode.set_symlink(link);
     auto inodeWrapper = std::make_shared<InodeWrapper>(inode, metaClient_);
 
-    EXPECT_CALL(*inodeManager_, GetInode(ino, _))
+    EXPECT_CALL(*inodeManager_, GetInode(ino, _, _))
         .WillOnce(
             DoAll(SetArgReferee<1>(inodeWrapper), Return(CURVEFS_ERROR::OK)));
 
@@ -1631,7 +1595,7 @@ TEST_F(TestFuseVolumeClient, FuseOpReadLinkFailed) {
     fuse_req_t req;
     fuse_ino_t ino = 1;
 
-    EXPECT_CALL(*inodeManager_, GetInode(ino, _))
+    EXPECT_CALL(*inodeManager_, GetInode(ino, _, _))
         .WillOnce(Return(CURVEFS_ERROR::INTERNAL));
 
     std::string linkStr;
@@ -1760,7 +1724,7 @@ TEST_F(TestFuseS3Client, FuseOpWriteSmallSize) {
     inode.set_length(0);
     auto inodeWrapper = std::make_shared<InodeWrapper>(inode, metaClient_);
 
-    EXPECT_CALL(*inodeManager_, GetInode(ino, _))
+    EXPECT_CALL(*inodeManager_, GetInode(ino, _, _))
         .WillOnce(
             DoAll(SetArgReferee<1>(inodeWrapper), Return(CURVEFS_ERROR::OK)));
 
@@ -1794,7 +1758,7 @@ TEST_F(TestFuseS3Client, FuseOpWriteFailed) {
         .WillOnce(Return(4))
         .WillOnce(Return(-1));
 
-    EXPECT_CALL(*inodeManager_, GetInode(ino, _))
+    EXPECT_CALL(*inodeManager_, GetInode(ino, _, _))
         .WillOnce(Return(CURVEFS_ERROR::INTERNAL));
 
     CURVEFS_ERROR ret =
@@ -1821,7 +1785,7 @@ TEST_F(TestFuseS3Client, FuseOpReadOverRange) {
     inode.set_length(4096);
     auto inodeWrapper = std::make_shared<InodeWrapper>(inode, metaClient_);
 
-    EXPECT_CALL(*inodeManager_, GetInode(ino, _))
+    EXPECT_CALL(*inodeManager_, GetInode(ino, _, _))
         .WillOnce(
             DoAll(SetArgReferee<1>(inodeWrapper), Return(CURVEFS_ERROR::OK)));
 
@@ -1847,7 +1811,7 @@ TEST_F(TestFuseS3Client, FuseOpReadFailed) {
     inode.set_length(4096);
     auto inodeWrapper = std::make_shared<InodeWrapper>(inode, metaClient_);
 
-    EXPECT_CALL(*inodeManager_, GetInode(ino, _))
+    EXPECT_CALL(*inodeManager_, GetInode(ino, _, _))
         .WillOnce(Return(CURVEFS_ERROR::INTERNAL))
         .WillOnce(
             DoAll(SetArgReferee<1>(inodeWrapper), Return(CURVEFS_ERROR::OK)));
@@ -1878,7 +1842,7 @@ TEST_F(TestFuseS3Client, FuseOpFsync) {
 
     auto inodeWrapper = std::make_shared<InodeWrapper>(inode, metaClient_);
     inodeWrapper->SetUid(32);
-    EXPECT_CALL(*inodeManager_, GetInode(ino, _))
+    EXPECT_CALL(*inodeManager_, GetInode(ino, _, _))
         .WillOnce(
             DoAll(SetArgReferee<1>(inodeWrapper), Return(CURVEFS_ERROR::OK)));
 
@@ -1923,7 +1887,7 @@ TEST_F(TestFuseS3Client, FuseOpFlush) {
     ASSERT_EQ(CURVEFS_ERROR::UNKNOWN, client_->FuseOpFlush(req, ino, fi));
 
     LOG(INFO) << "############ case4: enable cto and execute ok";
-    EXPECT_CALL(*inodeManager_, GetInode(ino, _))
+    EXPECT_CALL(*inodeManager_, GetInode(ino, _, _))
         .WillOnce(
             DoAll(SetArgReferee<1>(inodeWrapper), Return(CURVEFS_ERROR::OK)));
     EXPECT_CALL(*s3ClientAdaptor_, FlushAllCache(_))
@@ -2443,7 +2407,7 @@ TEST_F(TestFuseS3Client, FuseOpCreate_EnableSummary) {
 
     auto parentInodeWrapper = std::make_shared<InodeWrapper>(
         parentInode, metaClient_);
-    EXPECT_CALL(*inodeManager_, GetInode(_, _))
+    EXPECT_CALL(*inodeManager_, GetInode(_, _, _))
         .WillOnce(
             DoAll(SetArgReferee<1>(parentInodeWrapper),
                 Return(CURVEFS_ERROR::OK)))
@@ -2504,7 +2468,7 @@ TEST_F(TestFuseS3Client, FuseOpWrite_EnableSummary) {
         parentInode, metaClient_);
     EXPECT_CALL(*inodeManager_, ShipToFlush(_))
         .Times(2);
-    EXPECT_CALL(*inodeManager_, GetInode(_, _))
+    EXPECT_CALL(*inodeManager_, GetInode(_, _, _))
         .WillOnce(
             DoAll(SetArgReferee<1>(inodeWrapper), Return(CURVEFS_ERROR::OK)))
         .WillOnce(
@@ -2550,7 +2514,7 @@ TEST_F(TestFuseS3Client, FuseOpLink_EnableSummary) {
     pinode.mutable_xattr()->insert({XATTRFBYTES, "0"});
     auto pinodeWrapper = std::make_shared<InodeWrapper>(pinode, metaClient_);
 
-    EXPECT_CALL(*inodeManager_, GetInode(_, _))
+    EXPECT_CALL(*inodeManager_, GetInode(_, _, _))
         .WillOnce(
             DoAll(SetArgReferee<1>(inodeWrapper), Return(CURVEFS_ERROR::OK)))
         .WillRepeatedly(
@@ -2615,7 +2579,7 @@ TEST_F(TestFuseS3Client, FuseOpUnlink_EnableSummary) {
     auto parentInodeWrapper = std::make_shared<InodeWrapper>(
         parentInode, metaClient_);
 
-    EXPECT_CALL(*inodeManager_, GetInode(_, _))
+    EXPECT_CALL(*inodeManager_, GetInode(_, _, _))
         .WillOnce(
             DoAll(SetArgReferee<1>(parentInodeWrapper),
                 Return(CURVEFS_ERROR::OK)))
@@ -2679,7 +2643,7 @@ TEST_F(TestFuseS3Client, FuseOpOpen_Trunc_EnableSummary) {
 
     uint64_t parentId = 1;
 
-    EXPECT_CALL(*inodeManager_, GetInode(_, _))
+    EXPECT_CALL(*inodeManager_, GetInode(_, _, _))
         .WillOnce(
             DoAll(SetArgReferee<1>(inodeWrapper), Return(CURVEFS_ERROR::OK)))
         .WillOnce(

--- a/curvefs/test/client/test_inode_cache_manager.cpp
+++ b/curvefs/test/client/test_inode_cache_manager.cpp
@@ -125,88 +125,8 @@ TEST_F(TestInodeCacheManager, GetInode) {
               iCacheManager_->GetInode(inodeId2, inodeWrapper));
 }
 
-TEST_F(TestInodeCacheManager, RefreshInode) {
-    uint64_t inodeId = 100;
-    uint64_t fileLength = 100;
-
-    Inode inode;
-    inode.set_inodeid(inodeId);
-    inode.set_fsid(fsId_);
-    inode.set_length(fileLength);
-    inode.set_type(FsFileType::TYPE_S3);
-    auto s3ChunkInfoMap = inode.mutable_s3chunkinfomap();
-    S3ChunkInfoList *s3ChunkInfoList = new S3ChunkInfoList();
-    S3ChunkInfo *s3ChunkInfo = s3ChunkInfoList->add_s3chunks();
-    s3ChunkInfo->set_chunkid(1);
-    s3ChunkInfo->set_compaction(1);
-    s3ChunkInfo->set_offset(0);
-    s3ChunkInfo->set_len(1024);
-    s3ChunkInfo->set_size(65536);
-    s3ChunkInfo->set_zero(true);
-    s3ChunkInfoMap->insert({1, *s3ChunkInfoList});
-
-    // cache miss, get s3-inode from metaserver failed
-    EXPECT_CALL(*metaClient_, GetInode(fsId_, inodeId, _, _))
-        .WillOnce(Return(MetaStatusCode::NOT_FOUND));
-    ASSERT_EQ(CURVEFS_ERROR::NOTEXIST, iCacheManager_->RefreshInode(inodeId));
-
-    // cache miss, get s3-inode from metaserver ok, do not need streaming
-    EXPECT_CALL(*metaClient_, GetInode(fsId_, inodeId, _, _))
-        .WillOnce(DoAll(SetArgPointee<2>(inode), SetArgPointee<3>(false),
-                        Return(MetaStatusCode::OK)));
-    ASSERT_EQ(CURVEFS_ERROR::OK, iCacheManager_->RefreshInode(inodeId));
-
-    // cache miss, get s3-inode from metaserver, need streaming
-    uint64_t inodeId2 = 200;
-    Inode inode2 = inode;
-    inode2.set_inodeid(inodeId2);
-    EXPECT_CALL(*metaClient_, GetInode(fsId_, inodeId2, _, _))
-        .WillOnce(DoAll(SetArgPointee<2>(inode2), SetArgPointee<3>(true),
-                        Return(MetaStatusCode::OK)));
-    EXPECT_CALL(*metaClient_,
-                GetOrModifyS3ChunkInfo(fsId_, inodeId2, _, true, _, _))
-        .WillOnce(Return(MetaStatusCode::OK));
-    ASSERT_EQ(CURVEFS_ERROR::OK, iCacheManager_->RefreshInode(inodeId2));
-
-    // cache hit, refresh s3-inode from metaserver, do not need streaming
-    Inode inodenew = inode;
-    inodenew.set_length(fileLength * 3);
-    EXPECT_CALL(*metaClient_, GetInode(fsId_, inodeId, _, _))
-        .WillOnce(DoAll(SetArgPointee<2>(inodenew), SetArgPointee<3>(false),
-                        Return(MetaStatusCode::OK)));
-    EXPECT_CALL(*metaClient_,
-                GetOrModifyS3ChunkInfo(fsId_, inodeId, _, true, _, _))
-        .WillOnce(Return(MetaStatusCode::OK));
-    ASSERT_EQ(CURVEFS_ERROR::OK, iCacheManager_->RefreshInode(inodeId));
-    std::shared_ptr<InodeWrapper> inodeWrapper;
-    ASSERT_EQ(CURVEFS_ERROR::OK,
-              iCacheManager_->GetInode(inodeId, inodeWrapper));
-    ASSERT_EQ(inodenew.length(), inodeWrapper->GetLength());
-
-    // cache hit, refresh s3-inode from metaserver, need streaming
-    EXPECT_CALL(*metaClient_, GetInode(fsId_, inodeId, _, _))
-        .WillOnce(DoAll(SetArgPointee<2>(inodenew), SetArgPointee<3>(true),
-                        Return(MetaStatusCode::OK)));
-    EXPECT_CALL(*metaClient_,
-                GetOrModifyS3ChunkInfo(fsId_, inodeId, _, true, _, _))
-        .WillOnce(Return(MetaStatusCode::OK));
-    ASSERT_EQ(CURVEFS_ERROR::OK, iCacheManager_->RefreshInode(inodeId));
-
-    // cache miss, get file-inode from metaserver
-    Inode inodefile;
-    uint64_t inodefileid = 300;
-    inodefile.set_inodeid(inodefileid);
-    inodefile.set_fsid(fsId_);
-    inodefile.set_type(FsFileType::TYPE_FILE);
-    EXPECT_CALL(*metaClient_, GetInode(fsId_, inodefileid, _, _))
-        .WillOnce(DoAll(SetArgPointee<2>(inodefile), SetArgPointee<3>(false),
-                        Return(MetaStatusCode::OK)));
-    EXPECT_CALL(*metaClient_, GetVolumeExtent(fsId_, inodefileid, _, _))
-        .WillOnce(Return(MetaStatusCode::OK));
-    ASSERT_EQ(CURVEFS_ERROR::OK, iCacheManager_->RefreshInode(inodefileid));
-}
-
 TEST_F(TestInodeCacheManager, GetInodeAttr) {
+    curvefs::client::common::FLAGS_enableCto = false;
     uint64_t inodeId = 100;
     uint64_t parentId = 99;
     uint64_t fileLength = 100;

--- a/curvefs/test/client/volume/default_volume_storage_test.cpp
+++ b/curvefs/test/client/volume/default_volume_storage_test.cpp
@@ -65,7 +65,7 @@ class DefaultVolumeStorageTest : public ::testing::Test {
 };
 
 TEST_F(DefaultVolumeStorageTest, WriteAndReadTest_InodeNotFound) {
-    EXPECT_CALL(inodeCacheMgr_, GetInode(_, _))
+    EXPECT_CALL(inodeCacheMgr_, GetInode(_, _, _))
         .Times(2)
         .WillRepeatedly(Return(CURVEFS_ERROR::NOTEXIST));
 
@@ -102,8 +102,9 @@ TEST_F(DefaultVolumeStorageTest, ReadTest_BlockDevReadError) {
 
     ASSERT_EQ(CURVEFS_ERROR::OK, inodeWrapper->RefreshVolumeExtent());
 
-    EXPECT_CALL(inodeCacheMgr_, GetInode(_, _))
-        .WillOnce(Invoke([&](uint64_t, std::shared_ptr<InodeWrapper>& out) {
+    EXPECT_CALL(inodeCacheMgr_, GetInode(_, _, _))
+        .WillOnce(Invoke([&](uint64_t, std::shared_ptr<InodeWrapper>& out,
+                             bool) {
             out = inodeWrapper;
             return CURVEFS_ERROR::OK;
         }));
@@ -143,8 +144,9 @@ TEST_F(DefaultVolumeStorageTest, ReadTest_BlockDevReadSuccess) {
 
     ASSERT_EQ(CURVEFS_ERROR::OK, inodeWrapper->RefreshVolumeExtent());
 
-    EXPECT_CALL(inodeCacheMgr_, GetInode(_, _))
-        .WillOnce(Invoke([&](uint64_t, std::shared_ptr<InodeWrapper>& out) {
+    EXPECT_CALL(inodeCacheMgr_, GetInode(_, _, _))
+        .WillOnce(Invoke([&](uint64_t, std::shared_ptr<InodeWrapper>& out,
+                             bool) {
             out = inodeWrapper;
             return CURVEFS_ERROR::OK;
         }));
@@ -187,8 +189,9 @@ TEST_F(DefaultVolumeStorageTest, ReadTest_BlockDevReadHoleSuccess) {
 
     ASSERT_EQ(CURVEFS_ERROR::OK, inodeWrapper->RefreshVolumeExtent());
 
-    EXPECT_CALL(inodeCacheMgr_, GetInode(_, _))
-        .WillOnce(Invoke([&](uint64_t, std::shared_ptr<InodeWrapper>& out) {
+    EXPECT_CALL(inodeCacheMgr_, GetInode(_, _, _))
+        .WillOnce(Invoke([&](uint64_t, std::shared_ptr<InodeWrapper>& out,
+                             bool) {
             out = inodeWrapper;
             return CURVEFS_ERROR::OK;
         }));
@@ -228,8 +231,9 @@ TEST_F(DefaultVolumeStorageTest, WriteTest_PrepareError) {
 
     ASSERT_EQ(CURVEFS_ERROR::OK, inodeWrapper->RefreshVolumeExtent());
 
-    EXPECT_CALL(inodeCacheMgr_, GetInode(_, _))
-        .WillOnce(Invoke([&](uint64_t, std::shared_ptr<InodeWrapper>& out) {
+    EXPECT_CALL(inodeCacheMgr_, GetInode(_, _, _))
+        .WillOnce(Invoke([&](uint64_t, std::shared_ptr<InodeWrapper>& out,
+                             bool) {
             out = inodeWrapper;
             return CURVEFS_ERROR::OK;
         }));
@@ -260,8 +264,9 @@ TEST_F(DefaultVolumeStorageTest, WriteTest_BlockDevWriteError) {
 
     ASSERT_EQ(CURVEFS_ERROR::OK, inodeWrapper->RefreshVolumeExtent());
 
-    EXPECT_CALL(inodeCacheMgr_, GetInode(_, _))
-        .WillOnce(Invoke([&](uint64_t, std::shared_ptr<InodeWrapper>& out) {
+    EXPECT_CALL(inodeCacheMgr_, GetInode(_, _, _))
+        .WillOnce(Invoke([&](uint64_t, std::shared_ptr<InodeWrapper>& out,
+                             bool) {
             out = inodeWrapper;
             return CURVEFS_ERROR::OK;
         }));
@@ -304,8 +309,9 @@ TEST_F(DefaultVolumeStorageTest, WriteTest_BlockDevWriteSuccess) {
     ASSERT_EQ(CURVEFS_ERROR::OK, inodeWrapper->RefreshVolumeExtent());
 
 
-    EXPECT_CALL(inodeCacheMgr_, GetInode(_, _))
-        .WillOnce(Invoke([&](uint64_t, std::shared_ptr<InodeWrapper>& out) {
+    EXPECT_CALL(inodeCacheMgr_, GetInode(_, _, _))
+        .WillOnce(Invoke([&](uint64_t, std::shared_ptr<InodeWrapper>& out,
+                             bool) {
             out = inodeWrapper;
             return CURVEFS_ERROR::OK;
         }));


### PR DESCRIPTION
Signed-off-by: wanghai01 <seanhaizi@163.com>

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #xxx <!-- replace xxx with issue number -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
