### PR TITLE
[skipci] doc: update a jump links in README_cn.md 

### DIFF
--- a/README_cn.md
+++ b/README_cn.md
@@ -221,7 +221,7 @@ $ ./fio --thread --rw=randwrite --bs=4k --ioengine=nebd --nebd=cbd:pool//pfstest
 
 ##  贡献我们
 
-参与 Curve 项目开发详见[Curve 开源社区指南](Community_Guidelines_cn.md)并且请遵循[贡献者准则](https://github.com/opencurve/curve/blob/master/CODE_OF_CONDUCT.md), 我们期待您的贡献!
+参与 Curve 项目开发详见[Curve 开发者指南](developers_guide_cn.md)并且请遵循[贡献者准则](https://github.com/opencurve/curve/blob/master/CODE_OF_CONDUCT.md), 我们期待您的贡献!
 
 ## 最佳实践
 - [CurveBS+NFS搭建NFS存储](docs/practical/curvebs_nfs.md)


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: 

Problem Summary:
In the README_cn.md, 在 [贡献我们] 部分，点击 [Curve 开源社区指南]，会跳转至404页面。

### What is changed and how it works?
What's Changed:

How it Works:
我认为该链接应该跳转至developers_guide_cn.md。
更新跳转链接，将原 [Curve 开源社区指南] 更改为 [Curve 开发者指南](developers_guide_cn.md)。

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [√] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license

