### PR TITLE
clarified some variables and correct some spelling mistake

### DIFF
--- a/curvefs/conf/client.conf
+++ b/curvefs/conf/client.conf
@@ -63,7 +63,7 @@ spaceserver.rpcTimeoutMs=1000
 
 #### bdev
 # curve client's config file
-bdev.confpath=/etc/curve/client.conf
+bdev.confPath=/etc/curve/client.conf
 
 #### extentManager
 extentManager.preAllocSize=65536
@@ -86,12 +86,12 @@ fuseClient.dCacheLruSize=1000000
 fuseClient.enableICacheMetrics=true
 fuseClient.enableDCacheMetrics=true
 fuseClient.cto=true
-# you shoudle enable it when mount one filesystem to multi mountpoints,
-# it gurantee the consistent of file after rename, otherwise you should
+# you should enable it when mount one filesystem to multi mount points,
+# it guarantee the consistent of file after rename, otherwise you should
 # disable it for performance.
 fuseClient.enableMultiMountPointRename=true
 # splice will bring higher performance in some cases
-# but there're might be a kernel issue that will cause kernel panic when enabling it
+# but there might be a kernel issue that will cause kernel panic when enabling it
 # see https://lore.kernel.org/all/CAAmZXrsGg2xsP1CK+cbuEMumtrqdvD-NKnWzhNcvn71RV3c1yw@mail.gmail.com/
 # until this issue has been fixed, splice should be disabled
 fuseClient.enableSplice=false
@@ -109,39 +109,38 @@ volume.bigFileSize=1048576
 volume.volBlockSize=4096
 volume.fsBlockSize=4096
 
-# alloator type, supported {bitmap}
+# allocator type, supported {bitmap}
 volume.allocator.type=bitmap
 
 ## for bitmap allocator
 # size of each bit, default is 4MiB
-volume.bitmapallocator.size_per_bit=4194304
+volume.bitmapAllocator.size_per_bit=4194304
 
 # small allocation proportion [0-1]
-volume.bitmapallocator.small_alloc_proportion=0.2
+volume.bitmapAllocator.small_alloc_proportion=0.2
 
 # number of block groups that allocated once
-volume.blockgroup.allocate_once=4
+volume.blockGroup.allocate_once=4
 
 #### s3
 # this is for test. if s3.fakeS3=true, all data will be discarded
 s3.fakeS3=false
 # the max size that fuse send
 s3.fuseMaxSize=131072
-s3.pagesize=65536
+s3.pageSize=65536
 # prefetch blocks that disk cache use
 s3.prefetchBlocks=1
 # prefetch threads
 s3.prefetchExecQueueNum=1
 # start sleep when mem cache use ratio is greater than nearfullRatio,
-# sleep time increase follow with mem cache use raito, baseSleepUs is baseline.
+# sleep time increase follow with mem cache use ratio, baseSleepUs is baseline.
 s3.nearfullRatio=70
 s3.baseSleepUs=500
 
-# TODO(huyao): use more meaningfull name
 # background thread schedule time
-s3.intervalSec=3
+s3.threadScheduleInterval=3
 # data cache flush wait time
-s3.flushIntervalSec=5
+s3.cacheFlushIntervalSec=5
 s3.writeCacheMaxByte=838860800
 s3.readCacheMaxByte=209715200
 # http = 0, https = 1
@@ -173,7 +172,9 @@ s3.maxReadRetryIntervalMs = 1000
 s3.readRetryIntervalMs = 100
 # TODO(hongsong): limit bytes、iops/bps
 #### disk cache options
-# 0:not enable disk cache 1:onlyread 2:read/write
+# 0:not enable disk cache
+# 1:readonly
+# 2:read/write
 diskCache.diskCacheType=2  # __ANSIBLE_TEMPLATE__ {{ client_disk_cache_type | default('2') }} __ANSIBLE_TEMPLATE__
 # the file system writes files use flush or not
 diskCache.forceFlush=true
@@ -213,4 +214,4 @@ client.common.logDir=/data/logs/curvefs  # __CURVEADM_TEMPLATE__ /curvefs/client
 # we have loglevel: {0,3,6,9}
 # as the number increases, it becomes more and more detailed
 client.loglevel=0
-client.dummyserver.startport=9000
+client.dummyServer.startPort=9000

--- a/curvefs/src/client/common/config.cpp
+++ b/curvefs/src/client/common/config.cpp
@@ -112,7 +112,7 @@ void InitExcutorOption(Configuration *conf, ExcutorOpt *opts, bool internal) {
 
 void InitBlockDeviceOption(Configuration *conf,
                            BlockDeviceClientOptions *bdevOpt) {
-    conf->GetValueFatalIfFail("bdev.confpath", &bdevOpt->configPath);
+    conf->GetValueFatalIfFail("bdev.confPath", &bdevOpt->configPath);
 }
 
 void InitDiskCacheOption(Configuration *conf,
@@ -158,15 +158,15 @@ void InitS3Option(Configuration *conf, S3Option *s3Opt) {
     conf->GetValueFatalIfFail("s3.fakeS3", &FLAGS_useFakeS3);
     conf->GetValueFatalIfFail("s3.fuseMaxSize",
                               &s3Opt->s3ClientAdaptorOpt.fuseMaxSize);
-    conf->GetValueFatalIfFail("s3.pagesize",
+    conf->GetValueFatalIfFail("s3.pageSize",
                               &s3Opt->s3ClientAdaptorOpt.pageSize);
     conf->GetValueFatalIfFail("s3.prefetchBlocks",
                               &s3Opt->s3ClientAdaptorOpt.prefetchBlocks);
     conf->GetValueFatalIfFail("s3.prefetchExecQueueNum",
                               &s3Opt->s3ClientAdaptorOpt.prefetchExecQueueNum);
-    conf->GetValueFatalIfFail("s3.intervalSec",
+    conf->GetValueFatalIfFail("s3.threadScheduleInterval",
                               &s3Opt->s3ClientAdaptorOpt.intervalSec);
-    conf->GetValueFatalIfFail("s3.flushIntervalSec",
+    conf->GetValueFatalIfFail("s3.cacheFlushIntervalSec",
                               &s3Opt->s3ClientAdaptorOpt.flushIntervalSec);
     conf->GetValueFatalIfFail("s3.chunkFlushThreads",
                               &s3Opt->s3ClientAdaptorOpt.chunkFlushThreads);
@@ -196,12 +196,12 @@ void InitVolumeOption(Configuration *conf, VolumeOption *volumeOpt) {
                               &volumeOpt->allocatorOption.type);
 
     conf->GetValueFatalIfFail(
-        "volume.blockgroup.allocate_once",
+        "volume.blockGroup.allocate_once",
         &volumeOpt->allocatorOption.blockGroupOption.allocateOnce);
 
     if (volumeOpt->allocatorOption.type == "bitmap") {
         conf->GetValueFatalIfFail(
-            "volume.bitmapallocator.size_per_bit",
+            "volume.bitmapAllocator.size_per_bit",
             &volumeOpt->allocatorOption.bitmapAllocatorOption.sizePerBit);
         conf->GetValueFatalIfFail(
             "volume.bitmapallocator.small_alloc_proportion",
@@ -272,7 +272,7 @@ void InitFuseClientOption(Configuration *conf, FuseClientOption *clientOption) {
                               &clientOption->enableICacheMetrics);
     conf->GetValueFatalIfFail("fuseClient.enableDCacheMetrics",
                               &clientOption->enableDCacheMetrics);
-    conf->GetValueFatalIfFail("client.dummyserver.startport",
+    conf->GetValueFatalIfFail("client.dummyServer.startPort",
                               &clientOption->dummyServerStartPort);
     conf->GetValueFatalIfFail("fuseClient.enableMultiMountPointRename",
                               &clientOption->enableMultiMountPointRename);

--- a/curvefs/test/client/common/test_config.cpp
+++ b/curvefs/test/client/common/test_config.cpp
@@ -39,9 +39,9 @@ TEST(TestInitVolumeOption, Common) {
     conf.SetUInt64Value("volume.bigFileSize", 1ULL * 1024 * 1024);
     conf.SetUInt64Value("volume.volBlockSize", 4096);
     conf.SetUInt64Value("volume.fsBlockSize", 4096);
-    conf.SetUInt32Value("volume.blockgroup.allocate_once", 4);
+    conf.SetUInt32Value("volume.blockGroup.allocate_once", 4);
     conf.SetStringValue("volume.allocator.type", "bitmap");
-    conf.SetUInt64Value("volume.bitmapallocator.size_per_bit",
+    conf.SetUInt64Value("volume.bitmapAllocator.size_per_bit",
                         4ULL * 1024 * 1024);
     conf.SetDoubleValue("volume.bitmapallocator.small_alloc_proportion", 0.0);
 
@@ -55,9 +55,9 @@ TEST(TestInitVolumeOption, TypeError) {
     conf.SetUInt64Value("volume.bigFileSize", 1ULL * 1024 * 1024);
     conf.SetUInt64Value("volume.volBlockSize", 4096);
     conf.SetUInt64Value("volume.fsBlockSize", 4096);
-    conf.SetUInt32Value("volume.blockgroup.allocate_once", 4);
+    conf.SetUInt32Value("volume.blockGroup.allocate_once", 4);
     conf.SetStringValue("volume.allocator.type", "xxx");
-    conf.SetUInt64Value("volume.bitmapallocator.size_per_bit",
+    conf.SetUInt64Value("volume.bitmapAllocator.size_per_bit",
                         4ULL * 1024 * 1024);
     conf.SetDoubleValue("volume.bitmapallocator.small_alloc_proportion", 0.0);
 


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->
Signed-off-by: shentupenghui@gmail.com

### What problem does this PR solve?

Issue Number: #2049

Problem Summary:

there are some spelling mistake and unclear variable

### What is changed and how it works?

What's Changed:

1. Rename `s3.intervalSec` to `s3.threadScheduleInterval`
2. Correct come spelling mistake
3. Change some variable to camel-case style

How it Works:

Edited curvefs/conf/client.conf and replace same name in related files

Side effects(Breaking backward compatibility? Performance regression?):

No

### Check List

- [x] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license
