### PR TITLE
curvefs/client: optimize DiskCacheManager::UmountDiskCache()

### DIFF
--- a/curvefs/src/client/s3/disk_cache_manager.cpp
+++ b/curvefs/src/client/s3/disk_cache_manager.cpp
@@ -103,7 +103,7 @@ int DiskCacheManager::Init(std::shared_ptr<S3Client> client,
         return ret;
     }
 
-    // start aync upload thread
+    // start async upload thread
     cacheWrite_->AsyncUploadRun();
     std::thread uploadThread =
         std::thread(&DiskCacheManager::UploadAllCacheWriteFile, this);
@@ -172,16 +172,16 @@ bool DiskCacheManager::IsCached(const std::string name) {
     return true;
 }
 
+bool DiskCacheManager::IsCacheClean() {
+    return cacheWrite_->IsCacheClean();
+}
+
 int DiskCacheManager::UmountDiskCache() {
     LOG(INFO) << "umount disk cache.";
-    int ret;
     diskInitThread_.join();
-    ret = cacheWrite_->UploadAllCacheWriteFile();
-    if (ret < 0) {
-        LOG(ERROR) << "umount disk cache error.";
-    }
     TrimStop();
     cacheWrite_->AsyncUploadStop();
+    LOG_IF(ERROR, !IsCacheClean()) << "umount disk cache error.";
     LOG(INFO) << "umount disk cache end.";
     return 0;
 }
@@ -211,7 +211,7 @@ int DiskCacheManager::CreateDir() {
         LOG(ERROR) << "create cache read dir error. ret = " << ret;
         return ret;
     }
-    VLOG(9) << "create cache dir sucess.";
+    VLOG(9) << "create cache dir success.";
     return 0;
 }
 

--- a/curvefs/src/client/s3/disk_cache_manager.h
+++ b/curvefs/src/client/s3/disk_cache_manager.h
@@ -112,7 +112,7 @@ class DiskCacheManager {
     void InitMetrics(const std::string &fsName);
 
     /**
-     * @brief: has geted the origin used size or not.
+     * @brief: has got the origin used size or not.
      */
     virtual bool IsDiskUsedInited() {
         return diskUsedInit_.load();
@@ -160,6 +160,11 @@ class DiskCacheManager {
      */
     bool IsExceedFileNums();
 
+    /**
+     * @brief check whether cache dir does not exist or there is no cache file
+     */
+    bool IsCacheClean();
+
     curve::common::Thread backEndThread_;
     curve::common::Atomic<bool> isRunning_;
     curve::common::InterruptibleSleeper sleeper_;
@@ -188,7 +193,7 @@ class DiskCacheManager {
 
     S3ClientAdaptorOption option_;
 
-    // has geted the origin used size or not
+    // has got the origin used size or not
     std::atomic<bool> diskUsedInit_;
     curve::common::Thread diskInitThread_;
 };

--- a/curvefs/src/client/s3/disk_cache_manager_impl.cpp
+++ b/curvefs/src/client/s3/disk_cache_manager_impl.cpp
@@ -75,7 +75,7 @@ void DiskCacheManagerImpl::Enqueue(
 int DiskCacheManagerImpl::WriteReadDirectClosure(
     std::shared_ptr<PutObjectAsyncContext> context) {
         VLOG(9) << "WriteReadClosure start, name: " << context->key;
-        // Write to read cache, we don't care if the cache wirte success
+        // Write to read cache, we don't care if the cache write success
         int ret = WriteReadDirect(context->key,
                             context->buffer, context->bufferSize);
         VLOG(9) << "WriteReadClosure end, name: " << context->key;
@@ -186,13 +186,13 @@ bool DiskCacheManagerImpl::IsDiskCacheFull() {
 }
 
 int DiskCacheManagerImpl::UmountDiskCache() {
+    taskPool_.Stop();
     int ret;
     ret = diskCacheManager_->UmountDiskCache();
     if (ret < 0) {
         LOG(ERROR) << "umount disk cache error.";
         return -1;
     }
-    taskPool_.Stop();
     client_->Deinit();
     return 0;
 }

--- a/curvefs/src/client/s3/disk_cache_manager_impl.h
+++ b/curvefs/src/client/s3/disk_cache_manager_impl.h
@@ -83,7 +83,7 @@ class DiskCacheManagerImpl {
      * @brief Write obj
      * @param[in] name obj name
      * @param[in] buf what to write
-     * @param[in] length wtite length
+     * @param[in] length write length
      * @return success: write length, fail : < 0
      */
     int Write(const std::string name, const char *buf, uint64_t length);

--- a/curvefs/test/client/mock_disk_cache_write.h
+++ b/curvefs/test/client/mock_disk_cache_write.h
@@ -43,7 +43,7 @@ class MockDiskCacheWrite : public DiskCacheWrite {
                       const char* buf, uint64_t length, bool force));
 
     MOCK_METHOD1(CreateIoDir,
-                 int(bool writreDir));
+                 int(bool writeDir));
 
     MOCK_METHOD1(IsFileExist,
                  bool(const std::string file));
@@ -66,6 +66,8 @@ class MockDiskCacheWrite : public DiskCacheWrite {
     MOCK_METHOD1(AsyncUploadEnqueue,
                 void(const std::string objName));
     MOCK_METHOD1(UploadFileByInode, int(const std::string &inode));
+
+    MOCK_METHOD0(IsCacheClean, bool());
 };
 
 }  // namespace client

--- a/curvefs/test/client/test_disk_cache_manager.cpp
+++ b/curvefs/test/client/test_disk_cache_manager.cpp
@@ -277,8 +277,6 @@ TEST_F(TestDiskCacheManager, TrimRun_1) {
     option.diskCacheOpt.trimCheckIntervalSec = 1;
     EXPECT_CALL(*wrapper, stat(NotNull(), NotNull())).WillOnce(Return(-1));
     EXPECT_CALL(*wrapper, mkdir(_, _)).WillOnce(Return(-1));
-    EXPECT_CALL(*diskCacheWrite_, UploadAllCacheWriteFile())
-        .WillOnce(Return(0));
     diskCacheManager_->Init(client_, option);
     diskCacheManager_->InitMetrics("test");
     EXPECT_CALL(*wrapper, statfs(NotNull(), NotNull()))
@@ -312,8 +310,6 @@ TEST_F(TestDiskCacheManager, TrimCache_2) {
     option.diskCacheOpt.trimCheckIntervalSec = 1;
     EXPECT_CALL(*wrapper, stat(NotNull(), NotNull())).WillOnce(Return(-1));
     EXPECT_CALL(*wrapper, mkdir(_, _)).WillOnce(Return(-1));
-    EXPECT_CALL(*diskCacheWrite_, UploadAllCacheWriteFile())
-        .WillOnce(Return(0));
     diskCacheManager_->Init(client_, option);
     diskCacheManager_->InitMetrics("test");
     diskCacheManager_->AddCache("test");
@@ -349,8 +345,6 @@ TEST_F(TestDiskCacheManager, TrimCache_4) {
     option.diskCacheOpt.trimCheckIntervalSec = 1;
     EXPECT_CALL(*wrapper, stat(NotNull(), NotNull())).WillOnce(Return(-1));
     EXPECT_CALL(*wrapper, mkdir(_, _)).WillOnce(Return(-1));
-    EXPECT_CALL(*diskCacheWrite_, UploadAllCacheWriteFile())
-        .WillOnce(Return(0));
     diskCacheManager_->Init(client_, option);
     diskCacheManager_->InitMetrics("test");
     diskCacheManager_->AddCache("test");
@@ -387,8 +381,6 @@ TEST_F(TestDiskCacheManager, TrimCache_5) {
     option.diskCacheOpt.trimCheckIntervalSec = 1;
     EXPECT_CALL(*wrapper, stat(NotNull(), NotNull())).WillOnce(Return(-1));
     EXPECT_CALL(*wrapper, mkdir(_, _)).WillOnce(Return(-1));
-    EXPECT_CALL(*diskCacheWrite_, UploadAllCacheWriteFile())
-        .WillOnce(Return(0));
     diskCacheManager_->Init(client_, option);
     diskCacheManager_->InitMetrics("test");
     diskCacheManager_->AddCache("test");
@@ -427,8 +419,6 @@ TEST_F(TestDiskCacheManager, TrimCache_noexceed) {
         .Times(3)
         .WillOnce(Return(0))
         .WillOnce(Return(-1))
-        .WillOnce(Return(0));
-    EXPECT_CALL(*diskCacheWrite_, UploadAllCacheWriteFile())
         .WillOnce(Return(0));
     int ret = diskCacheManager_->TrimRun();
     diskCacheManager_->InitMetrics("test");
@@ -472,8 +462,6 @@ TEST_F(TestDiskCacheManager, TrimCache_exceed) {
     EXPECT_CALL(*wrapper, stat(NotNull(), NotNull()))
         .Times(2)
         .WillOnce(Return(-1))
-        .WillOnce(Return(0));
-    EXPECT_CALL(*diskCacheWrite_, UploadAllCacheWriteFile())
         .WillOnce(Return(0));
     diskCacheManager_->TrimRun();
     diskCacheManager_->InitMetrics("test");

--- a/curvefs/test/client/test_disk_cache_manager_impl.cpp
+++ b/curvefs/test/client/test_disk_cache_manager_impl.cpp
@@ -246,14 +246,12 @@ TEST_F(TestDiskCacheManagerImpl, IsCached) {
 }
 
 TEST_F(TestDiskCacheManagerImpl, UmountDiskCache) {
-    EXPECT_CALL(*diskCacheWrite_, UploadAllCacheWriteFile())
-        .WillOnce(Return(-1));
+    EXPECT_CALL(*diskCacheWrite_, IsCacheClean()).WillOnce(Return(true));
     diskCacheManagerImpl_->InitMetrics("test");
     int ret = diskCacheManagerImpl_->UmountDiskCache();
     ASSERT_EQ(0, ret);
 
-    EXPECT_CALL(*diskCacheWrite_, UploadAllCacheWriteFile())
-        .WillOnce(Return(0));
+    EXPECT_CALL(*diskCacheWrite_, IsCacheClean()).WillOnce(Return(false));
     diskCacheManagerImpl_->InitMetrics("test");
     ret = diskCacheManagerImpl_->UmountDiskCache();
     ASSERT_EQ(0, ret);

--- a/curvefs/test/client/test_disk_cache_write.cpp
+++ b/curvefs/test/client/test_disk_cache_write.cpp
@@ -462,10 +462,15 @@ TEST_F(TestDiskCacheWrite, AsyncUploadRun) {
     sleep(1);
     diskCacheWrite_->AsyncUploadEnqueue("test");
     std::string t1 = "test";
-    curve::common::Thread backEndThread =
-        std::thread(&DiskCacheWrite::AsyncUploadEnqueue, diskCacheWrite_, t1);
+    std::vector<curve::common::Thread> threads;
+    for (int i = 0; i < 5; i++) {
+        threads.emplace_back(&DiskCacheWrite::AsyncUploadEnqueue,
+                             diskCacheWrite_, t1);
+    }
     diskCacheWrite_->AsyncUploadStop();
-    backEndThread.join();
+    for (auto &t : threads) {
+        t.join();
+    }
 }
 
 TEST_F(TestDiskCacheWrite, UploadFileByInode) {


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: https://github.com/opencurve/curve/issues/1669

Problem Summary: 
don't need to call `UploadAllCacheWriteFile()` twice

### What is changed and how it works?

What's Changed:


How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
