### PR TITLE
curvefs/client: bug fix about memcache

### DIFF
--- a/curvefs/src/client/kvclient/memcache_client.h
+++ b/curvefs/src/client/kvclient/memcache_client.h
@@ -92,12 +92,9 @@ class MemCachedClient : public KVClient {
                 return false;
             }
         }
-
         memcached_behavior_set(client_, MEMCACHED_BEHAVIOR_DISTRIBUTION,
                                MEMCACHED_DISTRIBUTION_CONSISTENT);
         memcached_behavior_set(client_, MEMCACHED_BEHAVIOR_RETRY_TIMEOUT, 5);
-        memcached_behavior_set(client_,
-                               MEMCACHED_BEHAVIOR_REMOVE_FAILED_SERVERS, 1);
 
         return PushServer();
     }
@@ -117,9 +114,11 @@ class MemCachedClient : public KVClient {
         auto res = memcached_set(tcli, key.c_str(), key.length(), value,
                                  value_len, 0, 0);
         if (MEMCACHED_SUCCESS == res) {
+            VLOG(9) << "Set key = " << key << " OK";
             return true;
         }
         *errorlog = ResError(res);
+        LOG(ERROR) << "Set key = " << key << " error = " << *errorlog;
         return false;
     }
 
@@ -135,13 +134,21 @@ class MemCachedClient : public KVClient {
         memcached_return_t ue;
         char *res = memcached_get(tcli, key.c_str(), key.length(),
                                   &value_length, &flags, &ue);
-        if (res != nullptr && value) {
+        if (MEMCACHED_SUCCESS == ue && res != nullptr && value &&
+            value_length >= length) {
+            VLOG(9) << "Get key = " << key << " OK";
             memcpy(value, res + offset, length);
             free(res);
             return true;
         }
 
         *errorlog = ResError(ue);
+        if (ue != MEMCACHED_NOTFOUND) {
+            LOG(ERROR) << "Get key = " << key << " error = " << *errorlog
+                       << ", get_value_len = " << value_length
+                       << ", expect_value_len = " << length;
+        }
+
         return false;
     }
 

--- a/curvefs/test/client/client_memcache_test.cpp
+++ b/curvefs/test/client/client_memcache_test.cpp
@@ -73,6 +73,7 @@ class MemCachedTest : public ::testing::Test {
             std::this_thread::sleep_for(std::chrono::milliseconds(100));
             retry++;
         } while (1);
+        LOG(INFO) << "=============== memcache start ok";
     }
 
     void TearDown() {
@@ -116,11 +117,18 @@ TEST_F(MemCachedTest, MultiThreadTask) {
     // get
     for (int i = 0; i < 5; i++) {
         workers.emplace_back([&, i]() {
+            CountDownEvent taskEnvent(1);
             char *result = new char[4];
-            auto context = std::make_shared<GetKvCacheContext>(kvstr[i].first,
-                                                               result, 0, 4);
-            ASSERT_EQ(true, manager_.Get(context));
+            auto task =
+                std::make_shared<GetKVCacheTask>(kvstr[i].first, result, 0, 4);
+            task->done =
+                [&taskEnvent](const std::shared_ptr<GetKVCacheTask> &task) {
+                    taskEnvent.Signal();
+                };
+            manager_.Get(task);
+            taskEnvent.Wait();
             ASSERT_EQ(0, memcmp(result, kvstr[i].second.c_str(), 4));
+            ASSERT_TRUE(task->res);
         });
     }
     for (auto &iter : workers) {


### PR DESCRIPTION
1. When running the vdbech task, the memory usage of the mount point is very high
2. When running the vdbech task, the mount will coredump or the task will have data inconsistency
3. The memcache server fails over and then restarts and cannot be used by the client anymore

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #2251 #2250 #2248 #2247 #2246 <!-- replace xxx with issue number -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
