### PR TITLE
curvebs|unit test|supply WaitLeader

### DIFF
--- a/test/integration/common/peer_cluster.h
+++ b/test/integration/common/peer_cluster.h
@@ -149,10 +149,24 @@ class PeerCluster {
     int SignalPeer(const Peer &peer);
     /**
      * 反复重试直到等到新的leader产生
-     * @param leaderId出参，返回leader id
+     * @param leaderPeer出参，返回leader info
      * @return 0，成功；-1 失败
      */
     int WaitLeader(Peer *leaderPeer);
+
+    /**
+     * confirm leader 
+     * @param: LogicPoolID logicalPool id
+     * @param: copysetId copyset id
+     * @param: leaderAddr leader address
+     * @param: leader leader info
+     * @return 0，成功；-1 失败
+     */
+    int ConfirmLeader(const LogicPoolID &logicPoolId,
+                        const CopysetID &copysetId,
+                        const std::string& leaderAddr,
+                        Peer *leader);
+
 
     /**
      * Stop所有的peer


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Add ConfirmLeader to WaitLeader. If a follower is waked up after hang, it may deal with a expire heartbeat info and get a wrong leader. So follower must confirm the get leader

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
