### PR TITLE
[fix]curefs/client: memcache test hang

### DIFF
--- a/curvefs/test/client/client_memcache_test.cpp
+++ b/curvefs/test/client/client_memcache_test.cpp
@@ -48,11 +48,10 @@ class MemCachedTest : public ::testing::Test {
         if (0 > memcached_pid) {
             ASSERT_FALSE(true);
         } else if (0 == memcached_pid) {
-            std::string memcached_config =
-                "memcached -u root -p " + std::to_string(port);
-            ASSERT_EQ(0, execl("/bin/sh", "sh", "-c", memcached_config.c_str(),
-                               nullptr));
-            exit(0);
+            std::string memcached_port =
+                "-p " + std::to_string(port);
+            ASSERT_EQ(0, execlp("memcached", "memcached", "-u root",
+                                memcached_port.c_str(), nullptr));
         }
 
         std::shared_ptr<MemCachedClient> client(new MemCachedClient());


### PR DESCRIPTION
Signed-off-by: Cyber-SiKu <Cyber-SiKu@outlook.com>

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #xxx <!-- replace xxx with issue number -->

Problem Summary:

Because sh is used to start memcheched, the `sh` process is killed instead of the memcached.`tee` process to hang, grep fail.

### What is changed and how it works?

Use execlp to start memcached directly.

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
