### PR TITLE
[skipci] make gcc colorful output

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,3 +3,5 @@ build --copt -DHAVE_ZLIB=1 --copt -DGFLAGS_NS=google --copt -DUSE_BTHREAD_MUTEX
 build --cxxopt -Wno-error=format-security
 build:gcc7-later --cxxopt -faligned-new
 build --incompatible_blacklisted_protos_requires_proto_info=false
+build --copt=-fdiagnostics-color=always
+run --copt=-fdiagnostics-color=always


### PR DESCRIPTION
Signed-off-by: fan <yfan3763@gmail.com>

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #xxx <!-- replace xxx with issue number -->

Problem Summary: default gcc6.3 ouput is white, but we can add this flag to make it have colorful output.

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
