### PR TITLE
curvefs: clean up resources after failing to create fs

### DIFF
--- a/curvefs/proto/mds.proto
+++ b/curvefs/proto/mds.proto
@@ -58,6 +58,8 @@ enum FSStatusCode {
     FSNAME_INVALID = 33;
     INSERT_DENTRY_FAIL = 34;
     INSERT_MANAGE_INODE_FAIL = 35;
+    DELETE_DENTRY_FAIL = 36;
+    UPDATE_FS_FAIL = 37;
 }
 
 // fs interface

--- a/curvefs/src/mds/metaserverclient/metaserver_client.h
+++ b/curvefs/src/mds/metaserverclient/metaserver_client.h
@@ -88,6 +88,12 @@ class MetaserverClient {
                                       const std::string &name, uint64_t inodeId,
                                       const std::set<std::string> &addrs);
 
+    virtual FSStatusCode DeleteDentry(uint32_t poolId, uint32_t copysetId,
+                                      uint32_t partitionId, uint32_t fsId,
+                                      uint64_t parentInodeId,
+                                      const std::string &name,
+                                      const std::set<std::string> &addrs);
+
     virtual FSStatusCode CreatePartition(uint32_t fsId, uint32_t poolId,
                                          uint32_t copysetId,
                                          uint32_t partitionId, uint64_t idStart,

--- a/curvefs/src/mds/topology/topology_manager.cpp
+++ b/curvefs/src/mds/topology/topology_manager.cpp
@@ -751,6 +751,19 @@ void TopologyManager::CreatePartitions(const CreatePartitionRequest *request,
     }
 }
 
+TopoStatusCode TopologyManager::DeletePartition(uint32_t partitionId) {
+    DeletePartitionRequest request;
+    DeletePartitionResponse response;
+    request.set_partitionid(partitionId);
+    DeletePartition(&request, &response);
+
+    if (TopoStatusCode::TOPO_OK != response.statuscode()) {
+        return TopoStatusCode::TOPO_DELETE_PARTITION_ON_METASERVER_FAIL;
+    }
+
+    return TopoStatusCode::TOPO_OK;
+}
+
 void TopologyManager::DeletePartition(
     const DeletePartitionRequest *request,
     DeletePartitionResponse *response) {

--- a/curvefs/src/mds/topology/topology_manager.h
+++ b/curvefs/src/mds/topology/topology_manager.h
@@ -115,6 +115,8 @@ class TopologyManager {
     virtual TopoStatusCode CreatePartitionsAndGetMinPartition(
         FsIdType fsId, PartitionInfo *partition);
 
+    virtual TopoStatusCode DeletePartition(uint32_t partitionId);
+
     virtual TopoStatusCode CommitTxId(const std::vector<PartitionTxId>& txIds);
 
     virtual void CommitTx(const CommitTxRequest *request,

--- a/curvefs/test/mds/mock/mock_topology.h
+++ b/curvefs/test/mds/mock/mock_topology.h
@@ -411,6 +411,8 @@ class MockTopologyManager : public TopologyManager {
     MOCK_METHOD2(DeletePartition, void(const DeletePartitionRequest *request,
                                        DeletePartitionResponse *response));
 
+    MOCK_METHOD1(DeletePartition, TopoStatusCode(uint32_t partitionId));
+
     MOCK_METHOD2(CreatePartitionsAndGetMinPartition,
                  TopoStatusCode(FsIdType fsId, PartitionInfo *partition));
 


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->
Signed-off-by: Yatoro ajb459684460@gmail.com
### What problem does this PR solve?

Issue Number: https://github.com/opencurve/curve/issues/2043

Problem Summary: The resources created in the previous steps need to be cleaned up when create fs failed.

### What is changed and how it works?

What's Changed:
Make sure all resources are cleaned up on every steps of creating fs.

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [x] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license
