### PR TITLE
refator: `std::exception` should be catched by reference

### DIFF
--- a/curvefs/src/mds/topology/topology_storge_etcd.cpp
+++ b/curvefs/src/mds/topology/topology_storge_etcd.cpp
@@ -634,7 +634,7 @@ bool TopologyStorageEtcd::LoadFs2MemcacheCluster(
         }
         try {
             fs2MemcacheCluster->emplace(id, std::stoul(data.second));
-        } catch (std::exception) {
+        } catch (std::exception&) {
             // for std::stoul(data.second) exceptions
             return false;
         }


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Problem Summary:
`std::exception` should be passed by reference in catch clause, otherwise in later versions of gcc (eg: 8.3) this will be treated as an error.

### What is changed and how it works?

What's Changed:

pass by reference.

How it Works:

### Check List

- [x] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license
