### PR TITLE
support create volume directory by curve_ops_tool

### DIFF
--- a/src/tools/mds_client.cpp
+++ b/src/tools/mds_client.cpp
@@ -272,14 +272,20 @@ int MDSClient::DeleteFile(const std::string& fileName, bool forcedelete) {
 }
 
 int MDSClient::CreateFile(const std::string& fileName, uint64_t length,
-                   uint64_t stripeUnit, uint64_t stripeCount) {
+                          bool normalFile, uint64_t stripeUnit,
+                          uint64_t stripeCount) {
     curve::mds::CreateFileRequest request;
     curve::mds::CreateFileResponse response;
     request.set_filename(fileName);
-    request.set_filetype(curve::mds::FileType::INODE_PAGEFILE);
-    request.set_filelength(length);
-    request.set_stripeunit(stripeUnit);
-    request.set_stripecount(stripeCount);
+    if (normalFile) {
+        request.set_filetype(curve::mds::FileType::INODE_PAGEFILE);
+        request.set_filelength(length);
+        request.set_stripeunit(stripeUnit);
+        request.set_stripecount(stripeCount);
+    } else {
+        request.set_filetype(curve::mds::FileType::INODE_DIRECTORY);
+    }
+
     FillUserInfo(&request);
     curve::mds::CurveFSService_Stub stub(&channel_);
 

--- a/src/tools/mds_client.h
+++ b/src/tools/mds_client.h
@@ -167,15 +167,19 @@ class MDSClient {
                            bool forcedelete = false);
 
     /**
-     *  @brief 创建pageFile文件
-     *  @param fileName 文件名
+     *  @brief create pageFile or directory
+     *  @param fileName file name or dir name
      *  @param length 文件长度
+     *  @param normalFile is file or dir
      *  @param stripeUnit stripe unit size
      *  @param stripeCount the amount of stripes
      *  @return 成功返回0，失败返回-1
      */
-    virtual int CreateFile(const std::string& fileName, uint64_t length,
-                           uint64_t stripeUnit, uint64_t stripeCount);
+    virtual int CreateFile(const std::string& fileName,
+                           uint64_t length = 0,
+                           bool normalFile = true,
+                           uint64_t stripeUnit = 0,
+                           uint64_t stripeCount = 0);
 
     /**
      *  @brief List all volumes on copysets

--- a/src/tools/namespace_tool.cpp
+++ b/src/tools/namespace_tool.cpp
@@ -23,6 +23,7 @@
 #include "src/tools/namespace_tool.h"
 
 DEFINE_string(fileName, "", "file name");
+DEFINE_string(dirName, "", "directory name");
 DEFINE_string(expireTime, "7d", "Time for file in recyclebin exceed expire time "  // NOLINT
                                 "will be deleted (default: 7d)");
 DEFINE_bool(forcedelete, false, "force delete file or not");
@@ -122,8 +123,16 @@ int NameSpaceTool::RunCommand(const std::string &cmd) {
             return 0;
         }
     } else if (cmd == kCreateCmd) {
-        return core_->CreateFile(fileName, FLAGS_fileLength * mds::kGB,
-                             FLAGS_stripeUnit, FLAGS_stripeCount);
+        if (!FLAGS_dirName.empty() && !FLAGS_fileName.empty()) {
+            std::cout << "Parameter error: dirName and fileName "
+                      << "can't be set at the same time!" << std::endl;
+            return -1;
+        }
+        bool normalFile = FLAGS_dirName.empty();
+        std::string name = normalFile ? FLAGS_fileName : FLAGS_dirName;
+        return core_->CreateFile(name, FLAGS_fileLength * mds::kGB,
+                                 normalFile, FLAGS_stripeUnit,
+                                 FLAGS_stripeCount);
     } else if (cmd == kExtendCmd) {
         return core_->ExtendVolume(fileName, FLAGS_newSize * mds::kGB);
     } else if (cmd == kChunkLocatitonCmd) {
@@ -150,7 +159,9 @@ void NameSpaceTool::PrintHelp(const std::string &cmd) {
         std::cout << "If -fileName is specified, delete the files in recyclebin that the original directory is fileName" << std::endl;  // NOLINT
         std::cout << "expireTime: s=second, m=minute, h=hour, d=day, M=month, y=year" << std::endl;  // NOLINT
     } else if (cmd == kCreateCmd) {
-        std::cout << "curve_ops_tool " << cmd << " -fileName=/test -userName=test -password=123 -filelength=20 -stripeUnit=32768 -stripeCount=32  [-mdsAddr=127.0.0.1:6666] [-confPath=/etc/curve/tools.conf]" << std::endl;  // NOLINT
+        std::cout << "curve_ops_tool " << cmd << " -fileName=/test -userName=test -password=123 -fileLength=20 [-stripeUnit=32768] [-stripeCount=32]  [-mdsAddr=127.0.0.1:6666] [-confPath=/etc/curve/tools.conf]" << std::endl;  // NOLINT
+        std::cout << "curve_ops_tool " << cmd << " -dirName=/dir -userName=test -password=123 [-mdsAddr=127.0.0.1:6666] [-confPath=/etc/curve/tools.conf]" << std::endl;  // NOLINT
+        std::cout << "The first example can create a volume and the second create a directory." << std::endl;  // NOLINT
     } else if (cmd == kExtendCmd) {
         std::cout << "curve_ops_tool " << cmd << " -fileName=/test -userName=test -password=123 -newSize=30  [-mdsAddr=127.0.0.1:6666] [-confPath=/etc/curve/tools.conf]" << std::endl;  // NOLINT
     } else if (cmd == kDeleteCmd) {

--- a/src/tools/namespace_tool_core.cpp
+++ b/src/tools/namespace_tool_core.cpp
@@ -62,9 +62,10 @@ int NameSpaceToolCore::DeleteFile(const std::string& fileName,
 
 int NameSpaceToolCore::CreateFile(const std::string& fileName,
                                   uint64_t length,
+                                  bool normalFile,
                                   uint64_t stripeUnit,
                                   uint64_t stripeCount) {
-    return client_->CreateFile(fileName, length,
+    return client_->CreateFile(fileName, length, normalFile,
                                stripeUnit, stripeCount);
 }
 int NameSpaceToolCore::ExtendVolume(const std::string& fileName,

--- a/src/tools/namespace_tool_core.h
+++ b/src/tools/namespace_tool_core.h
@@ -102,15 +102,17 @@ class NameSpaceToolCore {
                            bool forcedelete = false);
 
     /**
-     *  @brief 创建pageFile文件
-     *  @param fileName 文件名
+     *  @brief create pageFile or directory
+     *  @param fileName file name or dir name
      *  @param length 文件长度
+     *  @param normalFile is file or dir
      *  @param stripeUnit stripe unit size
      *  @param stripeCount the amount of stripes
      *  @return 成功返回0，失败返回-1
      */
     virtual int CreateFile(const std::string& fileName, uint64_t length,
-                          uint64_t stripeUnit, uint64_t stripeCount);
+                           bool normalFile = true, uint64_t stripeUnit = 0,
+                           uint64_t stripeCount = 0);
 
    /**
      *  @brief 扩容卷

--- a/test/tools/mock/mock_mds_client.h
+++ b/test/tools/mock/mock_mds_client.h
@@ -48,7 +48,7 @@ class MockMDSClient : public MDSClient {
     MOCK_METHOD3(GetSegmentInfo, GetSegmentRes(const std::string&,
                                         uint64_t, PageFileSegment*));
     MOCK_METHOD2(DeleteFile, int(const std::string&, bool));
-    MOCK_METHOD4(CreateFile, int(const std::string&, uint64_t,
+    MOCK_METHOD5(CreateFile, int(const std::string&, uint64_t, bool,
                                  uint64_t, uint64_t));
     MOCK_METHOD2(ExtendVolume, int(const std::string&, uint64_t));
     MOCK_METHOD3(GetChunkServerListInCopySet, int(const PoolIdType&,

--- a/test/tools/mock/mock_namespace_tool_core.h
+++ b/test/tools/mock/mock_namespace_tool_core.h
@@ -47,7 +47,7 @@ class MockNameSpaceToolCore : public NameSpaceToolCore {
                                      const CopySetIdType&,
                                      std::vector<ChunkServerLocation>*));
     MOCK_METHOD2(DeleteFile, int(const std::string&, bool));
-    MOCK_METHOD4(CreateFile, int(const std::string&, uint64_t,
+    MOCK_METHOD5(CreateFile, int(const std::string&, uint64_t, bool,
                                 uint64_t, uint64_t));
     MOCK_METHOD3(GetAllocatedSize, int(const std::string&,
                                        uint64_t*, AllocMap*));

--- a/test/tools/namespace_tool_core_test.cpp
+++ b/test/tools/namespace_tool_core_test.cpp
@@ -143,18 +143,18 @@ TEST_F(NameSpaceToolCoreTest, CreateFile) {
     uint64_t stripeCount = 32;
 
     // 1、正常情况
-    EXPECT_CALL(*client_, CreateFile(_, _, _, _))
+    EXPECT_CALL(*client_, CreateFile(_, _, _, _, _))
         .Times(1)
         .WillOnce(Return(0));
     ASSERT_EQ(0, namespaceTool.CreateFile(fileName, length,
-                               stripeUnit, stripeCount));
+                               true, stripeUnit, stripeCount));
 
     // 2、创建失败
-    EXPECT_CALL(*client_, CreateFile(_, _, _, _))
+    EXPECT_CALL(*client_, CreateFile(_, _, _, _, _))
         .Times(1)
         .WillOnce(Return(-1));
     ASSERT_EQ(-1, namespaceTool.CreateFile(fileName, length,
-                               stripeUnit, stripeCount));
+                               true, stripeUnit, stripeCount));
 }
 
 TEST_F(NameSpaceToolCoreTest, ExtendVolume) {

--- a/test/tools/namespace_tool_test.cpp
+++ b/test/tools/namespace_tool_test.cpp
@@ -298,13 +298,13 @@ TEST_F(NameSpaceToolTest, CreateFile) {
         .WillOnce(Return(0));
 
     // 1、正常情况
-    EXPECT_CALL(*core_, CreateFile(_, _, _, _))
+    EXPECT_CALL(*core_, CreateFile(_, _, _, _, _))
         .Times(1)
         .WillOnce(Return(0));
     ASSERT_EQ(0, namespaceTool.RunCommand("create"));
 
     // 2、创建失败
-    EXPECT_CALL(*core_, CreateFile(_, _, _, _))
+    EXPECT_CALL(*core_, CreateFile(_, _, _, _, _))
         .Times(1)
         .WillOnce(Return(-1));
     ASSERT_EQ(-1, namespaceTool.RunCommand("create"));


### PR DESCRIPTION
create directory: curve_ops_tool create -fileName=/dir1 -isDir=true -userName=test -password=123

BTW, delete directory is already supported.

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #2035

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:
```
root@5dd029eb85a9:/curvebs# ./curve_ops_tool create --example
Example: 
curve_ops_tool create -fileName=/test -userName=test -password=123 -fileLength=20 [-stripeUnit=32768] [-stripeCount=32]  [-mdsAddr=127.0.0.1:6666] [-confPath=/etc/curve/tools.conf]
curve_ops_tool create -dirName=/dir -userName=test -password=123 [-mdsAddr=127.0.0.1:6666] [-confPath=/etc/curve/tools.conf]
The first example can create a volume and the second create a directory.
root@5dd029eb85a9:/curvebs# ./curve_ops_tool create -fileName=/dir11/test2 -userName=test -password=123 -fileLength=20 -stripeUnit=32768 -stripeCount=32
root@5dd029eb85a9:/curvebs# ./curve_ops_tool create -dirName=/dir12 -fileName=/test -userName=test -password=123
Parameter error: dirName and fileName can't be set at the same time!
root@5dd029eb85a9:/curvebs# ./curve_ops_tool create -dirName=/dir12 -userName=test -password=123
root@5dd029eb85a9:/curvebs# ./curve_ops_tool create -fileName=/test22 -userName=test -password=123 -fileLength=10 
root@5dd029eb85a9:/curvebs# ./curve_ops_tool list -fileName=/ | grep dir11 -a5
stripeCount: 0
allocated size: 0GB
file size: 10GB

id: 2004
fileName: "dir11"
parentId: 0
fileType: INODE_DIRECTORY
owner: "test"
chunkSize: 16777216
segmentSize: 1073741824
root@5dd029eb85a9:/curvebs# ./curve_ops_tool list -fileName=/ | grep dir12 -A10
fileName: "dir12"
parentId: 0
fileType: INODE_DIRECTORY
owner: "test"
chunkSize: 16777216
segmentSize: 1073741824
length: 0GB
ctime: 2022-11-17 10:44:29
seqNum: 1
fileStatus: kFileCreated
stripeUnit: 0
root@5dd029eb85a9:/curvebs# ./curve_ops_tool list -fileName=/ | grep test22 -A10
fileName: "test22"
parentId: 0
fileType: INODE_PAGEFILE
owner: "test"
chunkSize: 16777216
segmentSize: 1073741824
length: 10GB
ctime: 2022-11-17 10:44:44
seqNum: 1
fileStatus: kFileCreated
stripeUnit: 0
root@5dd029eb85a9:/curvebs# ./curve_ops_tool list -fileName=/dir11 
id: 2006
fileName: "test2"
parentId: 2004
fileType: INODE_PAGEFILE
owner: "test"
chunkSize: 16777216
segmentSize: 1073741824
length: 20GB
ctime: 2022-11-17 10:44:06
seqNum: 1
fileStatus: kFileCreated
stripeUnit: 32768
stripeCount: 32
allocated size: 0GB

Total file number: 1

```

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
