### PR TITLE
wip_enablesumindir

### DIFF
--- a/curvefs/src/client/fuse_client.cpp
+++ b/curvefs/src/client/fuse_client.cpp
@@ -205,6 +205,9 @@ CURVEFS_ERROR FuseClient::FuseOpInit(void *userdata,
 
     LOG(INFO) << "Mount " << fsName << " on " << mountpoint_.ShortDebugString()
               << " success!" << " enableSumInDir = " << enableSumInDir_;
+    if (enableSumInDir_) {
+        xattrManager_->RefreshAllXAttr();
+    }
 
     fsMetric_ = std::make_shared<FSMetric>(fsName);
 

--- a/curvefs/src/client/fuse_client.h
+++ b/curvefs/src/client/fuse_client.h
@@ -131,10 +131,10 @@ class FuseClient {
 
     virtual void FuseOpDestroy(void* userdata);
 
-    virtual CURVEFS_ERROR FuseOpWrite(fuse_req_t req, fuse_ino_t ino,
-                                      const char* buf, size_t size, off_t off,
-                                      struct fuse_file_info* fi,
-                                      size_t* wSize) = 0;
+    virtual CURVEFS_ERROR FuseOpWrite(fuse_req_t req, fuse_ino_t ino, 
+                                     const char* buf, size_t size, off_t off,
+                                     struct fuse_file_info* fi,
+                                     size_t* wSize) = 0;
 
     virtual CURVEFS_ERROR FuseOpRead(fuse_req_t req, fuse_ino_t ino,
                                      size_t size, off_t off,

--- a/curvefs/src/client/xattr_manager.h
+++ b/curvefs/src/client/xattr_manager.h
@@ -74,6 +74,10 @@ class XattrManager {
         isStop_.store(true);
     }
 
+    CURVEFS_ERROR RefreshAllXAttr();
+
+    CURVEFS_ERROR RefreshInodeXAttr(InodeAttr *attr);
+
     CURVEFS_ERROR GetXattr(const char* name, std::string *value,
         InodeAttr *attr, bool enableSumInDir);
 
@@ -100,6 +104,12 @@ class XattrManager {
         std::mutex *mapMutex,
         SummaryInfo *summaryInfo,
         std::mutex *valueMutex,
+        Atomic<uint32_t> *inflightNum,
+        Atomic<bool> *ret);
+
+    void ConcurrentRefreshInodeXattr(
+        std::stack<uint64_t> *iStack,
+        std::mutex *stackMutex, 
         Atomic<uint32_t> *inflightNum,
         Atomic<bool> *ret);
 


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?
When the fs mount is mounted multiple times with different enableSumInDir switches, the xattr information recorded in the metadata will be inaccurate
Issue Number: #2094 

Problem Summary:
use CalAllLayerSumInfo func to update attr's mutable_xattr() and then use this summary info to update this inode's xattr() .
### What is changed and how it works?

What's Changed:
fuse_client.cpp xattr_manager.h xattr_manager.cpp
How it Works:
just like above .
Side effects(Breaking backward compatibility? Performance regression?):
slow down the fs init time.
### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
