### PR TITLE
[skipci] doc: update two jump links in developers_guide/developers_guide_cn.md

### DIFF
--- a/developers_guide.md
+++ b/developers_guide.md
@@ -1,4 +1,4 @@
-[中文版](Community_Guidelines_cn.md)
+[中文版](developers_guide_cn.md)
 
 
 ## Overview

--- a/developers_guide_cn.md
+++ b/developers_guide_cn.md
@@ -1,4 +1,4 @@
-[English version](Community_Guidelines.md)
+[English version](developers_guide.md)
 
 
 ## 概述


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: 
Problem Summary:
Click the [中文版]/[English Version], it comes out a 404 page not found.
### What is changed and how it works?

What's Changed:

How it Works:
I think this link should jump to developers_guide.md/developers_guide_cn.md.
Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [√] Relevant documentation/comments is changed or added
- [√ ] I acknowledge that all my contributions will be made under the project's license
