### PR TITLE
[skipci]feat(peer): add remove peer command for bs

### DIFF
--- a/tools-v2/README.md
+++ b/tools-v2/README.md
@@ -52,6 +52,8 @@ A tool for CurveFS & CurveBs.
     - [status](#status-1)
       - [staus etcd](#staus-etcd)
       - [staus mds](#staus-mds)
+    - [delete](#delete-1)
+      - [delete peer](#delete-peer)
   - [Comparison of old and new commands](#comparison-of-old-and-new-commands)
     - [curve fs](#curve-fs)
     - [curve bs](#curve-bs)
@@ -955,6 +957,28 @@ Output:
 +-------------------+-------------------+-------------------+----------+
 ```
 
+### delete
+
+#### delete peer
+delete the peer from the copyset
+
+Usage:
+```bash
+curve bs delete peer
+```
+
+Output:
+```bash
++------------------+------------------+---------+---------+--------+
+|      LEADER      |       PEER       | COPYSET | RESULT  | REASON |
++------------------+------------------+---------+---------+--------+
+| 127.0.0.1:8201:0 | 127.0.0.1:8202:0 | (1:29)  | success | null   |
++------------------+------------------+---------+---------+--------+
+
+
+```
+
+
 ## Comparison of old and new commands
 
 ### curve fs
@@ -1004,19 +1028,19 @@ Output:
 | list | |
 | seginfo | |
 | delete | |
-| clean-recycle |
+| clean-recycle | |
 | create | |
 | chunk-location | |
 | check-consistency | |
-| remove-peer | |
+| remove-peer | curve bs delete peer |
 | transfer-leader | |
 | reset-peer | |
 | do-snapshot | |
 | do-snapshot-all | |
 | check-chunkserver | |
 | check-copyset | |
-| check-server ||
-| check-operator |
+| check-server | |
+| check-operator | |
 | list-may-broken-vol | |
 | set-copyset-availflag | |
 | update-throttle | |

--- a/tools-v2/internal/error/error.go
+++ b/tools-v2/internal/error/error.go
@@ -25,9 +25,10 @@ package cmderror
 import (
 	"fmt"
 
-	"github.com/opencurve/curve/tools-v2/proto/curvefs/proto/copyset"
+	fscopyset "github.com/opencurve/curve/tools-v2/proto/curvefs/proto/copyset"
 	"github.com/opencurve/curve/tools-v2/proto/curvefs/proto/mds"
 	"github.com/opencurve/curve/tools-v2/proto/curvefs/proto/topology"
+	"github.com/opencurve/curve/tools-v2/proto/proto/copyset"
 	"github.com/opencurve/curve/tools-v2/proto/proto/nameserver2"
 	bs_topo_statuscode "github.com/opencurve/curve/tools-v2/proto/proto/topology/statuscode"
 )
@@ -60,6 +61,9 @@ func init() {
 }
 
 func (ce *CmdError) ToError() error {
+	if ce == nil {
+		return nil
+	}
 	if ce.Code == CODE_SUCCESS {
 		return nil
 	}
@@ -237,7 +241,7 @@ var (
 		return NewInternalCmdError(1, "create http get request failed, the error is: %s")
 	}
 	ErrDataNoExpected = func() *CmdError {
-		return NewInternalCmdError(2, "data: %s is not as expected, the error is: %s")
+		return NewInternalCmdError(2, "data: %v is not as expected, the error is: %s")
 	}
 	ErrHttpClient = func() *CmdError {
 		return NewInternalCmdError(3, "http client get error: %s")
@@ -370,6 +374,14 @@ var (
 		return NewInternalCmdError(40, "delete file fail. the error is %s")
 	}
 
+	ErrRespTypeNoExpected = func() *CmdError {
+		return NewInternalCmdError(41, "the response type is not as expected, should be: %s")
+	}
+
+	ErrGetPeer = func() *CmdError {
+		return NewInternalCmdError(42, "invalid peer args, err: %s")
+	}
+
 	// http error
 	ErrHttpUnreadableResult = func() *CmdError {
 		return NewHttpResultCmdError(1, "http response is unreadable, the uri is: %s, the error is: %s")
@@ -448,7 +460,7 @@ var (
 		message := fmt.Sprintf("get copysets info failed: status code is %s", code.String())
 		return NewRpcReultCmdError(statusCode, message)
 	}
-	ErrCopysetOpSatus = func(statusCode copyset.COPYSET_OP_STATUS, addr string) *CmdError {
+	ErrBsCopysetOpStatus = func(statusCode copyset.COPYSET_OP_STATUS, addr string) *CmdError {
 		var message string
 		code := int(statusCode)
 		switch statusCode {
@@ -516,13 +528,13 @@ var (
 		}
 		return NewRpcReultCmdError(code, message)
 	}
-	ErrCopysetOpStatus = func(statusCode copyset.COPYSET_OP_STATUS, addr string) *CmdError {
+	ErrCopysetOpStatus = func(statusCode fscopyset.COPYSET_OP_STATUS, addr string) *CmdError {
 		var message string
 		code := int(statusCode)
 		switch statusCode {
-		case copyset.COPYSET_OP_STATUS_COPYSET_OP_STATUS_COPYSET_NOTEXIST:
+		case fscopyset.COPYSET_OP_STATUS_COPYSET_OP_STATUS_COPYSET_NOTEXIST:
 			message = fmt.Sprintf("not exist in %s", addr)
-		case copyset.COPYSET_OP_STATUS_COPYSET_OP_STATUS_SUCCESS:
+		case fscopyset.COPYSET_OP_STATUS_COPYSET_OP_STATUS_SUCCESS:
 			message = "ok"
 		default:
 			message = fmt.Sprintf("op status: %s in %s", statusCode.String(), addr)

--- a/tools-v2/internal/utils/copyset.go
+++ b/tools-v2/internal/utils/copyset.go
@@ -44,9 +44,9 @@ const (
 )
 
 const (
-	COPYSET_OK_STR = "ok"
-	COPYSET_WARN_STR = "warn"
-	COPYSET_ERROR_STR = "error"
+	COPYSET_OK_STR       = "ok"
+	COPYSET_WARN_STR     = "warn"
+	COPYSET_ERROR_STR    = "error"
 	COPYSET_NOTEXIST_STR = "not exist"
 )
 

--- a/tools-v2/internal/utils/row.go
+++ b/tools-v2/internal/utils/row.go
@@ -98,6 +98,9 @@ const (
 	ROW_IP              = "ip"
 	ROW_PORT            = "port"
 	ROW_REASON          = "reason"
+	ROW_PEER            = "peer"
+	ROW_COPYSET         = "copyset"
+	ROW_LEADER          = "leader"
 
 	// s3
 	ROW_S3CHUNKINFO_CHUNKID = "s3ChunkId"

--- a/tools-v2/pkg/cli/command/curvebs/bs.go
+++ b/tools-v2/pkg/cli/command/curvebs/bs.go
@@ -23,12 +23,13 @@
 package curvebs
 
 import (
+	"github.com/spf13/cobra"
+
 	basecmd "github.com/opencurve/curve/tools-v2/pkg/cli/command"
 	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/delete"
 	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/list"
 	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/query"
 	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/status"
-	"github.com/spf13/cobra"
 )
 
 type CurveBsCommand struct {

--- a/tools-v2/pkg/cli/command/curvebs/delete/delete.go
+++ b/tools-v2/pkg/cli/command/curvebs/delete/delete.go
@@ -7,131 +7,32 @@
 package delete
 
 import (
-	"context"
-	cmderror "github.com/opencurve/curve/tools-v2/internal/error"
-	cobrautil "github.com/opencurve/curve/tools-v2/internal/utils"
-	basecmd "github.com/opencurve/curve/tools-v2/pkg/cli/command"
-	"github.com/opencurve/curve/tools-v2/pkg/config"
-	"github.com/opencurve/curve/tools-v2/pkg/output"
-	"github.com/opencurve/curve/tools-v2/proto/proto/nameserver2"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-	"google.golang.org/grpc"
+
+	basecmd "github.com/opencurve/curve/tools-v2/pkg/cli/command"
+	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/delete/file"
+	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/delete/peer"
 )
 
-const (
-	deleteCliExample = `curve bs delete --filename /curvebs-file-name --username username [--password password] [--forcedelete true]`
-)
-
-type DeleteCertainFileRpc struct {
-	Info      *basecmd.Rpc
-	Request   *nameserver2.DeleteFileRequest
-	mdsClient nameserver2.CurveFSServiceClient
-}
-
-// DeleteCommand definition
 type DeleteCommand struct {
-	basecmd.FinalCurveCmd
-	Rpc      *DeleteCertainFileRpc
-	Response *nameserver2.DeleteFileResponse
+	basecmd.MidCurveCmd
 }
 
-var _ basecmd.FinalCurveCmdFunc = (*DeleteCommand)(nil)
+var _ basecmd.MidCurveCmdFunc = (*DeleteCommand)(nil) // check interface
 
-func (gRpc *DeleteCertainFileRpc) NewRpcClient(cc grpc.ClientConnInterface) {
-	gRpc.mdsClient = nameserver2.NewCurveFSServiceClient(cc)
-
+func (dCmd *DeleteCommand) AddSubCommands() {
+	dCmd.Cmd.AddCommand(
+		file.NewCommand(),
+		peer.NewCommand(),
+	)
 }
 
-func (gRpc *DeleteCertainFileRpc) Stub_Func(ctx context.Context) (interface{}, error) {
-	return gRpc.mdsClient.DeleteFile(ctx, gRpc.Request)
-}
-
-func (deleteCommand *DeleteCommand) Init(cmd *cobra.Command, args []string) error {
-	mdsAddrs, err := config.GetBsMdsAddrSlice(deleteCommand.Cmd)
-	if err.TypeCode() != cmderror.CODE_SUCCESS {
-		return err.ToError()
-	}
-	//get the default timeout and retrytimes
-	timeout := config.GetFlagDuration(deleteCommand.Cmd, config.RPCTIMEOUT)
-	retrytimes := config.GetFlagInt32(deleteCommand.Cmd, config.RPCRETRYTIMES)
-	filename := config.GetBsFlagString(deleteCommand.Cmd, config.CURVEBS_FILENAME)
-	username := config.GetBsFlagString(deleteCommand.Cmd, config.CURVEBS_USER)
-	password := config.GetBsFlagString(deleteCommand.Cmd, config.CURVEBS_PASSWORD)
-	forcedelete := config.GetFlagBool(deleteCommand.Cmd, config.CURVEBS_FORCEDELETE)
-	date, errDat := cobrautil.GetTimeofDayUs()
-	if errDat.TypeCode() != cmderror.CODE_SUCCESS {
-		return errDat.ToError()
-	}
-	deleteRequest := nameserver2.DeleteFileRequest{
-		FileName:    &filename,
-		Owner:       &username,
-		Date:        &date,
-		ForceDelete: &forcedelete,
-	}
-	if username == viper.GetString(config.VIPER_CURVEBS_USER) && len(password) != 0 {
-		strSig := cobrautil.GetString2Signature(date, username)
-		sig := cobrautil.CalcString2Signature(strSig, password)
-		deleteRequest.Signature = &sig
-	}
-	deleteCommand.Rpc = &DeleteCertainFileRpc{
-		Info:    basecmd.NewRpc(mdsAddrs, timeout, retrytimes, "DeleteFile"),
-		Request: &deleteRequest,
-	}
-	header := []string{cobrautil.ROW_RESULT, cobrautil.ROW_REASON}
-	deleteCommand.SetHeader(header)
-	deleteCommand.TableNew.SetAutoMergeCellsByColumnIndex(cobrautil.GetIndexSlice(
-		deleteCommand.Header, header,
-	))
-	return nil
-}
-
-func (deleteCommand *DeleteCommand) RunCommand(cmd *cobra.Command, args []string) error {
-	out := make(map[string]string)
-	result, err := basecmd.GetRpcResponse(deleteCommand.Rpc.Info, deleteCommand.Rpc)
-	if err.TypeCode() != cmderror.CODE_SUCCESS {
-		out[cobrautil.ROW_RESULT] = "failed"
-		out[cobrautil.ROW_REASON] = err.Message
-		return nil
-	}
-	deleteCommand.Response = result.(*nameserver2.DeleteFileResponse)
-	if deleteCommand.Response.GetStatusCode() != nameserver2.StatusCode_kOK {
-		err = cmderror.ErrBsDeleteFile()
-		out[cobrautil.ROW_RESULT] = "failed"
-		out[cobrautil.ROW_REASON] = err.Message
-		return nil
-	}
-	out[cobrautil.ROW_RESULT] = "success"
-	out[cobrautil.ROW_REASON] = ""
-	list := cobrautil.Map2List(out, []string{cobrautil.ROW_RESULT, cobrautil.ROW_REASON})
-	deleteCommand.TableNew.Append(list)
-	return nil
-}
-
-func (deleteCommand *DeleteCommand) Print(cmd *cobra.Command, args []string) error {
-	return output.FinalCmdOutput(&deleteCommand.FinalCurveCmd, deleteCommand)
-}
-
-func (deleteCommand *DeleteCommand) ResultPlainOutput() error {
-	return output.FinalCmdOutputPlain(&deleteCommand.FinalCurveCmd)
-}
-
-func (deleteCommand *DeleteCommand) AddFlags() {
-	config.AddBsFilenameRequiredFlag(deleteCommand.Cmd)
-	config.AddBsUsernameRequiredFlag(deleteCommand.Cmd)
-	config.AddBsPasswordOptionFlag(deleteCommand.Cmd)
-	config.AddBsForceDeleteOptionFlag(deleteCommand.Cmd)
-}
-
-// NewDeleteCommand return the mid cli
 func NewDeleteCommand() *cobra.Command {
-	deleteCommand := &DeleteCommand{
-		FinalCurveCmd: basecmd.FinalCurveCmd{
-			Use:     "delete",
-			Short:   "delete certain file in curvebs",
-			Example: deleteCliExample,
+	dCmd := &DeleteCommand{
+		basecmd.MidCurveCmd{
+			Use:   "delete",
+			Short: "delete resources in the curvebs",
 		},
 	}
-	basecmd.NewFinalCurveCli(&deleteCommand.FinalCurveCmd, deleteCommand)
-	return basecmd.NewFinalCurveCli(&deleteCommand.FinalCurveCmd, deleteCommand)
+	return basecmd.NewMidCurveCli(&dCmd.MidCurveCmd, dCmd)
 }

--- a/tools-v2/pkg/cli/command/curvebs/delete/file/file.go
+++ b/tools-v2/pkg/cli/command/curvebs/delete/file/file.go
@@ -1,0 +1,133 @@
+package file
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"google.golang.org/grpc"
+
+	cmderror "github.com/opencurve/curve/tools-v2/internal/error"
+	cobrautil "github.com/opencurve/curve/tools-v2/internal/utils"
+	basecmd "github.com/opencurve/curve/tools-v2/pkg/cli/command"
+	"github.com/opencurve/curve/tools-v2/pkg/config"
+	"github.com/opencurve/curve/tools-v2/pkg/output"
+	"github.com/opencurve/curve/tools-v2/proto/proto/nameserver2"
+)
+
+const (
+	deleteCliExample = `curve bs delete file --filename /curvebs-file-name --username username [--password password] [--forcedelete true]`
+)
+
+type DeleteCertainFileRpc struct {
+	Info      *basecmd.Rpc
+	Request   *nameserver2.DeleteFileRequest
+	mdsClient nameserver2.CurveFSServiceClient
+}
+
+// DeleteCommand definition
+type DeleteCommand struct {
+	basecmd.FinalCurveCmd
+	Rpc      *DeleteCertainFileRpc
+	Response *nameserver2.DeleteFileResponse
+}
+
+var _ basecmd.FinalCurveCmdFunc = (*DeleteCommand)(nil)
+
+func (gRpc *DeleteCertainFileRpc) NewRpcClient(cc grpc.ClientConnInterface) {
+	gRpc.mdsClient = nameserver2.NewCurveFSServiceClient(cc)
+
+}
+
+func (gRpc *DeleteCertainFileRpc) Stub_Func(ctx context.Context) (interface{}, error) {
+	return gRpc.mdsClient.DeleteFile(ctx, gRpc.Request)
+}
+
+func (deleteCommand *DeleteCommand) Init(cmd *cobra.Command, args []string) error {
+	mdsAddrs, err := config.GetBsMdsAddrSlice(deleteCommand.Cmd)
+	if err.TypeCode() != cmderror.CODE_SUCCESS {
+		return err.ToError()
+	}
+	//get the default timeout and retrytimes
+	timeout := config.GetFlagDuration(deleteCommand.Cmd, config.RPCTIMEOUT)
+	retrytimes := config.GetFlagInt32(deleteCommand.Cmd, config.RPCRETRYTIMES)
+	filename := config.GetBsFlagString(deleteCommand.Cmd, config.CURVEBS_FILENAME)
+	username := config.GetBsFlagString(deleteCommand.Cmd, config.CURVEBS_USER)
+	password := config.GetBsFlagString(deleteCommand.Cmd, config.CURVEBS_PASSWORD)
+	forcedelete := config.GetFlagBool(deleteCommand.Cmd, config.CURVEBS_FORCEDELETE)
+	date, errDat := cobrautil.GetTimeofDayUs()
+	if errDat.TypeCode() != cmderror.CODE_SUCCESS {
+		return errDat.ToError()
+	}
+	deleteRequest := nameserver2.DeleteFileRequest{
+		FileName:    &filename,
+		Owner:       &username,
+		Date:        &date,
+		ForceDelete: &forcedelete,
+	}
+	if username == viper.GetString(config.VIPER_CURVEBS_USER) && len(password) != 0 {
+		strSig := cobrautil.GetString2Signature(date, username)
+		sig := cobrautil.CalcString2Signature(strSig, password)
+		deleteRequest.Signature = &sig
+	}
+	deleteCommand.Rpc = &DeleteCertainFileRpc{
+		Info:    basecmd.NewRpc(mdsAddrs, timeout, retrytimes, "DeleteFile"),
+		Request: &deleteRequest,
+	}
+	header := []string{cobrautil.ROW_RESULT, cobrautil.ROW_REASON}
+	deleteCommand.SetHeader(header)
+	deleteCommand.TableNew.SetAutoMergeCellsByColumnIndex(cobrautil.GetIndexSlice(
+		deleteCommand.Header, header,
+	))
+	return nil
+}
+
+func (deleteCommand *DeleteCommand) RunCommand(cmd *cobra.Command, args []string) error {
+	out := make(map[string]string)
+	result, err := basecmd.GetRpcResponse(deleteCommand.Rpc.Info, deleteCommand.Rpc)
+	if err.TypeCode() != cmderror.CODE_SUCCESS {
+		out[cobrautil.ROW_RESULT] = "failed"
+		out[cobrautil.ROW_REASON] = err.Message
+		return nil
+	}
+	deleteCommand.Response = result.(*nameserver2.DeleteFileResponse)
+	if deleteCommand.Response.GetStatusCode() != nameserver2.StatusCode_kOK {
+		err = cmderror.ErrBsDeleteFile()
+		out[cobrautil.ROW_RESULT] = "failed"
+		out[cobrautil.ROW_REASON] = err.Message
+		return nil
+	}
+	out[cobrautil.ROW_RESULT] = "success"
+	out[cobrautil.ROW_REASON] = ""
+	list := cobrautil.Map2List(out, []string{cobrautil.ROW_RESULT, cobrautil.ROW_REASON})
+	deleteCommand.TableNew.Append(list)
+	return nil
+}
+
+func (deleteCommand *DeleteCommand) Print(cmd *cobra.Command, args []string) error {
+	return output.FinalCmdOutput(&deleteCommand.FinalCurveCmd, deleteCommand)
+}
+
+func (deleteCommand *DeleteCommand) ResultPlainOutput() error {
+	return output.FinalCmdOutputPlain(&deleteCommand.FinalCurveCmd)
+}
+
+func (deleteCommand *DeleteCommand) AddFlags() {
+	config.AddBsFilenameRequiredFlag(deleteCommand.Cmd)
+	config.AddBsUsernameRequiredFlag(deleteCommand.Cmd)
+	config.AddBsPasswordOptionFlag(deleteCommand.Cmd)
+	config.AddBsForceDeleteOptionFlag(deleteCommand.Cmd)
+}
+
+// NewCommand return the mid cli
+func NewCommand() *cobra.Command {
+	deleteCommand := &DeleteCommand{
+		FinalCurveCmd: basecmd.FinalCurveCmd{
+			Use:     "file",
+			Short:   "delete certain file in curvebs",
+			Example: deleteCliExample,
+		},
+	}
+	basecmd.NewFinalCurveCli(&deleteCommand.FinalCurveCmd, deleteCommand)
+	return basecmd.NewFinalCurveCli(&deleteCommand.FinalCurveCmd, deleteCommand)
+}

--- a/tools-v2/pkg/cli/command/curvebs/delete/peer/copyset.go
+++ b/tools-v2/pkg/cli/command/curvebs/delete/peer/copyset.go
@@ -1,0 +1,75 @@
+/*
+ *  Copyright (c) 2022 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * Project: tools-v2
+ * Created Date: 2022-11-30
+ * Author: zls1129@gmail.com
+ */
+
+package peer
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+
+	cmderror "github.com/opencurve/curve/tools-v2/internal/error"
+	basecmd "github.com/opencurve/curve/tools-v2/pkg/cli/command"
+	"github.com/opencurve/curve/tools-v2/proto/proto/common"
+	"github.com/opencurve/curve/tools-v2/proto/proto/copyset"
+)
+
+// DeleteBrokenCopysetRPC the rpc client for the rpc function DeleteBrokenCopyset
+type DeleteBrokenCopysetRPC struct {
+	Info    *basecmd.Rpc
+	Request *copyset.CopysetRequest
+	Cli     copyset.CopysetServiceClient
+}
+
+var _ basecmd.RpcFunc = (*DeleteBrokenCopysetRPC)(nil) // check interface
+
+// NewRpcClient ...
+func (ufRp *DeleteBrokenCopysetRPC) NewRpcClient(cc grpc.ClientConnInterface) {
+	ufRp.Cli = copyset.NewCopysetServiceClient(cc)
+}
+
+// Stub_Func ...
+func (ufRp *DeleteBrokenCopysetRPC) Stub_Func(ctx context.Context) (interface{}, error) {
+	return ufRp.Cli.DeleteBrokenCopyset(ctx, ufRp.Request)
+}
+
+// DeleteBrokenCopyset delete broken copyset.
+func DeleteBrokenCopyset(logicalPoolID, copysetID uint32, peer *common.Peer, opts Options) (interface{}, *cmderror.CmdError) {
+	rpcCli := &DeleteBrokenCopysetRPC{
+		Request: &copyset.CopysetRequest{
+			LogicPoolId: &logicalPoolID,
+			CopysetId:   &copysetID,
+		},
+		Info: basecmd.NewRpc([]string{peer.GetAddress()}, opts.Timeout, opts.RetryTimes, "DeleteBrokenCopyset"),
+	}
+	response, errCmd := basecmd.GetRpcResponse(rpcCli.Info, rpcCli)
+	if errCmd.TypeCode() != cmderror.CODE_SUCCESS {
+		return nil, errCmd
+	}
+	resp, ok := response.(*copyset.CopysetResponse)
+	if !ok {
+		pErr := cmderror.ErrRespTypeNoExpected()
+		pErr.Format(resp, "copyset.CopysetResponse")
+		return response, pErr
+	}
+	return resp, cmderror.ErrBsCopysetOpStatus(resp.GetStatus(), peer.GetAddress())
+}

--- a/tools-v2/pkg/cli/command/curvebs/delete/peer/leader.go
+++ b/tools-v2/pkg/cli/command/curvebs/delete/peer/leader.go
@@ -1,0 +1,145 @@
+/*
+ *  Copyright (c) 2022 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * Project: tools-v2
+ * Created Date: 2022-11-30
+ * Author: zls1129@gmail.com
+ */
+
+package peer
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	cmderror "github.com/opencurve/curve/tools-v2/internal/error"
+	basecmd "github.com/opencurve/curve/tools-v2/pkg/cli/command"
+	"github.com/opencurve/curve/tools-v2/proto/proto/cli2"
+	"github.com/opencurve/curve/tools-v2/proto/proto/common"
+	"google.golang.org/grpc"
+)
+
+// LeaderRpc the rpc client for the rpc function GetLeader
+type LeaderRpc struct {
+	Info    *basecmd.Rpc
+	Request *cli2.GetLeaderRequest2
+	Cli     cli2.CliService2Client
+}
+
+var _ basecmd.RpcFunc = (*LeaderRpc)(nil) // check interface
+
+// NewRpcClient ...
+func (ufRp *LeaderRpc) NewRpcClient(cc grpc.ClientConnInterface) {
+	ufRp.Cli = cli2.NewCliService2Client(cc)
+}
+
+// Stub_Func ...
+func (ufRp *LeaderRpc) Stub_Func(ctx context.Context) (interface{}, error) {
+	return ufRp.Cli.GetLeader(ctx, ufRp.Request)
+}
+
+// Configuration the configuration for peer.
+type Configuration struct {
+	Peers []*common.Peer
+}
+
+// Options rpc request options.
+type Options struct {
+	Timeout    time.Duration
+	RetryTimes int32
+}
+
+// ParsePeer parse the peer string
+func ParsePeer(peer string) (*common.Peer, *cmderror.CmdError) {
+	cs := strings.Split(peer, ":")
+	if len(cs) != 3 {
+		pErr := cmderror.ErrGetPeer()
+		pErr.Format(fmt.Sprintf("error format for the peer info %s", peer))
+		return nil, pErr
+	}
+	id, err := strconv.ParseUint(cs[2], 10, 64)
+	if err != nil {
+		pErr := cmderror.ErrGetPeer()
+		pErr.Format(fmt.Sprintf("error format for the peer id %s", cs[2]))
+		return nil, pErr
+	}
+	cs = cs[:2]
+	address := strings.Join(cs, ":")
+	return &common.Peer{
+		Id:      &id,
+		Address: &address,
+	}, nil
+}
+
+// ParseConfiguration parse the conf string into Configuration
+func ParseConfiguration(peers []string) (*Configuration, *cmderror.CmdError) {
+	if len(peers) == 0 {
+		pErr := cmderror.ErrGetPeer()
+		pErr.Format("empty group configuration")
+		return nil, pErr
+	}
+
+	configuration := &Configuration{}
+	for _, c := range peers {
+		peer, err := ParsePeer(c)
+		if err != nil {
+			return nil, err
+		}
+		configuration.Peers = append(configuration.Peers, peer)
+	}
+	return configuration, nil
+}
+
+// GetLeader get leader for the address.
+func GetLeader(logicalPoolID, copysetID uint32, conf Configuration, opts Options) (*common.Peer, *cmderror.CmdError) {
+	if len(conf.Peers) == 0 {
+		pErr := cmderror.ErrGetAddr()
+		pErr.Format("peers", conf.Peers)
+		return nil, pErr
+	}
+	var errors []*cmderror.CmdError
+	for _, peer := range conf.Peers {
+		rpcCli := &LeaderRpc{
+			Request: &cli2.GetLeaderRequest2{
+				LogicPoolId: &logicalPoolID,
+				CopysetId:   &copysetID,
+				Peer:        peer,
+			},
+			Info: basecmd.NewRpc([]string{peer.GetAddress()}, opts.Timeout, opts.RetryTimes, "GetLeader"),
+		}
+		response, errCmd := basecmd.GetRpcResponse(rpcCli.Info, rpcCli)
+		if errCmd.TypeCode() != cmderror.CODE_SUCCESS {
+			errors = append(errors, errCmd)
+			continue
+		}
+		resp, ok := response.(*cli2.GetLeaderResponse2)
+		if !ok {
+			pErr := cmderror.ErrRespTypeNoExpected()
+			pErr.Format("cli2.GetLeaderResponse2")
+			errors = append(errors, pErr)
+			continue
+		}
+		if resp.Leader != nil {
+			return resp.Leader, nil
+		}
+	}
+	ret := cmderror.MergeCmdError(errors)
+	return nil, &ret
+}

--- a/tools-v2/pkg/cli/command/curvebs/delete/peer/leader_test.go
+++ b/tools-v2/pkg/cli/command/curvebs/delete/peer/leader_test.go
@@ -1,0 +1,86 @@
+package peer
+
+import (
+	"fmt"
+	"testing"
+
+	"reflect"
+
+	"github.com/opencurve/curve/tools-v2/proto/proto/common"
+)
+
+func ptrUint64(val uint64) *uint64 {
+	return &val
+}
+
+func ptrString(val string) *string {
+	return &val
+}
+
+func TestParseConfiguration(t *testing.T) {
+	testCases := []struct {
+		desc      string
+		input     []string
+		want      *Configuration
+		wantError error
+	}{
+		{
+			desc:      "empty group",
+			wantError: fmt.Errorf("invalid peer args, err: empty group configuration"),
+		},
+		{
+			desc:      "error format1",
+			input:     []string{"1.1.1.1:90"},
+			wantError: fmt.Errorf("invalid peer args, err: error format for the peer info 1.1.1.1:90"),
+		},
+		{
+			desc:      "error format2",
+			input:     []string{"1.1.1.1:90:0:1"},
+			wantError: fmt.Errorf("invalid peer args, err: error format for the peer info 1.1.1.1:90:0:1"),
+		},
+		{
+			desc:      "error format3",
+			input:     []string{"1.1.1.1:90:ds"},
+			wantError: fmt.Errorf("invalid peer args, err: error format for the peer id ds"),
+		},
+		{
+			desc:  "success",
+			input: []string{"1.1.1.1:90:0", "1.1.1.1:91:1", "1.1.1.1:92:2"},
+			want: &Configuration{
+				Peers: []*common.Peer{
+					{
+						Id:      ptrUint64(0),
+						Address: ptrString("1.1.1.1:90"),
+					},
+					{
+						Id:      ptrUint64(1),
+						Address: ptrString("1.1.1.1:91"),
+					},
+					{
+						Id:      ptrUint64(2),
+						Address: ptrString("1.1.1.1:92"),
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			got, err := ParseConfiguration(tc.input)
+			if !cmpError(err.ToError(), tc.wantError) {
+				t.Errorf("want error %s is not same with got error %s", tc.wantError, err.ToError())
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("diff: want %v as not want  %s", tc.want, got)
+			}
+		})
+	}
+}
+
+// cmpError
+// true indicates the errors are same.
+func cmpError(e1, e2 error) bool {
+	return (e1 == nil && e2 == nil) ||
+		(e1 != nil && e2 != nil && e1.Error() == e2.Error())
+}

--- a/tools-v2/pkg/cli/command/curvebs/delete/peer/peer.go
+++ b/tools-v2/pkg/cli/command/curvebs/delete/peer/peer.go
@@ -1,0 +1,203 @@
+/*  Copyright (c) 2022 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * Project: tools-v2
+ * Created Date: 2022-11-30
+ * Author: zls1129@gmail.com
+ */
+
+package peer
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+
+	cmderror "github.com/opencurve/curve/tools-v2/internal/error"
+	cobrautil "github.com/opencurve/curve/tools-v2/internal/utils"
+	basecmd "github.com/opencurve/curve/tools-v2/pkg/cli/command"
+	"github.com/opencurve/curve/tools-v2/pkg/config"
+	"github.com/opencurve/curve/tools-v2/pkg/output"
+	"github.com/opencurve/curve/tools-v2/proto/proto/cli"
+	"github.com/opencurve/curve/tools-v2/proto/proto/common"
+)
+
+const (
+	deleteExample = `$ curve bs delete peer 127.0.0.1:8200:0 --logicalpoolid=1 --copysetid=10001
+ --peers=127.0.0.1:8200:0,127.0.0.1:8201:1,127.0.0.1:8202:2 --rpcretrytimes=1 --rpctimeout=10s`
+)
+
+// RPCClient the rpc client for the rpc function RemovePeer
+type RPCClient struct {
+	Info    *basecmd.Rpc
+	Request *cli.RemovePeerRequest
+	cli     cli.CliServiceClient
+}
+
+func (rpp *RPCClient) NewRpcClient(cc grpc.ClientConnInterface) {
+	rpp.cli = cli.NewCliServiceClient(cc)
+}
+
+func (rpp *RPCClient) Stub_Func(ctx context.Context) (interface{}, error) {
+	return rpp.cli.RemovePeer(ctx, rpp.Request)
+}
+
+var _ basecmd.RpcFunc = (*RPCClient)(nil) // check interface
+
+// Command the command to perform remove peer.
+type Command struct {
+	basecmd.FinalCurveCmd
+
+	// request parameters
+	opts          Options
+	logicalPoolID uint32
+	copysetID     uint32
+
+	conf       Configuration
+	removePeer *common.Peer
+}
+
+var _ basecmd.FinalCurveCmdFunc = (*Command)(nil) // check interface
+// NewCommand ...
+func NewCommand() *cobra.Command {
+	cCmd := &Command{
+		FinalCurveCmd: basecmd.FinalCurveCmd{
+			Use:     "peer",
+			Short:   "delete the peer from the copyset",
+			Example: deleteExample,
+		},
+	}
+	basecmd.NewFinalCurveCli(&cCmd.FinalCurveCmd, cCmd)
+	return cCmd.Cmd
+}
+
+func (cCmd *Command) AddFlags() {
+	config.AddRpcRetryTimesFlag(cCmd.Cmd)
+	config.AddRpcTimeoutFlag(cCmd.Cmd)
+
+	config.AddBSLogicalPoolIdFlag(cCmd.Cmd)
+	config.AddBSCopysetIdFlag(cCmd.Cmd)
+
+	config.AddBSPeersConfFlag(cCmd.Cmd)
+}
+
+func (cCmd *Command) Init(cmd *cobra.Command, args []string) error {
+	cCmd.opts = Options{}
+
+	cCmd.SetHeader([]string{cobrautil.ROW_LEADER, cobrautil.ROW_PEER, cobrautil.ROW_COPYSET, cobrautil.ROW_RESULT, cobrautil.ROW_REASON})
+	cCmd.TableNew.SetAutoMergeCellsByColumnIndex(cobrautil.GetIndexSlice(
+		cCmd.Header, []string{},
+	))
+
+	var err error
+	cCmd.opts.Timeout = config.GetFlagDuration(cCmd.Cmd, config.RPCTIMEOUT)
+	cCmd.opts.RetryTimes = config.GetFlagInt32(cCmd.Cmd, config.RPCRETRYTIMES)
+
+	cCmd.copysetID, err = config.GetBsFlagUint32(cCmd.Cmd, config.CURVEBS_COPYSET_ID)
+	if err != nil {
+		return err
+	}
+	cCmd.logicalPoolID, err = config.GetBsFlagUint32(cCmd.Cmd, config.CURVEBS_LOGIC_POOL_ID)
+	if err != nil {
+		return err
+	}
+
+	// parse peers config
+	peers := config.GetBsFlagStringSlice(cCmd.Cmd, config.CURVEBS_PEERS_ADDRESS)
+	c, e := ParseConfiguration(peers)
+	if e != nil {
+		return e.ToError()
+	}
+	fmt.Println(c)
+	cCmd.conf = *c
+
+	// parse peer conf
+	if len(args) < 1 {
+		pErr := cmderror.ErrGetPeer()
+		pErr.Format("should specified the peer address")
+		return pErr.ToError()
+	}
+	peer := args[0]
+	cCmd.removePeer, e = ParsePeer(peer)
+	if e != nil {
+		return e.ToError()
+	}
+	return nil
+}
+
+func (cCmd *Command) Print(cmd *cobra.Command, args []string) error {
+	return output.FinalCmdOutput(&cCmd.FinalCurveCmd, cCmd)
+}
+
+func (cCmd *Command) RunCommand(cmd *cobra.Command, args []string) error {
+	out := make(map[string]string)
+	out[cobrautil.ROW_PEER] = fmt.Sprintf("%s:%d", cCmd.removePeer.GetAddress(), cCmd.removePeer.GetId())
+	out[cobrautil.ROW_COPYSET] = fmt.Sprintf("(%d:%d)", cCmd.logicalPoolID, cCmd.copysetID)
+
+	// 1. acquire leader peer info.
+	leader, err := GetLeader(cCmd.logicalPoolID, cCmd.copysetID, cCmd.conf, cCmd.opts)
+	if err != nil {
+		out[cobrautil.ROW_RESULT] = "failed"
+		out[cobrautil.ROW_REASON] = err.ToError().Error()
+		cCmd.Error = err
+		return nil
+	}
+
+	out[cobrautil.ROW_LEADER] = fmt.Sprintf("%s", leader.GetAddress())
+	// 2. remove peer
+	cCmd.Result, err = cCmd.execRemovePeer(leader)
+	if err != nil {
+		out[cobrautil.ROW_RESULT] = "failed"
+		out[cobrautil.ROW_REASON] = err.ToError().Error()
+		cCmd.Error = err
+		return nil
+	}
+	out[cobrautil.ROW_RESULT] = "success"
+	out[cobrautil.ROW_REASON] = "null"
+	list := cobrautil.Map2List(out, cCmd.Header)
+	cCmd.TableNew.Append(list)
+	return nil
+}
+
+func (cCmd *Command) ResultPlainOutput() error {
+	return output.FinalCmdOutputPlain(&cCmd.FinalCurveCmd)
+}
+
+func (cCmd *Command) execRemovePeer(leader *common.Peer) (interface{}, *cmderror.CmdError) {
+	peer, err := ParsePeer(leader.GetAddress())
+	if err != nil {
+		return nil, err
+	}
+	leaderID := leader.GetAddress()
+	peerID := fmt.Sprintf("%s:%v", cCmd.removePeer.GetAddress(), cCmd.removePeer.GetId())
+	rpcCli := &RPCClient{
+		Info: basecmd.NewRpc([]string{peer.GetAddress()}, cCmd.opts.Timeout, cCmd.opts.RetryTimes, "RemovePeer"),
+		Request: &cli.RemovePeerRequest{
+			LogicPoolId: &cCmd.logicalPoolID,
+			CopysetId:   &cCmd.copysetID,
+			LeaderId:    &leaderID,
+			PeerId:      &peerID,
+		},
+	}
+
+	response, errCmd := basecmd.GetRpcResponse(rpcCli.Info, rpcCli)
+	if errCmd.TypeCode() != cmderror.CODE_SUCCESS {
+		return response, errCmd
+	}
+	return response, nil
+}

--- a/tools-v2/pkg/cli/curvecli.go
+++ b/tools-v2/pkg/cli/curvecli.go
@@ -26,13 +26,14 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
 	cobraUtil "github.com/opencurve/curve/tools-v2/internal/utils"
 	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs"
 	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvefs"
 	"github.com/opencurve/curve/tools-v2/pkg/cli/command/version"
 	config "github.com/opencurve/curve/tools-v2/pkg/config"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 func addSubCommands(cmd *cobra.Command) {

--- a/tools-v2/pkg/config/bs.go
+++ b/tools-v2/pkg/config/bs.go
@@ -24,6 +24,8 @@ package config
 import (
 	"strings"
 
+	"strconv"
+
 	"github.com/gookit/color"
 	cmderror "github.com/opencurve/curve/tools-v2/internal/error"
 	cobrautil "github.com/opencurve/curve/tools-v2/internal/utils"
@@ -50,9 +52,15 @@ const (
 	CURVEBS_FILENAME            = "filename"
 	VIPER_CURVEBS_FILENAME      = "curvebs.filename"
 	CURVEBS_FORCEDELETE         = "forcedelete"
-	CURVEBS_DEFAULT_FORCEDELETE = "false"
+	CURVEBS_DEFAULT_FORCEDELETE = false
 	CURVEBS_DIR                 = "dir"
 	VIPER_CURVEBS_DIR           = "curvebs.dir"
+	CURVEBS_LOGIC_POOL_ID       = "logicalpoolid"
+	VIPER_CURVEBS_LOGIC_POOL_ID = "curvebs.logicalpoolid"
+	CURVEBS_COPYSET_ID          = "copysetid"
+	VIPER_CURVEBS_COPYSET_ID    = "curvebs.copysetid"
+	CURVEBS_PEERS_ADDRESS       = "peers"
+	VIPER_CURVEBS_PEERS_ADDRESS = "curvebs.peers"
 )
 
 var (
@@ -62,13 +70,16 @@ var (
 		RPCRETRYTIMES: VIPER_GLOBALE_RPCRETRYTIMES,
 
 		// bs
-		CURVEBS_MDSADDR:      VIPER_CURVEBS_MDSADDR,
-		CURVEBS_MDSDUMMYADDR: VIPER_CURVEBS_MDSDUMMYADDR,
-		CURVEBS_PATH:         VIPER_CURVEBS_PATH,
-		CURVEBS_USER:         VIPER_CURVEBS_USER,
-		CURVEBS_PASSWORD:     VIPER_CURVEBS_PASSWORD,
-		CURVEBS_ETCDADDR:     VIPER_CURVEBS_ETCDADDR,
-		CURVEBS_DIR:          VIPER_CURVEBS_DIR,
+		CURVEBS_MDSADDR:       VIPER_CURVEBS_MDSADDR,
+		CURVEBS_MDSDUMMYADDR:  VIPER_CURVEBS_MDSDUMMYADDR,
+		CURVEBS_PATH:          VIPER_CURVEBS_PATH,
+		CURVEBS_USER:          VIPER_CURVEBS_USER,
+		CURVEBS_PASSWORD:      VIPER_CURVEBS_PASSWORD,
+		CURVEBS_ETCDADDR:      VIPER_CURVEBS_ETCDADDR,
+		CURVEBS_DIR:           VIPER_CURVEBS_DIR,
+		CURVEBS_LOGIC_POOL_ID: VIPER_CURVEBS_LOGIC_POOL_ID,
+		CURVEBS_COPYSET_ID:    VIPER_CURVEBS_COPYSET_ID,
+		CURVEBS_PEERS_ADDRESS: VIPER_CURVEBS_PEERS_ADDRESS,
 	}
 
 	BSFLAG2DEFAULT = map[string]interface{}{
@@ -87,6 +98,15 @@ func AddBsStringSliceOptionFlag(cmd *cobra.Command, name string, usage string) {
 		defaultValue = []string{}
 	}
 	cmd.Flags().StringSlice(name, defaultValue.([]string), usage)
+	err := viper.BindPFlag(BSFLAG2VIPER[name], cmd.Flags().Lookup(name))
+	if err != nil {
+		cobra.CheckErr(err)
+	}
+}
+
+func AddBsStringSliceRequiredFlag(cmd *cobra.Command, name string, usage string) {
+	cmd.Flags().StringSlice(name, nil, usage+color.Red.Sprint("[required]"))
+	cmd.MarkFlagRequired(name)
 	err := viper.BindPFlag(BSFLAG2VIPER[name], cmd.Flags().Lookup(name))
 	if err != nil {
 		cobra.CheckErr(err)
@@ -116,12 +136,12 @@ func AddBsStringRequiredFlag(cmd *cobra.Command, name string, usage string) {
 }
 
 func AddBsBoolOptionFlag(cmd *cobra.Command, name string, usage string) {
-	defaultValue := FLAG2DEFAULT[name]
+	defaultValue := BSFLAG2DEFAULT[name]
 	if defaultValue == nil {
 		defaultValue = false
 	}
 	cmd.Flags().Bool(name, defaultValue.(bool), usage)
-	err := viper.BindPFlag(FLAG2VIPER[name], cmd.Flags().Lookup(name))
+	err := viper.BindPFlag(BSFLAG2VIPER[name], cmd.Flags().Lookup(name))
 	if err != nil {
 		cobra.CheckErr(err)
 	}
@@ -170,8 +190,29 @@ func AddBsFilenameRequiredFlag(cmd *cobra.Command) {
 	AddBsStringRequiredFlag(cmd, CURVEBS_FILENAME, "the full path of file")
 }
 
+func AddBSLogicalPoolIdFlag(cmd *cobra.Command) {
+	AddBSUint32RequiredFlag(cmd, CURVEBS_LOGIC_POOL_ID, "logical pool id")
+}
+
+func AddBSCopysetIdFlag(cmd *cobra.Command) {
+	AddBSUint32RequiredFlag(cmd, CURVEBS_COPYSET_ID, "copyset id")
+}
+
+func AddBSPeersConfFlag(cmd *cobra.Command) {
+	AddBsStringSliceRequiredFlag(cmd, CURVEBS_PEERS_ADDRESS, "peers info.")
+}
+
 func AddBsForceDeleteOptionFlag(cmd *cobra.Command) {
 	AddBsBoolOptionFlag(cmd, CURVEBS_FORCEDELETE, "whether to force delete the file")
+}
+
+func AddBSUint32RequiredFlag(cmd *cobra.Command, name string, usage string) {
+	cmd.Flags().Uint32(name, uint32(0), usage+color.Red.Sprint("[required]"))
+	cmd.MarkFlagRequired(name)
+	err := viper.BindPFlag(BSFLAG2VIPER[name], cmd.Flags().Lookup(name))
+	if err != nil {
+		cobra.CheckErr(err)
+	}
 }
 
 // get stingslice flag
@@ -194,6 +235,22 @@ func GetBsFlagString(cmd *cobra.Command, flagName string) string {
 		value = viper.GetString(BSFLAG2VIPER[flagName])
 	}
 	return value
+}
+
+// GetBsFlagUint32 get uint32 flag
+func GetBsFlagUint32(cmd *cobra.Command, flagName string) (uint32, error) {
+	var value string
+	if cmd.Flag(flagName).Changed {
+		value = cmd.Flag(flagName).Value.String()
+	} else {
+		value = viper.GetString(BSFLAG2VIPER[flagName])
+	}
+	val, err := strconv.ParseUint(value, 10, 32)
+	if err != nil {
+		return 0, err
+	}
+
+	return uint32(val), nil
 }
 
 // get mdsaddr
@@ -224,4 +281,14 @@ func GetBsMdsAddrSlice(cmd *cobra.Command) ([]string, *cmderror.CmdError) {
 
 func GetBsMdsDummyAddrSlice(cmd *cobra.Command) ([]string, *cmderror.CmdError) {
 	return GetBsAddrSlice(cmd, CURVEBS_MDSDUMMYADDR)
+}
+
+func GetBsFlagBool(cmd *cobra.Command, flagName string) bool {
+	var value bool
+	if cmd.Flag(flagName).Changed {
+		value, _ = cmd.Flags().GetBool(flagName)
+	} else {
+		value = viper.GetBool(BSFLAG2VIPER[flagName])
+	}
+	return value
 }


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: https://github.com/opencurve/curve/issues/2021


we'd like to support `remove peer` command in [curve tool](https://github.com/opencurve/curve/tree/master/tools-v2)
`remove peer` is one of the commands to make configuration changes to a raft replication group.

- The implementation of the old tool is here：
https://github.com/opencurve/curve/blob/5e49aed29c6cbf75f046373ecfd17ec0d3fbe0c5/src/tools/curve_cli.cpp#L99
- The old command input and out put:
```
remove-peer : remove the peer from the copyset

curve_ops_tool remove-peer --example
Example
curve_ops_tool remove-peer -logicalPoolId=1 -copysetId=10001 -peer=127.0.0.1:8080:0 -conf=127.0.0.1:8080:0,127.0.0.1:8081:0,127.0.0.1:8082:0 -max_retry=3 -timeout_ms=100

output:
remove peer ok
```

- The new command we want:
```
curve bs peer reset --help                                                                                            4s
Usage:  curve bs peer remove [flags]

remove the peer from the copyset

Flags:
  -c, --conf string            config file (default is $HOME/.curve/curve.yaml or /etc/curve/curve.yaml)
      --copysetid uint32       copyset id[required]
      --curconf string         cur conf info.[required]
  -f, --format string          output format (json|plain) (default "plain")
  -h, --help                   print help
      --logicalpoolid uint32   logical pool id[required]
      --peer string            peer info[required]
      --removecopyset          whether need to remove broken copyset after remove peer (default false)
      --rpcretrytimes int32    rpc retry times (default 1)
      --rpctimeout duration    rpc timeout (default 10s)
      --showerror              display all errors in command
      --verbose                show some log

Examples:
$ curve bs peer remove --logicalpoolid=1 --copysetid=10001 --peer=127.0.0.1:8200:0
 --curconf=127.0.0.1:8200:0,127.0.0.1:8201:1,127.0.0.1:8202:2 --rpcretrytimes=1 --rpctimeout=10s --removecopyset=false

output:
configuration of replication group changed from [127.0.0.1:8201:0 127.0.0.1:8202:0] to [127.0.0.1:8201:0 127.0.0.1:8202:0]
Remove peer (127.0.0.1:8200:0)for copyset(1,12)  success

```
### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
