### PR TITLE
avoid memcpy when using RocksDB slice

### DIFF
--- a/curvefs/src/metaserver/dentry_storage.cpp
+++ b/curvefs/src/metaserver/dentry_storage.cpp
@@ -379,8 +379,7 @@ MetaStatusCode DentryStorage::List(const Dentry& dentry,
     time.start();
     for (iterator->SeekToFirst(); iterator->Valid(); iterator->Next()) {
         seekTimes++;
-        std::string skey = iterator->Key();
-        std::string svalue = iterator->Value();
+        absl::string_view skey = iterator->Key();
         if (!StringStartWith(skey, sprefix)) {
             break;
         } else if (!iterator->ParseFromValue(&current)) {

--- a/curvefs/src/metaserver/metastore.h
+++ b/curvefs/src/metaserver/metastore.h
@@ -30,6 +30,7 @@
 #include <memory>
 #include <string>
 
+#include "absl/strings/string_view.h"
 #include "curvefs/proto/metaserver.pb.h"
 #include "curvefs/src/common/rpc_stream.h"
 #include "curvefs/src/metaserver/copyset/snapshot_closure.h"
@@ -275,7 +276,7 @@ class MetaStoreImpl : public MetaStore {
 
     void PrepareStreamBuffer(butil::IOBuf* buffer,
                              uint64_t chunkIndex,
-                             const std::string& value);
+                             absl::string_view value);
 
     void SaveBackground(const std::string& path,
                         DumpFileClosure* child,

--- a/curvefs/src/metaserver/metastore_fstream.h
+++ b/curvefs/src/metaserver/metastore_fstream.h
@@ -58,29 +58,29 @@ class MetaStoreFStream {
 
  private:
     bool LoadPartition(uint32_t partitionId,
-                       const std::string& key,
-                       const std::string& value);
+                       absl::string_view key,
+                       absl::string_view value);
 
     bool LoadInode(uint32_t partitionId,
-                   const std::string& key,
-                   const std::string& value);
+                   absl::string_view key,
+                   absl::string_view value);
 
     bool LoadDentry(uint8_t version,
                     uint32_t partitionId,
-                    const std::string& key,
-                    const std::string& value);
+                    absl::string_view key,
+                    absl::string_view value);
 
     bool LoadPendingTx(uint32_t partitionId,
-                       const std::string& key,
-                       const std::string& value);
+                       absl::string_view key,
+                       absl::string_view value);
 
     bool LoadInodeS3ChunkInfoList(uint32_t partitionId,
-                                  const std::string& key,
-                                  const std::string& value);
+                                  absl::string_view key,
+                                  absl::string_view value);
 
     bool LoadVolumeExtentList(uint32_t partitionId,
-                              const std::string& key,
-                              const std::string& value);
+                              absl::string_view key,
+                              absl::string_view value);
 
     std::shared_ptr<Iterator> NewPartitionIterator();
 

--- a/curvefs/src/metaserver/storage/dumpfile.cpp
+++ b/curvefs/src/metaserver/storage/dumpfile.cpp
@@ -216,20 +216,20 @@ DUMPFILE_ERROR DumpFile::SaveInt(Int num, off_t* offset, uint32_t* checkSum) {
     return retCode;
 }
 
-DUMPFILE_ERROR DumpFile::SaveString(const std::string& str,
+DUMPFILE_ERROR DumpFile::SaveString(absl::string_view str,
                                     off_t* offset,
                                     uint32_t* checkSum) {
     size_t length = str.size();
-    auto retCode = Write(str.c_str(), *offset, length);
+    auto retCode = Write(str.data(), *offset, length);
     if (retCode == DUMPFILE_ERROR::OK) {
         *offset = (*offset) + length;
-        *checkSum = CRC32(*checkSum, str.c_str(), length);
+        *checkSum = CRC32(*checkSum, str.data(), length);
     }
 
     return retCode;
 }
 
-DUMPFILE_ERROR DumpFile::SaveEntry(const std::string& entry,
+DUMPFILE_ERROR DumpFile::SaveEntry(absl::string_view entry,
                                    off_t* offset,
                                    uint32_t* checkSum) {
     auto retCode = SaveInt<uint32_t>(entry.size(), offset, checkSum);
@@ -613,11 +613,11 @@ void DumpFileIterator::Next() {
     iter_.second = value;
 }
 
-std::string DumpFileIterator::Key() {
+absl::string_view DumpFileIterator::Key() {
     return iter_.first;
 }
 
-std::string DumpFileIterator::Value() {
+absl::string_view DumpFileIterator::Value() {
     return iter_.second;
 }
 

--- a/curvefs/src/metaserver/storage/dumpfile.h
+++ b/curvefs/src/metaserver/storage/dumpfile.h
@@ -29,6 +29,7 @@
 #include <utility>
 #include <condition_variable>
 
+#include "absl/strings/string_view.h"
 #include "curvefs/src/metaserver/storage/iterator.h"
 
 namespace curve {
@@ -174,11 +175,11 @@ class DumpFile {
     template <typename Int>
     DUMPFILE_ERROR SaveInt(Int num, off_t* offset, uint32_t* checkSum);
 
-    DUMPFILE_ERROR SaveString(const std::string& str,
+    DUMPFILE_ERROR SaveString(absl::string_view str,
                               off_t* offset,
                               uint32_t* checkSum);
 
-    DUMPFILE_ERROR SaveEntry(const std::string& entry,
+    DUMPFILE_ERROR SaveEntry(absl::string_view entry,
                              off_t* offset,
                              uint32_t* checkSum);
 
@@ -246,9 +247,9 @@ class DumpFileIterator : public Iterator {
 
     void Next() override;
 
-    std::string Key() override;
+    absl::string_view Key() override;
 
-    std::string Value() override;
+    absl::string_view Value() override;
 
     bool ParseFromValue(ValueType* value) override;
 

--- a/curvefs/src/metaserver/storage/iterator.h
+++ b/curvefs/src/metaserver/storage/iterator.h
@@ -27,6 +27,7 @@
 #include <vector>
 #include <memory>
 
+#include "absl/strings/string_view.h"
 #include "curvefs/src/metaserver/storage/common.h"
 
 namespace curvefs {
@@ -46,9 +47,9 @@ class Iterator {
 
     virtual void Next() = 0;
 
-    virtual std::string Key() = 0;
+    virtual absl::string_view Key() = 0;
 
-    virtual std::string Value() = 0;
+    virtual absl::string_view Value() = 0;
 
     virtual const ValueType* RawValue() const { return nullptr; }
 
@@ -92,11 +93,11 @@ class MergeIterator : public Iterator {
         FindCurrent();
     }
 
-    std::string Key() override {
+    absl::string_view Key() override {
         return current_->Key();
     }
 
-    std::string Value() override {
+    absl::string_view Value() override {
         return current_->Value();
     }
 
@@ -147,11 +148,11 @@ class ContainerIterator : public Iterator {
         iter_++;
     }
 
-    std::string Key() override {
+    absl::string_view Key() override {
         return iter_->first;
     }
 
-    std::string Value() override {
+    absl::string_view Value() override {
         return iter_->second;
     }
 

--- a/curvefs/src/metaserver/storage/memory_storage.h
+++ b/curvefs/src/metaserver/storage/memory_storage.h
@@ -177,11 +177,11 @@ class MemoryStorageIterator : public Iterator {
         current_++;
     }
 
-    std::string Key() override {
+    absl::string_view Key() override {
         return current_->first;
     }
 
-    std::string Value() override {
+    absl::string_view Value() override {
         return "";
     }
 
@@ -203,6 +203,8 @@ class MemoryStorageIterator : public Iterator {
 
 template<typename ContainerType>
 class UnorderedContainerIterator : public MemoryStorageIterator<ContainerType> {
+private:
+    std::string svalue_;
  public:
     using MemoryStorageIterator<ContainerType>::MemoryStorageIterator;
 
@@ -210,13 +212,13 @@ class UnorderedContainerIterator : public MemoryStorageIterator<ContainerType> {
         this->current_ = this->container_->begin();
     }
 
-    std::string Value() override {
-        std::string svalue;
+    absl::string_view Value() override {
+        svalue_.clear();
         auto message = this->current_->second.Message();
-        if (!message->SerializeToString(&svalue)) {
+        if (!message->SerializeToString(&svalue_)) {
             this->status_ = -1;
         }
-        return svalue;
+        return svalue_;
     }
 
     const ValueType* RawValue() const override {
@@ -240,7 +242,7 @@ public MemoryStorageIterator<ContainerType> {
         this->current_ = this->container_->begin();
     }
 
-    std::string Value() override {
+    absl::string_view Value() override {
         return this->current_->second;
     }
 
@@ -254,6 +256,8 @@ public MemoryStorageIterator<ContainerType> {
 
 template<typename ContainerType>
 class OrderedContainerIterator : public MemoryStorageIterator<ContainerType> {
+ private:
+    std::string svalue_;
  public:
     using MemoryStorageIterator<ContainerType>::MemoryStorageIterator;
 
@@ -261,13 +265,13 @@ class OrderedContainerIterator : public MemoryStorageIterator<ContainerType> {
         this->current_ = this->container_->lower_bound(this->prefix_);
     }
 
-    std::string Value() override {
-        std::string svalue;
+    absl::string_view Value() override {
+        svalue_.clear();
         auto message = this->current_->second.Message();
-        if (!message->SerializeToString(&svalue)) {
+        if (!message->SerializeToString(&svalue_)) {
             this->status_ = -1;
         }
-        return svalue;
+        return svalue_;
     }
 
     const ValueType* RawValue() const override {
@@ -291,7 +295,7 @@ public MemoryStorageIterator<ContainerType> {
         this->current_ = this->container_->lower_bound(this->prefix_);
     }
 
-    std::string Value() override {
+    absl::string_view Value() override {
         return this->current_->second;
     }
 

--- a/curvefs/src/metaserver/storage/rocksdb_storage.cpp
+++ b/curvefs/src/metaserver/storage/rocksdb_storage.cpp
@@ -194,8 +194,8 @@ std::string RocksDBStorage::ToInternalKey(const std::string& name,
 }
 
 // extract user key from internal key: prefix:key => key
-std::string RocksDBStorage::ToUserKey(const std::string& ikey) {
-    return ikey.substr(GetKeyPrefixLength() + kDelimiter_.size());
+absl::string_view RocksDBStorage::ToUserKey(absl::string_view ikey_view) {
+    return ikey_view.substr(GetKeyPrefixLength() + kDelimiter_.size());
 }
 
 Status RocksDBStorage::Get(const std::string& name,

--- a/curvefs/src/metaserver/storage/rocksdb_storage.h
+++ b/curvefs/src/metaserver/storage/rocksdb_storage.h
@@ -144,7 +144,7 @@ class RocksDBStorage : public KVStorage, public StorageTransaction {
                               const std::string& key,
                               bool ordered);
 
-    std::string ToUserKey(const std::string& ikey);
+    absl::string_view ToUserKey(absl::string_view ikey_view);
 
     Status Get(const std::string& name,
                const std::string& key,
@@ -343,17 +343,17 @@ class RocksDBStorageIterator : public Iterator {
         iter_->Next();
     }
 
-    std::string Key() {
+    absl::string_view Key() {
         RocksDBPerfGuard guard(OP_ITERATOR_GET_KEY);
         auto slice = iter_->key();
-        auto ikey = std::string(slice.data(), slice.size());
-        return storage_->ToUserKey(ikey);
+        absl::string_view ikey_view(slice.data(), slice.size());
+        return storage_->ToUserKey(ikey_view);
     }
 
-    std::string Value() {
+    absl::string_view Value() {
         RocksDBPerfGuard guard(OP_ITERATOR_GET_VALUE);
         auto slice = iter_->value();
-        return std::string(slice.data(), slice.size());
+        return absl::string_view(slice.data(), slice.size());
     }
 
     bool ParseFromValue(ValueType* value) override {

--- a/curvefs/test/metaserver/storage/dumpfile_test.cpp
+++ b/curvefs/test/metaserver/storage/dumpfile_test.cpp
@@ -47,8 +47,8 @@ class HashIterator : public Iterator {
     bool Valid() override { return iter_ != hash_->end(); }
     void SeekToFirst() override { iter_ = hash_->begin(); }
     void Next() override { iter_++; }
-    std::string Key() override { return iter_->first; }
-    std::string Value() override { return iter_->second; }
+    absl::string_view Key() override { return iter_->first; }
+    absl::string_view Value() override { return iter_->second; }
     int Status() override { return 0; }
 
  private:
@@ -93,8 +93,8 @@ class DumpFileTest : public ::testing::Test {
             auto key = iter->Key();
             auto value = iter->Value();
             ASSERT_EQ(key, value);
-            ASSERT_TRUE(hash->find(key) != hash->end());
-            hash->erase(key);
+            ASSERT_TRUE(hash->find(std::string(key)) != hash->end());
+            hash->erase(std::string(key));
         }
 
         ASSERT_EQ(hash->size(), 0);

--- a/curvefs/test/metaserver/storage/iterator_test.cpp
+++ b/curvefs/test/metaserver/storage/iterator_test.cpp
@@ -49,8 +49,8 @@ class HashIterator : public Iterator {
     bool Valid() override { return iter_ != hash_->end(); }
     void SeekToFirst() override { iter_ = hash_->begin(); }
     void Next() override { iter_++; }
-    std::string Key() override { return iter_->first; }
-    std::string Value() override { return iter_->second; }
+    absl::string_view Key() override { return iter_->first; }
+    absl::string_view Value() override { return iter_->second; }
     bool ParseFromValue(ValueType* value) { return true; }
     int Status() override { return 0; }
 
@@ -171,7 +171,7 @@ TEST_F(IteratorTest, MergeIterator) {
         for (auto& hash : hashs) {
             children.push_back(std::make_shared<HashIterator>(&hash));
             for (const auto& item : hash) {
-                except.push_back(std::make_pair(item.first, item.second));
+                except.push_back(std::make_pair(std::string(item.first), std::string(item.second)));
             }
         }
 
@@ -179,7 +179,7 @@ TEST_F(IteratorTest, MergeIterator) {
         for (iter.SeekToFirst(); iter.Valid(); iter.Next()) {
             auto key = iter.Key();
             auto value = iter.Value();
-            out.push_back(std::make_pair(key, value));
+            out.push_back(std::make_pair(std::string(key), std::string(value)));
         }
 
         ASSERT_EQ(except, out);

--- a/curvefs/test/metaserver/storage/storage_fstream_test.cpp
+++ b/curvefs/test/metaserver/storage/storage_fstream_test.cpp
@@ -133,8 +133,8 @@ void StorageFstreamTest::TestSave(std::shared_ptr<KVStorage> kvStorage,
     auto callback = [&](uint8_t version,
                         ENTRY_TYPE type,
                         uint32_t partitionId,
-                        const std::string& key,
-                        const std::string& value) {
+                        absl::string_view key,
+                        absl::string_view value) {
         if (version == 2) {
             nVersion++;
         }
@@ -241,8 +241,8 @@ TEST_F(StorageFstreamTest, MiscTest) {
         auto callback = [&](uint8_t version,
                             ENTRY_TYPE type,
                             uint32_t partitionId,
-                            const std::string& key,
-                            const std::string& value) {
+                            absl::string_view key,
+                            absl::string_view value) {
             return true;
         };
         bool succ = LoadFromFile("__not_found__", &dummyVersion, callback);
@@ -254,8 +254,8 @@ TEST_F(StorageFstreamTest, MiscTest) {
         auto callback = [&](uint8_t version,
                             ENTRY_TYPE type,
                             uint32_t partitionId,
-                            const std::string& key,
-                            const std::string& value) {
+                            absl::string_view key,
+                            absl::string_view value) {
             return false;
         };
         bool succ = LoadFromFile(pathname_, &dummyVersion, callback);

--- a/src/common/BUILD
+++ b/src/common/BUILD
@@ -53,6 +53,7 @@ cc_library(
         "//external:glog",
         "//src/common/concurrent:curve_concurrent",
         ":macros",
+        "@com_google_absl//absl/strings",
     ],
     linkopts = [
         "-luuid",

--- a/src/common/string_util.h
+++ b/src/common/string_util.h
@@ -37,6 +37,8 @@
 #include <vector>
 #include <stdexcept>
 
+#include "absl/strings/string_view.h"
+
 namespace curve {
 namespace common {
 
@@ -116,6 +118,11 @@ inline bool StringToInt(const std::string &value, int32_t *out) noexcept {
 
 inline bool StringStartWith(const std::string& value,
                             const std::string& starting) {
+    return value.rfind(starting, 0) == 0;
+}
+
+inline bool StringStartWith(absl::string_view value,
+                            absl::string_view starting) {
     return value.rfind(starting, 0) == 0;
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: [#1583](https://github.com/opencurve/curve/issues/1583)

### What is changed and how it works?

What's Changed:
1. add a new interface to expose raw string buffer
2. remove useless Value() called from iterator
3.  use butil::IOBufAppender to improve append 

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
