### PR TITLE
[tools-v2] add CLI `curve bs update peer`

### DIFF
--- a/tools-v2/README.md
+++ b/tools-v2/README.md
@@ -54,6 +54,8 @@ A tool for CurveFS & CurveBs.
       - [staus mds](#staus-mds)
     - [delete](#delete-1)
       - [delete peer](#delete-peer)
+    - [update](#update)
+      - [update peer](#update-peer)
   - [Comparison of old and new commands](#comparison-of-old-and-new-commands)
     - [curve fs](#curve-fs)
     - [curve bs](#curve-bs)
@@ -981,6 +983,26 @@ Output:
 
 ```
 
+### update
+
+#### update peer
+
+reset peer
+
+Usage:
+```bash
+curve bs update peer 127.0.0.0:8200:0 --logicalpoolid=1 --copysetid=1
+```
+
+Output:
+```
++----------------------+---------+---------+--------+
+|         PEER         | COPYSET | RESULT  | REASON |
++----------------------+---------+---------+--------+
+|   127.0.0.0:8200:0   | (1:1)   | success | null   |
++----------------------+---------+---------+--------+
+```
+
 ## Comparison of old and new commands
 
 ### curve fs
@@ -1036,7 +1058,7 @@ Output:
 | check-consistency | |
 | remove-peer | curve bs delete peer |
 | transfer-leader | |
-| reset-peer | |
+| reset-peer | curve bs update peer |
 | do-snapshot | |
 | do-snapshot-all | |
 | check-chunkserver | |

--- a/tools-v2/internal/error/error.go
+++ b/tools-v2/internal/error/error.go
@@ -280,7 +280,7 @@ var (
 		return NewInternalCmdError(14, "invalid %s: %s")
 	}
 	ErrSplitPeer = func() *CmdError {
-		return NewInternalCmdError(15, "split peer[%s] failed")
+		return NewInternalCmdError(15, "split peer[%s] failed, peer should be like: 127.0.0.1:8200:0")
 	}
 	ErrMarshalJson = func() *CmdError {
 		return NewInternalCmdError(16, "marshal %s to json error, the error is: %s")

--- a/tools-v2/internal/utils/row.go
+++ b/tools-v2/internal/utils/row.go
@@ -115,6 +115,8 @@ const (
 	ROW_VALUE_OFFLINE = "offline"
 	ROW_VALUE_UNKNOWN = "unknown"
 	ROW_VALUE_SUCCESS = "success"
+	ROW_VALUE_FAILED  = "failed"
+	ROW_VALUE_NULL    = "null"
 )
 
 // topology type

--- a/tools-v2/pkg/cli/command/curvebs/bs.go
+++ b/tools-v2/pkg/cli/command/curvebs/bs.go
@@ -31,6 +31,7 @@ import (
 	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/list"
 	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/query"
 	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/status"
+	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/update"
 )
 
 type CurveBsCommand struct {
@@ -46,6 +47,7 @@ func (bsCmd *CurveBsCommand) AddSubCommands() {
 		status.NewStatusCommand(),
 		delete.NewDeleteCommand(),
 		create.NewCreateCmd(),
+		update.NewUpdateCommand(),
 	)
 }
 

--- a/tools-v2/pkg/cli/command/curvebs/update/peer/peer.go
+++ b/tools-v2/pkg/cli/command/curvebs/update/peer/peer.go
@@ -1,0 +1,208 @@
+/*
+ *  Copyright (c) 2023 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * Project: CurveCli
+ * Created Date: 2023-02-27
+ * Author: zweix
+ */
+
+package peer
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+
+	cmderror "github.com/opencurve/curve/tools-v2/internal/error"
+	cobrautil "github.com/opencurve/curve/tools-v2/internal/utils"
+	basecmd "github.com/opencurve/curve/tools-v2/pkg/cli/command"
+	"github.com/opencurve/curve/tools-v2/pkg/config"
+	"github.com/opencurve/curve/tools-v2/pkg/output"
+	"github.com/opencurve/curve/tools-v2/proto/proto/cli2"
+	"github.com/opencurve/curve/tools-v2/proto/proto/common"
+)
+
+const (
+	updateExample = `$ curve bs update peer 127.0.0.0:8200:0 --logicalpoolid=1 --copysetid=1`
+)
+
+type ResetRpc struct {
+	Info    *basecmd.Rpc
+	Request *cli2.ResetPeerRequest2
+	Client  cli2.CliService2Client
+}
+
+func (rRpc *ResetRpc) NewRpcClient(cc grpc.ClientConnInterface) {
+	rRpc.Client = cli2.NewCliService2Client(cc)
+}
+
+func (rRpc *ResetRpc) Stub_Func(ctx context.Context) (interface{}, error) {
+	return rRpc.Client.ResetPeer(ctx, rRpc.Request)
+}
+
+// Options rpc request options.
+type Options struct {
+	Timeout    time.Duration
+	RetryTimes int32
+}
+
+type PeerCommand struct {
+	basecmd.FinalCurveCmd
+
+	// request parameters
+	opts          Options
+	logicalPoolID uint32
+	copysetID     uint32
+
+	resetPeer *common.Peer
+}
+
+var _ basecmd.FinalCurveCmdFunc = (*PeerCommand)(nil) // check interface
+
+// NewCommand ...
+func NewPeerCommand() *cobra.Command {
+	peerCmd := &PeerCommand{
+		FinalCurveCmd: basecmd.FinalCurveCmd{
+			Use:     "peer",
+			Short:   "update(reset) the peer from the copyset",
+			Example: updateExample,
+		},
+	}
+	basecmd.NewFinalCurveCli(&peerCmd.FinalCurveCmd, peerCmd)
+	return peerCmd.Cmd
+}
+
+func (pCmd *PeerCommand) AddFlags() {
+	config.AddRpcRetryTimesFlag(pCmd.Cmd)
+	config.AddRpcTimeoutFlag(pCmd.Cmd)
+
+	config.AddBSLogicalPoolIdFlag(pCmd.Cmd)
+	config.AddBSCopysetIdFlag(pCmd.Cmd)
+}
+
+// ParsePeer parse the peer string
+func ParsePeer(peer string) (*common.Peer, *cmderror.CmdError) {
+	cs := strings.Split(peer, ":")
+	if len(cs) != 3 {
+		pErr := cmderror.ErrSplitPeer()
+		pErr.Format(peer)
+		return nil, pErr
+	}
+	id, err := strconv.ParseUint(cs[2], 10, 64)
+	if err != nil {
+		pErr := cmderror.ErrSplitPeer()
+		pErr.Format(peer)
+		return nil, pErr
+	}
+	cs = cs[:2]
+	address := strings.Join(cs, ":")
+	return &common.Peer{
+		Id:      &id,
+		Address: &address,
+	}, nil
+}
+
+func (pCmd *PeerCommand) Init(cmd *cobra.Command, args []string) error {
+	pCmd.opts = Options{}
+
+	pCmd.SetHeader([]string{cobrautil.ROW_PEER, cobrautil.ROW_COPYSET, cobrautil.ROW_RESULT, cobrautil.ROW_REASON})
+	pCmd.TableNew.SetAutoMergeCellsByColumnIndex(cobrautil.GetIndexSlice(
+		pCmd.Header, []string{},
+	))
+
+	var err error
+	var e *cmderror.CmdError
+
+	pCmd.opts.Timeout = config.GetFlagDuration(pCmd.Cmd, config.RPCTIMEOUT)
+	pCmd.opts.RetryTimes = config.GetFlagInt32(pCmd.Cmd, config.RPCRETRYTIMES)
+
+	pCmd.copysetID, err = config.GetBsFlagUint32(pCmd.Cmd, config.CURVEBS_COPYSET_ID)
+	if err != nil {
+		return err
+	}
+
+	pCmd.logicalPoolID, err = config.GetBsFlagUint32(pCmd.Cmd, config.CURVEBS_LOGIC_POOL_ID)
+	if err != nil {
+		return err
+	}
+
+	// parse peer conf
+	if len(args) < 1 {
+		pErr := cmderror.ErrGetPeer()
+		pErr.Format("should specified the peer address")
+		return pErr.ToError()
+	}
+	pCmd.resetPeer, e = ParsePeer(args[0])
+	if e != nil {
+		return e.ToError()
+	}
+	return nil
+}
+
+func (pCmd *PeerCommand) Print(cmd *cobra.Command, args []string) error {
+	return output.FinalCmdOutput(&pCmd.FinalCurveCmd, pCmd)
+}
+
+func (pCmd *PeerCommand) RunCommand(cmd *cobra.Command, args []string) error {
+	out := make(map[string]string)
+	out[cobrautil.ROW_PEER] = fmt.Sprintf("%s:%d", pCmd.resetPeer.GetAddress(), pCmd.resetPeer.GetId())
+	out[cobrautil.ROW_COPYSET] = fmt.Sprintf("(%d:%d)", pCmd.logicalPoolID, pCmd.copysetID)
+
+	var err *cmderror.CmdError
+	pCmd.Result, err = pCmd.execResetPeer()
+	if err != nil {
+		out[cobrautil.ROW_RESULT] = cobrautil.ROW_VALUE_FAILED
+		out[cobrautil.ROW_REASON] = err.ToError().Error()
+		pCmd.Error = err
+		return nil
+	}
+	out[cobrautil.ROW_RESULT] = cobrautil.ROW_VALUE_SUCCESS
+	out[cobrautil.ROW_REASON] = cobrautil.ROW_VALUE_NULL
+	list := cobrautil.Map2List(out, pCmd.Header)
+	pCmd.TableNew.Append(list)
+	return nil
+}
+
+func (pCmd *PeerCommand) ResultPlainOutput() error {
+	return output.FinalCmdOutputPlain(&pCmd.FinalCurveCmd)
+}
+
+func (pCmd *PeerCommand) execResetPeer() (interface{}, *cmderror.CmdError) {
+	rpcCli := &ResetRpc{
+		Info: basecmd.NewRpc([]string{pCmd.resetPeer.GetAddress()}, pCmd.opts.Timeout, pCmd.opts.RetryTimes, "RsetPeer"),
+		Request: &cli2.ResetPeerRequest2{
+			LogicPoolId: &pCmd.logicalPoolID,
+			CopysetId:   &pCmd.copysetID,
+			RequestPeer: pCmd.resetPeer,
+			OldPeers:    []*common.Peer{pCmd.resetPeer},
+			NewPeers:    []*common.Peer{pCmd.resetPeer},
+		},
+	}
+
+	response, errCmd := basecmd.GetRpcResponse(rpcCli.Info, rpcCli)
+
+	if errCmd.TypeCode() != cmderror.CODE_SUCCESS {
+		return response, errCmd
+	}
+
+	return response, nil
+}

--- a/tools-v2/pkg/cli/command/curvebs/update/update.go
+++ b/tools-v2/pkg/cli/command/curvebs/update/update.go
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (c) 2022 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * Project: CurveCli
+ * Created Date: 2023-02-27
+ * Author: zweix
+ */
+
+package update
+
+import (
+	"github.com/spf13/cobra"
+
+	basecmd "github.com/opencurve/curve/tools-v2/pkg/cli/command"
+	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/update/peer"
+)
+
+type UpdateCommand struct {
+	basecmd.MidCurveCmd
+}
+
+var _ basecmd.MidCurveCmdFunc = (*UpdateCommand)(nil)
+
+func (updateCmd *UpdateCommand) AddSubCommands() {
+	updateCmd.Cmd.AddCommand(
+		peer.NewPeerCommand(),
+	)
+}
+
+func NewUpdateCommand() *cobra.Command {
+	updateCmd := &UpdateCommand{
+		basecmd.MidCurveCmd{
+			Use:   "update",
+			Short: "update resources in the curvebs",
+		},
+	}
+	return basecmd.NewMidCurveCli(&updateCmd.MidCurveCmd, updateCmd)
+}


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

add cli `curve bs update peer`, corresponding to old cli `curve_ops_tool reset-peer`.

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

```bash
curve bs update peer
# example: curve bs update peer 10.246.159.82:8202:0 --logicalpoolid=1 --copysetid=1
```

Side effects(Breaking backward compatibility? Performance regression?):

1. `curve_ops_tool check-copyset -logicalPoolId=1 -copysetId=1 --detail`
    ```
    peer_id: 10.246.159.82:8201:0
    state: LEADER
    ...
    peer_id: 10.246.159.82:8200:0
    state: FOLLOWER
    ...
    peer_id: 10.246.159.82:8202:0
    state: FOLLOWER
    ```
2. curveadm stop first peer and second peer
3. `curve_ops_tool check-copyset -logicalPoolId=1 -copysetId=1 --detail`
    ```
    Copyset is not healthy!

    [4294967297]
    peer_id: 10.246.159.82:8202:0
    state: FOLLOWER
    ```
4. `./curve bs update peer  10.246.159.82:8202:0 --logicalpoolid=1 --copysetid=1 --rpcretrytimes=1 --rpctimeout=10s`
    output:
    ```
    +----------------------+---------+---------+--------+
    |         PEER         | COPYSET | RESULT  | REASON |
    +----------------------+---------+---------+--------+
    | 10.246.159.82:8202:0 | (1:1)   | success | null   |
    +----------------------+---------+---------+--------+
    ```
5.  `curve_ops_tool check-copyset -logicalPoolId=1 -copysetId=1 --detail`
    ```
    peer_id: 10.246.159.82:8202:0
    state: LEADER
    ```

#### Test

+ Json output
    ```
    {
    "error": null,
    "result": {}
    }
    ```

+ Missing parameter args[0]
    ```
    Error: invalid peer args, err: should specified the peer address
    ```

+ Missing else args：output help

+ Parameter args[0] format error
    + input：
        ```
        ./curve bs update peer 10.246.159.82:2:0 --logicalpoolid=123 --copysetid=1 
        ```
    + output:        
        ```
        Error: dial to rpc server 10.246.159.82:2 failed, the error is: context deadline exceeded
        ```

+ Else args format error: No prompt, no effect
+ When chunkserver health is to execute commands: No prompt, no effect

### Check List

- [x] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license
