### PR TITLE
Add help_msg in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,17 +11,61 @@ tag?= "curvebs:unknown"
 case?= "*"
 os?= "debian9"
 
+define help_msg
+## list
+Usage:
+    make list stor=bs/fs
+Examples:
+    make list stor=bs
+
+## build
+Usage:
+    make build stor=bs/fs only=TARGET dep=0/1 release=0/1 os=OS
+Examples:
+    make build stor=bs only=//src/chunkserver:chunkserver
+    make build stor=bs only=src/* dep=0
+    make build stor=fs only=test/* os=debian9
+    make build stor=fs release=1
+
+
+## dep
+Usage:
+    make dep stor=bs/fs
+Examples:
+    make dep stor=bs
+
+
+## install
+Usage:
+    make install stor=bs/fs prefix=PREFIX only=TARGET
+Examples:
+    make install stor=bs prefix=/usr/local/curvebs only=*
+    make install stor=bs prefix=/usr/local/curvebs only=chunkserver
+    make install stor=fs prefix=/usr/local/curvefs only=etcd
+
+
+## image
+Usage:
+    make image stor=bs/fs tag=TAG os=OS
+Examples:
+    make image stor=bs tag=opencurvedocker/curvebs:v1.2 os=debian9
+endef
+export help_msg
+
+help:
+	@echo "$$help_msg"
+
 list:
-	@bash util/build.sh --stor=${stor} --list
+	@bash util/build.sh --stor=$(stor) --list
 
 build:
-	@bash util/build.sh --stor=${stor} --only=$(only) --dep=$(dep) --release=$(release) --os=$(os)
+	@bash util/build.sh --stor=$(stor) --only=$(only) --dep=$(dep) --release=$(release) --os=$(os)
 
 dep:
-	@bash util/build.sh --stor=${stor} --only="" --dep=1
+	@bash util/build.sh --stor=$(stor) --only="" --dep=1
 
 install:
-	@bash util/install.sh --stor=${stor} --prefix=$(prefix) --only=$(only)
+	@bash util/install.sh --stor=$(stor) --prefix=$(prefix) --only=$(only)
 
 image:
-	@bash util/image.sh ${stor} $(tag) $(os)
+	@bash util/image.sh $(stor) $(tag) $(os)

--- a/util/build.sh
+++ b/util/build.sh
@@ -225,15 +225,13 @@ main() {
     get_version
 
     if [[ "$g_stor" != "bs" && "$g_stor" != "fs" ]]; then
-        usage
         die "stor option must be either bs or fs\n"
     fi
 
     if [ "$g_list" -eq 1 ]; then
         list_target
     elif [[ "$g_target" == "" && "$g_depend" -ne 1 ]]; then
-        usage
-        exit 1
+        die "must not disable both only option or dep option\n"
     else
         if [ "$g_depend" -eq 1 ]; then
             build_requirements

--- a/util/install.sh
+++ b/util/install.sh
@@ -316,13 +316,11 @@ main() {
     get_build_mode
 
     if [[ -n "$g_stor" && "$g_stor" != "bs" && "$g_stor" != "fs" ]]; then
-        usage
         die "stor option must be either bs or fs\n"
     fi
 
     if [[ $g_prefix == "" || $g_only == "" ]]; then
-        usage
-        exit 1
+        die "prefix option and only option must not be empty\n"
     elif [ "$g_only" == "etcd" ]; then
         install_etcd
     elif [ "$g_only" == "monitor" ]; then


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: #2104

Problem Summary:

### What is changed and how it works?

What's Changed:
`make help` will give examples about building and installing.  
Don't print usage msg on encountering failure in util/build.sh and util/install.sh.  

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [x] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license
