### PR TITLE
[fix] use golang.google.cn to dowanlod go1.12.8

### DIFF
--- a/thirdparties/etcdclient/Makefile
+++ b/thirdparties/etcdclient/Makefile
@@ -22,7 +22,7 @@ all: intall-go install-etcdclient libetcdclient
 
 intall-go:
 	mkdir -p $(pwd)/tmp
-	cd $(pwd)/tmp && wget -N https://curve-build.nos-eastchina1.126.net/go1.12.8.linux-amd64.tar.gz
+	cd $(pwd)/tmp && wget -N https://golang.google.cn/dl/go1.12.8.linux-amd64.tar.gz
 	cd $(pwd)/tmp && tar zxvf go1.12.8.linux-amd64.tar.gz
 
 install-etcdclient:


### PR DESCRIPTION
use golang.google.cn to downlaod go1.12.8

Signed-off-by: Cyber-SiKu <Cyber-SiKu@outlook.com>

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #xxx <!-- replace xxx with issue number -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
