### PR TITLE
[skipci] doc: update two jump links in README/README_cn.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Please refer to the [Test environment configuration](docs/cn/测试环境配置�
 See [Governance](https://github.com/opencurve/community/blob/master/GOVERNANCE.md).
 
 ##  Contribute us
-Participation in the Curve project is described in the [Curve Open Source Community Guidelines](Community_Guidelines.md) and is subject to a [contributor contract](https://github.com/opencurve/curve/blob/master/CODE_OF_CONDUCT.md).
+Participation in the Curve project is described in the [Curve Developers Guidelines](developers_guide.md) and is subject to a [contributor contract](https://github.com/opencurve/curve/blob/master/CODE_OF_CONDUCT.md).
 We welcome your contribution!
 
 ## Code of Conduct

--- a/README_cn.md
+++ b/README_cn.md
@@ -221,7 +221,7 @@ $ ./fio --thread --rw=randwrite --bs=4k --ioengine=nebd --nebd=cbd:pool//pfstest
 
 ##  贡献我们
 
-参与 Curve 项目开发详见[Curve 开源社区指南](Community_Guidelines_cn.md)并且请遵循[贡献者准则](https://github.com/opencurve/curve/blob/master/CODE_OF_CONDUCT.md), 我们期待您的贡献!
+参与 Curve 项目开发详见[Curve 开发者指南](developers_guide_cn.md)并且请遵循[贡献者准则](https://github.com/opencurve/curve/blob/master/CODE_OF_CONDUCT.md), 我们期待您的贡献!
 
 ## 最佳实践
 - [CurveBS+NFS搭建NFS存储](docs/practical/curvebs_nfs.md)


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #xxx <!-- replace xxx with issue number -->

Problem Summary:
In the README.md/README_cn.md, In Contribute Us Part, click the [Curve Open Source Community Guidelines]/[Curve 开源社区指南], it comes out a 404 page not found.
### What is changed and how it works?

What's Changed:

How it Works:
I think this link should jump to developers_guide.md/developers_guide_cn.md.
Update the original links to developers_guide.md/developers_guide_cn.md and change the name[Curve Open Source Community Guidelines]/[Curve 开源社区指南] to [Curve Developers Guidelines]/[Curve 开发者指南].

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [√ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
