### PR TITLE
[style] Clean up warnings in code compilation

### DIFF
--- a/curvefs/src/client/fuse_client.cpp
+++ b/curvefs/src/client/fuse_client.cpp
@@ -172,6 +172,8 @@ void FuseClient::Fini() {
 
 CURVEFS_ERROR FuseClient::FuseOpInit(void *userdata,
                                      struct fuse_conn_info *conn) {
+    (void)userdata;
+    (void)conn;
     return CURVEFS_ERROR::OK;
 }
 
@@ -253,6 +255,7 @@ void GetDentryParamFromInodeAttr(
 
 CURVEFS_ERROR FuseClient::FuseOpLookup(fuse_req_t req, fuse_ino_t parent,
                                        const char *name, fuse_entry_param *e) {
+    (void)req;
     VLOG(1) << "FuseOpLookup parent: " << parent
             << ", name: " << name;
     if (strlen(name) > option_.maxNameLength) {
@@ -285,6 +288,7 @@ CURVEFS_ERROR FuseClient::FuseOpLookup(fuse_req_t req, fuse_ino_t parent,
 
 CURVEFS_ERROR FuseClient::FuseOpOpen(fuse_req_t req, fuse_ino_t ino,
                                      struct fuse_file_info *fi) {
+    (void)req;
     VLOG(1) << "FuseOpOpen, ino: " << ino;
     std::shared_ptr<InodeWrapper> inodeWrapper;
     CURVEFS_ERROR ret = inodeManager_->GetInode(ino, inodeWrapper);
@@ -674,6 +678,7 @@ CURVEFS_ERROR FuseClient::GetOrCreateRecycleDir(fuse_req_t req, Dentry *out) {
 
 CURVEFS_ERROR FuseClient::MoveToRecycle(fuse_req_t req, fuse_ino_t ino,
             fuse_ino_t parent, const char* name, FsFileType type) {
+    (void)type;
     // 1. check recycle exist, if not exist, create recycle dir
     Dentry recycleDir;
     CURVEFS_ERROR ret = GetOrCreateRecycleDir(req, &recycleDir);
@@ -810,6 +815,7 @@ CURVEFS_ERROR FuseClient::RemoveNode(fuse_req_t req, fuse_ino_t parent,
 
 CURVEFS_ERROR FuseClient::FuseOpOpenDir(fuse_req_t req, fuse_ino_t ino,
                                         struct fuse_file_info *fi) {
+    (void)req;
     VLOG(1) << "FuseOpOpenDir ino = " << ino;
     std::shared_ptr<InodeWrapper> inodeWrapper;
     CURVEFS_ERROR ret = inodeManager_->GetInode(ino, inodeWrapper);
@@ -829,6 +835,7 @@ CURVEFS_ERROR FuseClient::FuseOpOpenDir(fuse_req_t req, fuse_ino_t ino,
 
 CURVEFS_ERROR FuseClient::FuseOpReleaseDir(fuse_req_t req, fuse_ino_t ino,
                                            struct fuse_file_info *fi) {
+    (void)req;
     uint64_t dindex = fi->fh;
     VLOG(1) << "FuseOpReleaseDir, ino: " << ino << ", dindex: " << dindex;
     dirBuf_->DirBufferRelease(dindex);
@@ -924,7 +931,7 @@ CURVEFS_ERROR FuseClient::FuseOpReadDirPlus(fuse_req_t req, fuse_ino_t ino,
         bufHead->wasRead = true;
     }
 
-    if (off < bufHead->size) {
+    if (off < static_cast<ssize_t>(bufHead->size)) {
         *buffer = bufHead->p + off;
         *rSize = std::min(bufHead->size - off, size);
     } else {
@@ -937,6 +944,7 @@ CURVEFS_ERROR FuseClient::FuseOpReadDirPlus(fuse_req_t req, fuse_ino_t ino,
 CURVEFS_ERROR FuseClient::FuseOpRename(fuse_req_t req, fuse_ino_t parent,
                                        const char *name, fuse_ino_t newparent,
                                        const char *newname) {
+    (void)req;
     VLOG(1) << "FuseOpRename from (" << parent << ", " << name << ") to ("
             << newparent << ", " << newname << ")";
     if (strlen(name) > option_.maxNameLength ||
@@ -986,6 +994,8 @@ CURVEFS_ERROR FuseClient::FuseOpRename(fuse_req_t req, fuse_ino_t parent,
 CURVEFS_ERROR FuseClient::FuseOpGetAttr(fuse_req_t req, fuse_ino_t ino,
                                         struct fuse_file_info *fi,
                                         struct stat *attr) {
+    (void)req;
+    (void)fi;
     VLOG(1) << "FuseOpGetAttr ino = " << ino;
     InodeAttr inodeAttr;
     CURVEFS_ERROR ret =
@@ -1003,6 +1013,8 @@ CURVEFS_ERROR FuseClient::FuseOpSetAttr(fuse_req_t req, fuse_ino_t ino,
                                         struct stat *attr, int to_set,
                                         struct fuse_file_info *fi,
                                         struct stat *attrOut) {
+    (void)req;
+    (void)fi;
     VLOG(1) << "FuseOpSetAttr to_set: " << to_set << ", ino: " << ino
             << ", attr: " << *attr;
     std::shared_ptr<InodeWrapper> inodeWrapper;
@@ -1095,6 +1107,7 @@ CURVEFS_ERROR FuseClient::FuseOpSetAttr(fuse_req_t req, fuse_ino_t ino,
 CURVEFS_ERROR FuseClient::FuseOpGetXattr(fuse_req_t req, fuse_ino_t ino,
                                          const char* name, std::string* value,
                                          size_t size) {
+    (void)req;
     VLOG(9) << "FuseOpGetXattr, ino: " << ino
             << ", name: " << name << ", size = " << size;
     if (option_.disableXattr) {
@@ -1134,6 +1147,8 @@ CURVEFS_ERROR FuseClient::FuseOpGetXattr(fuse_req_t req, fuse_ino_t ino,
 CURVEFS_ERROR FuseClient::FuseOpSetXattr(fuse_req_t req, fuse_ino_t ino,
                                          const char* name, const char* value,
                                          size_t size, int flags) {
+    (void)req;
+    (void)flags;
     if (option_.disableXattr) {
         return CURVEFS_ERROR::NOTSUPPORT;
     }
@@ -1173,6 +1188,7 @@ CURVEFS_ERROR FuseClient::FuseOpSetXattr(fuse_req_t req, fuse_ino_t ino,
 
 CURVEFS_ERROR FuseClient::FuseOpListXattr(fuse_req_t req, fuse_ino_t ino,
                             char *value, size_t size, size_t *realSize) {
+    (void)req;
     VLOG(1) << "FuseOpListXattr, ino: " << ino << ", size = " << size;
     InodeAttr inodeAttr;
     CURVEFS_ERROR ret = inodeManager_->GetInodeAttr(ino, &inodeAttr);
@@ -1301,6 +1317,7 @@ CURVEFS_ERROR FuseClient::FuseOpLink(fuse_req_t req, fuse_ino_t ino,
                                      fuse_ino_t newparent, const char *newname,
                                      FsFileType type,
                                      fuse_entry_param *e) {
+    (void)req;
     if (strlen(newname) > option_.maxNameLength) {
         return CURVEFS_ERROR::NAMETOOLONG;
     }
@@ -1370,6 +1387,7 @@ CURVEFS_ERROR FuseClient::FuseOpLink(fuse_req_t req, fuse_ino_t ino,
 
 CURVEFS_ERROR FuseClient::FuseOpReadLink(fuse_req_t req, fuse_ino_t ino,
                                          std::string *linkStr) {
+    (void)req;
     VLOG(1) << "FuseOpReadLink, ino: " << ino << ", linkStr: " << linkStr;
     InodeAttr attr;
     CURVEFS_ERROR ret = inodeManager_->GetInodeAttr(ino, &attr);
@@ -1384,6 +1402,8 @@ CURVEFS_ERROR FuseClient::FuseOpReadLink(fuse_req_t req, fuse_ino_t ino,
 
 CURVEFS_ERROR FuseClient::FuseOpRelease(fuse_req_t req, fuse_ino_t ino,
                                         struct fuse_file_info *fi) {
+    (void)req;
+    (void)fi;
     VLOG(1) << "FuseOpRelease, ino: " << ino;
     if (FLAGS_enableCto) {
         inodeManager_->RemoveOpenedInode(ino);

--- a/curvefs/src/client/fuse_client.h
+++ b/curvefs/src/client/fuse_client.h
@@ -93,11 +93,11 @@ class FuseClient {
         dentryManager_(std::make_shared<DentryCacheManagerImpl>(metaClient_)),
         dirBuf_(std::make_shared<DirBuffer>()),
         fsInfo_(nullptr),
-        mdsBase_(nullptr),
-        isStop_(true),
         init_(false),
         enableSumInDir_(false),
-        warmupManager_(nullptr) {}
+        warmupManager_(nullptr),
+        mdsBase_(nullptr),
+        isStop_(true) {}
 
     virtual ~FuseClient() {}
 
@@ -112,11 +112,11 @@ class FuseClient {
             dentryManager_(dentryManager),
             dirBuf_(std::make_shared<DirBuffer>()),
             fsInfo_(nullptr),
-            mdsBase_(nullptr),
-            isStop_(true),
             init_(false),
             enableSumInDir_(false),
-            warmupManager_(warmupManager) {}
+            warmupManager_(warmupManager),
+            mdsBase_(nullptr),
+            isStop_(true) {}
 
     virtual CURVEFS_ERROR Init(const FuseClientOption &option);
 
@@ -221,11 +221,16 @@ class FuseClient {
                                       struct fuse_file_info* fi) = 0;
     virtual CURVEFS_ERROR FuseOpFlush(fuse_req_t req, fuse_ino_t ino,
                                       struct fuse_file_info *fi) {
+        (void)req;
+        (void)ino;
+        (void)fi;
         return CURVEFS_ERROR::OK;
     }
 
     virtual CURVEFS_ERROR FuseOpStatFs(fuse_req_t req, fuse_ino_t ino,
                                        struct statvfs* stbuf) {
+        (void)req;
+        (void)ino;
         // TODO(chengyi01,wuhanqing): implement in s3 and volume client
         stbuf->f_frsize = stbuf->f_bsize = fsInfo_->blocksize();
         stbuf->f_blocks = 10UL << 30;

--- a/curvefs/src/client/fuse_common.h
+++ b/curvefs/src/client/fuse_common.h
@@ -34,9 +34,9 @@ extern "C" {
 #endif
 
 struct MountOption {
-    char* mountPoint;
-    char* fsName;
-    char* fsType;
+    const char* mountPoint;
+    const char* fsName;
+    const char* fsType;
     char* conf;
     char* mdsAddr;
 };

--- a/curvefs/src/client/fuse_s3_client.cpp
+++ b/curvefs/src/client/fuse_s3_client.cpp
@@ -146,6 +146,7 @@ CURVEFS_ERROR FuseS3Client::FuseOpWrite(fuse_req_t req, fuse_ino_t ino,
                                         const char *buf, size_t size, off_t off,
                                         struct fuse_file_info *fi,
                                         size_t *wSize) {
+    (void)req;
     // check align
     if (fi->flags & O_DIRECT) {
         if (!(is_aligned(off, DirectIOAlignment) &&
@@ -214,6 +215,7 @@ CURVEFS_ERROR FuseS3Client::FuseOpRead(fuse_req_t req, fuse_ino_t ino,
                                        size_t size, off_t off,
                                        struct fuse_file_info *fi, char *buffer,
                                        size_t *rSize) {
+    (void)req;
     // check align
     if (fi->flags & O_DIRECT) {
         if (!(is_aligned(off, DirectIOAlignment) &&
@@ -232,7 +234,7 @@ CURVEFS_ERROR FuseS3Client::FuseOpRead(fuse_req_t req, fuse_ino_t ino,
     uint64_t fileSize = inodeWrapper->GetLength();
 
     size_t len = 0;
-    if (fileSize <= off) {
+    if (static_cast<int64_t>(fileSize) <= off) {
         *rSize = 0;
         return CURVEFS_ERROR::OK;
     } else if (fileSize < off + size) {
@@ -306,6 +308,8 @@ CURVEFS_ERROR FuseS3Client::FuseOpUnlink(fuse_req_t req, fuse_ino_t parent,
 CURVEFS_ERROR FuseS3Client::FuseOpFsync(fuse_req_t req, fuse_ino_t ino,
                                         int datasync,
                                         struct fuse_file_info *fi) {
+    (void)req;
+    (void)fi;
     VLOG(1) << "FuseOpFsync, ino: " << ino << ", datasync: " << datasync;
 
     CURVEFS_ERROR ret = s3Adaptor_->Flush(ino);
@@ -334,6 +338,8 @@ CURVEFS_ERROR FuseS3Client::Truncate(InodeWrapper *inode, uint64_t length) {
 
 CURVEFS_ERROR FuseS3Client::FuseOpFlush(fuse_req_t req, fuse_ino_t ino,
                                         struct fuse_file_info *fi) {
+    (void)req;
+    (void)fi;
     VLOG(1) << "FuseOpFlush, ino: " << ino;
     CURVEFS_ERROR ret = CURVEFS_ERROR::OK;
 

--- a/curvefs/src/client/fuse_volume_client.cpp
+++ b/curvefs/src/client/fuse_volume_client.cpp
@@ -134,6 +134,7 @@ CURVEFS_ERROR FuseVolumeClient::FuseOpWrite(fuse_req_t req,
                                             off_t off,
                                             struct fuse_file_info *fi,
                                             size_t *wSize) {
+    (void)req;
     VLOG(9) << "write start, ino: " << ino << ", offset: " << off
             << ", length: " << size;
 
@@ -189,6 +190,7 @@ CURVEFS_ERROR FuseVolumeClient::FuseOpRead(fuse_req_t req,
                                            struct fuse_file_info *fi,
                                            char *buffer,
                                            size_t *rSize) {
+    (void)req;
     VLOG(3) << "read start, ino: " << ino << ", offset: " << off
             << ", length: " << size;
 
@@ -272,6 +274,8 @@ CURVEFS_ERROR FuseVolumeClient::FuseOpUnlink(fuse_req_t req, fuse_ino_t parent,
 CURVEFS_ERROR FuseVolumeClient::FuseOpFsync(fuse_req_t req, fuse_ino_t ino,
                                             int datasync,
                                             struct fuse_file_info *fi) {
+    (void)req;
+    (void)fi;
     VLOG(3) << "FuseOpFsync start, ino: " << ino << ", datasync: " << datasync;
 
     CURVEFS_ERROR ret = storage_->Flush(ino);
@@ -298,12 +302,16 @@ CURVEFS_ERROR FuseVolumeClient::FuseOpFsync(fuse_req_t req, fuse_ino_t ino,
 }
 
 CURVEFS_ERROR FuseVolumeClient::Truncate(InodeWrapper *inode, uint64_t length) {
+    (void)inode;
+    (void)length;
     // Todo: call volume truncate
     return CURVEFS_ERROR::OK;
 }
 
 CURVEFS_ERROR FuseVolumeClient::FuseOpFlush(fuse_req_t req, fuse_ino_t ino,
                                             struct fuse_file_info *fi) {
+    (void)req;
+    (void)fi;
     VLOG(9) << "FuseOpFlush, ino: " << ino;
 
     CURVEFS_ERROR ret = storage_->Flush(ino);

--- a/curvefs/src/client/inode_wrapper.cpp
+++ b/curvefs/src/client/inode_wrapper.cpp
@@ -559,6 +559,7 @@ class UpdateInodeAsyncS3Done : public MetaServerClientDone {
 }  // namespace
 
 void InodeWrapper::AsyncS3(MetaServerClientDone *done, bool internal) {
+    (void)internal;
     if (dirty_ || !s3ChunkInfoAdd_.empty()) {
         LockSyncingInode();
         LockSyncingS3ChunkInfo();

--- a/curvefs/src/client/inode_wrapper.h
+++ b/curvefs/src/client/inode_wrapper.h
@@ -80,7 +80,7 @@ class InodeWrapper : public std::enable_shared_from_this<InodeWrapper> {
     InodeWrapper(Inode inode,
                  std::shared_ptr<MetaServerClient> metaClient,
                  std::shared_ptr<S3ChunkInfoMetric> s3ChunkInfoMetric = nullptr,
-                 uint64_t maxDataSize = ULONG_MAX,
+                 int64_t maxDataSize = LONG_MAX,
                  uint32_t refreshDataInterval = UINT_MAX)
         : inode_(std::move(inode)),
           status_(InodeStatus::kNormal),
@@ -400,8 +400,8 @@ class InodeWrapper : public std::enable_shared_from_this<InodeWrapper> {
     InodeAttr dirtyAttr_;
 
     InodeStatus status_;
-    uint64_t baseMaxDataSize_;
-    uint64_t maxDataSize_;
+    int64_t baseMaxDataSize_;
+    int64_t maxDataSize_;
     uint32_t refreshDataInterval_;
     uint64_t lastRefreshTime_;
 

--- a/curvefs/src/client/main.cpp
+++ b/curvefs/src/client/main.cpp
@@ -109,7 +109,7 @@ void extra_options_help() {
 
 std::string match_any_pattern(
     const std::unordered_map<std::string, char**>& patterns, const char* src) {
-    int src_len = strlen(src);
+    size_t src_len = strlen(src);
     for (const auto& pair : patterns) {
         const auto& pattern = pair.first;
         if (pattern.length() < src_len &&

--- a/curvefs/src/client/metric/client_metric.h
+++ b/curvefs/src/client/metric/client_metric.h
@@ -269,7 +269,6 @@ struct DiskCacheMetric {
 
 struct KVClientMetric {
     static const std::string prefix;
-
     InterfaceMetric kvClientGet;
     InterfaceMetric kvClientSet;
 

--- a/curvefs/src/client/rpcclient/mds_client.cpp
+++ b/curvefs/src/client/rpcclient/mds_client.cpp
@@ -59,6 +59,8 @@ MdsClientImpl::Init(const ::curve::client::MetaServerOption &mdsOpt,
 FSStatusCode MdsClientImpl::MountFs(const std::string& fsName,
                                     const Mountpoint& mountPt, FsInfo* fsInfo) {
     auto task = RPCTask {
+        (void)addrindex;
+        (void)rpctimeoutMS;
         mdsClientMetric_.mountFs.qps.count << 1;
         LatencyUpdater updater(&mdsClientMetric_.mountFs.latency);
         MountFsResponse response;
@@ -88,6 +90,8 @@ FSStatusCode MdsClientImpl::MountFs(const std::string& fsName,
 FSStatusCode MdsClientImpl::UmountFs(const std::string& fsName,
                                      const Mountpoint& mountPt) {
     auto task = RPCTask {
+        (void)addrindex;
+        (void)rpctimeoutMS;
         mdsClientMetric_.umountFs.qps.count << 1;
         LatencyUpdater updater(&mdsClientMetric_.umountFs.latency);
         UmountFsResponse response;
@@ -113,6 +117,8 @@ FSStatusCode MdsClientImpl::UmountFs(const std::string& fsName,
 FSStatusCode MdsClientImpl::GetFsInfo(const std::string &fsName,
                                       FsInfo *fsInfo) {
     auto task = RPCTask {
+        (void)addrindex;
+        (void)rpctimeoutMS;
         mdsClientMetric_.getFsInfo.qps.count << 1;
         LatencyUpdater updater(&mdsClientMetric_.getFsInfo.latency);
         GetFsInfoResponse response;
@@ -143,6 +149,8 @@ FSStatusCode MdsClientImpl::GetFsInfo(const std::string &fsName,
 
 FSStatusCode MdsClientImpl::GetFsInfo(uint32_t fsId, FsInfo *fsInfo) {
     auto task = RPCTask {
+        (void)addrindex;
+        (void)rpctimeoutMS;
         mdsClientMetric_.getFsInfo.qps.count << 1;
         LatencyUpdater updater(&mdsClientMetric_.getFsInfo.latency);
         GetFsInfoResponse response;
@@ -203,6 +211,9 @@ bool MdsClientImpl::GetMetaServerInfo(
     ::curve::common::StringToUll(strs[1], &port);
 
     auto task = RPCTask {
+        (void)addrindex;
+        (void)rpctimeoutMS;
+        (void)addrindex;
         mdsClientMetric_.getMetaServerInfo.qps.count << 1;
         LatencyUpdater updater(&mdsClientMetric_.getMetaServerInfo.latency);
         GetMetaServerInfoResponse response;
@@ -239,6 +250,8 @@ bool MdsClientImpl::GetMetaServerListInCopysets(
     const LogicPoolID &logicalpooid, const std::vector<CopysetID> &copysetidvec,
     std::vector<CopysetInfo<MetaserverID>> *cpinfoVec) {
     auto task = RPCTask {
+        (void)addrindex;
+        (void)rpctimeoutMS;
         mdsClientMetric_.getMetaServerListInCopysets.qps.count << 1;
         LatencyUpdater updater(
             &mdsClientMetric_.getMetaServerListInCopysets.latency);
@@ -290,6 +303,8 @@ bool MdsClientImpl::GetMetaServerListInCopysets(
 bool MdsClientImpl::CreatePartition(
     uint32_t fsID, uint32_t count, std::vector<PartitionInfo> *partitionInfos) {
     auto task = RPCTask {
+        (void)addrindex;
+        (void)rpctimeoutMS;
         mdsClientMetric_.createPartition.qps.count << 1;
         LatencyUpdater updater(&mdsClientMetric_.createPartition.latency);
         CreatePartitionResponse response;
@@ -335,6 +350,8 @@ bool MdsClientImpl::GetCopysetOfPartitions(
     const std::vector<uint32_t> &partitionIDList,
     std::map<uint32_t, Copyset> *copysetMap) {
     auto task = RPCTask {
+        (void)addrindex;
+        (void)rpctimeoutMS;
         mdsClientMetric_.getCopysetOfPartitions.qps.count << 1;
         LatencyUpdater updater(
             &mdsClientMetric_.getCopysetOfPartitions.latency);
@@ -379,6 +396,8 @@ bool MdsClientImpl::GetCopysetOfPartitions(
 bool MdsClientImpl::ListPartition(uint32_t fsID,
                                   std::vector<PartitionInfo> *partitionInfos) {
     auto task = RPCTask {
+        (void)addrindex;
+        (void)rpctimeoutMS;
         mdsClientMetric_.listPartition.qps.count << 1;
         LatencyUpdater updater(&mdsClientMetric_.listPartition.latency);
         ListPartitionResponse response;
@@ -416,6 +435,8 @@ bool MdsClientImpl::ListPartition(uint32_t fsID,
 bool MdsClientImpl::AllocOrGetMemcacheCluster(uint32_t fsId,
                                               MemcacheClusterInfo* cluster) {
     auto task = RPCTask {
+        (void)addrindex;
+        (void)rpctimeoutMS;
         mdsClientMetric_.allocOrGetMemcacheCluster.qps.count << 1;
         LatencyUpdater updater(
             &mdsClientMetric_.allocOrGetMemcacheCluster.latency);
@@ -447,6 +468,8 @@ bool MdsClientImpl::AllocOrGetMemcacheCluster(uint32_t fsId,
 FSStatusCode MdsClientImpl::AllocS3ChunkId(uint32_t fsId, uint32_t idNum,
                                            uint64_t *chunkId) {
     auto task = RPCTask {
+        (void)addrindex;
+        (void)rpctimeoutMS;
         mdsClientMetric_.allocS3ChunkId.qps.count << 1;
         LatencyUpdater updater(&mdsClientMetric_.allocS3ChunkId.latency);
         AllocateS3ChunkResponse response;
@@ -480,6 +503,8 @@ MdsClientImpl::RefreshSession(const std::vector<PartitionTxId> &txIds,
                               const std::string& fsName,
                               const Mountpoint& mountpoint) {
     auto task = RPCTask {
+        (void)addrindex;
+        (void)rpctimeoutMS;
         mdsClientMetric_.refreshSession.qps.count << 1;
         LatencyUpdater updater(&mdsClientMetric_.refreshSession.latency);
         RefreshSessionRequest request;
@@ -517,6 +542,8 @@ MdsClientImpl::RefreshSession(const std::vector<PartitionTxId> &txIds,
 FSStatusCode MdsClientImpl::GetLatestTxId(const GetLatestTxIdRequest& request,
                                           GetLatestTxIdResponse* response) {
     auto task = RPCTask {
+        (void)addrindex;
+        (void)rpctimeoutMS;
         VLOG(3) << "GetLatestTxId [request]: " << request.DebugString();
         mdsClientMetric_.getLatestTxId.qps.count << 1;
         LatencyUpdater updater(&mdsClientMetric_.getLatestTxId.latency);
@@ -552,6 +579,8 @@ FSStatusCode MdsClientImpl::GetLatestTxId(const GetLatestTxIdRequest& request,
 
 FSStatusCode MdsClientImpl::CommitTx(const CommitTxRequest& request) {
     auto task = RPCTask {
+        (void)addrindex;
+        (void)rpctimeoutMS;
         VLOG(3) << "CommitTx [request]: " << request.DebugString();
         mdsClientMetric_.commitTx.qps.count << 1;
         LatencyUpdater updater(&mdsClientMetric_.commitTx.latency);
@@ -670,6 +699,8 @@ SpaceErrCode MdsClientImpl::AllocateVolumeBlockGroup(
     const std::string &owner,
     std::vector<curvefs::mds::space::BlockGroup> *groups) {
     auto task = RPCTask {
+        (void)addrindex;
+        (void)rpctimeoutMS;
         AllocateBlockGroupResponse response;
         mdsbasecli_->AllocateVolumeBlockGroup(fsId, count, owner, &response,
                                               cntl, channel);
@@ -705,6 +736,8 @@ SpaceErrCode MdsClientImpl::AcquireVolumeBlockGroup(
     const std::string &owner,
     curvefs::mds::space::BlockGroup *groups) {
     auto task = RPCTask {
+        (void)addrindex;
+        (void)rpctimeoutMS;
         AcquireBlockGroupResponse response;
         mdsbasecli_->AcquireVolumeBlockGroup(fsId, blockGroupOffset, owner,
                                              &response, cntl, channel);
@@ -730,6 +763,8 @@ SpaceErrCode MdsClientImpl::ReleaseVolumeBlockGroup(
     const std::string &owner,
     const std::vector<curvefs::mds::space::BlockGroup> &blockGroups) {
     auto task = RPCTask {
+        (void)addrindex;
+        (void)rpctimeoutMS;
         ReleaseBlockGroupResponse response;
         mdsbasecli_->ReleaseVolumeBlockGroup(fsId, owner, blockGroups,
                                              &response, cntl, channel);

--- a/curvefs/src/client/s3/client_s3_adaptor.cpp
+++ b/curvefs/src/client/s3/client_s3_adaptor.cpp
@@ -333,6 +333,7 @@ int S3ClientAdaptorImpl::Stop() {
 int S3ClientAdaptorImpl::ExecAsyncDownloadTask(
     void *meta,
     bthread::TaskIterator<AsyncDownloadTask> &iter) {  // NOLINT
+    (void)meta;
     if (iter.is_queue_stopped()) {
         return 0;
     }

--- a/curvefs/src/client/s3/disk_cache_base.cpp
+++ b/curvefs/src/client/s3/disk_cache_base.cpp
@@ -88,7 +88,7 @@ std::string DiskCacheBase::GetCacheIoFullDir() {
 int DiskCacheBase::CreateDir(const std::string dir) {
     size_t p = dir.find_last_of('/');
     std::string dirPath = dir;
-    if (p != -1) {
+    if (p != -1ULL) {
         dirPath.erase(dirPath.begin()+p, dirPath.end());
     }
     std::vector<std::string> names;

--- a/curvefs/src/client/s3/disk_cache_manager.cpp
+++ b/curvefs/src/client/s3/disk_cache_manager.cpp
@@ -159,13 +159,12 @@ int DiskCacheManager::ClearReadCache(const std::list<std::string> &files) {
     return cacheRead_->ClearReadCache(files);
 }
 
-void DiskCacheManager::AddCache(const std::string name,
-  bool cacheWriteExist) {
+void DiskCacheManager::AddCache(const std::string &name) {
     cachedObjName_->Put(name);
     VLOG(9) << "cache size is: " << cachedObjName_->Size();
 }
 
-bool DiskCacheManager::IsCached(const std::string name) {
+bool DiskCacheManager::IsCached(const std::string &name) {
     if (!cachedObjName_->IsCached(name)) {
         VLOG(9) << "not cached, name = " << name;
         return false;

--- a/curvefs/src/client/s3/disk_cache_manager.h
+++ b/curvefs/src/client/s3/disk_cache_manager.h
@@ -65,7 +65,7 @@ class DiskCacheManager {
         const S3ClientAdaptorOption option);
 
     virtual int UmountDiskCache();
-    virtual bool IsCached(const std::string name);
+    virtual bool IsCached(const std::string &name);
 
     /**
      * @brief add obj to cachedObjName
@@ -73,8 +73,7 @@ class DiskCacheManager {
      * @param[in] cacheWriteExist whether the obj is
      *                            exist in cache write
      */
-    void AddCache(const std::string name,
-      bool cacheWriteExist = true);
+    void AddCache(const std::string &name);
 
     int CreateDir();
     std::string GetCacheReadFullDir();

--- a/curvefs/src/client/s3/disk_cache_manager_impl.cpp
+++ b/curvefs/src/client/s3/disk_cache_manager_impl.cpp
@@ -151,7 +151,7 @@ int DiskCacheManagerImpl::WriteReadDirect(const std::string fileName,
         return ret;
     }
     // add cache.
-    diskCacheManager_->AddCache(fileName, false);
+    diskCacheManager_->AddCache(fileName);
     return ret;
 }
 
@@ -165,7 +165,7 @@ int DiskCacheManagerImpl::Read(const std::string name, char *buf,
     }
     // read disk file maybe fail because of disk file has been removed.
     int ret = diskCacheManager_->ReadDiskFile(name, buf, offset, length);
-    if (ret < 0 || ret < length) {
+    if (ret < static_cast<int64_t>(length)) {
         LOG(ERROR) << "read disk file error. readRet = " << ret;
         ret = client_->Download(name, buf, offset, length);
         if (ret < 0) {

--- a/curvefs/src/client/s3/disk_cache_read.cpp
+++ b/curvefs/src/client/s3/disk_cache_read.cpp
@@ -47,7 +47,7 @@ int DiskCacheRead::ReadDiskFile(const std::string name, char *buf,
     VLOG(6) << "ReadDiskFile start. name = " << name << ", offset = " << offset
             << ", length = " << length;
     std::string fileFullPath;
-    int fd, ret;
+    int fd;
     fileFullPath = GetCacheIoFullDir() + "/" + name;
     fd = posixWrapper_->open(fileFullPath.c_str(), O_RDONLY, MODE);
     if (fd < 0) {
@@ -69,7 +69,7 @@ int DiskCacheRead::ReadDiskFile(const std::string name, char *buf,
         posixWrapper_->close(fd);
         return readLen;
     }
-    if (readLen < length) {
+    if (readLen < static_cast<ssize_t>(length)) {
         LOG(ERROR) << "read disk file is not entirely. read len = " << readLen
                    << ", but want len = " << length << ", file = " << name;
         posixWrapper_->close(fd);
@@ -148,7 +148,7 @@ int DiskCacheRead::WriteDiskFile(const std::string fileName, const char *buf,
         return fd;
     }
     ssize_t writeLen = posixWrapper_->write(fd, buf, length);
-    if (writeLen < 0 || writeLen < length) {
+    if (writeLen < static_cast<ssize_t>(length)) {
         LOG(ERROR) << "write disk file error. ret = " << writeLen
                    << ", file = " << fileName;
         posixWrapper_->close(fd);

--- a/curvefs/src/client/s3/disk_cache_write.cpp
+++ b/curvefs/src/client/s3/disk_cache_write.cpp
@@ -336,8 +336,6 @@ int DiskCacheWrite::UploadAllCacheWriteFile() {
     VLOG(3) << "upload all cached write file start.";
     std::string fileFullPath;
     bool ret;
-    DIR *cacheWriteDir = NULL;
-    struct dirent *cacheWriteDirent = NULL;
     int doRet;
     fileFullPath = GetCacheIoFullDir();
     ret = IsFileExist(fileFullPath);
@@ -472,7 +470,7 @@ int DiskCacheWrite::WriteDiskFile(const std::string fileName, const char *buf,
         return fd;
     }
     ssize_t writeLen = posixWrapper_->write(fd, buf, length);
-    if (writeLen < 0 || writeLen < length) {
+    if (writeLen < static_cast<ssize_t>(length)) {
         LOG(ERROR) << "write disk file error. ret: " << writeLen
                    << ", file: " << fileName
                    << ", error: " << errno;

--- a/curvefs/src/client/warmup/warmup_manager.cpp
+++ b/curvefs/src/client/warmup/warmup_manager.cpp
@@ -366,8 +366,7 @@ void WarmupManagerS3Impl::TravelChunk(fuse_ino_t ino,
     uint64_t chunkSize = s3Adaptor_->GetChunkSize();
     uint32_t objectPrefix = s3Adaptor_->GetObjectPrefix();
     uint64_t offset, len, chunkid, compaction;
-    for (size_t i = 0; i < chunkInfo.s3chunks_size(); i++) {
-        auto const &chunkinfo = chunkInfo.s3chunks(i);
+    for (const auto &chunkinfo : chunkInfo.s3chunks()) {
         auto fsId = fsInfo_->fsid();
         chunkid = chunkinfo.chunkid();
         compaction = chunkinfo.compaction();
@@ -375,8 +374,6 @@ void WarmupManagerS3Impl::TravelChunk(fuse_ino_t ino,
         len = chunkinfo.len();
         // the offset in the chunk
         uint64_t chunkPos = offset % chunkSize;
-        // the offset in the block
-        uint64_t blockPos = chunkPos % blockSize;
         // the first blockIndex
         uint64_t blockIndexBegin = chunkPos / blockSize;
 
@@ -468,6 +465,7 @@ void WarmupManagerS3Impl::WarmUpAllObjs(
     GetObjectAsyncCallBack cb =
         [&](const S3Adapter *adapter,
             const std::shared_ptr<GetObjectAsyncContext> &context) {
+            (void)adapter;
             if (bgFetchStop_.load(std::memory_order_acquire)) {
                 VLOG(9) << "need stop warmup";
                 cond.Signal();

--- a/curvefs/src/client/xattr_manager.h
+++ b/curvefs/src/client/xattr_manager.h
@@ -126,13 +126,13 @@ class XattrManager {
     // dentry cache manager
     std::shared_ptr<DentryCacheManager> dentryManager_;
 
-    Atomic<bool> isStop_;
-
     InterruptibleSleeper sleeper_;
 
     uint32_t listDentryLimit_;
 
     uint32_t listDentryThreads_;
+
+    Atomic<bool> isStop_;
 };
 
 }  // namespace client

--- a/curvefs/src/common/process.cpp
+++ b/curvefs/src/common/process.cpp
@@ -24,37 +24,39 @@
 
 #include "curvefs/src/common/process.h"
 
-extern char** environ;
+extern char **environ;
 
 namespace curvefs {
 namespace common {
 
-char** Process::OsArgv_ = nullptr;
-char* Process::OsArgvLast_ = nullptr;
+char **Process::OsArgv_ = nullptr;
+char *Process::OsArgvLast_ = nullptr;
 
 pid_t Process::SpawnProcess(ProcFunc proc) {
     pid_t pid = fork();
 
     switch (pid) {
-        case -1:
-            return -1;
-        case 0:
-            proc();
-            break;
-        default:
-            break;
+    case -1:
+        return -1;
+    case 0:
+        proc();
+        break;
+    default:
+        break;
     }
 
     return pid;
 }
 
-void Process::InitSetProcTitle(int argc, char* const* argv) {
+void Process::InitSetProcTitle(int argc, char *const *argv) {
+    (void)argc;  // Silence the warning
+
     size_t size = 0;
     for (auto i = 0; environ[i]; i++) {
         size += strlen(environ[i]) + 1;
     }
 
-    OsArgv_ = (char**) argv;  // NOLINT
+    OsArgv_ = (char **)argv;  // NOLINT
     OsArgvLast_ = OsArgv_[0];
     for (auto i = 0; OsArgv_[i]; i++) {
         if (OsArgvLast_ == OsArgv_[i]) {
@@ -62,7 +64,7 @@ void Process::InitSetProcTitle(int argc, char* const* argv) {
         }
     }
 
-    char* p = new (std::nothrow) char[size];
+    char *p = new (std::nothrow) char[size];
     for (auto i = 0; environ[i]; i++) {
         if (OsArgvLast_ == environ[i]) {
             size = strlen(environ[i]) + 1;
@@ -78,15 +80,15 @@ void Process::InitSetProcTitle(int argc, char* const* argv) {
     OsArgvLast_--;
 }
 
-void Process::SetProcTitle(const std::string& title) {
+void Process::SetProcTitle(const std::string &title) {
     OsArgv_[1] = NULL;
     strncpy(OsArgv_[0], title.c_str(), OsArgvLast_ - OsArgv_[0]);
 }
 
-bool Process::InitSignals(const std::vector<Signal>& signals) {
+bool Process::InitSignals(const std::vector<Signal> &signals) {
     struct sigaction sa;
 
-    for (const auto& signal : signals) {
+    for (const auto &signal : signals) {
         memset(&sa, 0, sizeof(struct sigaction));
         if (signal.handler) {
             sa.sa_sigaction = signal.handler;

--- a/curvefs/src/common/rpc_stream.cpp
+++ b/curvefs/src/common/rpc_stream.cpp
@@ -257,6 +257,8 @@ std::shared_ptr<StreamConnection> StreamServer::Accept(brpc::Controller* cntl) {
 int StreamServer::on_received_messages(brpc::StreamId id,
                                        butil::IOBuf* const buffers[],
                                        size_t size) {
+    (void)buffers;  // Slience the warnings
+    (void)size;
     LOG(ERROR) << "on_received_messages: stream (streamId=" << id
                << ") in server-side should not reveice any message"
                << ", but now we received";

--- a/curvefs/src/mds/fs_storage.cpp
+++ b/curvefs/src/mds/fs_storage.cpp
@@ -424,14 +424,14 @@ bool PersisKVStorage::RenameFromStorage(const FsInfoWrapper& oldFs,
         OpType::OpDelete,
         const_cast<char*>(oldKey.c_str()),
         const_cast<char*>(""),
-        oldKey.size(),
+        static_cast<int>(oldKey.size()),
         0};
     Operation op2{
         OpType::OpPut,
         const_cast<char*>(newKey.c_str()),
         const_cast<char*>(newValue.c_str()),
-        newKey.size(),
-        newValue.size()};
+        static_cast<int>(newKey.size()),
+        static_cast<int>(newValue.size())};
     std::vector<Operation> ops{op1, op2};
     int ret = storage_->TxnN(ops);
     if (ret != EtcdErrCode::EtcdOK) {

--- a/curvefs/src/mds/heartbeat/heartbeat_service.cpp
+++ b/curvefs/src/mds/heartbeat/heartbeat_service.cpp
@@ -36,6 +36,7 @@ void HeartbeatServiceImpl::MetaServerHeartbeat(
     const ::curvefs::mds::heartbeat::MetaServerHeartbeatRequest *request,
     ::curvefs::mds::heartbeat::MetaServerHeartbeatResponse *response,
     ::google::protobuf::Closure *done) {
+    (void)controller;
     brpc::ClosureGuard doneGuard(done);
     heartbeatManager_->MetaServerHeartbeat(*request, response);
 }

--- a/curvefs/src/mds/schedule/leaderScheduler.cpp
+++ b/curvefs/src/mds/schedule/leaderScheduler.cpp
@@ -201,6 +201,7 @@ bool LeaderScheduler::TransferLeaderOut(MetaServerIdType source,
                                         uint16_t replicaNum, PoolIdType poolId,
                                         Operator *op,
                                         CopySetInfo *selectedCopySet) {
+    (void)poolId;
     // find all copyset with source metaserver as its leader as the candidate
     std::vector<CopySetInfo> candidateInfos;
     for (auto &cInfo : topo_->GetCopySetInfosInMetaServer(source)) {

--- a/curvefs/src/mds/schedule/recoverScheduler.cpp
+++ b/curvefs/src/mds/schedule/recoverScheduler.cpp
@@ -71,7 +71,7 @@ int RecoverScheduler::Schedule() {
         // alarm if over half of the replicas are offline
         int deadBound =
             copysetInfo.peers.size() - (copysetInfo.peers.size() / 2 + 1);
-        if (offlinelists.size() > deadBound) {
+        if (static_cast<int>(offlinelists.size()) > deadBound) {
             LOG(ERROR) << "recoverSchdeuler find "
                        << copysetInfo.CopySetInfoStr() << " has "
                        << offlinelists.size()

--- a/curvefs/src/mds/topology/topology.cpp
+++ b/curvefs/src/mds/topology/topology.cpp
@@ -300,8 +300,9 @@ TopoStatusCode TopologyImpl::UpdateServer(const Server &data) {
     }
 }
 
-TopoStatusCode TopologyImpl::UpdateMetaServerOnlineState(
-    const OnlineState &onlineState, MetaServerIdType id) {
+TopoStatusCode
+TopologyImpl::UpdateMetaServerOnlineState(const OnlineState &onlineState,
+                                          MetaServerIdType id) {
     ReadLockGuard rlockMetaServerMap(metaServerMutex_);
     auto it = metaServerMap_.find(id);
     if (it != metaServerMap_.end()) {
@@ -454,8 +455,8 @@ ZoneIdType TopologyImpl::FindZone(const std::string &zoneName,
     return static_cast<ZoneIdType>(UNINITIALIZE_ID);
 }
 
-ServerIdType TopologyImpl::FindServerByHostName(
-    const std::string &hostName) const {
+ServerIdType
+TopologyImpl::FindServerByHostName(const std::string &hostName) const {
     ReadLockGuard rlockServer(serverMutex_);
     for (auto it = serverMap_.begin(); it != serverMap_.end(); it++) {
         if (it->second.GetHostName() == hostName) {
@@ -616,8 +617,9 @@ TopoStatusCode TopologyImpl::UpdatePartition(const Partition &data) {
     }
 }
 
-TopoStatusCode TopologyImpl::UpdatePartitionStatistic(
-    uint32_t partitionId, PartitionStatistic statistic) {
+TopoStatusCode
+TopologyImpl::UpdatePartitionStatistic(uint32_t partitionId,
+                                       PartitionStatistic statistic) {
     WriteLockGuard wlockPartition(partitionMutex_);
     auto it = partitionMap_.find(partitionId);
     if (it != partitionMap_.end()) {
@@ -686,8 +688,8 @@ std::list<CopySetKey> TopologyImpl::GetAvailableCopysetKeyList() const {
     ReadLockGuard rlockCopySet(copySetMutex_);
     std::list<CopySetKey> result;
     for (auto const &it : copySetMap_) {
-        if (it.second.GetPartitionNum()
-                            >= option_.maxPartitionNumberInCopyset) {
+        if (it.second.GetPartitionNum() >=
+            option_.maxPartitionNumberInCopyset) {
             continue;
         }
         result.push_back(it.first);
@@ -700,8 +702,8 @@ std::vector<CopySetInfo> TopologyImpl::GetAvailableCopysetList() const {
     ReadLockGuard rlockCopySet(copySetMutex_);
     std::vector<CopySetInfo> result;
     for (auto const &it : copySetMap_) {
-        if (it.second.GetPartitionNum()
-                            >= option_.maxPartitionNumberInCopyset) {
+        if (it.second.GetPartitionNum() >=
+            option_.maxPartitionNumberInCopyset) {
             continue;
         }
         result.push_back(it.second);
@@ -740,8 +742,8 @@ int TopologyImpl::GetAvailableCopysetNum() const {
     ReadLockGuard rlockCopySet(copySetMutex_);
     int num = 0;
     for (auto const &it : copySetMap_) {
-        if (it.second.GetPartitionNum()
-                            >= option_.maxPartitionNumberInCopyset) {
+        if (it.second.GetPartitionNum() >=
+            option_.maxPartitionNumberInCopyset) {
             continue;
         }
         num++;
@@ -749,8 +751,8 @@ int TopologyImpl::GetAvailableCopysetNum() const {
     return num;
 }
 
-std::list<Partition> TopologyImpl::GetPartitionOfFs(
-    FsIdType id, PartitionFilter filter) const {
+std::list<Partition>
+TopologyImpl::GetPartitionOfFs(FsIdType id, PartitionFilter filter) const {
     std::list<Partition> ret;
     ReadLockGuard rlockPartitionMap(partitionMutex_);
     for (auto it = partitionMap_.begin(); it != partitionMap_.end(); it++) {
@@ -761,8 +763,9 @@ std::list<Partition> TopologyImpl::GetPartitionOfFs(
     return ret;
 }
 
-std::list<Partition> TopologyImpl::GetPartitionInfosInPool(
-    PoolIdType poolId, PartitionFilter filter) const {
+std::list<Partition>
+TopologyImpl::GetPartitionInfosInPool(PoolIdType poolId,
+                                      PartitionFilter filter) const {
     std::list<Partition> ret;
     ReadLockGuard rlockPartitionMap(partitionMutex_);
     for (auto it = partitionMap_.begin(); it != partitionMap_.end(); it++) {
@@ -773,8 +776,8 @@ std::list<Partition> TopologyImpl::GetPartitionInfosInPool(
     return ret;
 }
 
-std::list<Partition> TopologyImpl::GetPartitionInfosInCopyset(
-    CopySetIdType copysetId) const {
+std::list<Partition>
+TopologyImpl::GetPartitionInfosInCopyset(CopySetIdType copysetId) const {
     std::list<Partition> ret;
     ReadLockGuard rlockPartitionMap(partitionMutex_);
     for (auto it = partitionMap_.begin(); it != partitionMap_.end(); it++) {
@@ -786,8 +789,8 @@ std::list<Partition> TopologyImpl::GetPartitionInfosInCopyset(
 }
 
 // getList
-std::vector<MetaServerIdType> TopologyImpl::GetMetaServerInCluster(
-    MetaServerFilter filter) const {
+std::vector<MetaServerIdType>
+TopologyImpl::GetMetaServerInCluster(MetaServerFilter filter) const {
     std::vector<MetaServerIdType> ret;
     ReadLockGuard rlockMetaServerMap(metaServerMutex_);
     for (auto it = metaServerMap_.begin(); it != metaServerMap_.end(); it++) {
@@ -799,8 +802,8 @@ std::vector<MetaServerIdType> TopologyImpl::GetMetaServerInCluster(
     return ret;
 }
 
-std::vector<ServerIdType> TopologyImpl::GetServerInCluster(
-    ServerFilter filter) const {
+std::vector<ServerIdType>
+TopologyImpl::GetServerInCluster(ServerFilter filter) const {
     std::vector<ServerIdType> ret;
     ReadLockGuard rlockServer(serverMutex_);
     for (auto it = serverMap_.begin(); it != serverMap_.end(); it++) {
@@ -811,8 +814,8 @@ std::vector<ServerIdType> TopologyImpl::GetServerInCluster(
     return ret;
 }
 
-std::vector<ZoneIdType> TopologyImpl::GetZoneInCluster(
-    ZoneFilter filter) const {
+std::vector<ZoneIdType>
+TopologyImpl::GetZoneInCluster(ZoneFilter filter) const {
     std::vector<ZoneIdType> ret;
     ReadLockGuard rlockZone(zoneMutex_);
     for (auto it = zoneMap_.begin(); it != zoneMap_.end(); it++) {
@@ -823,8 +826,8 @@ std::vector<ZoneIdType> TopologyImpl::GetZoneInCluster(
     return ret;
 }
 
-std::vector<PoolIdType> TopologyImpl::GetPoolInCluster(
-    PoolFilter filter) const {
+std::vector<PoolIdType>
+TopologyImpl::GetPoolInCluster(PoolFilter filter) const {
     std::vector<PoolIdType> ret;
     ReadLockGuard rlockPool(poolMutex_);
     for (auto it = poolMap_.begin(); it != poolMap_.end(); it++) {
@@ -835,8 +838,9 @@ std::vector<PoolIdType> TopologyImpl::GetPoolInCluster(
     return ret;
 }
 
-std::list<MetaServerIdType> TopologyImpl::GetMetaServerInServer(
-    ServerIdType id, MetaServerFilter filter) const {
+std::list<MetaServerIdType>
+TopologyImpl::GetMetaServerInServer(ServerIdType id,
+                                    MetaServerFilter filter) const {
     std::list<MetaServerIdType> ret;
     ReadLockGuard rlockMetaServerMap(metaServerMutex_);
     for (auto it = metaServerMap_.begin(); it != metaServerMap_.end(); it++) {
@@ -848,8 +852,9 @@ std::list<MetaServerIdType> TopologyImpl::GetMetaServerInServer(
     return ret;
 }
 
-std::list<MetaServerIdType> TopologyImpl::GetMetaServerInZone(
-    ZoneIdType id, MetaServerFilter filter) const {
+std::list<MetaServerIdType>
+TopologyImpl::GetMetaServerInZone(ZoneIdType id,
+                                  MetaServerFilter filter) const {
     std::list<MetaServerIdType> ret;
     std::list<ServerIdType> serverList = GetServerInZone(id);
     for (ServerIdType s : serverList) {
@@ -859,8 +864,9 @@ std::list<MetaServerIdType> TopologyImpl::GetMetaServerInZone(
     return ret;
 }
 
-std::list<MetaServerIdType> TopologyImpl::GetMetaServerInPool(
-    PoolIdType id, MetaServerFilter filter) const {
+std::list<MetaServerIdType>
+TopologyImpl::GetMetaServerInPool(PoolIdType id,
+                                  MetaServerFilter filter) const {
     std::list<MetaServerIdType> ret;
     std::list<ZoneIdType> zoneList = GetZoneInPool(id);
     for (ZoneIdType z : zoneList) {
@@ -870,13 +876,13 @@ std::list<MetaServerIdType> TopologyImpl::GetMetaServerInPool(
     return ret;
 }
 
-uint32_t TopologyImpl::GetMetaServerNumInPool(
-    PoolIdType id, MetaServerFilter filter) const {
+uint32_t TopologyImpl::GetMetaServerNumInPool(PoolIdType id,
+                                              MetaServerFilter filter) const {
     return GetMetaServerInPool(id, filter).size();
 }
 
-std::list<ServerIdType> TopologyImpl::GetServerInZone(
-    ZoneIdType id, ServerFilter filter) const {
+std::list<ServerIdType>
+TopologyImpl::GetServerInZone(ZoneIdType id, ServerFilter filter) const {
     std::list<ServerIdType> ret;
     ReadLockGuard rlockServer(serverMutex_);
     for (auto it = serverMap_.begin(); it != serverMap_.end(); it++) {
@@ -899,8 +905,8 @@ std::list<ZoneIdType> TopologyImpl::GetZoneInPool(PoolIdType id,
     return ret;
 }
 
-std::vector<CopySetIdType> TopologyImpl::GetCopySetsInPool(
-    PoolIdType poolId, CopySetFilter filter) const {
+std::vector<CopySetIdType>
+TopologyImpl::GetCopySetsInPool(PoolIdType poolId, CopySetFilter filter) const {
     std::vector<CopySetIdType> ret;
     ReadLockGuard rlockCopySet(copySetMutex_);
     for (const auto &it : copySetMap_) {
@@ -911,14 +917,14 @@ std::vector<CopySetIdType> TopologyImpl::GetCopySetsInPool(
     return ret;
 }
 
-uint32_t TopologyImpl::GetCopySetNumInPool(
-    PoolIdType poolId, CopySetFilter filter) const {
+uint32_t TopologyImpl::GetCopySetNumInPool(PoolIdType poolId,
+                                           CopySetFilter filter) const {
     return GetCopySetsInPool(poolId, filter).size();
 }
 
 
-std::vector<CopySetKey> TopologyImpl::GetCopySetsInCluster(
-    CopySetFilter filter) const {
+std::vector<CopySetKey>
+TopologyImpl::GetCopySetsInCluster(CopySetFilter filter) const {
     std::vector<CopySetKey> ret;
     ReadLockGuard rlockCopySet(copySetMutex_);
     for (const auto &it : copySetMap_) {
@@ -929,8 +935,9 @@ std::vector<CopySetKey> TopologyImpl::GetCopySetsInCluster(
     return ret;
 }
 
-std::vector<CopySetInfo> TopologyImpl::GetCopySetInfosInPool(
-    PoolIdType poolId, CopySetFilter filter) const {
+std::vector<CopySetInfo>
+TopologyImpl::GetCopySetInfosInPool(PoolIdType poolId,
+                                    CopySetFilter filter) const {
     std::vector<CopySetInfo> ret;
     ReadLockGuard rlockCopySet(copySetMutex_);
     for (const auto &it : copySetMap_) {
@@ -941,8 +948,9 @@ std::vector<CopySetInfo> TopologyImpl::GetCopySetInfosInPool(
     return ret;
 }
 
-std::vector<CopySetKey> TopologyImpl::GetCopySetsInMetaServer(
-    MetaServerIdType id, CopySetFilter filter) const {
+std::vector<CopySetKey>
+TopologyImpl::GetCopySetsInMetaServer(MetaServerIdType id,
+                                      CopySetFilter filter) const {
     std::vector<CopySetKey> ret;
     ReadLockGuard rlockCopySet(copySetMutex_);
     for (const auto &it : copySetMap_) {
@@ -1052,8 +1060,9 @@ TopoStatusCode TopologyImpl::Init(const TopologyOption &option) {
     }
 
     // for upgrade and keep compatibility
-    // the old version have no partitionIndex in etcd, so need update here of upgrade  // NOLINT
-    // if the fs in old cluster already delete some partitions, it is incompatible.    // NOLINT
+    // the old version have no partitionIndex in etcd, so need update here of
+    // upgrade  // NOLINT if the fs in old cluster already delete some
+    // partitions, it is incompatible.    // NOLINT
     if (!RefreshPartitionIndexOfFS(partitionMap_)) {
         LOG(ERROR) << "[TopologyImpl::init],  RefreshPartitionIndexOfFS fail.";
         return TopoStatusCode::TOPO_STORGE_FAIL;
@@ -1278,8 +1287,8 @@ bool TopologyImpl::GetClusterInfo(ClusterInformation *info) {
 }
 
 // update partition tx, and ensure atomicity
-TopoStatusCode TopologyImpl::UpdatePartitionTxIds(
-    std::vector<PartitionTxId> txIds) {
+TopoStatusCode
+TopologyImpl::UpdatePartitionTxIds(std::vector<PartitionTxId> txIds) {
     std::vector<Partition> partitions;
     WriteLockGuard wlockPartition(partitionMutex_);
     for (auto item : txIds) {
@@ -1380,20 +1389,20 @@ uint32_t TopologyImpl::GetLeaderNumInMetaserver(MetaServerIdType id) const {
 }
 
 void TopologyImpl::GetAvailableMetaserversUnlock(
-                    std::vector<const MetaServer *>* vec) {
+    std::vector<const MetaServer *> *vec) {
     for (const auto &it : metaServerMap_) {
-        if (it.second.GetOnlineState() == OnlineState::ONLINE
-            && it.second.GetMetaServerSpace().IsMetaserverResourceAvailable()
-            && GetCopysetNumInMetaserver(it.first)
-                                    < option_.maxCopysetNumInMetaserver) {
+        if (it.second.GetOnlineState() == OnlineState::ONLINE &&
+            it.second.GetMetaServerSpace().IsMetaserverResourceAvailable() &&
+            GetCopysetNumInMetaserver(it.first) <
+                option_.maxCopysetNumInMetaserver) {
             vec->emplace_back(&(it.second));
         }
     }
 }
 
 TopoStatusCode TopologyImpl::GenCandidateMapUnlock(
-        PoolIdType poolId,
-        std::map<ZoneIdType, std::vector<MetaServerIdType>>* candidateMap) {
+    PoolIdType poolId,
+    std::map<ZoneIdType, std::vector<MetaServerIdType>> *candidateMap) {
     // 1. get all online and available metaserver
     std::vector<const MetaServer *> metaservers;
     GetAvailableMetaserversUnlock(&metaservers);
@@ -1402,7 +1411,7 @@ TopoStatusCode TopologyImpl::GenCandidateMapUnlock(
         Server server;
         if (!GetServer(serverId, &server)) {
             LOG(ERROR) << "get server failed when choose metaservers,"
-                    << " the serverId = " << serverId;
+                       << " the serverId = " << serverId;
             return TopoStatusCode::TOPO_SERVER_NOT_FOUND;
         }
 
@@ -1418,8 +1427,8 @@ TopoStatusCode TopologyImpl::GenCandidateMapUnlock(
 }
 
 TopoStatusCode TopologyImpl::GenCopysetAddrBatchForPool(
-            PoolIdType poolId, uint16_t replicaNum,
-            std::list<CopysetCreateInfo>* copysetList) {
+    PoolIdType poolId, uint16_t replicaNum,
+    std::list<CopysetCreateInfo> *copysetList) {
     // 1. genarate candidateMap
     std::map<ZoneIdType, std::vector<MetaServerIdType>> candidateMap;
     auto ret = GenCandidateMapUnlock(poolId, &candidateMap);
@@ -1432,8 +1441,9 @@ TopoStatusCode TopologyImpl::GenCopysetAddrBatchForPool(
     // 2. return error if candidate map has no enough replicaNum
     if (candidateMap.size() < replicaNum) {
         LOG(WARNING) << "can not find available metaserver for copyset, "
-                     << "poolId = " << poolId << " need replica num = "
-                     << replicaNum << ", but only has available zone num = "
+                     << "poolId = " << poolId
+                     << " need replica num = " << replicaNum
+                     << ", but only has available zone num = "
                      << candidateMap.size();
         return TopoStatusCode::TOPO_METASERVER_NOT_FOUND;
     }
@@ -1461,13 +1471,13 @@ TopoStatusCode TopologyImpl::GenCopysetAddrBatchForPool(
         std::shuffle(zoneIds.begin(), zoneIds.end(), randomGenerator);
 
         std::vector<MetaServerIdType> msIds;
-        for (int i = 0; i < minSize; i++) {
+        for (uint32_t i = 0; i < minSize; i++) {
             for (const auto &zoneId : zoneIds) {
                 msIds.push_back(candidateMap[zoneId][i]);
             }
         }
 
-        for (int i = 0; i < msIds.size() / replicaNum; i++) {
+        for (size_t i = 0; i < msIds.size() / replicaNum; i++) {
             CopysetCreateInfo copysetInfo;
             copysetInfo.poolId = poolId;
             copysetInfo.copysetId = UNINITIALIZE_ID;
@@ -1485,7 +1495,7 @@ TopoStatusCode TopologyImpl::GenCopysetAddrBatchForPool(
 // Check if there is no copy on the pool.
 // Generate copyset on the empty copyset pools.
 void TopologyImpl::GenCopysetIfPoolEmptyUnlocked(
-        std::list<CopysetCreateInfo>* copysetList) {
+    std::list<CopysetCreateInfo> *copysetList) {
     for (const auto &it : poolMap_) {
         PoolIdType poolId = it.first;
         uint32_t metaserverNum = GetMetaServerNumInPool(poolId);
@@ -1494,7 +1504,7 @@ void TopologyImpl::GenCopysetIfPoolEmptyUnlocked(
         }
 
         uint32_t copysetNum = GetCopySetNumInPool(poolId);
-        if (copysetNum !=0) {
+        if (copysetNum != 0) {
             continue;
         }
 
@@ -1505,17 +1515,16 @@ void TopologyImpl::GenCopysetIfPoolEmptyUnlocked(
             continue;
         }
         std::list<CopysetCreateInfo> tempCopysetList;
-        TopoStatusCode ret = GenCopysetAddrBatchForPool(poolId, replicaNum,
-                                                        &tempCopysetList);
+        TopoStatusCode ret =
+            GenCopysetAddrBatchForPool(poolId, replicaNum, &tempCopysetList);
         if (TopoStatusCode::TOPO_OK == ret) {
             LOG(INFO) << "Initial Generate copyset addr for pool " << poolId
                       << " success, gen copyset num = "
                       << tempCopysetList.size();
             copysetList->splice(copysetList->end(), tempCopysetList);
         } else {
-            LOG(WARNING) << "Initial Generate copyset addr for pool "
-                         << poolId << " fail, statusCode = "
-                         << TopoStatusCode_Name(ret);
+            LOG(WARNING) << "Initial Generate copyset addr for pool " << poolId
+                         << " fail, statusCode = " << TopoStatusCode_Name(ret);
         }
     }
 
@@ -1529,10 +1538,10 @@ void TopologyImpl::GenCopysetIfPoolEmptyUnlocked(
 // 3. according to the pool order of step 2, generate copyset add in the pool
 //    in turn until enough copyset add is generated
 TopoStatusCode TopologyImpl::GenSubsequentCopysetAddrBatchUnlocked(
-    uint32_t needCreateNum, std::list<CopysetCreateInfo>* copysetList) {
+    uint32_t needCreateNum, std::list<CopysetCreateInfo> *copysetList) {
     LOG(INFO) << "GenSubsequentCopysetAddrBatch needCreateNum = "
-              << needCreateNum << ", copysetList size = "
-              << copysetList->size() << " begin";
+              << needCreateNum << ", copysetList size = " << copysetList->size()
+              << " begin";
 
     MetaServerFilter filter = [](const MetaServer &ms) {
         return ms.GetOnlineState() == OnlineState::ONLINE;
@@ -1546,8 +1555,8 @@ TopoStatusCode TopologyImpl::GenSubsequentCopysetAddrBatchUnlocked(
     }
 
     // sort pool list by copyset average num
-    std::sort(poolList.begin(), poolList.end(),
-        [=](const Pool& a, const Pool& b) {
+    std::sort(
+        poolList.begin(), poolList.end(), [=](const Pool &a, const Pool &b) {
             PoolIdType poolId1 = a.GetId();
             PoolIdType poolId2 = b.GetId();
             uint32_t copysetNum1 = GetCopySetNumInPool(poolId1);
@@ -1564,8 +1573,8 @@ TopoStatusCode TopologyImpl::GenSubsequentCopysetAddrBatchUnlocked(
             PoolIdType poolId = it->GetId();
             uint16_t replicaNum = it->GetReplicaNum();
             std::list<CopysetCreateInfo> tempCopysetList;
-            TopoStatusCode ret = GenCopysetAddrBatchForPool(poolId,
-                                    replicaNum, &tempCopysetList);
+            TopoStatusCode ret = GenCopysetAddrBatchForPool(poolId, replicaNum,
+                                                            &tempCopysetList);
             if (TopoStatusCode::TOPO_OK == ret) {
                 copysetList->splice(copysetList->end(), tempCopysetList);
                 if (copysetList->size() >= needCreateNum) {
@@ -1573,9 +1582,10 @@ TopoStatusCode TopologyImpl::GenSubsequentCopysetAddrBatchUnlocked(
                 }
                 it++;
             } else {
-                LOG(WARNING) << "Generate " << needCreateNum
-                        << " copyset addr for pool " << poolId
-                        << "fail, statusCode = " << TopoStatusCode_Name(ret);
+                LOG(WARNING)
+                    << "Generate " << needCreateNum << " copyset addr for pool "
+                    << poolId
+                    << "fail, statusCode = " << TopoStatusCode_Name(ret);
                 it = poolList.erase(it);
             }
         }
@@ -1596,8 +1606,9 @@ TopoStatusCode TopologyImpl::GenSubsequentCopysetAddrBatchUnlocked(
 //    in this step is enough, return the list.
 // 2. Sort the pools according to the average number of copies,
 //    and traverse each pool to create copies until the number is sufficient.
-TopoStatusCode TopologyImpl::GenCopysetAddrBatch(uint32_t needCreateNum,
-                             std::list<CopysetCreateInfo>* copysetList) {
+TopoStatusCode
+TopologyImpl::GenCopysetAddrBatch(uint32_t needCreateNum,
+                                  std::list<CopysetCreateInfo> *copysetList) {
     ReadLockGuard rlockPool(poolMutex_);
     ReadLockGuard rlockMetaserver(metaServerMutex_);
     ReadLockGuard rlockCopyset(copySetMutex_);
@@ -1680,14 +1691,14 @@ bool TopologyImpl::RefreshPartitionIndexOfFS(
 std::list<MemcacheServer> TopologyImpl::ListMemcacheServers() const {
     ReadLockGuard rlockMemcacheCluster(memcacheClusterMutex_);
     std::list<MemcacheServer> ret;
-    for (auto const& cluster : memcacheClusterMap_) {
-        auto const& servers = cluster.second.GetServers();
+    for (auto const &cluster : memcacheClusterMap_) {
+        auto const &servers = cluster.second.GetServers();
         ret.insert(ret.begin(), servers.cbegin(), servers.cend());
     }
     return ret;
 }
 
-TopoStatusCode TopologyImpl::AddMemcacheCluster(const MemcacheCluster& data) {
+TopoStatusCode TopologyImpl::AddMemcacheCluster(const MemcacheCluster &data) {
     WriteLockGuard wlockMemcacheCluster(memcacheClusterMutex_);
     // storage_ to storage
     TopoStatusCode ret = TopoStatusCode::TOPO_OK;
@@ -1700,7 +1711,7 @@ TopoStatusCode TopologyImpl::AddMemcacheCluster(const MemcacheCluster& data) {
     return ret;
 }
 
-TopoStatusCode TopologyImpl::AddMemcacheCluster(MemcacheCluster&& data) {
+TopoStatusCode TopologyImpl::AddMemcacheCluster(MemcacheCluster &&data) {
     WriteLockGuard wlockMemcacheCluster(memcacheClusterMutex_);
     // storage_ to storage
     TopoStatusCode ret = TopoStatusCode::TOPO_OK;
@@ -1716,14 +1727,15 @@ TopoStatusCode TopologyImpl::AddMemcacheCluster(MemcacheCluster&& data) {
 std::list<MemcacheCluster> TopologyImpl::ListMemcacheClusters() const {
     std::list<MemcacheCluster> ret;
     ReadLockGuard rlockMemcacheCluster(memcacheClusterMutex_);
-    for (auto const& cluster : memcacheClusterMap_) {
+    for (auto const &cluster : memcacheClusterMap_) {
         ret.emplace_back(cluster.second);
     }
     return ret;
 }
 
-TopoStatusCode TopologyImpl::AllocOrGetMemcacheCluster(
-    FsIdType fsId, MemcacheClusterInfo* cluster) {
+TopoStatusCode
+TopologyImpl::AllocOrGetMemcacheCluster(FsIdType fsId,
+                                        MemcacheClusterInfo *cluster) {
     TopoStatusCode ret = TopoStatusCode::TOPO_OK;
     WriteLockGuard wlockFs2MemcacheCluster(fs2MemcacheClusterMutex_);
     ReadLockGuard rlockMemcacheCluster(memcacheClusterMutex_);

--- a/curvefs/src/mds/topology/topology_item.cpp
+++ b/curvefs/src/mds/topology/topology_item.cpp
@@ -24,6 +24,7 @@
 
 #include <string>
 #include <vector>
+#include <memory>
 
 #include "json/json.h"
 #include "src/common/string_util.h"
@@ -53,11 +54,15 @@ bool ClusterInformation::ParseFromString(const std::string &value) {
 
 bool Pool::TransRedundanceAndPlaceMentPolicyFromJsonStr(
     const std::string &jsonStr, RedundanceAndPlaceMentPolicy *rap) {
-    Json::Reader reader;
+    Json::CharReaderBuilder builder;
+    std::unique_ptr<Json::CharReader> reader(builder.newCharReader());
     Json::Value rapJson;
-    if (!reader.parse(jsonStr, rapJson)) {
+    JSONCPP_STRING errormsg;
+    if (!reader->parse(jsonStr.data(), jsonStr.data() + jsonStr.length(),
+                       &rapJson, &errormsg)) {
         return false;
     }
+
     if (!rapJson["replicaNum"].isNull()) {
         rap->replicaNum = rapJson["replicaNum"].asInt();
     } else {
@@ -204,13 +209,17 @@ std::string CopySetInfo::GetCopySetMembersStr() const {
 }
 
 bool CopySetInfo::SetCopySetMembersByJson(const std::string &jsonStr) {
-    Json::Reader reader;
+    Json::CharReaderBuilder builder;
+    std::unique_ptr<Json::CharReader> reader(builder.newCharReader());
     Json::Value copysetMemJson;
-    if (!reader.parse(jsonStr, copysetMemJson)) {
+    JSONCPP_STRING errormsg;
+    if (!reader->parse(jsonStr.data(), jsonStr.data() + jsonStr.length(),
+                       &copysetMemJson, &errormsg)) {
         return false;
     }
+
     peers_.clear();
-    for (int i = 0; i < copysetMemJson.size(); i++) {
+    for (uint32_t i = 0; i < copysetMemJson.size(); i++) {
         if (copysetMemJson[i].isInt()) {
             peers_.insert(copysetMemJson[i].asInt());
         } else {
@@ -299,14 +308,14 @@ common::PartitionInfo Partition::ToPartitionInfo() {
     return info;
 }
 
-bool MemcacheCluster::ParseFromString(const std::string& value) {
+bool MemcacheCluster::ParseFromString(const std::string &value) {
     MemcacheClusterInfo data;
     bool ret = data.ParseFromString(value);
     (*this) = static_cast<MemcacheCluster>(data);
     return ret;
 }
 
-bool MemcacheCluster::SerializeToString(std::string* value) const {
+bool MemcacheCluster::SerializeToString(std::string *value) const {
     return static_cast<MemcacheClusterInfo>(*this).SerializeToString(value);
 }
 

--- a/curvefs/src/mds/topology/topology_metric.cpp
+++ b/curvefs/src/mds/topology/topology_metric.cpp
@@ -40,8 +40,11 @@ std::map<FsIdType, FsMetricPtr> gFsMetrics;
 
 void TopologyMetricService::UpdateTopologyMetrics() {
     // process metaserver
-    std::vector<MetaServerIdType> metaservers = topo_->GetMetaServerInCluster(
-        [](const MetaServer &ms) { return true; });
+    std::vector<MetaServerIdType> metaservers =
+        topo_->GetMetaServerInCluster([](const MetaServer &ms) {
+            (void)ms;
+            return true;
+        });
 
     for (auto msId : metaservers) {
         auto it = gMetaServerMetrics.find(msId);
@@ -103,10 +106,10 @@ void TopologyMetricService::UpdateTopologyMetrics() {
             auto fileType2InodeNum = pit->GetFileType2InodeNum();
             auto itFsId2FileType2InodeNum = fsId2FileType2InodeNum.find(fsId);
             if (itFsId2FileType2InodeNum == fsId2FileType2InodeNum.end()) {
-                fsId2FileType2InodeNum.emplace(
-                    fsId, std::move(fileType2InodeNum));
+                fsId2FileType2InodeNum.emplace(fsId,
+                                               std::move(fileType2InodeNum));
             } else {
-                for (auto const& fileType2Inode : fileType2InodeNum) {
+                for (auto const &fileType2Inode : fileType2InodeNum) {
                     auto itFileType2InodeNum =
                         itFsId2FileType2InodeNum->second.find(
                             fileType2Inode.first);
@@ -202,7 +205,7 @@ void TopologyMetricService::UpdateTopologyMetrics() {
     }
 
     // set fsId2FileType2InodeNum metric
-    for (auto const& fsId2FileType2InodeNumPair : fsId2FileType2InodeNum) {
+    for (auto const &fsId2FileType2InodeNumPair : fsId2FileType2InodeNum) {
         auto it = gFsMetrics.find(fsId2FileType2InodeNumPair.first);
         if (it == gFsMetrics.end()) {
             FsMetricPtr cptr(new FsMetric(fsId2FileType2InodeNumPair.first));
@@ -211,7 +214,7 @@ void TopologyMetricService::UpdateTopologyMetrics() {
                      .first;
         }
         // set according to fstype
-        for (auto const& fileType2InodeNumPair :
+        for (auto const &fileType2InodeNumPair :
              fsId2FileType2InodeNumPair.second) {
             auto it2 = it->second->fileType2InodeNum_.find(
                 fileType2InodeNumPair.first);  //  find file type

--- a/curvefs/src/mds/topology/topology_service.cpp
+++ b/curvefs/src/mds/topology/topology_service.cpp
@@ -755,6 +755,8 @@ void TopologyServiceImpl::StatMetadataUsage(
     const ::curvefs::mds::topology::StatMetadataUsageRequest* request,
     ::curvefs::mds::topology::StatMetadataUsageResponse* response,
     ::google::protobuf::Closure* done) {
+    (void)controller;
+    (void)request;
     brpc::ClosureGuard guard(done);
     LOG(INFO) << "start to state metadata usage.";
     topologyManager_->GetMetaServersSpace(response->mutable_metadatausages());

--- a/curvefs/src/mds/topology/topology_storge_etcd.cpp
+++ b/curvefs/src/mds/topology/topology_storge_etcd.cpp
@@ -490,8 +490,8 @@ bool TopologyStorageEtcd::UpdatePartitions(
             OpType::OpPut,
             const_cast<char*>(keys[i].data()),
             const_cast<char*>(values[i].data()),
-            keys[i].size(),
-            values[i].size()
+            static_cast<int>(keys[i].size()),
+            static_cast<int>(values[i].size())
         };
         ops.emplace_back(op);
     }

--- a/curvefs/src/metaserver/dentry_storage.cpp
+++ b/curvefs/src/metaserver/dentry_storage.cpp
@@ -77,7 +77,7 @@ void DentryVector::Insert(const Dentry& dentry) {
 }
 
 void DentryVector::Delete(const Dentry& dentry) {
-    for (size_t i = 0; i < vec_->dentrys_size(); i++) {
+    for (int i = 0; i < vec_->dentrys_size(); i++) {
         if (vec_->dentrys(i) == dentry) {
             vec_->mutable_dentrys()->DeleteSubrange(i, 1);
             nPendingDel_ += 1;

--- a/curvefs/src/metaserver/recycle_cleaner.cpp
+++ b/curvefs/src/metaserver/recycle_cleaner.cpp
@@ -63,7 +63,7 @@ bool RecycleCleaner::IsDirTimeOut(const std::string& dir) {
 
     struct tm tmDir;
     memset(&tmDir, 0, sizeof(tmDir));
-    char* c = strptime(dir.c_str(), "%Y-%m-%d-%H", &tmDir);
+    (void)strptime(dir.c_str(), "%Y-%m-%d-%H", &tmDir);
 
     time_t dirTime = mktime(&tmDir);
     if (dirTime <= 0) {

--- a/curvefs/src/metaserver/s3compact_manager.cpp
+++ b/curvefs/src/metaserver/s3compact_manager.cpp
@@ -22,6 +22,7 @@
 
 #include "curvefs/src/metaserver/s3compact_manager.h"
 
+#include <cstdint>
 #include <list>
 #include <mutex>
 
@@ -45,7 +46,7 @@ void S3AdapterManager::Init() {
     std::lock_guard<std::mutex> lock(mtx_);
     if (inited_) return;
     used_.resize(size_);
-    for (int i = 0; i < size_; i++) {
+    for (uint64_t i = 0; i < size_; i++) {
         s3adapters_.emplace_back(new S3Adapter());
     }
     for (auto& s3adapter : s3adapters_) {

--- a/curvefs/src/metaserver/storage/dumpfile.cpp
+++ b/curvefs/src/metaserver/storage/dumpfile.cpp
@@ -178,7 +178,7 @@ DUMPFILE_ERROR DumpFile::Write(const char* buffer,
     if (ret < 0) {
         LOG(ERROR) << "Write file failed, retCode = " << ret;
         return DUMPFILE_ERROR::WRITE_FAILED;
-    } else if (ret != length) {
+    } else if (ret != static_cast<int>(length)) {
         LOG(ERROR) << "Write file failed, expect write " << length
                    << " bytes, actual write " << ret << " bytes";
         return DUMPFILE_ERROR::WRITE_FAILED;
@@ -192,7 +192,7 @@ DUMPFILE_ERROR DumpFile::Read(char* buffer, off_t offset, size_t length) {
     if (ret < 0) {
         LOG(ERROR) << "Read file failed, retCode = " << ret;
         return DUMPFILE_ERROR::READ_FAILED;
-    } else if (ret != length) {
+    } else if (ret != static_cast<int>(length)) {
         LOG(ERROR) << "Read file failed, expect read " << length
                    << " bytes, actual read " << ret << " bytes";
         return DUMPFILE_ERROR::READ_FAILED;
@@ -375,6 +375,7 @@ DUMPFILE_ERROR DumpFile::WaitSaveDone(pid_t childpid) {
 }
 
 void DumpFile::SignalHandler(int signo, siginfo_t* siginfo, void* ucontext) {
+    (void)ucontext;
     auto pid = (siginfo && siginfo->si_pid) ? siginfo->si_pid : -1;
     LOG(INFO) << "Signal " << signo << " received from " << pid;
     _exit(2);
@@ -398,7 +399,6 @@ DUMPFILE_ERROR DumpFile::InitSignals() {
 
 DUMPFILE_ERROR DumpFile::CloseSockets() {
     std::vector<std::string> names;
-    pid_t pid = getpid();
     if (fs_->List("/proc/self/fd", &names) != 0) {
         return DUMPFILE_ERROR::LIST_FAILED;
     }

--- a/curvefs/src/metaserver/storage/iterator.h
+++ b/curvefs/src/metaserver/storage/iterator.h
@@ -50,11 +50,11 @@ class Iterator {
 
     virtual std::string Value() = 0;
 
-    virtual const ValueType* RawValue() const { return nullptr; }
+    virtual const ValueType *RawValue() const { return nullptr; }
 
     virtual int Status() = 0;
 
-    virtual bool ParseFromValue(ValueType* value) { return true; }
+    virtual bool ParseFromValue(ValueType * /*value*/) { return true; }
 
     virtual void DisablePrefixChecking() {}
 };
@@ -64,24 +64,21 @@ class MergeIterator : public Iterator {
     using ChildrenType = std::vector<std::shared_ptr<Iterator>>;
 
  public:
-    explicit MergeIterator(const ChildrenType& children)
-        : current_(nullptr), children_(children) {
-    }
+    explicit MergeIterator(const ChildrenType &children)
+        : children_(children), current_(nullptr) {}
 
     uint64_t Size() override {
         uint64_t size = 0;
-        for (const auto& child : children_) {
+        for (const auto &child : children_) {
             size += child->Size();
         }
         return size;
     }
 
-    bool Valid() override {
-        return (current_ != nullptr) && (Status() == 0);
-    }
+    bool Valid() override { return (current_ != nullptr) && (Status() == 0); }
 
     void SeekToFirst() override {
-        for (const auto& child : children_) {
+        for (const auto &child : children_) {
             child->SeekToFirst();
         }
         FindCurrent();
@@ -92,16 +89,12 @@ class MergeIterator : public Iterator {
         FindCurrent();
     }
 
-    std::string Key() override {
-        return current_->Key();
-    }
+    std::string Key() override { return current_->Key(); }
 
-    std::string Value() override {
-        return current_->Value();
-    }
+    std::string Value() override { return current_->Value(); }
 
     int Status() override {
-        for (const auto& child : children_) {
+        for (const auto &child : children_) {
             if (child->Status() != 0) {
                 return child->Status();
             }
@@ -112,7 +105,7 @@ class MergeIterator : public Iterator {
  private:
     void FindCurrent() {
         current_ = nullptr;
-        for (const auto& child : children_) {
+        for (const auto &child : children_) {
             if (child->Valid()) {
                 current_ = child;
                 break;
@@ -125,39 +118,24 @@ class MergeIterator : public Iterator {
     std::shared_ptr<Iterator> current_;
 };
 
-template<typename ContainerType>
-class ContainerIterator : public Iterator {
+template <typename ContainerType> class ContainerIterator : public Iterator {
  public:
     explicit ContainerIterator(std::shared_ptr<ContainerType> container)
         : container_(container) {}
 
-    uint64_t Size() override {
-        return container_->size();
-    }
+    uint64_t Size() override { return container_->size(); }
 
-    bool Valid() override {
-        return iter_ != container_->end();
-    }
+    bool Valid() override { return iter_ != container_->end(); }
 
-    void SeekToFirst() override {
-        iter_ = container_->begin();
-    }
+    void SeekToFirst() override { iter_ = container_->begin(); }
 
-    void Next() override {
-        iter_++;
-    }
+    void Next() override { iter_++; }
 
-    std::string Key() override {
-        return iter_->first;
-    }
+    std::string Key() override { return iter_->first; }
 
-    std::string Value() override {
-        return iter_->second;
-    }
+    std::string Value() override { return iter_->second; }
 
-    int Status() override {
-        return 0;
-    }
+    int Status() override { return 0; }
 
  protected:
     const std::shared_ptr<ContainerType> container_;

--- a/curvefs/src/metaserver/storage/memory_storage.cpp
+++ b/curvefs/src/metaserver/storage/memory_storage.cpp
@@ -301,11 +301,14 @@ StorageOptions MemoryStorage::GetStorageOptions() const {
 
 bool MemoryStorage::Checkpoint(const std::string& dir,
                                std::vector<std::string>* files) {
+    (void)dir;
+    (void)files;
     LOG(WARNING) << "Not supported";
     return false;
 }
 
 bool MemoryStorage::Recover(const std::string& dir) {
+    (void)dir;
     LOG(WARNING) << "Not supported";
     return false;
 }

--- a/curvefs/src/metaserver/storage/memory_storage.h
+++ b/curvefs/src/metaserver/storage/memory_storage.h
@@ -149,10 +149,10 @@ class MemoryStorageIterator : public Iterator {
  public:
     MemoryStorageIterator(std::shared_ptr<ContainerType> container,
                           const std::string& prefix)
-        : container_(container),
-          prefix_(prefix),
+        : prefix_(prefix),
+          status_(0),
           prefixChecking_(true),
-          status_(0) {}
+          container_(container) {}
 
     // NOTE: now we can't caclute the size for range operate
     uint64_t Size() override {

--- a/curvefs/src/metaserver/storage/rocksdb_event_listener.cpp
+++ b/curvefs/src/metaserver/storage/rocksdb_event_listener.cpp
@@ -44,6 +44,7 @@ MetricEventListener::MetricEventListener()
 
 void MetricEventListener::OnFlushBegin(rocksdb::DB* db,
                                        const rocksdb::FlushJobInfo& /*info*/) {
+    (void)db;
     flushing_ << 1;
     rocksdbFlushStart = butil::cpuwide_time_us();
 }
@@ -51,6 +52,7 @@ void MetricEventListener::OnFlushBegin(rocksdb::DB* db,
 void MetricEventListener::OnFlushCompleted(
     rocksdb::DB* db,
     const rocksdb::FlushJobInfo& info) {
+    (void)db;
     flushing_ << -1;
     flushLatency_ << (butil::cpuwide_time_us() - rocksdbFlushStart);
     flushedBytes_ << info.table_properties.data_size;
@@ -64,6 +66,7 @@ void MetricEventListener::OnMemTableSealed(
 void MetricEventListener::OnCompactionBegin(
     rocksdb::DB* db,
     const rocksdb::CompactionJobInfo& /*info*/) {
+    (void)db;
     compacting_ << 1;
     rocksdbCompactionStart = butil::cpuwide_time_us();
 }
@@ -71,6 +74,7 @@ void MetricEventListener::OnCompactionBegin(
 void MetricEventListener::OnCompactionCompleted(
     rocksdb::DB* db,
     const rocksdb::CompactionJobInfo& /*info*/) {
+    (void)db;
     compacting_ << -1;
     compactionLatency_ << (butil::cpuwide_time_us() - rocksdbCompactionStart);
 }

--- a/curvefs/src/metaserver/storage/rocksdb_storage.h
+++ b/curvefs/src/metaserver/storage/rocksdb_storage.h
@@ -374,13 +374,13 @@ class RocksDBStorageIterator : public Iterator {
     }
 
  private:
+    RocksDBStorage* storage_;
     std::string prefix_;
     uint64_t size_;
     int status_;
-    bool ordered_;
     bool prefixChecking_;
+    bool ordered_;
     std::unique_ptr<rocksdb::Iterator> iter_;
-    RocksDBStorage* storage_;
     rocksdb::ReadOptions readOptions_;
 };
 

--- a/curvefs/src/metaserver/transaction.cpp
+++ b/curvefs/src/metaserver/transaction.cpp
@@ -81,7 +81,7 @@ inline bool RenameTx::operator==(const RenameTx& rhs) {
 std::ostream& operator<<(std::ostream& os, const RenameTx& renameTx) {
     auto dentrys = renameTx.dentrys_;
     os << "txId = " << renameTx.txId_;
-    for (int i = 0; i < dentrys.size(); i++) {
+    for (size_t i = 0; i < dentrys.size(); i++) {
         os << ", dentry[" << i << "] = ("
            << dentrys[i].ShortDebugString() << ")";
     }

--- a/curvefs/src/tools/list/curvefs_copysetinfo_list.cpp
+++ b/curvefs/src/tools/list/curvefs_copysetinfo_list.cpp
@@ -49,11 +49,10 @@ int CopysetInfoListTool::Init() {
     return 0;
 }
 
-void CopysetInfoListTool::AddUpdateFlags() {
-    AddUpdateFlagsFunc(SetMdsAddr);
-}
+void CopysetInfoListTool::AddUpdateFlags() { AddUpdateFlagsFunc(SetMdsAddr); }
 
-bool CopysetInfoListTool::AfterSendRequestToHost(const std::string& host) {
+bool CopysetInfoListTool::AfterSendRequestToHost(const std::string &host) {
+    (void)host;
     bool ret = true;
     if (controller_->Failed()) {
         errorOutput_ << "get all copysetInfo from [ " << FLAGS_mdsAddr
@@ -62,11 +61,12 @@ bool CopysetInfoListTool::AfterSendRequestToHost(const std::string& host) {
                      << std::endl;
         ret = false;
     } else if (show_) {
-        for (auto const& i : response_->copysetvalues()) {
+        for (auto const &i : response_->copysetvalues()) {
             std::cout << "copyset["
                       << copyset::GetCopysetKey(i.copysetinfo().poolid(),
                                                 i.copysetinfo().copysetid())
-                      << "]:" << std::endl << i.DebugString() << std::endl;
+                      << "]:" << std::endl
+                      << i.DebugString() << std::endl;
         }
         std::cout << std::endl;
     }

--- a/curvefs/src/tools/query/curvefs_copyset_query.cpp
+++ b/curvefs/src/tools/query/curvefs_copyset_query.cpp
@@ -126,7 +126,7 @@ bool CopysetQueryTool::AfterSendRequestToHost(const std::string& host) {
                     for (auto const& j : key2Status_[i]) {
                         std::cout << j.ShortDebugString() << std::endl;
                     }
-                    if (key2Status_[i].size() !=
+                    if (static_cast<int>(key2Status_[i].size()) !=
                         key2Info_[i][0].copysetinfo().peers().size()) {
                         std::cerr << "copysetStatus not match the number of "
                                      "copysetInfo's peers!"

--- a/curvefs/test/client/chunk_cache_manager_test.cpp
+++ b/curvefs/test/client/chunk_cache_manager_test.cpp
@@ -77,7 +77,6 @@ class ChunkCacheManagerTest : public testing::Test {
 TEST_F(ChunkCacheManagerTest, test_write_new_data) {
     uint64_t offset = 0;
     uint64_t len = 1024;
-    int length = len;
     char *buf = new char[len];
 
     chunkCacheManager_->WriteNewDataCache(s3ClientAdaptor_, offset, len, buf);

--- a/curvefs/test/client/client_s3_adaptor_test.cpp
+++ b/curvefs/test/client/client_s3_adaptor_test.cpp
@@ -123,7 +123,7 @@ TEST_F(ClientS3AdaptorTest, write_success) {
     uint64_t inodeId = 1;
     uint64_t offset = 0;
     uint64_t length = 1024;
-    char buf[length] = {0};
+    char *buf = new char[length];
     memset(buf, 'a', length);
     auto fileCache = std::make_shared<MockFileCacheManager>();
     EXPECT_CALL(*mockFsCacheManager_, FindOrCreateFileCacheManager(_, _))
@@ -135,32 +135,35 @@ TEST_F(ClientS3AdaptorTest, write_success) {
     EXPECT_CALL(*mockFsCacheManager_, MemCacheRatio()).WillOnce(Return(10));
     EXPECT_CALL(*fileCache, Write(_, _, _)).WillOnce(Return(length));
     ASSERT_EQ(length, s3ClientAdaptor_->Write(inodeId, offset, length, buf));
+    delete[] buf;
 }
 
 TEST_F(ClientS3AdaptorTest, read_success) {
     uint64_t inodeId = 1;
     uint64_t offset = 0;
     uint64_t length = 1024;
-    char buf[length] = {0};
+    char *buf = new char[length];
     memset(buf, 'a', length);
     auto fileCache = std::make_shared<MockFileCacheManager>();
     EXPECT_CALL(*mockFsCacheManager_, FindOrCreateFileCacheManager(_, _))
         .WillOnce(Return(fileCache));
     EXPECT_CALL(*fileCache, Read(_, _, _, _)).WillOnce(Return(length));
     ASSERT_EQ(length, s3ClientAdaptor_->Read(inodeId, offset, length, buf));
+    delete[] buf;
 }
 
 TEST_F(ClientS3AdaptorTest, read_fail) {
     uint64_t inodeId = 1;
     uint64_t offset = 0;
     uint64_t length = 1024;
-    char buf[length] = {0};
+    char *buf = new char[length];
     memset(buf, 'a', length);
     auto fileCache = std::make_shared<MockFileCacheManager>();
     EXPECT_CALL(*mockFsCacheManager_, FindOrCreateFileCacheManager(_, _))
         .WillOnce(Return(fileCache));
     EXPECT_CALL(*fileCache, Read(_, _, _, _)).WillOnce(Return(-1));
     ASSERT_EQ(-1, s3ClientAdaptor_->Read(inodeId, offset, length, buf));
+    delete[] buf;
 }
 
 TEST_F(ClientS3AdaptorTest, truncate_small) {

--- a/curvefs/test/client/client_s3_test.cpp
+++ b/curvefs/test/client/client_s3_test.cpp
@@ -111,7 +111,6 @@ TEST_F(ClientS3Test, uploadync) {
 
 TEST_F(ClientS3Test, downloadAsync) {
     const std::string obj("test");
-    uint64_t offset = 0;
     uint64_t len = 1024;
     char* buf = new char[len];
 

--- a/curvefs/test/client/mock_client_s3_cache_manager.h
+++ b/curvefs/test/client/mock_client_s3_cache_manager.h
@@ -26,6 +26,7 @@
 #include <gmock/gmock.h>
 #include <utility>
 #include <vector>
+#include <memory>
 #include "curvefs/src/client/s3/client_s3_cache_manager.h"
 
 namespace curvefs {

--- a/curvefs/test/client/rpcclient/metaserver_client_test.cpp
+++ b/curvefs/test/client/rpcclient/metaserver_client_test.cpp
@@ -345,12 +345,8 @@ TEST_F(MetaServerClientImplTest, test_CreateDentry_rpc_error) {
     d.set_txid(10);
 
     // out
-    MetaserverID metaServerID = 1;
     butil::EndPoint target;
     butil::str2endpoint(addr_.c_str(), &target);
-    LogicPoolID poolID = 1;
-    CopysetID copysetID = 100;
-    uint32_t partitionID = 200;
     uint64_t applyIndex = 10;
 
     curvefs::metaserver::CreateDentryResponse response;
@@ -379,12 +375,8 @@ TEST_F(MetaServerClientImplTest, test_CreateDentry_create_dentry_ok) {
     d.set_txid(10);
 
     // out
-    MetaserverID metaServerID = 1;
     butil::EndPoint target;
     butil::str2endpoint(addr_.c_str(), &target);
-    LogicPoolID poolID = 1;
-    CopysetID copysetID = 100;
-    uint32_t partitionID = 200;
     uint64_t applyIndex = 10;
 
     curvefs::metaserver::CreateDentryResponse response;
@@ -414,12 +406,8 @@ TEST_F(MetaServerClientImplTest, test_CreateDentry_copyset_not_exist) {
     d.set_txid(10);
 
     // out
-    MetaserverID metaServerID = 1;
     butil::EndPoint target;
     butil::str2endpoint(addr_.c_str(), &target);
-    LogicPoolID poolID = 1;
-    CopysetID copysetID = 100;
-    uint32_t partitionID = 200;
     uint64_t applyIndex = 10;
 
     curvefs::metaserver::CreateDentryResponse response;
@@ -460,12 +448,8 @@ TEST_F(MetaServerClientImplTest,
     d.set_txid(10);
 
     // out
-    MetaserverID metaServerID = 1;
     butil::EndPoint target;
     butil::str2endpoint(addr_.c_str(), &target);
-    LogicPoolID poolID = 1;
-    CopysetID copysetID = 100;
-    uint32_t partitionID = 200;
     uint64_t applyIndex = 10;
 
     curvefs::metaserver::CreateDentryResponse response;
@@ -492,12 +476,8 @@ TEST_F(MetaServerClientImplTest, test_DeleteDentry) {
     std::string name = "test";
 
     // out
-    MetaserverID metaServerID = 1;
     butil::EndPoint target;
     butil::str2endpoint(addr_.c_str(), &target);
-    LogicPoolID poolID = 1;
-    CopysetID copysetID = 100;
-    uint32_t partitionID = 200;
     uint64_t applyIndex = 10;
 
     curvefs::metaserver::DeleteDentryResponse response;
@@ -614,12 +594,8 @@ TEST_F(MetaServerClientImplTest, test_GetInode) {
     uint64_t inodeid = 2;
 
     // out
-    MetaserverID metaServerID = 1;
     butil::EndPoint target;
     butil::str2endpoint(addr_.c_str(), &target);
-    LogicPoolID poolID = 1;
-    CopysetID copysetID = 100;
-    uint32_t partitionID = 200;
     uint64_t applyIndex = 10;
     curvefs::metaserver::Inode out;
     out.set_inodeid(inodeid);
@@ -725,12 +701,8 @@ TEST_F(MetaServerClientImplTest, test_UpdateInodeAttr) {
     inode.set_symlink("test9");
 
     // out
-    MetaserverID metaServerID = 1;
     butil::EndPoint target;
     butil::str2endpoint(addr_.c_str(), &target);
-    LogicPoolID poolID = 1;
-    CopysetID copysetID = 100;
-    uint32_t partitionID = 200;
     uint64_t applyIndex = 10;
     curvefs::metaserver::Inode out;
 
@@ -950,12 +922,8 @@ TEST_F(MetaServerClientImplTest, test_CreateInode) {
     inode.symlink = "test9";
 
     // out
-    MetaserverID metaServerID = 1;
     butil::EndPoint target;
     butil::str2endpoint(addr_.c_str(), &target);
-    LogicPoolID poolID = 1;
-    CopysetID copysetID = 100;
-    uint32_t partitionID = 200;
     uint64_t applyIndex = 10;
     curvefs::metaserver::Inode out;
     out.set_inodeid(100);
@@ -1062,12 +1030,8 @@ TEST_F(MetaServerClientImplTest, test_DeleteInode) {
     uint64_t inodeid = 1;
 
     // out
-    MetaserverID metaServerID = 1;
     butil::EndPoint target;
     butil::str2endpoint(addr_.c_str(), &target);
-    LogicPoolID poolID = 1;
-    CopysetID copysetID = 100;
-    uint32_t partitionID = 200;
     uint64_t applyIndex = 10;
 
     curvefs::metaserver::DeleteInodeResponse response;

--- a/curvefs/test/client/test_disk_cache_manager.cpp
+++ b/curvefs/test/client/test_disk_cache_manager.cpp
@@ -196,12 +196,12 @@ TEST_F(TestDiskCacheManager, IsCached) {
     bool ret = diskCacheManager_->IsCached(fileName);
     ASSERT_EQ(false, ret);
 
-    diskCacheManager_->AddCache(fileName, false);
+    diskCacheManager_->AddCache(fileName);
     diskCacheManager_->AddCache(fileName2);
     ret = diskCacheManager_->IsCached(fileName2);
     ASSERT_EQ(true, ret);
 
-    diskCacheManager_->AddCache(fileName, false);
+    diskCacheManager_->AddCache(fileName);
     diskCacheManager_->AddCache(fileName2);
     ret = diskCacheManager_->IsCached(fileName);
     ASSERT_EQ(true, ret);
@@ -236,11 +236,6 @@ TEST_F(TestDiskCacheManager, IsDiskCacheFull) {
     int ret = diskCacheManager_->IsDiskCacheFull();
     ASSERT_EQ(true, ret);
 
-    struct statfs stat;
-    stat.f_frsize = 1;
-    stat.f_blocks = 1;
-    stat.f_bfree = 0;
-    stat.f_bavail = 0;
     ret = diskCacheManager_->IsDiskCacheFull();
     ASSERT_EQ(true, ret);
 }
@@ -285,7 +280,7 @@ TEST_F(TestDiskCacheManager, TrimRun_1) {
     diskCacheManager_->InitMetrics("test");
     EXPECT_CALL(*wrapper, statfs(NotNull(), NotNull()))
         .WillRepeatedly(Return(-1));
-    int ret = diskCacheManager_->TrimRun();
+    (void)diskCacheManager_->TrimRun();
     sleep(6);
     diskCacheManager_->UmountDiskCache();
 }
@@ -318,7 +313,7 @@ TEST_F(TestDiskCacheManager, TrimCache_2) {
     diskCacheManager_->Init(client_, option);
     diskCacheManager_->InitMetrics("test");
     diskCacheManager_->AddCache("test");
-    int ret = diskCacheManager_->TrimRun();
+    (void)diskCacheManager_->TrimRun();
     sleep(6);
     diskCacheManager_->UmountDiskCache();
 }
@@ -354,7 +349,7 @@ TEST_F(TestDiskCacheManager, TrimCache_4) {
     diskCacheManager_->Init(client_, option);
     diskCacheManager_->InitMetrics("test");
     diskCacheManager_->AddCache("test");
-    int ret = diskCacheManager_->TrimRun();
+    (void)diskCacheManager_->TrimRun();
     sleep(6);
     diskCacheManager_->UmountDiskCache();
 }
@@ -391,7 +386,7 @@ TEST_F(TestDiskCacheManager, TrimCache_5) {
     diskCacheManager_->Init(client_, option);
     diskCacheManager_->InitMetrics("test");
     diskCacheManager_->AddCache("test");
-    int ret = diskCacheManager_->TrimRun();
+    (void)diskCacheManager_->TrimRun();
     sleep(6);
     diskCacheManager_->UmountDiskCache();
 }
@@ -432,7 +427,7 @@ TEST_F(TestDiskCacheManager, TrimCache_noexceed) {
         .Times(2)
         .WillOnce(Return(-1))
         .WillOnce(DoAll(SetArgPointee<1>(rf), Return(0)));
-    int ret = diskCacheManager_->TrimRun();
+    (void)diskCacheManager_->TrimRun();
     diskCacheManager_->InitMetrics("test");
     sleep(6);
     diskCacheManager_->UmountDiskCache();

--- a/curvefs/test/client/test_disk_cache_write.cpp
+++ b/curvefs/test/client/test_disk_cache_write.cpp
@@ -193,7 +193,6 @@ TEST_F(TestDiskCacheWrite, ReadFile) {
 }
 
 TEST_F(TestDiskCacheWrite, UploadFile) {
-    uint64_t length = 10;
     EXPECT_CALL(*wrapper_, stat(NotNull(), NotNull()))
         .WillOnce(Return(-1));
     std::string fileName = "test";
@@ -460,7 +459,7 @@ TEST_F(TestDiskCacheWrite, AsyncUploadRun) {
     }));
     diskCacheWrite_->AsyncUploadEnqueue("test");
     diskCacheWrite_->AsyncUploadEnqueue("test");
-    int ret = diskCacheWrite_->AsyncUploadRun();
+    (void)diskCacheWrite_->AsyncUploadRun();
     sleep(1);
     diskCacheWrite_->AsyncUploadEnqueue("test");
     std::string t1 = "test";

--- a/curvefs/test/client/test_fuse_s3_client.cpp
+++ b/curvefs/test/client/test_fuse_s3_client.cpp
@@ -209,7 +209,6 @@ TEST_F(TestFuseS3Client, test_Init_with_KVCache) {
 // GetInode failed; bad fd
 TEST_F(TestFuseS3Client, warmUp_inodeBadFd) {
     sleep(1);
-    fuse_ino_t parent = 1;
     std::string name = "test";
     fuse_ino_t inodeid = 2;
 
@@ -863,9 +862,9 @@ TEST_F(TestFuseS3Client, warmUp_FetchChildDentry_suc_ListDentry) {
 TEST_F(TestFuseS3Client, FuseInit_when_fs_exist) {
     MountOption mOpts;
     memset(&mOpts, 0, sizeof(mOpts));
-    mOpts.fsName = "s3fs";
-    mOpts.mountPoint = "host1:/test";
-    mOpts.fsType = "s3";
+    mOpts.fsName = const_cast<char*>("s3fs");
+    mOpts.mountPoint = const_cast<char*>("host1:/test");
+    mOpts.fsType = const_cast<char*>("s3");
 
     std::string fsName = mOpts.fsName;
     FsInfo fsInfoExp;
@@ -886,9 +885,9 @@ TEST_F(TestFuseS3Client, FuseInit_when_fs_exist) {
 TEST_F(TestFuseS3Client, FuseOpDestroy) {
     MountOption mOpts;
     memset(&mOpts, 0, sizeof(mOpts));
-    mOpts.fsName = "s3fs";
-    mOpts.mountPoint = "host1:/test";
-    mOpts.fsType = "s3";
+    mOpts.fsName = const_cast<char*>("s3fs");
+    mOpts.mountPoint = const_cast<char*>("host1:/test");
+    mOpts.fsType = const_cast<char*>("s3");
 
     std::string fsName = mOpts.fsName;
 
@@ -899,7 +898,7 @@ TEST_F(TestFuseS3Client, FuseOpDestroy) {
 }
 
 TEST_F(TestFuseS3Client, FuseOpWriteSmallSize) {
-    fuse_req_t req;
+    fuse_req_t req = nullptr;
     fuse_ino_t ino = 1;
     const char *buf = "xxx";
     size_t size = 4;
@@ -929,7 +928,7 @@ TEST_F(TestFuseS3Client, FuseOpWriteSmallSize) {
 }
 
 TEST_F(TestFuseS3Client, FuseOpWriteFailed) {
-    fuse_req_t req;
+    fuse_req_t req = nullptr;
     fuse_ino_t ino = 1;
     const char *buf = "xxx";
     size_t size = 4;
@@ -959,7 +958,7 @@ TEST_F(TestFuseS3Client, FuseOpWriteFailed) {
 }
 
 TEST_F(TestFuseS3Client, FuseOpReadOverRange) {
-    fuse_req_t req;
+    fuse_req_t req = nullptr;
     fuse_ino_t ino = 1;
     size_t size = 4;
     off_t off = 5000;
@@ -985,7 +984,7 @@ TEST_F(TestFuseS3Client, FuseOpReadOverRange) {
 }
 
 TEST_F(TestFuseS3Client, FuseOpReadFailed) {
-    fuse_req_t req;
+    fuse_req_t req = nullptr;
     fuse_ino_t ino = 1;
     size_t size = 4;
     off_t off = 0;
@@ -1016,9 +1015,9 @@ TEST_F(TestFuseS3Client, FuseOpReadFailed) {
 }
 
 TEST_F(TestFuseS3Client, FuseOpFsync) {
-    fuse_req_t req;
+    fuse_req_t req = nullptr;
     fuse_ino_t ino = 1;
-    struct fuse_file_info *fi;
+    struct fuse_file_info *fi = nullptr;
 
     Inode inode;
     inode.set_inodeid(ino);
@@ -1046,9 +1045,9 @@ TEST_F(TestFuseS3Client, FuseOpFsync) {
 }
 
 TEST_F(TestFuseS3Client, FuseOpFlush) {
-    fuse_req_t req;
+    fuse_req_t req = nullptr;
     fuse_ino_t ino = 1;
-    struct fuse_file_info *fi;
+    struct fuse_file_info *fi = nullptr;
     Inode inode;
     inode.set_inodeid(ino);
     inode.set_length(0);
@@ -1086,7 +1085,7 @@ TEST_F(TestFuseS3Client, FuseOpFlush) {
 
 TEST_F(TestFuseS3Client, FuseOpGetXattr_NotSummaryInfo) {
     // in
-    fuse_req_t req;
+    fuse_req_t req = nullptr;
     fuse_ino_t ino = 1;
     const char name[] = "security.selinux";
     size_t size = 100;
@@ -1098,7 +1097,7 @@ TEST_F(TestFuseS3Client, FuseOpGetXattr_NotSummaryInfo) {
 
 TEST_F(TestFuseS3Client, FuseOpGetXattr_NotEnableSumInDir) {
     // in
-    fuse_req_t req;
+    fuse_req_t req = nullptr;
     fuse_ino_t ino = 1;
     const char rname[] = "curve.dir.rfbytes";
     const char name[] = "curve.dir.fbytes";
@@ -1200,7 +1199,7 @@ TEST_F(TestFuseS3Client, FuseOpGetXattr_NotEnableSumInDir) {
 
 TEST_F(TestFuseS3Client, FuseOpGetXattr_NotEnableSumInDir_Failed) {
     // in
-    fuse_req_t req;
+    fuse_req_t req = nullptr;
     fuse_ino_t ino = 1;
     const char rname[] = "curve.dir.rfbytes";
     const char name[] = "curve.dir.fbytes";
@@ -1328,7 +1327,7 @@ TEST_F(TestFuseS3Client, FuseOpGetXattr_NotEnableSumInDir_Failed) {
 TEST_F(TestFuseS3Client, FuseOpGetXattr_EnableSumInDir) {
     client_->SetEnableSumInDir(true);
     // in
-    fuse_req_t req;
+    fuse_req_t req = nullptr;
     fuse_ino_t ino = 1;
     const char name[] = "curve.dir.rentries";
     size_t size = 100;
@@ -1396,7 +1395,7 @@ TEST_F(TestFuseS3Client, FuseOpGetXattr_EnableSumInDir) {
 TEST_F(TestFuseS3Client, FuseOpGetXattr_EnableSumInDir_Failed) {
     client_->SetEnableSumInDir(true);
     // in
-    fuse_req_t req;
+    fuse_req_t req = nullptr;
     fuse_ino_t ino = 1;
     const char name[] = "curve.dir.entries";
     const char rname[] = "curve.dir.rentries";
@@ -1604,7 +1603,7 @@ TEST_F(TestFuseS3Client, FuseOpCreate_EnableSummary) {
 TEST_F(TestFuseS3Client, FuseOpWrite_EnableSummary) {
     client_->SetEnableSumInDir(true);
 
-    fuse_req_t req;
+    fuse_req_t req = nullptr;
     fuse_ino_t ino = 1;
     const char* buf = "xxx";
     size_t size = 4;
@@ -1628,8 +1627,6 @@ TEST_F(TestFuseS3Client, FuseOpWrite_EnableSummary) {
     parentInode.mutable_xattr()->insert({XATTRSUBDIRS, "0"});
     parentInode.mutable_xattr()->insert({XATTRENTRIES, "1"});
     parentInode.mutable_xattr()->insert({XATTRFBYTES, "0"});
-
-    uint64_t parentId = 1;
 
     auto parentInodeWrapper = std::make_shared<InodeWrapper>(
         parentInode, metaClient_);
@@ -1660,7 +1657,7 @@ TEST_F(TestFuseS3Client, FuseOpWrite_EnableSummary) {
 TEST_F(TestFuseS3Client, FuseOpLink_EnableSummary) {
     client_->SetEnableSumInDir(true);
 
-    fuse_req_t req;
+    fuse_req_t req = nullptr;
     fuse_ino_t ino = 1;
     fuse_ino_t newparent = 2;
     const char* newname = "xxxx";
@@ -1705,7 +1702,7 @@ TEST_F(TestFuseS3Client, FuseOpLink_EnableSummary) {
 TEST_F(TestFuseS3Client, FuseOpUnlink_EnableSummary) {
     client_->SetEnableSumInDir(true);
 
-    fuse_req_t req;
+    fuse_req_t req = nullptr;
     fuse_ino_t parent = 1;
     std::string name = "xxx";
     uint32_t nlink = 100;
@@ -1788,7 +1785,7 @@ TEST_F(TestFuseS3Client, FuseOpUnlink_EnableSummary) {
 TEST_F(TestFuseS3Client, FuseOpOpen_Trunc_EnableSummary) {
     client_->SetEnableSumInDir(true);
 
-    fuse_req_t req;
+    fuse_req_t req = nullptr;
     fuse_ino_t ino = 1;
     struct fuse_file_info fi;
     fi.flags = O_TRUNC | O_WRONLY;
@@ -1815,8 +1812,6 @@ TEST_F(TestFuseS3Client, FuseOpOpen_Trunc_EnableSummary) {
 
     auto parentInodeWrapper = std::make_shared<InodeWrapper>(
         parentInode, metaClient_);
-
-    uint64_t parentId = 1;
 
     EXPECT_CALL(*inodeManager_, GetInode(_, _))
         .WillOnce(
@@ -1846,9 +1841,8 @@ TEST_F(TestFuseS3Client, FuseOpListXattr) {
     std::memset(buf, 0, 256);
     size_t size = 0;
 
-    fuse_req_t req;
+    fuse_req_t req = nullptr;
     fuse_ino_t ino = 1;
-    struct fuse_file_info fi;
     InodeAttr inode;
     inode.set_inodeid(ino);
     inode.set_length(4096);
@@ -1907,7 +1901,7 @@ TEST_F(TestFuseS3Client, FuseOpListXattr) {
 
 TEST_F(TestFuseS3Client, FuseOpSetXattr_TooLong) {
     // in
-    fuse_req_t req;
+    fuse_req_t req = nullptr;
     fuse_ino_t ino = 1;
     const char name[] = "security.selinux";
     size_t size = 64 * 1024 + 1;
@@ -1921,7 +1915,7 @@ TEST_F(TestFuseS3Client, FuseOpSetXattr_TooLong) {
 
 TEST_F(TestFuseS3Client, FuseOpSetXattr) {
     // in
-    fuse_req_t req;
+    fuse_req_t req = nullptr;
     fuse_ino_t ino = 1;
     const char name[] = "security.selinux";
     size_t size = 100;

--- a/curvefs/test/client/test_fuse_volume_client.cpp
+++ b/curvefs/test/client/test_fuse_volume_client.cpp
@@ -215,7 +215,7 @@ TEST_F(TestFuseVolumeClient, FuseOpDestroy) {
 }
 
 TEST_F(TestFuseVolumeClient, FuseOpLookup) {
-    fuse_req_t req;
+    fuse_req_t req = nullptr;
     fuse_ino_t parent = 1;
     std::string name = "test";
 
@@ -241,7 +241,7 @@ TEST_F(TestFuseVolumeClient, FuseOpLookup) {
 }
 
 TEST_F(TestFuseVolumeClient, FuseOpLookupFail) {
-    fuse_req_t req;
+    fuse_req_t req = nullptr;
     fuse_ino_t parent = 1;
     std::string name = "test";
 
@@ -269,7 +269,7 @@ TEST_F(TestFuseVolumeClient, FuseOpLookupFail) {
 }
 
 TEST_F(TestFuseVolumeClient, FuseOpLookupNameTooLong) {
-    fuse_req_t req;
+    fuse_req_t req = nullptr;
     fuse_ino_t parent = 1;
     std::string name = "aaaaaaaaaaaaaaaaaaaaa";
 
@@ -336,7 +336,7 @@ TEST_F(TestFuseVolumeClient, FuseOpRead) {
 }
 
 TEST_F(TestFuseVolumeClient, FuseOpOpen) {
-    fuse_req_t req;
+    fuse_req_t req = nullptr;
     fuse_ino_t ino = 1;
     struct fuse_file_info fi;
     fi.flags = 0;
@@ -357,7 +357,7 @@ TEST_F(TestFuseVolumeClient, FuseOpOpen) {
 }
 
 TEST_F(TestFuseVolumeClient, FuseOpOpenFailed) {
-    fuse_req_t req;
+    fuse_req_t req = nullptr;
     fuse_ino_t ino = 1;
     struct fuse_file_info fi;
     fi.flags = 0;
@@ -428,8 +428,6 @@ TEST_F(TestFuseVolumeClient, FuseOpMkDir) {
     fuse_ino_t parent = 1;
     const char *name = "xxx";
     mode_t mode = 1;
-    struct fuse_file_info fi;
-    fi.flags = 0;
 
     fuse_ino_t ino = 2;
     Inode inode;
@@ -512,7 +510,7 @@ TEST_F(TestFuseVolumeClient, FuseOpCreateNameTooLong) {
 }
 
 TEST_F(TestFuseVolumeClient, FuseOpUnlink) {
-    fuse_req_t req;
+    fuse_req_t req = nullptr;
     fuse_ino_t parent = 1;
     std::string name = "xxx";
     uint32_t nlink = 100;
@@ -573,7 +571,7 @@ TEST_F(TestFuseVolumeClient, FuseOpUnlink) {
 }
 
 TEST_F(TestFuseVolumeClient, FuseOpRmDir) {
-    fuse_req_t req;
+    fuse_req_t req = nullptr;
     fuse_ino_t parent = 1;
     std::string name = "xxx";
     uint32_t nlink = 100;
@@ -637,7 +635,7 @@ TEST_F(TestFuseVolumeClient, FuseOpRmDir) {
 }
 
 TEST_F(TestFuseVolumeClient, FuseOpUnlinkFailed) {
-    fuse_req_t req;
+    fuse_req_t req = nullptr;
     fuse_ino_t parent = 1;
     std::string name = "xxx";
     uint32_t nlink = 100;
@@ -713,7 +711,7 @@ TEST_F(TestFuseVolumeClient, FuseOpUnlinkFailed) {
 }
 
 TEST_F(TestFuseVolumeClient, FuseOpUnlinkNameTooLong) {
-    fuse_req_t req;
+    fuse_req_t req = nullptr;
     fuse_ino_t parent = 1;
     std::string name = "aaaaaaaaaaaaaaaaaaaaa";
 
@@ -722,7 +720,7 @@ TEST_F(TestFuseVolumeClient, FuseOpUnlinkNameTooLong) {
 }
 
 TEST_F(TestFuseVolumeClient, FuseOpOpenDir) {
-    fuse_req_t req;
+    fuse_req_t req = nullptr;
     fuse_ino_t ino = 1;
     struct fuse_file_info fi;
 
@@ -742,7 +740,7 @@ TEST_F(TestFuseVolumeClient, FuseOpOpenDir) {
 }
 
 TEST_F(TestFuseVolumeClient, FuseOpOpenDirFaild) {
-    fuse_req_t req;
+    fuse_req_t req = nullptr;
     fuse_ino_t ino = 1;
     struct fuse_file_info fi;
 
@@ -762,7 +760,7 @@ TEST_F(TestFuseVolumeClient, FuseOpOpenDirFaild) {
 }
 
 TEST_F(TestFuseVolumeClient, FuseOpOpenAndFuseOpReadDir) {
-    fuse_req_t req;
+    fuse_req_t req = nullptr;
     fuse_ino_t ino = 1;
     size_t size = 100;
     off_t off = 0;
@@ -808,7 +806,7 @@ TEST_F(TestFuseVolumeClient, FuseOpOpenAndFuseOpReadDir) {
 }
 
 TEST_F(TestFuseVolumeClient, FuseOpOpenAndFuseOpReadDirFailed) {
-    fuse_req_t req;
+    fuse_req_t req = nullptr;
     fuse_ino_t ino = 1;
     size_t size = 100;
     off_t off = 0;
@@ -851,7 +849,7 @@ TEST_F(TestFuseVolumeClient, FuseOpOpenAndFuseOpReadDirFailed) {
 }
 
 TEST_F(TestFuseVolumeClient, FuseOpRenameBasic) {
-    fuse_req_t req;
+    fuse_req_t req = nullptr;
     fuse_ino_t parent = 1;
     std::string name = "A";
     fuse_ino_t newparent = 3;
@@ -977,7 +975,7 @@ TEST_F(TestFuseVolumeClient, FuseOpRenameBasic) {
 }
 
 TEST_F(TestFuseVolumeClient, FuseOpRenameOverwrite) {
-    fuse_req_t req;
+    fuse_req_t req = nullptr;
     fuse_ino_t parent = 1;
     std::string name = "A";
     fuse_ino_t newparent = 3;
@@ -1119,7 +1117,7 @@ TEST_F(TestFuseVolumeClient, FuseOpRenameOverwrite) {
 }
 
 TEST_F(TestFuseVolumeClient, FuseOpRenameOverwriteDir) {
-    fuse_req_t req;
+    fuse_req_t req = nullptr;
     fuse_ino_t parent = 1;
     std::string name = "A";
     fuse_ino_t newparent = 3;
@@ -1162,7 +1160,7 @@ TEST_F(TestFuseVolumeClient, FuseOpRenameOverwriteDir) {
 }
 
 TEST_F(TestFuseVolumeClient, FuseOpRenameNameTooLong) {
-    fuse_req_t req;
+    fuse_req_t req = nullptr;
     fuse_ino_t parent = 1;
     std::string name1 = "aaaaaaaaaaaaaaaaaaaaa";
     std::string name2 = "xxx";
@@ -1184,7 +1182,7 @@ TEST_F(TestFuseVolumeClient, FuseOpRenameNameTooLong) {
 }
 
 TEST_F(TestFuseVolumeClient, FuseOpRenameParallel) {
-    fuse_req_t req;
+    fuse_req_t req = nullptr;
     uint64_t txId = 0;
     auto dentry = GenDentry(1, 1, "A", 0, 10, FILE);
     dentry.set_type(FsFileType::TYPE_DIRECTORY);
@@ -1308,7 +1306,7 @@ TEST_F(TestFuseVolumeClient, FuseOpRenameParallel) {
 }
 
 TEST_F(TestFuseVolumeClient, FuseOpGetAttr) {
-    fuse_req_t req;
+    fuse_req_t req = nullptr;
     fuse_ino_t ino = 1;
     struct fuse_file_info fi;
     memset(&fi, 0, sizeof(fi));
@@ -1327,7 +1325,7 @@ TEST_F(TestFuseVolumeClient, FuseOpGetAttr) {
 }
 
 TEST_F(TestFuseVolumeClient, FuseOpGetAttrFailed) {
-    fuse_req_t req;
+    fuse_req_t req = nullptr;
     fuse_ino_t ino = 1;
     struct fuse_file_info fi;
     memset(&fi, 0, sizeof(fi));
@@ -1348,7 +1346,7 @@ TEST_F(TestFuseVolumeClient, FuseOpGetAttrFailed) {
 TEST_F(TestFuseVolumeClient, FuseOpGetAttrEnableCto) {
     curvefs::client::common::FLAGS_enableCto = true;
 
-    fuse_req_t req;
+    fuse_req_t req = nullptr;
     fuse_ino_t ino = 1;
     struct fuse_file_info fi;
     memset(&fi, 0, sizeof(fi));
@@ -1372,7 +1370,7 @@ TEST_F(TestFuseVolumeClient, FuseOpGetAttrEnableCto) {
 }
 
 TEST_F(TestFuseVolumeClient, FuseOpSetAttr) {
-    fuse_req_t req;
+    fuse_req_t req = nullptr;
     fuse_ino_t ino = 1;
     struct stat attr;
     int to_set;
@@ -1418,7 +1416,7 @@ TEST_F(TestFuseVolumeClient, FuseOpSetAttr) {
 }
 
 TEST_F(TestFuseVolumeClient, FuseOpSetAttrFailed) {
-    fuse_req_t req;
+    fuse_req_t req = nullptr;
     fuse_ino_t ino = 1;
     struct stat attr;
     int to_set;
@@ -1566,7 +1564,7 @@ TEST_F(TestFuseVolumeClient, FuseOpSymlinkNameTooLong) {
 }
 
 TEST_F(TestFuseVolumeClient, FuseOpLink) {
-    fuse_req_t req;
+    fuse_req_t req = nullptr;
     fuse_ino_t ino = 1;
     fuse_ino_t newparent = 2;
     const char *newname = "xxxx";
@@ -1617,7 +1615,7 @@ TEST_F(TestFuseVolumeClient, FuseOpLink) {
 }
 
 TEST_F(TestFuseVolumeClient, FuseOpLinkFailed) {
-    fuse_req_t req;
+    fuse_req_t req = nullptr;
     fuse_ino_t ino = 1;
     fuse_ino_t newparent = 2;
     const char *newname = "xxxx";
@@ -1686,7 +1684,7 @@ TEST_F(TestFuseVolumeClient, FuseOpLinkFailed) {
 }
 
 TEST_F(TestFuseVolumeClient, FuseOpReadLink) {
-    fuse_req_t req;
+    fuse_req_t req = nullptr;
     fuse_ino_t ino = 1;
     const char *link = "/a/b/xxx";
 
@@ -1709,7 +1707,7 @@ TEST_F(TestFuseVolumeClient, FuseOpReadLink) {
 }
 
 TEST_F(TestFuseVolumeClient, FuseOpReadLinkFailed) {
-    fuse_req_t req;
+    fuse_req_t req = nullptr;
     fuse_ino_t ino = 1;
 
     EXPECT_CALL(*inodeManager_, GetInodeAttr(ino, _))
@@ -1721,7 +1719,7 @@ TEST_F(TestFuseVolumeClient, FuseOpReadLinkFailed) {
 }
 
 TEST_F(TestFuseVolumeClient, FuseOpRelease) {
-    fuse_req_t req;
+    fuse_req_t req = nullptr;
     fuse_ino_t ino = 1;
     struct fuse_file_info fi;
     memset(&fi, 0, sizeof(fi));

--- a/curvefs/test/mds/fs_manager_test2.cpp
+++ b/curvefs/test/mds/fs_manager_test2.cpp
@@ -159,7 +159,6 @@ TEST_F(FsManagerTest2, CreateFoundConflictFsNameAndNotIdenticalToPreviousOne) {
     std::string fsname = "hello";
     FSType type = FSType::TYPE_S3;
     uint64_t blocksize = 4 * 1024;
-    bool enableSumInDir = false;
     FsDetail detail;
     auto* s3Info = detail.mutable_s3info();
     s3Info->set_ak("hello");
@@ -247,7 +246,6 @@ TEST_F(FsManagerTest2, CreateFoundUnCompleteOperation) {
     std::string fsname = "hello";
     FSType type = FSType::TYPE_S3;
     uint64_t blocksize = 4 * 1024;
-    bool enableSumInDir = false;
     FsDetail detail;
     auto* s3Info = detail.mutable_s3info();
     s3Info->set_ak("hello");
@@ -330,7 +328,6 @@ TEST_F(FsManagerTest2, createHybridFs) {
     std::string fsname = "hello";
     FSType type = FSType::TYPE_HYBRID;
     uint64_t blocksize = 4 * 1024;
-    bool enableSumInDir = false;
     FsDetail detail;
     auto* s3Info = detail.mutable_s3info();
     s3Info->set_ak("hello");

--- a/curvefs/test/mds/heartbeat/copyset_conf_generator_test.cpp
+++ b/curvefs/test/mds/heartbeat/copyset_conf_generator_test.cpp
@@ -29,13 +29,13 @@
 #include "curvefs/test/mds/mock/mock_coordinator.h"
 #include "curvefs/test/mds/mock/mock_topology.h"
 
+using ::curvefs::mds::MockCoordinator;
+using ::curvefs::mds::topology::CopySetIdType;
 using ::curvefs::mds::topology::MockIdGenerator;
 using ::curvefs::mds::topology::MockStorage;
 using ::curvefs::mds::topology::MockTokenGenerator;
 using ::curvefs::mds::topology::MockTopology;
-using ::curvefs::mds::MockCoordinator;
 using ::curvefs::mds::topology::TopoStatusCode;
-using ::curvefs::mds::topology::CopySetIdType;
 using ::curvefs::mds::topology::UNINITIALIZE_ID;
 using ::testing::_;
 using ::testing::DoAll;
@@ -72,15 +72,14 @@ class TestCopysetConfGenerator : public ::testing::Test {
 };
 
 TEST_F(TestCopysetConfGenerator, get_copyset_fail) {
-    MetaServerIdType reportId;
+    MetaServerIdType reportId = 1;
     PoolIdType poolId = 1;
     CopySetIdType copysetId = 2;
     ::curvefs::mds::topology::CopySetInfo reportCopySetInfo(poolId, copysetId);
     ::curvefs::mds::heartbeat::ConfigChangeInfo configChInfo;
     ::curvefs::mds::heartbeat::CopySetConf copysetConf;
 
-    EXPECT_CALL(*topology_, GetCopySet(_, _))
-        .WillOnce(Return(false));
+    EXPECT_CALL(*topology_, GetCopySet(_, _)).WillOnce(Return(false));
 
     bool ret = generator_->GenCopysetConf(reportId, reportCopySetInfo,
                                           configChInfo, &copysetConf);
@@ -206,8 +205,8 @@ TEST_F(TestCopysetConfGenerator, get_report_copyset_follower2) {
     recordCopySetInfo.SetEpoch(3);
     EXPECT_CALL(*topology_, GetCopySet(_, _))
         .WillOnce(DoAll(SetArgPointee<1>(recordCopySetInfo), Return(true)));
-    ret = generator_->GenCopysetConf(reportId, reportCopySetInfo,
-                                          configChInfo, &copysetConf);
+    ret = generator_->GenCopysetConf(reportId, reportCopySetInfo, configChInfo,
+                                     &copysetConf);
     ASSERT_FALSE(ret);
 }
 
@@ -342,8 +341,7 @@ TEST_F(TestCopysetConfGenerator, get_report_copyset_follower7) {
     EXPECT_CALL(*coordinator_, MetaserverGoingToAdd(_, _))
         .WillOnce(Return(false));
 
-    EXPECT_CALL(*topology_, GetMetaServer(_, _))
-        .WillOnce(Return(false));
+    EXPECT_CALL(*topology_, GetMetaServer(_, _)).WillOnce(Return(false));
 
     sleep(1);
     bool ret = generator_->GenCopysetConf(reportId, reportCopySetInfo,

--- a/curvefs/test/mds/mds_test.cpp
+++ b/curvefs/test/mds/mds_test.cpp
@@ -54,8 +54,8 @@ using ::curve::kvstorage::EtcdClientImp;
 namespace curvefs {
 namespace mds {
 
-const char* kEtcdAddr = "127.0.0.1:20032";
-const char* kMdsListenAddr = "127.0.0.1:20035";
+const char *kEtcdAddr = "127.0.0.1:20032";
+const char *kMdsListenAddr = "127.0.0.1:20035";
 
 class MdsTest : public ::testing::Test {
  protected:
@@ -63,9 +63,7 @@ class MdsTest : public ::testing::Test {
 
     void TearDown() override {}
 
-    static void ClearEnv() {
-        system("rm -rf curve_fs_test_mds.etcd");
-    }
+    static void ClearEnv() { system("rm -rf curve_fs_test_mds.etcd"); }
 
     static void StartEtcd() {
         etcdPid_ = fork();
@@ -88,7 +86,8 @@ class MdsTest : public ::testing::Test {
         }
 
         auto client = std::make_shared<EtcdClientImp>();
-        EtcdConf conf{const_cast<char*>(kEtcdAddr), strlen(kEtcdAddr), 1000};
+        EtcdConf conf{const_cast<char *>(kEtcdAddr),
+                      static_cast<int>(strlen(kEtcdAddr)), 1000};
         uint64_t now = curve::common::TimeUtility::GetTimeofDaySec();
         bool initSucc = false;
         while (curve::common::TimeUtility::GetTimeofDaySec() - now <= 50) {
@@ -124,7 +123,7 @@ class MdsTest : public ::testing::Test {
 pid_t MdsTest::etcdPid_ = 0;
 
 void GetChunkIds(std::shared_ptr<curve::common::Configuration> conf,
-                 int numChunkIds, vector<uint64_t>* data) {
+                 int numChunkIds, vector<uint64_t> *data) {
     brpc::Channel channel;
     std::string allocateServer(kMdsListenAddr);
     if (channel.Init(allocateServer.c_str(), NULL) != 0) {
@@ -134,7 +133,7 @@ void GetChunkIds(std::shared_ptr<curve::common::Configuration> conf,
         return;
     }
 
-    brpc::Controller* cntl = new brpc::Controller();
+    brpc::Controller *cntl = new brpc::Controller();
     AllocateS3ChunkRequest request;
     AllocateS3ChunkResponse response;
     curvefs::mds::MdsService_Stub stub(&channel);

--- a/curvefs/test/mds/schedule/recoverScheduler_test.cpp
+++ b/curvefs/test/mds/schedule/recoverScheduler_test.cpp
@@ -192,7 +192,6 @@ TEST_F(TestRecoverSheduler, test_all_metaServer_online_offline) {
     MetaServerIdType id1 = 1;
     MetaServerIdType id2 = 2;
     MetaServerIdType id3 = 3;
-    MetaServerIdType id4 = 4;
     Operator op;
     EXPECT_CALL(*topoAdapter_, GetAvgScatterWidthInPool(_))
         .WillRepeatedly(Return(90));

--- a/curvefs/test/mds/topology/test_topology_manager.cpp
+++ b/curvefs/test/mds/topology/test_topology_manager.cpp
@@ -652,7 +652,6 @@ TEST_F(TestTopologyManager, test_RegistServer_PoolNotFound) {
 }
 
 TEST_F(TestTopologyManager, test_RegistServer_ZoneNotFound) {
-    ServerIdType id = 0x31;
     PoolIdType poolId = 0x11;
     ZoneIdType zoneId = 0x21;
     PrepareAddPool(poolId, "pool1");
@@ -674,7 +673,6 @@ TEST_F(TestTopologyManager, test_RegistServer_ZoneNotFound) {
 }
 
 TEST_F(TestTopologyManager, test_RegistServer_AllocateIdFail) {
-    ServerIdType id = 0x31;
     PoolIdType poolId = 0x11;
     ZoneIdType zoneId = 0x21;
     PrepareAddPool(poolId, "pool");
@@ -1110,7 +1108,6 @@ TEST_F(TestTopologyManager, test_CreateZone_success) {
 
 TEST_F(TestTopologyManager, test_CreateZone_AllocateIdFail) {
     PoolIdType poolId = 0x11;
-    ZoneIdType zoneId = 0x21;
     PrepareAddPool(poolId, "poolname1");
 
     CreateZoneRequest request;
@@ -1930,8 +1927,6 @@ TEST_F(TestTopologyManager,
 TEST_F(TestTopologyManager,
        test_CreatePartitionWithOutAvailableCopyset_HaveNoAvailableMetaserver) {
     PoolIdType poolId = 0x11;
-    CopySetIdType copysetId = 0x51;
-    PartitionIdType partitionId = 0x61;
 
     Pool::RedundanceAndPlaceMentPolicy policy;
     policy.replicaNum = 3;
@@ -1969,8 +1964,6 @@ TEST_F(TestTopologyManager,
 TEST_F(TestTopologyManager,
        test_CreatePartitionWithOutAvailableCopyset_MetaServerSpaceIsFull) {
     PoolIdType poolId = 0x11;
-    CopySetIdType copysetId = 0x51;
-    PartitionIdType partitionId = 0x61;
 
     Pool::RedundanceAndPlaceMentPolicy policy;
     policy.replicaNum = 3;
@@ -2081,8 +2074,6 @@ TEST_F(TestTopologyManager,
 TEST_F(TestTopologyManager,
        test_CreatePartitionWithOutAvailableCopyset_HaveOfflineMetaserver1) {
     PoolIdType poolId = 0x11;
-    CopySetIdType copysetId = 0x51;
-    PartitionIdType partitionId = 0x61;
 
     Pool::RedundanceAndPlaceMentPolicy policy;
     policy.replicaNum = 3;
@@ -2681,8 +2672,6 @@ TEST_F(TestTopologyManager, test_ListPartitionEmpty_Success) {
     PoolIdType poolId = 0x11;
     CopySetIdType copysetId = 0x51;
     PartitionIdType pId1 = 0x61;
-    PartitionIdType pId2 = 0x62;
-    PartitionIdType pId3 = 0x63;
 
     Pool::RedundanceAndPlaceMentPolicy policy;
     policy.replicaNum = 3;
@@ -2818,7 +2807,6 @@ TEST_F(TestTopologyManager, test_GetCopysetOfPartition_CopysetNotFound) {
 }
 
 TEST_F(TestTopologyManager, test_GetCopysetMembers_Success) {
-    FsIdType fsId = 0x01;
     PoolIdType poolId = 0x11;
     CopySetIdType copysetId = 0x51;
 
@@ -2892,8 +2880,6 @@ TEST_F(TestTopologyManager, test_RegistMemcacheCluster_AllocateIdFail) {
     server.set_ip("127.0.0.1");
     server.set_port(1);
     *request.add_servers() = server;
-
-    MemcacheClusterIdType mcCId(1);
 
     EXPECT_CALL(*idGenerator_, GenMemCacheClusterId())
         .WillOnce(Return(UNINITIALIZE_ID));

--- a/curvefs/test/metaserver/inode_manager_test.cpp
+++ b/curvefs/test/metaserver/inode_manager_test.cpp
@@ -63,7 +63,6 @@ auto localfs = curve::fs::Ext4FileSystemImpl::getInstance();
 class InodeManagerTest : public ::testing::Test {
  protected:
     void SetUp() override {
-        auto tablename = "partition:1";
         dataDir_ = RandomStoragePath();
         StorageOptions options;
         options.dataDir = dataDir_;
@@ -415,7 +414,6 @@ TEST_F(InodeManagerTest, GetOrModifyS3ChunkInfo) {
 
 TEST_F(InodeManagerTest, UpdateInode) {
     // create inode
-    uint32_t fsId = 1;
     uint64_t ino = 2;
 
     Inode inode;

--- a/curvefs/test/metaserver/metastore_test.cpp
+++ b/curvefs/test/metaserver/metastore_test.cpp
@@ -1645,7 +1645,7 @@ TEST_F(MetastoreTest, GetInodeWithPaddingS3Meta) {
         request.set_mode(777);
         request.set_type(FsFileType::TYPE_FILE);
 
-        auto rc = metastore.CreateInode(&request, &response);
+        (void)metastore.CreateInode(&request, &response);
         ASSERT_EQ(response.statuscode(), MetaStatusCode::OK);
         inodeId = response.inode().inodeid();
     }

--- a/curvefs/test/metaserver/recycle_cleaner_test.cpp
+++ b/curvefs/test/metaserver/recycle_cleaner_test.cpp
@@ -154,7 +154,7 @@ TEST_F(RecycleCleanerTest, time_func_test) {
 
     struct tm tmDir;
     memset(&tmDir, 0, sizeof(tmDir));
-    char* c = strptime(now, "%Y-%m-%d-%H", &tmDir);
+    (void)strptime(now, "%Y-%m-%d-%H", &tmDir);
 
     time_t dirTime = mktime(&tmDir);
     LOG(INFO) << "befor, time = " << timeStamp;

--- a/curvefs/test/metaserver/s3compact/s3compact_test.cpp
+++ b/curvefs/test/metaserver/s3compact/s3compact_test.cpp
@@ -259,7 +259,7 @@ TEST_F(S3CompactTest, test_GetNeedCompact) {
             ref->set_offset(i + 64 * j);
             ref->set_len(1);
         }
-        s3chunkinfoMap.insert({j, l});
+        s3chunkinfoMap.insert({static_cast<uint64_t>(j), l});
     }
     ASSERT_EQ(impl_->GetNeedCompact(s3chunkinfoMap, 64 * 19 + 30, 64).size(),
               opts_.maxChunksPerCompact);

--- a/curvefs/test/metaserver/storage/storage_test.cpp
+++ b/curvefs/test/metaserver/storage/storage_test.cpp
@@ -845,7 +845,6 @@ void TestMixOperator(std::shared_ptr<KVStorage> kvStorage) {
 
 void TestTransaction(std::shared_ptr<KVStorage> kvStorage) {
     Status s;
-    size_t size;
     Dentry value;
     std::shared_ptr<Iterator> iterator;
     std::shared_ptr<StorageTransaction> txn;

--- a/nebd/src/common/stringstatus.cpp
+++ b/nebd/src/common/stringstatus.cpp
@@ -42,7 +42,7 @@ void StringStatus::Update() {
     int count = 0;
     for (auto &item : kvs_) {
         count += 1;
-        if (count == kvs_.size()) {
+        if (count == static_cast<int>(kvs_.size())) {
             jsonStr +=
                 "\"" + item.first + "\"" + ":" + "\"" + item.second + "\"";
         } else {

--- a/nebd/src/part1/libnebd.cpp
+++ b/nebd/src/part1/libnebd.cpp
@@ -80,11 +80,19 @@ int nebd_lib_close(int fd) {
 }
 
 int nebd_lib_pread(int fd, void* buf, off_t offset, size_t length) {
+    (void)fd;
+    (void)buf;
+    (void)offset;
+    (void)length;
     // not support sync read
     return -1;
 }
 
 int nebd_lib_pwrite(int fd, const void* buf, off_t offset, size_t length) {
+    (void)fd;
+    (void)buf;
+    (void)offset;
+    (void)length;
     // not support sync write
     return -1;
 }
@@ -102,6 +110,7 @@ int nebd_lib_aio_pwrite(int fd, NebdClientAioContext* context) {
 }
 
 int nebd_lib_sync(int fd) {
+    (void)fd;
     return 0;
 }
 

--- a/nebd/src/part1/nebd_client.cpp
+++ b/nebd/src/part1/nebd_client.cpp
@@ -243,6 +243,7 @@ int NebdClient::Extend(int fd, int64_t newsize) {
     auto task = [&](brpc::Controller* cntl,
                     brpc::Channel* channel,
                     bool* rpcFailed) -> int64_t {
+        (void)channel;
         nebd::client::NebdFileService_Stub stub(&channel_);
         nebd::client::ResizeRequest request;
         nebd::client::ResizeResponse response;
@@ -359,7 +360,9 @@ int NebdClient::AioRead(int fd, NebdClientAioContext* aioctx) {
     return 0;
 }
 
-static void EmptyDeleter(void* m) {}
+static void EmptyDeleter(void* m) {
+    (void)m;
+}
 
 int NebdClient::AioWrite(int fd, NebdClientAioContext* aioctx) {
     auto task = [this, fd, aioctx]() {
@@ -622,6 +625,7 @@ void NebdClient::InitLogger(const LogOption& logOption) {
 
 int NebdClient::ExecAsyncRpcTask(void* meta,
                                  bthread::TaskIterator<AsyncRpcTask>& iter) {  // NOLINT
+    (void)meta;
     if (iter.is_queue_stopped()) {
         return 0;
     }

--- a/nebd/src/part2/file_service.cpp
+++ b/nebd/src/part2/file_service.cpp
@@ -118,6 +118,7 @@ void NebdFileServiceImpl::OpenFile(
     const nebd::client::OpenFileRequest* request,
     nebd::client::OpenFileResponse* response,
     google::protobuf::Closure* done) {
+    (void)cntl_base;
     brpc::ClosureGuard doneGuard(done);
     response->set_retcode(RetCode::kNoOK);
 
@@ -282,6 +283,7 @@ void NebdFileServiceImpl::GetInfo(
     const nebd::client::GetInfoRequest* request,
     nebd::client::GetInfoResponse* response,
     google::protobuf::Closure* done) {
+    (void)cntl_base;
     brpc::ClosureGuard doneGuard(done);
     response->set_retcode(RetCode::kNoOK);
 
@@ -306,6 +308,7 @@ void NebdFileServiceImpl::CloseFile(
     const nebd::client::CloseFileRequest* request,
     nebd::client::CloseFileResponse* response,
     google::protobuf::Closure* done) {
+    (void)cntl_base;
     brpc::ClosureGuard doneGuard(done);
     response->set_retcode(RetCode::kNoOK);
 
@@ -326,6 +329,7 @@ void NebdFileServiceImpl::ResizeFile(
     const nebd::client::ResizeRequest* request,
     nebd::client::ResizeResponse* response,
     google::protobuf::Closure* done) {
+    (void)cntl_base;
     brpc::ClosureGuard doneGuard(done);
     response->set_retcode(RetCode::kNoOK);
 
@@ -345,6 +349,7 @@ void NebdFileServiceImpl::InvalidateCache(
     const nebd::client::InvalidateCacheRequest* request,
     nebd::client::InvalidateCacheResponse* response,
     google::protobuf::Closure* done) {
+    (void)cntl_base;
     brpc::ClosureGuard doneGuard(done);
     response->set_retcode(RetCode::kNoOK);
 

--- a/nebd/src/part2/heartbeat_service.cpp
+++ b/nebd/src/part2/heartbeat_service.cpp
@@ -34,6 +34,7 @@ void NebdHeartbeatServiceImpl::KeepAlive(
         const nebd::client::HeartbeatRequest* request,
         nebd::client::HeartbeatResponse* response,
         google::protobuf::Closure* done) {
+    (void)cntl_base;
     brpc::ClosureGuard doneGuard(done);
     bool ok = true;
     uint64_t curTime = TimeUtility::GetTimeofDayMs();

--- a/nebd/src/part2/metafile_manager.cpp
+++ b/nebd/src/part2/metafile_manager.cpp
@@ -118,7 +118,7 @@ int NebdMetaFileManager::AtomicWriteFile(const Json::Value& root) {
     int writeSize = wrapper_->pwrite(fd, jsonString.c_str(),
                                      jsonString.size(), 0);
     wrapper_->close(fd);
-    if (writeSize != jsonString.size()) {
+    if (writeSize != static_cast<int>(jsonString.size())) {
         LOG(ERROR) << "Write tmp file " << tmpFilePath << " fail";
         return -1;
     }
@@ -206,7 +206,6 @@ int NebdMetaFileParser::Parse(Json::Value root,
 
     for (const auto& volume : volumes) {
         std::string fileName;
-        int fd;
         NebdFileMeta meta;
 
         if (volume[kFileName].isNull()) {

--- a/nebd/src/part2/request_executor_curve.cpp
+++ b/nebd/src/part2/request_executor_curve.cpp
@@ -270,6 +270,7 @@ int CurveRequestExecutor::AioWrite(
 
 int CurveRequestExecutor::Flush(
     NebdFileInstance* fd, NebdServerAioContext* aioctx) {
+    (void)fd;
 
     aioctx->ret = 0;
     aioctx->cb(aioctx);

--- a/nebd/test/common/rw_lock_test.cpp
+++ b/nebd/test/common/rw_lock_test.cpp
@@ -78,7 +78,6 @@ TEST(RWLockTest, basic_test) {
     auto readFunc = [&] {
         for (uint64_t i = 0; i < 10000; ++i) {
             ReadLockGuard readLockGuard(rwlock);
-            auto j = writeCnt + i;
         }
     };
     {
@@ -147,7 +146,6 @@ TEST(BthreadRWLockTest, basic_test) {
     auto readFunc = [&] {
         for (uint64_t i = 0; i < 10000; ++i) {
             ReadLockGuard readLockGuard(rwlock);
-            auto j = writeCnt + i;
         }
     };
     {

--- a/nebd/test/utils/config_generator.h
+++ b/nebd/test/utils/config_generator.h
@@ -33,7 +33,6 @@ namespace nebd {
 namespace common {
 
 static const char* kNebdClientConfigPath = "nebd/etc/nebd/nebd-client.conf";
-static const char* kNebdServerConfigPath = "nebd/etc/nebd/nebd-server.conf";
 
 class NebdClientConfigGenerator {
  public:

--- a/src/chunkserver/braft_cli_service.cpp
+++ b/src/chunkserver/braft_cli_service.cpp
@@ -207,6 +207,7 @@ void BRaftCliServiceImpl::transfer_leader(
     const TransferLeaderRequest *request,
     TransferLeaderResponse *response,
     ::google::protobuf::Closure *done) {
+    (void)response;
     brpc::Controller *cntl = (brpc::Controller *) controller;
     brpc::ClosureGuard done_guard(done);
     scoped_refptr<braft::NodeImpl> node;

--- a/src/chunkserver/braft_cli_service2.cpp
+++ b/src/chunkserver/braft_cli_service2.cpp
@@ -161,6 +161,7 @@ static void change_peers_returned(brpc::Controller* cntl,
                                   scoped_refptr<braft::NodeImpl> /*node*/,
                                   ::google::protobuf::Closure* done,
                                   const butil::Status& st) {
+    (void)request;
     brpc::ClosureGuard done_guard(done);
     if (!st.ok()) {
         cntl->SetFailed(st.error_code(), "%s", st.error_cstr());
@@ -275,6 +276,7 @@ void BRaftCliServiceImpl2::TransferLeader(
     const TransferLeaderRequest2 *request,
     TransferLeaderResponse2 *response,
     ::google::protobuf::Closure *done) {
+    (void)response;
     brpc::Controller *cntl = (brpc::Controller *) controller;
     brpc::ClosureGuard done_guard(done);
     scoped_refptr<braft::NodeImpl> node;
@@ -305,6 +307,7 @@ void BRaftCliServiceImpl2::ResetPeer(RpcController* controller,
                                      const ResetPeerRequest2* request,
                                      ResetPeerResponse2* response,
                                      Closure* done) {
+    (void)response;
     brpc::Controller* cntl = (brpc::Controller*)controller;
     brpc::ClosureGuard done_guard(done);
     scoped_refptr<braft::NodeImpl> node;
@@ -342,6 +345,7 @@ static void snapshot_returned(brpc::Controller* cntl,
                               scoped_refptr<braft::NodeImpl> node,
                               ::google::protobuf::Closure* done,
                               const butil::Status& st) {
+    (void)node;
     brpc::ClosureGuard done_guard(done);
     if (!st.ok()) {
         cntl->SetFailed(st.error_code(), "%s", st.error_cstr());
@@ -352,6 +356,7 @@ void BRaftCliServiceImpl2::Snapshot(RpcController* controller,
                                     const SnapshotRequest2* request,
                                     SnapshotResponse2* response,
                                     Closure* done) {
+    (void)response;
     brpc::Controller* cntl = (brpc::Controller*)controller;
     brpc::ClosureGuard done_guard(done);
     scoped_refptr<braft::NodeImpl> node;
@@ -374,6 +379,8 @@ void BRaftCliServiceImpl2::SnapshotAll(RpcController* controller,
                                        const SnapshotAllRequest* request,
                                        SnapshotAllResponse* response,
                                        Closure* done) {
+    (void)request;
+    (void)response;
     brpc::Controller* cntl = (brpc::Controller*)controller;
     brpc::ClosureGuard done_guard(done);
     braft::NodeManager *const nm = braft::NodeManager::GetInstance();

--- a/src/chunkserver/chunk_service.cpp
+++ b/src/chunkserver/chunk_service.cpp
@@ -211,6 +211,8 @@ void ChunkServiceImpl::CreateS3CloneChunk(RpcController* controller,
                        const CreateS3CloneChunkRequest* request,
                        CreateS3CloneChunkResponse* response,
                        Closure* done) {
+    (void)controller;
+    (void)request;
     brpc::ClosureGuard doneGuard(done);
     response->set_status(CHUNK_OP_STATUS::CHUNK_OP_STATUS_INVALID_REQUEST);
     LOG(INFO) << "Invalid request, serverSide Not implement yet";
@@ -238,7 +240,6 @@ void ChunkServiceImpl::ReadChunk(RpcController *controller,
     }
 
     // 判断request参数是否合法
-    auto maxSize = copysetNodeManager_->GetCopysetNodeOptions().maxChunkSize;
     if (!CheckRequestOffsetAndLength(request->offset(), request->size())) {
         response->set_status(CHUNK_OP_STATUS::CHUNK_OP_STATUS_INVALID_REQUEST);
         LOG(ERROR) << "I/O request, op: " << request->optype()
@@ -425,6 +426,7 @@ void ChunkServiceImpl::GetChunkInfo(RpcController *controller,
                                     const GetChunkInfoRequest *request,
                                     GetChunkInfoResponse *response,
                                     Closure *done) {
+    (void)controller;
     ChunkServiceClosure* closure =
         new (std::nothrow) ChunkServiceClosure(inflightThrottle_,
                                                nullptr,
@@ -494,6 +496,7 @@ void ChunkServiceImpl::GetChunkHash(RpcController *controller,
                                     const GetChunkHashRequest *request,
                                     GetChunkHashResponse *response,
                                     Closure *done) {
+    (void)controller;
     brpc::ClosureGuard doneGuard(done);
 
     // 判断request参数是否合法
@@ -553,6 +556,7 @@ void ChunkServiceImpl::UpdateEpoch(RpcController *controller,
                 const UpdateEpochRequest *request,
                 UpdateEpochResponse *response,
                 Closure *done) {
+    (void)controller;
     brpc::ClosureGuard doneGuard(done);
     bool success = epochMap_->UpdateEpoch(request->fileid(), request->epoch());
     if (success) {

--- a/src/chunkserver/chunkserver_metrics.h
+++ b/src/chunkserver/chunkserver_metrics.h
@@ -36,11 +36,11 @@
 #include "src/common/configuration.h"
 #include "src/chunkserver/datastore/file_pool.h"
 
-using curve::common::Uncopyable;
-using curve::common::RWLock;
-using curve::common::ReadLockGuard;
-using curve::common::WriteLockGuard;
 using curve::common::Configuration;
+using curve::common::ReadLockGuard;
+using curve::common::RWLock;
+using curve::common::Uncopyable;
+using curve::common::WriteLockGuard;
 
 namespace curve {
 namespace chunkserver {
@@ -54,8 +54,7 @@ class Trash;
 template <typename Tp>
 using PassiveStatusPtr = std::shared_ptr<bvar::PassiveStatus<Tp>>;
 
-template <typename Tp>
-using AdderPtr = std::shared_ptr<bvar::Adder<Tp>>;
+template <typename Tp> using AdderPtr = std::shared_ptr<bvar::Adder<Tp>>;
 
 // 使用LatencyRecorder的实现来统计读写请求的size情况
 // 可以统计分位值、最大值、中位数、平均值等情况
@@ -72,7 +71,7 @@ class IOMetric {
      * @param prefix: 用于bvar曝光时使用的前缀
      * @return 成功返回0，失败返回-1
      */
-    int Init(const std::string& prefix);
+    int Init(const std::string &prefix);
     /**
      * IO请求到来时统计requestNum
      */
@@ -88,25 +87,25 @@ class IOMetric {
 
  public:
     // io请求的数量
-    bvar::Adder<uint64_t>    reqNum_;
+    bvar::Adder<uint64_t> reqNum_;
     // 成功io的数量
-    bvar::Adder<uint64_t>    ioNum_;
+    bvar::Adder<uint64_t> ioNum_;
     // 失败的io个数
-    bvar::Adder<uint64_t>    errorNum_;
+    bvar::Adder<uint64_t> errorNum_;
     // 所有io的数据量
-    bvar::Adder<uint64_t>    ioBytes_;
+    bvar::Adder<uint64_t> ioBytes_;
     // io的延时情况（分位值、最大值、中位数、平均值）
-    bvar::LatencyRecorder    latencyRecorder_;
+    bvar::LatencyRecorder latencyRecorder_;
     // io大小的情况（分位值、最大值、中位数、平均值）
-    IOSizeRecorder           sizeRecorder_;
+    IOSizeRecorder sizeRecorder_;
     // 最近1秒请求的IO数量
-    bvar::PerSecond<bvar::Adder<uint64_t>>    rps_;
+    bvar::PerSecond<bvar::Adder<uint64_t>> rps_;
     // 最近1秒的iops
-    bvar::PerSecond<bvar::Adder<uint64_t>>    iops_;
+    bvar::PerSecond<bvar::Adder<uint64_t>> iops_;
     // 最近1秒的出错IO数量
-    bvar::PerSecond<bvar::Adder<uint64_t>>    eps_;
+    bvar::PerSecond<bvar::Adder<uint64_t>> eps_;
     // 最近1秒的数据量
-    bvar::PerSecond<bvar::Adder<uint64_t>>    bps_;
+    bvar::PerSecond<bvar::Adder<uint64_t>> bps_;
 };
 using IOMetricPtr = std::shared_ptr<IOMetric>;
 
@@ -121,11 +120,8 @@ enum class CSIOMetricType {
 class CSIOMetric {
  public:
     CSIOMetric()
-        : readMetric_(nullptr)
-        , writeMetric_(nullptr)
-        , recoverMetric_(nullptr)
-        , pasteMetric_(nullptr)
-        , downloadMetric_(nullptr) {}
+        : readMetric_(nullptr), writeMetric_(nullptr), recoverMetric_(nullptr),
+          pasteMetric_(nullptr), downloadMetric_(nullptr) {}
 
     ~CSIOMetric() {}
 
@@ -143,9 +139,7 @@ class CSIOMetric {
      * @param latUS: 此次io的延时
      * @param hasError: 此次io是否有错误产生
      */
-    void OnResponse(CSIOMetricType type,
-                    size_t size,
-                    int64_t latUs,
+    void OnResponse(CSIOMetricType type, size_t size, int64_t latUs,
                     bool hasError);
 
     /**
@@ -159,7 +153,7 @@ class CSIOMetric {
      * 初始化各项op的metric统计项
      * @return 成功返回0，失败返回-1
      */
-    int Init(const std::string& prefix);
+    int Init(const std::string &prefix);
     /**
      * 释放各项op的metric资源
      */
@@ -181,12 +175,9 @@ class CSIOMetric {
 class CSCopysetMetric {
  public:
     CSCopysetMetric()
-        : logicPoolId_(0)
-        , copysetId_(0)
-        , chunkCount_(nullptr)
-        , snapshotCount_(nullptr)
-        , cloneChunkCount_(nullptr)
-        , walSegmentCount_(nullptr) {}
+        : logicPoolId_(0), copysetId_(0), chunkCount_(nullptr),
+          walSegmentCount_(nullptr), snapshotCount_(nullptr),
+          cloneChunkCount_(nullptr) {}
 
     ~CSCopysetMetric() {}
 
@@ -196,27 +187,25 @@ class CSCopysetMetric {
      * @param copysetId: copyset的id
      * @return 成功返回0，失败返回-1
      */
-    int Init(const LogicPoolID& logicPoolId, const CopysetID& copysetId);
+    int Init(const LogicPoolID &logicPoolId, const CopysetID &copysetId);
 
     /**
      * 监控DataStore指标，主要包括chunk的数量、快照的数量等
      * @param datastore: 该copyset下的datastore指针
      */
-    void MonitorDataStore(CSDataStore* datastore);
+    void MonitorDataStore(CSDataStore *datastore);
 
     /**
      * @brief: Monitor log storage's metric, like the number of WAL segment file
      * @param logStorage: The pointer to CurveSegmentLogStorage
      */
-    void MonitorCurveSegmentLogStorage(CurveSegmentLogStorage* logStorage);
+    void MonitorCurveSegmentLogStorage(CurveSegmentLogStorage *logStorage);
 
     /**
      * 执行请求前记录metric
      * @param type: 请求对应的metric类型
      */
-    void OnRequest(CSIOMetricType type) {
-        ioMetrics_.OnRequest(type);
-    }
+    void OnRequest(CSIOMetricType type) { ioMetrics_.OnRequest(type); }
 
     /**
      * 执行请求后记录metric
@@ -226,9 +215,7 @@ class CSCopysetMetric {
      * @param latUS: 此次io的延时
      * @param hasError: 此次io是否有错误产生
      */
-    void OnResponse(CSIOMetricType type,
-                    size_t size,
-                    int64_t latUs,
+    void OnResponse(CSIOMetricType type, size_t size, int64_t latUs,
                     bool hasError) {
         ioMetrics_.OnResponse(type, size, latUs, hasError);
     }
@@ -272,10 +259,8 @@ class CSCopysetMetric {
 
  private:
     inline std::string Prefix() {
-        return "copyset_"
-               + std::to_string(logicPoolId_)
-               + "_"
-               + std::to_string(copysetId_);
+        return "copyset_" + std::to_string(logicPoolId_) + "_" +
+               std::to_string(copysetId_);
     }
 
  private:
@@ -375,7 +360,7 @@ class ChunkServerMetric : public Uncopyable {
      * @pa)ram option: 初始化配置项
      * @return 成功返回0，失败返回-1
      */
-    int Init(const ChunkServerMetricOptions& option);
+    int Init(const ChunkServerMetricOptions &option);
 
     /**
      * 释放metric资源
@@ -389,8 +374,7 @@ class ChunkServerMetric : public Uncopyable {
      * @param copysetId: 此次io操作所在的copysetid
      * @param type: 请求类型
      */
-    void OnRequest(const LogicPoolID& logicPoolId,
-                   const CopysetID& copysetId,
+    void OnRequest(const LogicPoolID &logicPoolId, const CopysetID &copysetId,
                    CSIOMetricType type);
 
     /**
@@ -403,11 +387,8 @@ class ChunkServerMetric : public Uncopyable {
      * @param latUS: 此次io的延时
      * @param hasError: 此次io是否有错误产生
      */
-    void OnResponse(const LogicPoolID& logicPoolId,
-                    const CopysetID& copysetId,
-                    CSIOMetricType type,
-                    size_t size,
-                    int64_t latUs,
+    void OnResponse(const LogicPoolID &logicPoolId, const CopysetID &copysetId,
+                    CSIOMetricType type, size_t size, int64_t latUs,
                     bool hasError);
 
     /**
@@ -417,8 +398,8 @@ class ChunkServerMetric : public Uncopyable {
      * @param copysetId: copyset的id
      * @return 成功返回0，失败返回-1，如果指定metric已存在返回失败
      */
-    int CreateCopysetMetric(const LogicPoolID& logicPoolId,
-                            const CopysetID& copysetId);
+    int CreateCopysetMetric(const LogicPoolID &logicPoolId,
+                            const CopysetID &copysetId);
 
     /**
      * 获取指定copyset的metric
@@ -426,8 +407,8 @@ class ChunkServerMetric : public Uncopyable {
      * @param copysetId: copyset的id
      * @return 成功返回指定的copyset metric，失败返回nullptr
      */
-    CopysetMetricPtr GetCopysetMetric(const LogicPoolID& logicPoolId,
-                                      const CopysetID& copysetId);
+    CopysetMetricPtr GetCopysetMetric(const LogicPoolID &logicPoolId,
+                                      const CopysetID &copysetId);
 
     /**
      * 删除指定copyset的metric
@@ -435,26 +416,26 @@ class ChunkServerMetric : public Uncopyable {
      * @param copysetId: copyset的id
      * @return 成功返回0，失败返回-1
      */
-    int RemoveCopysetMetric(const LogicPoolID& logicPoolId,
-                            const CopysetID& copysetId);
+    int RemoveCopysetMetric(const LogicPoolID &logicPoolId,
+                            const CopysetID &copysetId);
 
     /**
      * 监视chunk分配池，主要监视池中chunk的数量
      * @param chunkFilePool: chunkfilePool的对象指针
      */
-    void MonitorChunkFilePool(FilePool* chunkFilePool);
+    void MonitorChunkFilePool(FilePool *chunkFilePool);
 
     /**
      * 监视wal segment分配池，主要监视池中segment的数量
      * @param walFilePool: walfilePool的对象指针
      */
-    void MonitorWalFilePool(FilePool* walFilePool);
+    void MonitorWalFilePool(FilePool *walFilePool);
 
     /**
      * 监视回收站
      * @param trash: trash的对象指针
      */
-    void MonitorTrash(Trash* trash);
+    void MonitorTrash(Trash *trash);
 
     /**
      * 增加 leader count 计数
@@ -470,7 +451,7 @@ class ChunkServerMetric : public Uncopyable {
      * 更新配置项数据
      * @param conf: 配置内容
      */
-    void ExposeConfigMetric(common::Configuration* conf);
+    void ExposeConfigMetric(common::Configuration *conf);
 
     /**
      * 获取指定类型的IOMetric
@@ -481,13 +462,9 @@ class ChunkServerMetric : public Uncopyable {
         return ioMetrics_.GetIOMetric(type);
     }
 
-    CopysetMetricMap* GetCopysetMetricMap() {
-        return &copysetMetricMap_;
-    }
+    CopysetMetricMap *GetCopysetMetricMap() { return &copysetMetricMap_; }
 
-    uint32_t GetCopysetCount() {
-        return copysetMetricMap_.Size();
-    }
+    uint32_t GetCopysetCount() { return copysetMetricMap_.Size(); }
 
     uint32_t GetLeaderCount() const {
         if (leaderCount_ == nullptr)
@@ -570,7 +547,7 @@ class ChunkServerMetric : public Uncopyable {
     // chunkserver上的IO类型的metric统计
     CSIOMetric ioMetrics_;
     // 用于单例模式的自指指针
-    static ChunkServerMetric* self_;
+    static ChunkServerMetric *self_;
 };
 
 }  // namespace chunkserver

--- a/src/chunkserver/cli.cpp
+++ b/src/chunkserver/cli.cpp
@@ -206,6 +206,8 @@ butil::Status Snapshot(const LogicPoolID &logicPoolId,
                        const CopysetID &copysetId,
                        const PeerId &peer,
                        const braft::cli::CliOptions &options) {
+    (void)logicPoolId;
+    (void)copysetId;
     brpc::Channel channel;
     if (channel.Init(peer.addr, NULL) != 0) {
         return butil::Status(-1, "Fail to init channel to %s",

--- a/src/chunkserver/clone_copyer.cpp
+++ b/src/chunkserver/clone_copyer.cpp
@@ -62,7 +62,7 @@ void OriginCopyer::DeleteExpiredCurveCache(void* arg) {
     while (taskCopyer->curveOpenTime_.size() > 0) {
         CurveOpenTimestamp oldestCache = *taskCopyer->curveOpenTime_.begin();
         if (now.tv_sec - oldestCache.lastUsedSec <
-            taskCopyer->curveFileTimeoutSec_) {
+            static_cast<int64_t>(taskCopyer->curveFileTimeoutSec_)) {
             break;
         }
 
@@ -186,6 +186,7 @@ void OriginCopyer::DownloadFromS3(const string& objectName,
     GetObjectAsyncCallBack cb =
         [=] (const S3Adapter* adapter,
              const std::shared_ptr<GetObjectAsyncContext>& context) {
+            (void)adapter;
             brpc::ClosureGuard doneGuard(done);
             if (context->retCode != 0) {
                 done->SetFailed();

--- a/src/chunkserver/clone_core.cpp
+++ b/src/chunkserver/clone_core.cpp
@@ -47,9 +47,9 @@ DownloadClosure::DownloadClosure(std::shared_ptr<ReadChunkRequest> readRequest,
                                  Closure* done)
     : isFailed_(false)
     , beginTime_(TimeUtility::GetTimeofDayUs())
-    , readRequest_(readRequest)
-    , cloneCore_(cloneCore)
     , downloadCtx_(downloadCtx)
+    , cloneCore_(cloneCore)
+    , readRequest_(readRequest)
     , done_(done) {
     // 记录初始metric
     if (readRequest_ != nullptr) {
@@ -354,7 +354,6 @@ int CloneCore::ReadThenMerge(std::shared_ptr<ReadChunkRequest> readRequest,
                              const butil::IOBuf* cloneData,
                              char* chunkData) {
     const ChunkRequest* request = readRequest->request_;
-    ChunkID id = readRequest->ChunkId();
     std::shared_ptr<CSDataStore> dataStore = readRequest->datastore_;
 
     off_t offset = request->offset();

--- a/src/chunkserver/concurrent_apply/concurrent_apply.h
+++ b/src/chunkserver/concurrent_apply/concurrent_apply.h
@@ -61,8 +61,8 @@ class CURVE_CACHELINE_ALIGNMENT ConcurrentApplyModule {
  public:
     ConcurrentApplyModule(): start_(false),
                              rconcurrentsize_(0),
-                             wconcurrentsize_(0),
                              rqueuedepth_(0),
+                             wconcurrentsize_(0),
                              wqueuedepth_(0),
                              cond_(0) {}
 

--- a/src/chunkserver/copyset_node.cpp
+++ b/src/chunkserver/copyset_node.cpp
@@ -75,10 +75,10 @@ CopysetNode::CopysetNode(const LogicPoolID &logicPoolId,
     chunkDataRpath_(),
     appliedIndex_(0),
     leaderTerm_(-1),
+    configChange_(std::make_shared<ConfigurationChange>()),
+    lastSnapshotIndex_(0),
     scaning_(false),
     lastScanSec_(0),
-    lastSnapshotIndex_(0),
-    configChange_(std::make_shared<ConfigurationChange>()),
     enableOdsyncWhenOpenChunkFile_(false),
     isSyncing_(false),
     checkSyncingIntervalMs_(500) {
@@ -504,6 +504,7 @@ void CopysetNode::on_leader_start(int64_t term) {
 }
 
 void CopysetNode::on_leader_stop(const butil::Status &status) {
+    (void)status;
     leaderTerm_.store(-1, std::memory_order_release);
     ChunkServerMetric::GetInstance()->DecreaseLeaderCount();
     LOG(INFO) << "Copyset: " << GroupIdString()

--- a/src/chunkserver/copyset_service.cpp
+++ b/src/chunkserver/copyset_service.cpp
@@ -84,6 +84,7 @@ void CopysetServiceImpl::CreateCopysetNode2(RpcController *controller,
                                             const CopysetRequest2 *request,
                                             CopysetResponse2 *response,
                                             Closure *done) {
+    (void)controller;
     brpc::ClosureGuard doneGuard(done);
 
     Copyset copyset;
@@ -138,6 +139,7 @@ void CopysetServiceImpl::DeleteBrokenCopyset(RpcController* controller,
                                              const CopysetRequest* request,
                                              CopysetResponse* response,
                                              Closure* done) {
+    (void)controller;
     LOG(INFO) << "Receive delete broken copyset request";
 
     brpc::ClosureGuard doneGuard(done);
@@ -163,6 +165,7 @@ void CopysetServiceImpl::GetCopysetStatus(RpcController *controller,
                                         const CopysetStatusRequest *request,
                                         CopysetStatusResponse *response,
                                         Closure *done) {
+    (void)controller;
     brpc::ClosureGuard doneGuard(done);
 
     LOG(INFO) << "Received GetCopysetStatus request: "

--- a/src/chunkserver/datastore/chunkserver_chunkfile.cpp
+++ b/src/chunkserver/datastore/chunkserver_chunkfile.cpp
@@ -300,6 +300,7 @@ CSErrorCode CSChunkFile::Write(SequenceNum sn,
                                off_t offset,
                                size_t length,
                                uint32_t* cost) {
+    (void)cost;
     WriteLockGuard writeGuard(rwLock_);
     if (!CheckOffsetAndLength(
             offset, length, isCloneChunk_ ? pageSize_ : FLAGS_minIoAlignment)) {

--- a/src/chunkserver/datastore/chunkserver_datastore.cpp
+++ b/src/chunkserver/datastore/chunkserver_datastore.cpp
@@ -39,8 +39,8 @@ CSDataStore::CSDataStore(std::shared_ptr<LocalFileSystem> lfs,
                          const DataStoreOptions& options)
     : chunkSize_(options.chunkSize),
       pageSize_(options.pageSize),
-      baseDir_(options.baseDir),
       locationLimit_(options.locationLimit),
+      baseDir_(options.baseDir),
       chunkFilePool_(chunkFilePool),
       lfs_(lfs),
       enableOdsyncWhenOpenChunkFile_(options.enableOdsyncWhenOpenChunkFile) {
@@ -147,6 +147,7 @@ CSErrorCode CSDataStore::ReadChunk(ChunkID id,
                                    char * buf,
                                    off_t offset,
                                    size_t length) {
+    (void)sn;
     auto chunkFile = metaCache_.Get(id);
     if (chunkFile == nullptr) {
         return CSErrorCode::ChunkNotExistError;
@@ -163,6 +164,7 @@ CSErrorCode CSDataStore::ReadChunk(ChunkID id,
 
 CSErrorCode CSDataStore::ReadChunkMetaPage(ChunkID id, SequenceNum sn,
                                            char * buf) {
+    (void)sn;
     auto chunkFile = metaCache_.Get(id);
     if (chunkFile == nullptr) {
         return CSErrorCode::ChunkNotExistError;

--- a/src/chunkserver/heartbeat_helper.cpp
+++ b/src/chunkserver/heartbeat_helper.cpp
@@ -89,6 +89,7 @@ bool HeartbeatHelper::CopySetConfValid(
 
 bool HeartbeatHelper::NeedPurge(const butil::EndPoint &csEp,
     const CopySetConf &conf, const CopysetNodePtr &copyset) {
+    (void)copyset;
     // CLDCFS-1004 bug-fix: mds下发epoch为0, 配置为空的copyset
     if (0 == conf.epoch() && conf.peers().empty()) {
         LOG(INFO) << "Clean copyset "

--- a/src/chunkserver/op_request.cpp
+++ b/src/chunkserver/op_request.cpp
@@ -208,6 +208,7 @@ void DeleteChunkRequest::OnApply(uint64_t index,
 void DeleteChunkRequest::OnApplyFromLog(std::shared_ptr<CSDataStore> datastore,
                                         const ChunkRequest &request,
                                         const butil::IOBuf &data) {
+    (void)data;
     // NOTE: 处理过程中优先使用参数传入的datastore/request
     auto ret = datastore->DeleteChunk(request.chunkid(),
                                       request.sn());
@@ -363,6 +364,9 @@ void ReadChunkRequest::OnApply(uint64_t index,
 void ReadChunkRequest::OnApplyFromLog(std::shared_ptr<CSDataStore> datastore,
                                       const ChunkRequest &request,
                                       const butil::IOBuf &data) {
+    (void)datastore;
+    (void)request;
+    (void)data;
     // NOTE: 处理过程中优先使用参数传入的datastore/request
     // read什么都不用做
 }
@@ -571,6 +575,9 @@ void ReadSnapshotRequest::OnApply(uint64_t index,
 void ReadSnapshotRequest::OnApplyFromLog(std::shared_ptr<CSDataStore> datastore,
                                          const ChunkRequest &request,
                                          const butil::IOBuf &data) {
+    (void)datastore;
+    (void)request;
+    (void)data;
     // NOTE: 处理过程中优先使用参数传入的datastore/request
     // read什么都不用做
 }
@@ -607,6 +614,7 @@ void DeleteSnapshotRequest::OnApply(uint64_t index,
 void DeleteSnapshotRequest::OnApplyFromLog(std::shared_ptr<CSDataStore> datastore,  //NOLINT
                                            const ChunkRequest &request,
                                            const butil::IOBuf &data) {
+    (void)data;
     // NOTE: 处理过程中优先使用参数传入的datastore/request
     auto ret = datastore->DeleteSnapshotChunkOrCorrectSn(
         request.chunkid(), request.correctedsn());
@@ -669,6 +677,7 @@ void CreateCloneChunkRequest::OnApply(uint64_t index,
 void CreateCloneChunkRequest::OnApplyFromLog(std::shared_ptr<CSDataStore> datastore,  //NOLINT
                                              const ChunkRequest &request,
                                              const butil::IOBuf &data) {
+    (void)data;
     // NOTE: 处理过程中优先使用参数传入的datastore/request
     auto ret = datastore->CreateCloneChunk(request.chunkid(),
                                            request.sn(),
@@ -806,6 +815,7 @@ void ScanChunkRequest::OnApply(uint64_t index,
 void ScanChunkRequest::OnApplyFromLog(std::shared_ptr<CSDataStore> datastore,  //NOLINT
                                                const ChunkRequest &request,
                                                const butil::IOBuf &data) {
+    (void)data;
     uint32_t crc = 0;
     size_t size = request.size();
     std::unique_ptr<char[]> readBuffer(new(std::nothrow)char[size]);

--- a/src/chunkserver/raftlog/curve_segment.cpp
+++ b/src/chunkserver/raftlog/curve_segment.cpp
@@ -80,7 +80,7 @@ int CurveSegment::create() {
         return -1;
     }
     res = ::lseek(_fd, _meta_page_size, SEEK_SET);
-    if (res != _meta_page_size) {
+    if (res != static_cast<int>(_meta_page_size)) {
         LOG(ERROR) << "lseek fail! error: " << strerror(errno);
         return -1;
     }
@@ -231,7 +231,7 @@ int CurveSegment::load(braft::ConfigurationManager* configuration_manager) {
 int CurveSegment::_load_meta() {
     char* metaPage = new char[_meta_page_size];
     int res = ::pread(_fd, metaPage, _meta_page_size, 0);
-    if (res != _meta_page_size) {
+    if (res != static_cast<int>(_meta_page_size)) {
         delete metaPage;
         return -1;
     }
@@ -437,7 +437,7 @@ int CurveSegment::append(const braft::LogEntry* entry) {
         data.copy_to(write_buf + kEntryHeaderSize, real_length);
         int ret = ::pwrite(_direct_fd, write_buf, to_write, _meta.bytes);
         free(write_buf);
-        if (ret != to_write) {
+        if (ret != static_cast<int>(to_write)) {
             LOG(ERROR) << "Fail to write directly to fd=" << _direct_fd
                        << ", buf=" << write_buf << ", size=" << to_write
                        << ", offset=" << _meta.bytes << ", error=" << berror();
@@ -486,7 +486,7 @@ int CurveSegment::_update_meta_page() {
         ret = ::pwrite(_fd, metaPage, _meta_page_size, 0);
     }
     free(metaPage);
-    if (ret != _meta_page_size) {
+    if (ret != static_cast<int>(_meta_page_size)) {
         LOG(ERROR) << "Fail to write meta page into fd="
                    << (FLAGS_enableWalDirectWrite ? _direct_fd : _fd)
                    << ", path: " << _path << berror();
@@ -642,7 +642,6 @@ int CurveSegment::sync(bool will_sync) {
 }
 
 int CurveSegment::unlink() {
-    int ret = 0;
     std::string path(_path);
     if (_is_open) {
         butil::string_appendf(&path, "/" CURVE_SEGMENT_OPEN_PATTERN,

--- a/src/chunkserver/raftlog/curve_segment_log_storage.cpp
+++ b/src/chunkserver/raftlog/curve_segment_log_storage.cpp
@@ -424,6 +424,7 @@ int CurveSegmentLogStorage::append_entry(const braft::LogEntry* entry) {
 int CurveSegmentLogStorage::append_entries(
                     const std::vector<braft::LogEntry*>& entries,
                     braft::IOMetric* metric) {
+    (void)metric;
     if (entries.empty()) {
         return 0;
     }

--- a/src/chunkserver/raftlog/curve_segment_log_storage.h
+++ b/src/chunkserver/raftlog/curve_segment_log_storage.h
@@ -38,8 +38,8 @@
 //          Zhangyi Chen(chenzhangyi01@baidu.com)
 //          Xiong,Kai(xiongkai@baidu.com)
 
-#ifndef  SRC_CHUNKSERVER_RAFTLOG_CURVE_SEGMENT_LOG_STORAGE_H_
-#define  SRC_CHUNKSERVER_RAFTLOG_CURVE_SEGMENT_LOG_STORAGE_H_
+#ifndef SRC_CHUNKSERVER_RAFTLOG_CURVE_SEGMENT_LOG_STORAGE_H_
+#define SRC_CHUNKSERVER_RAFTLOG_CURVE_SEGMENT_LOG_STORAGE_H_
 
 #include <butil/atomicops.h>
 #include <butil/iobuf.h>
@@ -64,25 +64,23 @@ class CurveSegmentLogStorage;
 
 struct LogStorageOptions {
     std::shared_ptr<FilePool> walFilePool;
-    std::function<void(CurveSegmentLogStorage*)> monitorMetricCb;
+    std::function<void(CurveSegmentLogStorage *)> monitorMetricCb;
 
     LogStorageOptions() = default;
-    LogStorageOptions(std::shared_ptr<FilePool> walFilePool,
-        std::function<void(CurveSegmentLogStorage*)> monitorMetricCb)
-        : walFilePool(walFilePool), monitorMetricCb(monitorMetricCb) {
-    }
+    LogStorageOptions(
+        std::shared_ptr<FilePool> walFilePool,
+        std::function<void(CurveSegmentLogStorage *)> monitorMetricCb)
+        : walFilePool(walFilePool), monitorMetricCb(monitorMetricCb) {}
 };
 
 struct LogStorageStatus {
     explicit LogStorageStatus(uint32_t walSegmentFileCount)
-        : walSegmentFileCount(walSegmentFileCount) {
-    }
+        : walSegmentFileCount(walSegmentFileCount) {}
 
     uint32_t walSegmentFileCount;
 };
 
-LogStorageOptions StoreOptForCurveSegmentLogStorage(
-    LogStorageOptions options);
+LogStorageOptions StoreOptForCurveSegmentLogStorage(LogStorageOptions options);
 
 void RegisterCurveSegmentLogStorageOrDie();
 
@@ -96,31 +94,23 @@ void RegisterCurveSegmentLogStorageOrDie();
 //      log_inprogress_0001001: open segment
 class CurveSegmentLogStorage : public braft::LogStorage {
  public:
-    typedef std::map<int64_t, scoped_refptr<Segment> > SegmentMap;
+    typedef std::map<int64_t, scoped_refptr<Segment>> SegmentMap;
 
-    explicit CurveSegmentLogStorage(const std::string& path,
-        bool enable_sync = true,
+    explicit CurveSegmentLogStorage(
+        const std::string &path, bool enable_sync = true,
         std::shared_ptr<FilePool> walFilePool = nullptr)
-        : _path(path)
-        , _first_log_index(1)
-        , _last_log_index(0)
-        , _checksum_type(0)
-        , _enable_sync(enable_sync)
-        , _walFilePool(walFilePool)
-    {}
+        : _path(path), _first_log_index(1), _last_log_index(0),
+          _walFilePool(walFilePool), _checksum_type(0),
+          _enable_sync(enable_sync) {}
 
     CurveSegmentLogStorage()
-        : _first_log_index(1)
-        , _last_log_index(0)
-        , _checksum_type(0)
-        , _enable_sync(true)
-        , _walFilePool(nullptr)
-    {}
+        : _first_log_index(1), _last_log_index(0), _walFilePool(nullptr),
+          _checksum_type(0), _enable_sync(true) {}
 
     virtual ~CurveSegmentLogStorage() {}
 
     // init logstorage, check consistency and integrity
-    virtual int init(braft::ConfigurationManager* configuration_manager);
+    virtual int init(braft::ConfigurationManager *configuration_manager);
 
     // first log index in log
     virtual int64_t first_log_index() {
@@ -131,18 +121,17 @@ class CurveSegmentLogStorage : public braft::LogStorage {
     virtual int64_t last_log_index();
 
     // get logentry by index
-    virtual braft::LogEntry* get_entry(const int64_t index);
+    virtual braft::LogEntry *get_entry(const int64_t index);
 
     // get logentry's term by index
     virtual int64_t get_term(const int64_t index);
 
     // append entry to log
-    int append_entry(const braft::LogEntry* entry);
+    int append_entry(const braft::LogEntry *entry);
 
     // append entries to log and update IOMetric, return success append number
-    virtual int append_entries(
-        const std::vector<braft::LogEntry*>& entries,
-        braft::IOMetric* metric);
+    virtual int append_entries(const std::vector<braft::LogEntry *> &entries,
+                               braft::IOMetric *metric);
 
     // delete logs from storage's head, [1, first_index_kept) will be discarded
     virtual int truncate_prefix(const int64_t first_index_kept);
@@ -153,13 +142,11 @@ class CurveSegmentLogStorage : public braft::LogStorage {
 
     virtual int reset(const int64_t next_log_index);
 
-    LogStorage* new_instance(const std::string& uri) const;
+    LogStorage *new_instance(const std::string &uri) const;
 
-    SegmentMap& segments() {
-        return _segments;
-    }
+    SegmentMap &segments() { return _segments; }
 
-    void list_files(std::vector<std::string>* seg_files);
+    void list_files(std::vector<std::string> *seg_files);
 
     void sync();
 
@@ -170,15 +157,13 @@ class CurveSegmentLogStorage : public braft::LogStorage {
     int save_meta(const int64_t log_index);
     int load_meta();
     int list_segments(bool is_empty);
-    int load_segments(braft::ConfigurationManager* configuration_manager);
-    int get_segment(int64_t log_index, scoped_refptr<Segment>* ptr);
-    void pop_segments(
-            int64_t first_index_kept,
-            std::vector<scoped_refptr<Segment> >* poped);
-    void pop_segments_from_back(
-            const int64_t first_index_kept,
-            std::vector<scoped_refptr<Segment> >* popped,
-            scoped_refptr<Segment>* last_segment);
+    int load_segments(braft::ConfigurationManager *configuration_manager);
+    int get_segment(int64_t log_index, scoped_refptr<Segment> *ptr);
+    void pop_segments(int64_t first_index_kept,
+                      std::vector<scoped_refptr<Segment>> *poped);
+    void pop_segments_from_back(const int64_t first_index_kept,
+                                std::vector<scoped_refptr<Segment>> *popped,
+                                scoped_refptr<Segment> *last_segment);
 
 
     std::string _path;

--- a/src/chunkserver/raftsnapshot/curve_file_service.h
+++ b/src/chunkserver/raftsnapshot/curve_file_service.h
@@ -70,7 +70,7 @@ class BAIDU_CACHELINE_ALIGNMENT CurveFileService : public braft::FileService {
     void set_snapshot_attachment(SnapshotAttachment *snapshot_attachment);
     void clear_snapshot_attachment() {
         BAIDU_SCOPED_LOCK(_mutex);
-        auto ret = _snapshot_attachment.release();
+        (void)_snapshot_attachment.release();
     }
 
  private:

--- a/src/chunkserver/register.cpp
+++ b/src/chunkserver/register.cpp
@@ -53,8 +53,8 @@ Register::Register(const RegisterOptions &ops) {
 }
 
 int Register::RegisterToMDS(const ChunkServerMetadata *localMetadata,
-    ChunkServerMetadata *metadata,
-    const std::shared_ptr<EpochMap> &epochMap) {
+                            ChunkServerMetadata *metadata,
+                            const std::shared_ptr<EpochMap> &epochMap) {
     ::curve::mds::topology::ChunkServerRegistRequest req;
     ::curve::mds::topology::ChunkServerRegistResponse resp;
     req.set_disktype(ops_.chunkserverDiskType);
@@ -65,7 +65,7 @@ int Register::RegisterToMDS(const ChunkServerMetadata *localMetadata,
     }
     req.set_port(ops_.chunkserverPort);
     uint64_t chunkPoolSize = ops_.chunkFilepool->Size() *
-                ops_.chunkFilepool->GetFilePoolOpt().fileSize;
+                             ops_.chunkFilepool->GetFilePoolOpt().fileSize;
     req.set_chunkfilepoolsize(chunkPoolSize);
     if (ops_.chunkFilepool->GetFilePoolOpt().getFileFromPool) {
         req.set_usechunkfilepoolaswalpool(ops_.useChunkFilePoolAsWalPool);
@@ -107,8 +107,7 @@ int Register::RegisterToMDS(const ChunkServerMetadata *localMetadata,
             break;
         } else {
             LOG(ERROR) << ops_.chunkserverInternalIp << ":"
-                       << ops_.chunkserverPort
-                       << " Fail to register to MDS "
+                       << ops_.chunkserverPort << " Fail to register to MDS "
                        << mdsEps_[inServiceIndex_]
                        << ", cntl errorCode: " << cntl.ErrorCode() << ","
                        << " cntl error: " << cntl.ErrorText() << ","
@@ -131,8 +130,8 @@ int Register::RegisterToMDS(const ChunkServerMetadata *localMetadata,
     }
 
     if (resp.epochmap_size() != 0) {
-        for (auto it = resp.epochmap().begin();
-            it != resp.epochmap().end(); it++) {
+        for (auto it = resp.epochmap().begin(); it != resp.epochmap().end();
+             it++) {
             epochMap->UpdateEpoch(it->first, it->second);
         }
     }
@@ -173,8 +172,8 @@ int Register::PersistChunkServerMeta(const ChunkServerMetadata &metadata) {
         return -1;
     }
 
-    if (ops_.fs->Write(
-        fd, metaStr.c_str(), 0, metaStr.size()) < metaStr.size()) {
+    if (ops_.fs->Write(fd, metaStr.c_str(), 0, metaStr.size()) <
+        static_cast<int>(metaStr.size())) {
         LOG(ERROR) << "Failed to write chunkserver metadata file";
         return -1;
     }

--- a/src/chunkserver/scan_service.cpp
+++ b/src/chunkserver/scan_service.cpp
@@ -29,6 +29,7 @@ void ScanServiceImpl::FollowScanMap(RpcController *controller,
                        const FollowScanMapRequest *request,
                        FollowScanMapResponse *response,
                        Closure *done) {
+    (void)controller;
     brpc::ClosureGuard doneGuard(done);
     scanManager_->DealFollowerScanMap(*request, response);
 }

--- a/src/chunkserver/trash.cpp
+++ b/src/chunkserver/trash.cpp
@@ -185,7 +185,7 @@ bool Trash::IsCopysetInTrash(const std::string &dirName) {
     // 目录是十进制形式
     // 例如：2860448220024 (poolId: 666, copysetId: 888)
     uint64_t groupId;
-    int n = dirName.find(".");
+    auto n = dirName.find(".");
     if (n == std::string::npos) {
         return false;
     }
@@ -259,6 +259,7 @@ bool Trash::RecycleChunksAndWALInDir(
 
 bool Trash::RecycleChunkfile(
     const std::string &filepath, const std::string &filename) {
+    (void)filename;
     LockGuard lg(mtx_);
     if (0 != chunkFilePool_->RecycleFile(filepath)) {
         LOG(ERROR) << "Trash  failed recycle chunk " << filepath
@@ -272,6 +273,7 @@ bool Trash::RecycleChunkfile(
 
 bool Trash::RecycleWAL(
     const std::string &filepath, const std::string &filename) {
+    (void)filename;
     LockGuard lg(mtx_);
     if (walPool_ != nullptr && 0 != walPool_->RecycleFile(filepath)) {
         LOG(ERROR) << "Trash  failed recycle WAL " << filepath

--- a/src/client/chunkserver_broadcaster.h
+++ b/src/client/chunkserver_broadcaster.h
@@ -24,6 +24,7 @@
 #define SRC_CLIENT_CHUNKSERVER_BROADCASTER_H_
 
 #include <list>
+#include <memory>
 
 #include "include/client/libcurve_define.h"
 #include "src/client/client_common.h"

--- a/src/client/chunkserver_client.cpp
+++ b/src/client/chunkserver_client.cpp
@@ -25,6 +25,7 @@
 #include <brpc/channel.h>
 #include <bthread/bthread.h>
 #include <algorithm>
+#include <memory>
 
 using curve::chunkserver::ChunkService_Stub;
 using curve::chunkserver::CHUNK_OP_STATUS;

--- a/src/client/io_tracker.cpp
+++ b/src/client/io_tracker.cpp
@@ -50,8 +50,8 @@ IOTracker::IOTracker(IOManager* iomanager,
                      FileMetric* clientMetric,
                      bool disableStripe)
     : mc_(mc),
-      iomanager_(iomanager),
       scheduler_(scheduler),
+      iomanager_(iomanager),
       fileMetric_(clientMetric),
       disableStripe_(disableStripe) {
     id_         = tracekerID_.fetch_add(1, std::memory_order_relaxed);

--- a/src/client/io_tracker.h
+++ b/src/client/io_tracker.h
@@ -336,12 +336,12 @@ class CURVE_CACHELINE_ALIGNMENT IOTracker {
     // store segment indices that can be discarded
     std::unordered_set<SegmentIndex> discardSegments_;
 
+    // metacache为当前fileinstance的元数据信息
+    MetaCache* mc_;
+
     // scheduler用来将用户线程与client自己的线程切分
     // 大IO被切分之后，将切分的reqlist传给scheduler向下发送
     RequestScheduler* scheduler_;
-
-    // metacache为当前fileinstance的元数据信息
-    MetaCache* mc_;
 
     // 对于异步IO，Tracker需要向上层通知当前IO已经处理结束
     // iomanager可以将该tracker释放

--- a/src/client/libcbd_ext4.cpp
+++ b/src/client/libcbd_ext4.cpp
@@ -28,7 +28,7 @@ extern "C" {
 
 CurveOptions g_cbd_ext4_options = {false, 0};
 
-int cbd_ext4_init(const CurveOptions* options) {
+int cbd_ext4_init(const CurveOptions *options) {
     if (g_cbd_ext4_options.inited) {
         return 0;
     }
@@ -45,47 +45,47 @@ int cbd_ext4_init(const CurveOptions* options) {
     return 0;
 }
 
-int cbd_ext4_fini() {
-    return 0;
-}
+int cbd_ext4_fini() { return 0; }
 
-int cbd_ext4_open(const char* filename) {
+int cbd_ext4_open(const char *filename) {
     int fd = -1;
     char path[CBD_MAX_FILE_PATH_LEN] = {0};
 #ifdef CBD_BACKEND_EXT4
-    strcat(path, g_cbd_ext4_options.datahome);  //NOLINT
-    strcat(path, "/");  //NOLINT
+    strcat(path, g_cbd_ext4_options.datahome);  // NOLINT
+    strcat(path, "/");                          // NOLINT
 #endif
-    strcat(path, filename);    //NOLINT
+    strcat(path, filename);  // NOLINT
 
     fd = open(path, O_RDWR | O_CREAT, 0660);
 
     return fd;
 }
 
-int cbd_ext4_close(int fd) {
-    return close(fd);
-}
+int cbd_ext4_close(int fd) { return close(fd); }
 
-int cbd_ext4_pread(int fd, void* buf, off_t offset, size_t length) {
+int cbd_ext4_pread(int fd, void *buf, off_t offset, size_t length) {
     return pread(fd, buf, length, offset);
 }
 
-int cbd_ext4_pwrite(int fd, const void* buf, off_t offset, size_t length) {
+int cbd_ext4_pwrite(int fd, const void *buf, off_t offset, size_t length) {
     return pwrite(fd, buf, length, offset);
 }
 
 int cbd_ext4_pdiscard(int fd, off_t offset, size_t length) {
+    (void)fd;
+    (void)offset;
+    (void)length;
     return 0;
 }
 
 void cbd_ext4_aio_callback(union sigval sigev_value) {
-    CurveAioContext* context = (CurveAioContext *)sigev_value.sival_ptr;    //NOLINT
+    CurveAioContext *context =
+        (CurveAioContext *)sigev_value.sival_ptr;  // NOLINT
     context->cb(context);
 }
 
-int cbd_ext4_aio_pread(int fd, CurveAioContext* context) {
-    struct aiocb* cb;
+int cbd_ext4_aio_pread(int fd, CurveAioContext *context) {
+    struct aiocb *cb;
 
     cb = (struct aiocb *)malloc(sizeof(struct aiocb));
     if (!cb) {
@@ -98,14 +98,14 @@ int cbd_ext4_aio_pread(int fd, CurveAioContext* context) {
     cb->aio_nbytes = context->length;
     cb->aio_buf = context->buf;
     cb->aio_sigevent.sigev_notify = SIGEV_THREAD;
-    cb->aio_sigevent.sigev_value.sival_ptr = (void*)context;    //NOLINT
+    cb->aio_sigevent.sigev_value.sival_ptr = (void *)context;  // NOLINT
     cb->aio_sigevent.sigev_notify_function = cbd_ext4_aio_callback;
 
     return aio_read(cb);
 }
 
-int cbd_ext4_aio_pwrite(int fd, CurveAioContext* context) {
-    struct aiocb* cb;
+int cbd_ext4_aio_pwrite(int fd, CurveAioContext *context) {
+    struct aiocb *cb;
 
     cb = (struct aiocb *)malloc(sizeof(struct aiocb));
     if (!cb) {
@@ -118,32 +118,31 @@ int cbd_ext4_aio_pwrite(int fd, CurveAioContext* context) {
     cb->aio_nbytes = context->length;
     cb->aio_buf = context->buf;
     cb->aio_sigevent.sigev_notify = SIGEV_THREAD;
-    cb->aio_sigevent.sigev_value.sival_ptr = (void*)context;    //NOLINT
+    cb->aio_sigevent.sigev_value.sival_ptr = (void *)context;  // NOLINT
     cb->aio_sigevent.sigev_notify_function = cbd_ext4_aio_callback;
 
     return aio_write(cb);
 }
 
-int cbd_ext4_aio_pdiscard(int fd, CurveAioContext* aioctx) {
+int cbd_ext4_aio_pdiscard(int fd, CurveAioContext *aioctx) {
+    (void)fd;
     aioctx->ret = aioctx->length;
     aioctx->cb(aioctx);
     return 0;
 }
 
-int cbd_ext4_sync(int fd) {
-    return fsync(fd);
-}
+int cbd_ext4_sync(int fd) { return fsync(fd); }
 
-int64_t cbd_ext4_filesize(const char* filename) {
+int64_t cbd_ext4_filesize(const char *filename) {
     struct stat st;
     int ret;
 
     char path[CBD_MAX_FILE_PATH_LEN] = {0};
 #ifdef CBD_BACKEND_EXT4
-    strcat(path, g_cbd_ext4_options.datahome);  //NOLINT
-    strcat(path, "/");  //NOLINT
+    strcat(path, g_cbd_ext4_options.datahome);  // NOLINT
+    strcat(path, "/");                          // NOLINT
 #endif
-    strcat(path, filename);    //NOLINT
+    strcat(path, filename);  // NOLINT
 
     ret = stat(path, &st);
     if (ret) {
@@ -153,9 +152,9 @@ int64_t cbd_ext4_filesize(const char* filename) {
     }
 }
 
-int cbd_ext4_increase_epoch(const char* filename) {
+int cbd_ext4_increase_epoch(const char *filename) {
+    (void)filename;
     return 0;
 }
 
 }  // extern "C"
-

--- a/src/client/libcbd_libcurve.cpp
+++ b/src/client/libcbd_libcurve.cpp
@@ -91,6 +91,7 @@ int cbd_libcurve_aio_pdiscard(int fd, CurveAioContext* context) {
 
 int cbd_libcurve_sync(int fd) {
     // Ignored as it always sync writes to chunkserver currently
+    (void)fd;
     return 0;
 }
 

--- a/src/client/libcurve_file.cpp
+++ b/src/client/libcurve_file.cpp
@@ -48,7 +48,7 @@
 #include "src/common/fast_align.h"
 
 bool globalclientinited_ = false;
-curve::client::FileClient* globalclient = nullptr;
+curve::client::FileClient *globalclient = nullptr;
 
 using curve::client::UserInfo;
 
@@ -72,9 +72,9 @@ char g_processname[kProcessNameMax];
 
 class LoggerGuard {
  private:
-    friend void InitLogging(const std::string& confPath);
+    friend void InitLogging(const std::string &confPath);
 
-    explicit LoggerGuard(const std::string& confpath) {
+    explicit LoggerGuard(const std::string &confpath) {
         InitInternal(confpath);
     }
 
@@ -84,13 +84,13 @@ class LoggerGuard {
         }
     }
 
-    void InitInternal(const std::string& confpath);
+    void InitInternal(const std::string &confpath);
 
  private:
     bool needShutdown_ = false;
 };
 
-void LoggerGuard::InitInternal(const std::string& confPath) {
+void LoggerGuard::InitInternal(const std::string &confPath) {
     curve::common::Configuration conf;
     conf.SetConfigPath(confPath);
 
@@ -120,26 +120,22 @@ void LoggerGuard::InitInternal(const std::string& confPath) {
     LOG_IF(WARNING, !conf.GetStringValue("global.logPath", &FLAGS_log_dir))
         << "config no logpath info, using default dir '/tmp'";
 
-    std::string processName = std::string("libcurve-").append(
-        curve::common::UUIDGenerator().GenerateUUID().substr(0, 8));
-    snprintf(g_processname, sizeof(g_processname),
-            "%s", processName.c_str());
+    std::string processName =
+        std::string("libcurve-")
+            .append(curve::common::UUIDGenerator().GenerateUUID().substr(0, 8));
+    snprintf(g_processname, sizeof(g_processname), "%s", processName.c_str());
     google::InitGoogleLogging(g_processname);
     needShutdown_ = true;
 }
 
-void InitLogging(const std::string& confPath) {
+void InitLogging(const std::string &confPath) {
     static LoggerGuard guard(confPath);
 }
 
 }  // namespace
 
 FileClient::FileClient()
-    : rwlock_(),
-      fdcount_(0),
-      fileserviceMap_(),
-      clientconfig_(),
-      mdsClient_(),
+    : rwlock_(), fdcount_(0), fileserviceMap_(), clientconfig_(), mdsClient_(),
       csClient_(std::make_shared<ChunkServerClient>()),
       csBroadCaster_(std::make_shared<ChunkServerBroadCaster>(csClient_)),
       inited_(false),
@@ -150,7 +146,7 @@ bool FileClient::CheckAligned(off_t offset, size_t length) const {
            common::is_aligned(length, kMinIOAlignment);
 }
 
-int FileClient::Init(const std::string& configpath) {
+int FileClient::Init(const std::string &configpath) {
     if (inited_) {
         LOG(WARNING) << "already inited!";
         return 0;
@@ -187,8 +183,7 @@ int FileClient::Init(const std::string& configpath) {
 
     mdsClient_ = std::move(tmpMdsClient);
 
-    int rc2 = csClient_->Init(
-        clientconfig_.GetFileServiceOption().csClientOpt);
+    int rc2 = csClient_->Init(clientconfig_.GetFileServiceOption().csClientOpt);
     if (rc2 != 0) {
         LOG(ERROR) << "Init ChunkServer Client failed!";
         return -LIBCURVE_ERROR::FAILED;
@@ -221,11 +216,10 @@ void FileClient::UnInit() {
     inited_ = false;
 }
 
-int FileClient::Open(const std::string& filename,
-                     const UserInfo_t& userinfo,
-                     const OpenFlags& openflags) {
+int FileClient::Open(const std::string &filename, const UserInfo_t &userinfo,
+                     const OpenFlags &openflags) {
     LOG(INFO) << "Opening filename: " << filename << ", flags: " << openflags;
-    FileInstance* fileserv = FileInstance::NewInitedFileInstance(
+    FileInstance *fileserv = FileInstance::NewInitedFileInstance(
         clientconfig_.GetFileServiceOption(), mdsClient_, filename, userinfo,
         openflags, false);
     if (fileserv == nullptr) {
@@ -256,9 +250,9 @@ int FileClient::Open(const std::string& filename,
     return fd;
 }
 
-int FileClient::Open4ReadOnly(const std::string& filename,
-                              const UserInfo_t& userinfo, bool disableStripe) {
-    FileInstance* instance = FileInstance::Open4Readonly(
+int FileClient::Open4ReadOnly(const std::string &filename,
+                              const UserInfo_t &userinfo, bool disableStripe) {
+    FileInstance *instance = FileInstance::Open4Readonly(
         clientconfig_.GetFileServiceOption(), mdsClient_, filename, userinfo);
 
     if (instance == nullptr) {
@@ -283,16 +277,16 @@ int FileClient::Open4ReadOnly(const std::string& filename,
     return fd;
 }
 
-int FileClient::IncreaseEpoch(const std::string& filename,
-                              const UserInfo_t& userinfo) {
+int FileClient::IncreaseEpoch(const std::string &filename,
+                              const UserInfo_t &userinfo) {
     LOG(INFO) << "IncreaseEpoch, filename: " << filename;
     FInfo_t fi;
     FileEpoch_t fEpoch;
     std::list<CopysetPeerInfo<ChunkServerID>> csLocs;
     LIBCURVE_ERROR ret;
     if (mdsClient_ != nullptr) {
-        ret = mdsClient_->IncreaseEpoch(filename, userinfo,
-            &fi, &fEpoch, &csLocs);
+        ret = mdsClient_->IncreaseEpoch(filename, userinfo, &fi, &fEpoch,
+                                        &csLocs);
         LOG_IF(ERROR, ret != LIBCURVE_ERROR::OK)
             << "IncreaseEpoch failed, filename: " << filename
             << ", ret: " << ret;
@@ -301,11 +295,10 @@ int FileClient::IncreaseEpoch(const std::string& filename,
         return -LIBCURVE_ERROR::FAILED;
     }
 
-    int ret2 = csBroadCaster_->BroadCastFileEpoch(
-        fEpoch.fileId, fEpoch.epoch, csLocs);
+    int ret2 =
+        csBroadCaster_->BroadCastFileEpoch(fEpoch.fileId, fEpoch.epoch, csLocs);
     LOG_IF(ERROR, ret2 != LIBCURVE_ERROR::OK)
-        << "BroadCastEpoch failed, filename: " << filename
-        << ", ret: " << ret2;
+        << "BroadCastEpoch failed, filename: " << filename << ", ret: " << ret2;
 
     // update epoch if file is already open
     auto it = fileserviceFileNameMap_.find(filename);
@@ -315,8 +308,8 @@ int FileClient::IncreaseEpoch(const std::string& filename,
     return ret2;
 }
 
-int FileClient::Create(const std::string& filename,
-    const UserInfo_t& userinfo, size_t size) {
+int FileClient::Create(const std::string &filename, const UserInfo_t &userinfo,
+                       size_t size) {
     LIBCURVE_ERROR ret;
     if (mdsClient_ != nullptr) {
         ret = mdsClient_->CreateFile(filename, userinfo, size);
@@ -329,13 +322,13 @@ int FileClient::Create(const std::string& filename,
     return -ret;
 }
 
-int FileClient::Create2(const std::string& filename,
-    const UserInfo_t& userinfo, size_t size,
-    uint64_t stripeUnit, uint64_t stripeCount) {
+int FileClient::Create2(const std::string &filename, const UserInfo_t &userinfo,
+                        size_t size, uint64_t stripeUnit,
+                        uint64_t stripeCount) {
     LIBCURVE_ERROR ret;
     if (mdsClient_ != nullptr) {
-        ret = mdsClient_->CreateFile(filename, userinfo, size, true,
-                                     stripeUnit, stripeCount);
+        ret = mdsClient_->CreateFile(filename, userinfo, size, true, stripeUnit,
+                                     stripeCount);
         LOG_IF(ERROR, ret != LIBCURVE_ERROR::OK)
             << "Create file failed, filename: " << filename << ", ret: " << ret;
     } else {
@@ -345,7 +338,7 @@ int FileClient::Create2(const std::string& filename,
     return -ret;
 }
 
-int FileClient::Read(int fd, char* buf, off_t offset, size_t len) {
+int FileClient::Read(int fd, char *buf, off_t offset, size_t len) {
     // 长度为0，直接返回，不做任何操作
     if (len == 0) {
         return -LIBCURVE_ERROR::OK;
@@ -366,7 +359,7 @@ int FileClient::Read(int fd, char* buf, off_t offset, size_t len) {
     return fileserviceMap_[fd]->Read(buf, offset, len);
 }
 
-int FileClient::Write(int fd, const char* buf, off_t offset, size_t len) {
+int FileClient::Write(int fd, const char *buf, off_t offset, size_t len) {
     // 长度为0，直接返回，不做任何操作
     if (len == 0) {
         return -LIBCURVE_ERROR::OK;
@@ -398,7 +391,7 @@ int FileClient::Discard(int fd, off_t offset, size_t length) {
     return iter->second->Discard(offset, length);
 }
 
-int FileClient::AioRead(int fd, CurveAioContext* aioctx,
+int FileClient::AioRead(int fd, CurveAioContext *aioctx,
                         UserDataType dataType) {
     // 长度为0，直接返回，不做任何操作
     if (aioctx->length == 0) {
@@ -423,7 +416,7 @@ int FileClient::AioRead(int fd, CurveAioContext* aioctx,
     return ret;
 }
 
-int FileClient::AioWrite(int fd, CurveAioContext* aioctx,
+int FileClient::AioWrite(int fd, CurveAioContext *aioctx,
                          UserDataType dataType) {
     // 长度为0，直接返回，不做任何操作
     if (aioctx->length == 0) {
@@ -449,7 +442,7 @@ int FileClient::AioWrite(int fd, CurveAioContext* aioctx,
     return ret;
 }
 
-int FileClient::AioDiscard(int fd, CurveAioContext* aioctx) {
+int FileClient::AioDiscard(int fd, CurveAioContext *aioctx) {
     ReadLockGuard lk(rwlock_);
     auto iter = fileserviceMap_.find(fd);
     if (CURVE_UNLIKELY(iter == fileserviceMap_.end())) {
@@ -460,14 +453,13 @@ int FileClient::AioDiscard(int fd, CurveAioContext* aioctx) {
     }
 }
 
-int FileClient::Rename(const UserInfo_t& userinfo,
-    const std::string& oldpath, const std::string& newpath) {
+int FileClient::Rename(const UserInfo_t &userinfo, const std::string &oldpath,
+                       const std::string &newpath) {
     LIBCURVE_ERROR ret;
     if (mdsClient_ != nullptr) {
         ret = mdsClient_->RenameFile(userinfo, oldpath, newpath);
         LOG_IF(ERROR, ret != LIBCURVE_ERROR::OK)
-            << "Rename failed, OldPath: " << oldpath
-            << ", NewPath: " << newpath
+            << "Rename failed, OldPath: " << oldpath << ", NewPath: " << newpath
             << ", ret: " << ret;
     } else {
         LOG(ERROR) << "global mds client not inited!";
@@ -476,15 +468,14 @@ int FileClient::Rename(const UserInfo_t& userinfo,
     return -ret;
 }
 
-int FileClient::Extend(const std::string& filename,
-    const UserInfo_t& userinfo, uint64_t newsize) {
+int FileClient::Extend(const std::string &filename, const UserInfo_t &userinfo,
+                       uint64_t newsize) {
     LIBCURVE_ERROR ret;
     if (mdsClient_ != nullptr) {
         ret = mdsClient_->Extend(filename, userinfo, newsize);
         LOG_IF(ERROR, ret != LIBCURVE_ERROR::OK)
             << "Extend failed, filename: " << filename
-            << ", NewSize: " << newsize
-            << ", ret: " << ret;
+            << ", NewSize: " << newsize << ", ret: " << ret;
     } else {
         LOG(ERROR) << "global mds client not inited!";
         return -LIBCURVE_ERROR::FAILED;
@@ -492,15 +483,14 @@ int FileClient::Extend(const std::string& filename,
     return -ret;
 }
 
-int FileClient::Unlink(const std::string& filename,
-    const UserInfo_t& userinfo, bool deleteforce) {
+int FileClient::Unlink(const std::string &filename, const UserInfo_t &userinfo,
+                       bool deleteforce) {
     LIBCURVE_ERROR ret;
     if (mdsClient_ != nullptr) {
         ret = mdsClient_->DeleteFile(filename, userinfo, deleteforce);
         LOG_IF(ERROR, ret != LIBCURVE_ERROR::OK)
             << "Unlink failed, filename: " << filename
-            << ", force: " << deleteforce
-            << ", ret: " << ret;
+            << ", force: " << deleteforce << ", ret: " << ret;
     } else {
         LOG(ERROR) << "global mds client not inited!";
         return -LIBCURVE_ERROR::FAILED;
@@ -508,14 +498,13 @@ int FileClient::Unlink(const std::string& filename,
     return -ret;
 }
 
-int FileClient::Recover(const std::string& filename,
-    const UserInfo_t& userinfo, uint64_t fileId) {
+int FileClient::Recover(const std::string &filename, const UserInfo_t &userinfo,
+                        uint64_t fileId) {
     LIBCURVE_ERROR ret;
     if (mdsClient_ != nullptr) {
         ret = mdsClient_->RecoverFile(filename, userinfo, fileId);
         LOG_IF(ERROR, ret != LIBCURVE_ERROR::OK)
-            << "Recover failed, filename: " << filename
-            << ", ret: " << ret;
+            << "Recover failed, filename: " << filename << ", ret: " << ret;
     } else {
         LOG(ERROR) << "global mds client not inited!";
         return -LIBCURVE_ERROR::FAILED;
@@ -523,8 +512,8 @@ int FileClient::Recover(const std::string& filename,
     return -ret;
 }
 
-int FileClient::StatFile(const std::string& filename,
-    const UserInfo_t& userinfo, FileStatInfo* finfo) {
+int FileClient::StatFile(const std::string &filename,
+                         const UserInfo_t &userinfo, FileStatInfo *finfo) {
     FInfo_t fi;
     FileEpoch_t fEpoch;
     int ret;
@@ -538,18 +527,18 @@ int FileClient::StatFile(const std::string& filename,
     }
 
     if (ret == LIBCURVE_ERROR::OK) {
-        finfo->id       = fi.id;
+        finfo->id = fi.id;
         finfo->parentid = fi.parentid;
-        finfo->ctime    = fi.ctime;
-        finfo->length   = fi.length;
+        finfo->ctime = fi.ctime;
+        finfo->length = fi.length;
         finfo->filetype = fi.filetype;
         finfo->stripeUnit = fi.stripeUnit;
         finfo->stripeCount = fi.stripeCount;
 
         memcpy(finfo->filename, fi.filename.c_str(),
-                std::min(sizeof(finfo->filename), fi.filename.size() + 1));
+               std::min(sizeof(finfo->filename), fi.filename.size() + 1));
         memcpy(finfo->owner, fi.owner.c_str(),
-                std::min(sizeof(finfo->owner), fi.owner.size() + 1));
+               std::min(sizeof(finfo->owner), fi.owner.size() + 1));
 
         finfo->fileStatus = static_cast<int>(fi.filestatus);
     }
@@ -557,8 +546,8 @@ int FileClient::StatFile(const std::string& filename,
     return -ret;
 }
 
-int FileClient::Listdir(const std::string& dirpath,
-    const UserInfo_t& userinfo, std::vector<FileStatInfo>* filestatVec) {
+int FileClient::Listdir(const std::string &dirpath, const UserInfo_t &userinfo,
+                        std::vector<FileStatInfo> *filestatVec) {
     LIBCURVE_ERROR ret;
     if (mdsClient_ != nullptr) {
         ret = mdsClient_->Listdir(dirpath, userinfo, filestatVec);
@@ -572,7 +561,7 @@ int FileClient::Listdir(const std::string& dirpath,
     return -ret;
 }
 
-int FileClient::Mkdir(const std::string& dirpath, const UserInfo_t& userinfo) {
+int FileClient::Mkdir(const std::string &dirpath, const UserInfo_t &userinfo) {
     LIBCURVE_ERROR ret;
     if (mdsClient_ != nullptr) {
         ret = mdsClient_->CreateFile(dirpath, userinfo, 0, false);
@@ -593,7 +582,7 @@ int FileClient::Mkdir(const std::string& dirpath, const UserInfo_t& userinfo) {
     return -ret;
 }
 
-int FileClient::Rmdir(const std::string& dirpath, const UserInfo_t& userinfo) {
+int FileClient::Rmdir(const std::string &dirpath, const UserInfo_t &userinfo) {
     LIBCURVE_ERROR ret;
     if (mdsClient_ != nullptr) {
         ret = mdsClient_->DeleteFile(dirpath, userinfo);
@@ -606,8 +595,9 @@ int FileClient::Rmdir(const std::string& dirpath, const UserInfo_t& userinfo) {
     return -ret;
 }
 
-int FileClient::ChangeOwner(const std::string& filename,
-    const std::string& newOwner, const UserInfo_t& userinfo) {
+int FileClient::ChangeOwner(const std::string &filename,
+                            const std::string &newOwner,
+                            const UserInfo_t &userinfo) {
     LIBCURVE_ERROR ret;
     if (mdsClient_ != nullptr) {
         ret = mdsClient_->ChangeOwner(filename, newOwner, userinfo);
@@ -655,14 +645,14 @@ int FileClient::Close(int fd) {
     return -LIBCURVE_ERROR::FAILED;
 }
 
-int FileClient::GetClusterId(char* buf, int len) {
+int FileClient::GetClusterId(char *buf, int len) {
     std::string result = GetClusterId();
 
     if (result.empty()) {
         return -LIBCURVE_ERROR::FAILED;
     }
 
-    if (len >= result.size() + 1) {
+    if (static_cast<size_t>(len) >= result.size() + 1) {
         snprintf(buf, len, "%s", result.c_str());
         return LIBCURVE_ERROR::OK;
     }
@@ -689,7 +679,7 @@ std::string FileClient::GetClusterId() {
     return {};
 }
 
-int FileClient::GetFileInfo(int fd, FInfo* finfo) {
+int FileClient::GetFileInfo(int fd, FInfo *finfo) {
     int ret = -LIBCURVE_ERROR::FAILED;
     ReadLockGuard lk(rwlock_);
 
@@ -745,23 +735,21 @@ bool FileClient::StartDummyServer() {
     return true;
 }
 
-}   // namespace client
-}   // namespace curve
+}  // namespace client
+}  // namespace curve
 
 
 // 全局初始化与反初始化
-int GlobalInit(const char* configpath);
+int GlobalInit(const char *configpath);
 void GlobalUnInit();
 
-int Init(const char* path) {
-    return GlobalInit(path);
-}
+int Init(const char *path) { return GlobalInit(path); }
 
-int Open4Qemu(const char* filename) {
+int Open4Qemu(const char *filename) {
     curve::client::UserInfo_t userinfo;
     std::string realname;
-    bool ret = curve::client::ServiceHelper::GetUserInfoFromFilename(filename,
-               &realname, &userinfo.owner);
+    bool ret = curve::client::ServiceHelper::GetUserInfoFromFilename(
+        filename, &realname, &userinfo.owner);
     if (!ret) {
         LOG(ERROR) << "get user info from filename failed!";
         return -LIBCURVE_ERROR::FAILED;
@@ -775,11 +763,11 @@ int Open4Qemu(const char* filename) {
     return globalclient->Open(realname, userinfo);
 }
 
-int IncreaseEpoch(const char* filename) {
+int IncreaseEpoch(const char *filename) {
     curve::client::UserInfo_t userinfo;
     std::string realname;
-    bool ret = curve::client::ServiceHelper::GetUserInfoFromFilename(filename,
-               &realname, &userinfo.owner);
+    bool ret = curve::client::ServiceHelper::GetUserInfoFromFilename(
+        filename, &realname, &userinfo.owner);
     if (!ret) {
         LOG(ERROR) << "get user info from filename failed!";
         return -LIBCURVE_ERROR::FAILED;
@@ -793,11 +781,11 @@ int IncreaseEpoch(const char* filename) {
     return globalclient->IncreaseEpoch(realname, userinfo);
 }
 
-int Extend4Qemu(const char* filename, int64_t newsize) {
+int Extend4Qemu(const char *filename, int64_t newsize) {
     curve::client::UserInfo_t userinfo;
     std::string realname;
-    bool ret = curve::client::ServiceHelper::GetUserInfoFromFilename(filename,
-               &realname, &userinfo.owner);
+    bool ret = curve::client::ServiceHelper::GetUserInfoFromFilename(
+        filename, &realname, &userinfo.owner);
     if (!ret) {
         LOG(ERROR) << "get user info from filename failed!";
         return -LIBCURVE_ERROR::FAILED;
@@ -812,20 +800,20 @@ int Extend4Qemu(const char* filename, int64_t newsize) {
     }
 
     return globalclient->Extend(realname, userinfo,
-            static_cast<uint64_t>(newsize));
+                                static_cast<uint64_t>(newsize));
 }
 
-int Open(const char* filename, const C_UserInfo_t* userinfo) {
+int Open(const char *filename, const C_UserInfo_t *userinfo) {
     if (globalclient == nullptr) {
         LOG(ERROR) << "not inited!";
         return -LIBCURVE_ERROR::FAILED;
     }
 
     return globalclient->Open(filename,
-            UserInfo(userinfo->owner, userinfo->password));
+                              UserInfo(userinfo->owner, userinfo->password));
 }
 
-int Read(int fd, char* buf, off_t offset, size_t length) {
+int Read(int fd, char *buf, off_t offset, size_t length) {
     if (globalclient == nullptr) {
         LOG(ERROR) << "not inited!";
         return -LIBCURVE_ERROR::FAILED;
@@ -834,7 +822,7 @@ int Read(int fd, char* buf, off_t offset, size_t length) {
     return globalclient->Read(fd, buf, offset, length);
 }
 
-int Write(int fd, const char* buf, off_t offset, size_t length) {
+int Write(int fd, const char *buf, off_t offset, size_t length) {
     if (globalclient == nullptr) {
         LOG(ERROR) << "not inited!";
         return -LIBCURVE_ERROR::FAILED;
@@ -852,32 +840,30 @@ int Discard(int fd, off_t offset, size_t length) {
     return globalclient->Discard(fd, offset, length);
 }
 
-int AioRead(int fd, CurveAioContext* aioctx) {
+int AioRead(int fd, CurveAioContext *aioctx) {
     if (globalclient == nullptr) {
         LOG(ERROR) << "not inited!";
         return -LIBCURVE_ERROR::FAILED;
     }
 
-    DVLOG(9) << "offset: " << aioctx->offset
-        << " length: " << aioctx->length
-        << " op: " << aioctx->op;
+    DVLOG(9) << "offset: " << aioctx->offset << " length: " << aioctx->length
+             << " op: " << aioctx->op;
     return globalclient->AioRead(fd, aioctx);
 }
 
-int AioWrite(int fd, CurveAioContext* aioctx) {
+int AioWrite(int fd, CurveAioContext *aioctx) {
     if (globalclient == nullptr) {
         LOG(ERROR) << "not inited!";
         return -LIBCURVE_ERROR::FAILED;
     }
 
-    DVLOG(9) << "offset: " << aioctx->offset
-        << " length: " << aioctx->length
-        << " op: " << aioctx->op
-        << " buf: " << *(unsigned int*)aioctx->buf;
+    DVLOG(9) << "offset: " << aioctx->offset << " length: " << aioctx->length
+             << " op: " << aioctx->op
+             << " buf: " << *(unsigned int *)aioctx->buf;
     return globalclient->AioWrite(fd, aioctx);
 }
 
-int AioDiscard(int fd, CurveAioContext* aioctx) {
+int AioDiscard(int fd, CurveAioContext *aioctx) {
     if (globalclient == nullptr) {
         LOG(ERROR) << "Not inited!";
         return -LIBCURVE_ERROR::FAILED;
@@ -886,98 +872,96 @@ int AioDiscard(int fd, CurveAioContext* aioctx) {
     return globalclient->AioDiscard(fd, aioctx);
 }
 
-int Create(const char* filename, const C_UserInfo_t* userinfo, size_t size) {
+int Create(const char *filename, const C_UserInfo_t *userinfo, size_t size) {
     if (globalclient == nullptr) {
         LOG(ERROR) << "not inited!";
         return -LIBCURVE_ERROR::FAILED;
     }
 
-    return globalclient->Create(filename,
-            UserInfo(userinfo->owner, userinfo->password), size);
+    return globalclient->Create(
+        filename, UserInfo(userinfo->owner, userinfo->password), size);
 }
 
-int Create2(const char* filename, const C_UserInfo_t* userinfo, size_t size,
-                                uint64_t stripeUnit, uint64_t stripeCount) {
+int Create2(const char *filename, const C_UserInfo_t *userinfo, size_t size,
+            uint64_t stripeUnit, uint64_t stripeCount) {
     if (globalclient == nullptr) {
         LOG(ERROR) << "not inited!";
         return -LIBCURVE_ERROR::FAILED;
     }
 
     return globalclient->Create2(filename,
-            UserInfo(userinfo->owner, userinfo->password),
-                       size, stripeUnit, stripeCount);
+                                 UserInfo(userinfo->owner, userinfo->password),
+                                 size, stripeUnit, stripeCount);
 }
 
-int Rename(const C_UserInfo_t* userinfo,
-    const char* oldpath, const char* newpath) {
+int Rename(const C_UserInfo_t *userinfo, const char *oldpath,
+           const char *newpath) {
     if (globalclient == nullptr) {
         LOG(ERROR) << "not inited!";
         return -LIBCURVE_ERROR::FAILED;
     }
 
     return globalclient->Rename(UserInfo(userinfo->owner, userinfo->password),
-            oldpath, newpath);
+                                oldpath, newpath);
 }
 
-int Extend(const char* filename,
-    const C_UserInfo_t* userinfo, uint64_t newsize) {
+int Extend(const char *filename, const C_UserInfo_t *userinfo,
+           uint64_t newsize) {
     if (globalclient == nullptr) {
         LOG(ERROR) << "not inited!";
         return -LIBCURVE_ERROR::FAILED;
     }
 
-    return globalclient->Extend(filename,
-            UserInfo(userinfo->owner, userinfo->password), newsize);
+    return globalclient->Extend(
+        filename, UserInfo(userinfo->owner, userinfo->password), newsize);
 }
 
-int Unlink(const char* filename, const C_UserInfo_t* userinfo) {
-    if (globalclient == nullptr) {
-        LOG(ERROR) << "not inited!";
-        return -LIBCURVE_ERROR::FAILED;
-    }
-
-    return globalclient->Unlink(filename,
-            UserInfo(userinfo->owner, userinfo->password));
-}
-
-int DeleteForce(const char* filename, const C_UserInfo_t* userinfo) {
+int Unlink(const char *filename, const C_UserInfo_t *userinfo) {
     if (globalclient == nullptr) {
         LOG(ERROR) << "not inited!";
         return -LIBCURVE_ERROR::FAILED;
     }
 
     return globalclient->Unlink(filename,
-            UserInfo(userinfo->owner, userinfo->password),
-            true);
+                                UserInfo(userinfo->owner, userinfo->password));
 }
 
-int Recover(const char* filename, const C_UserInfo_t* userinfo,
-                                  uint64_t fileId) {
+int DeleteForce(const char *filename, const C_UserInfo_t *userinfo) {
     if (globalclient == nullptr) {
         LOG(ERROR) << "not inited!";
         return -LIBCURVE_ERROR::FAILED;
     }
 
-    return globalclient->Recover(filename,
-            UserInfo(userinfo->owner, userinfo->password),
-            fileId);
+    return globalclient->Unlink(
+        filename, UserInfo(userinfo->owner, userinfo->password), true);
 }
 
-DirInfo_t* OpenDir(const char* dirpath, const C_UserInfo_t* userinfo) {
+int Recover(const char *filename, const C_UserInfo_t *userinfo,
+            uint64_t fileId) {
+    if (globalclient == nullptr) {
+        LOG(ERROR) << "not inited!";
+        return -LIBCURVE_ERROR::FAILED;
+    }
+
+    return globalclient->Recover(
+        filename, UserInfo(userinfo->owner, userinfo->password), fileId);
+}
+
+DirInfo_t *OpenDir(const char *dirpath, const C_UserInfo_t *userinfo) {
     if (globalclient == nullptr) {
         LOG(ERROR) << "not inited!";
         return nullptr;
     }
 
-    DirInfo_t* dirinfo = new (std::nothrow) DirInfo_t;
-    dirinfo->dirpath = const_cast<char*>(dirpath);
-    dirinfo->userinfo = const_cast<C_UserInfo_t*>(userinfo);
+    DirInfo_t *dirinfo = new (std::nothrow) DirInfo_t;
+    dirinfo->dirpath = const_cast<char *>(dirpath);
+    dirinfo->userinfo = const_cast<C_UserInfo_t *>(userinfo);
     dirinfo->fileStat = nullptr;
 
     return dirinfo;
 }
 
-int Listdir(DirInfo_t* dirinfo) {
+int Listdir(DirInfo_t *dirinfo) {
     if (globalclient == nullptr) {
         LOG(ERROR) << "not inited!";
         return -LIBCURVE_ERROR::FAILED;
@@ -989,9 +973,10 @@ int Listdir(DirInfo_t* dirinfo) {
     }
 
     std::vector<FileStatInfo> fileStat;
-    int ret = globalclient->Listdir(dirinfo->dirpath,
-             UserInfo(dirinfo->userinfo->owner, dirinfo->userinfo->password),
-             &fileStat);
+    int ret = globalclient->Listdir(
+        dirinfo->dirpath,
+        UserInfo(dirinfo->userinfo->owner, dirinfo->userinfo->password),
+        &fileStat);
 
     dirinfo->dirSize = fileStat.size();
     dirinfo->fileStat = new (std::nothrow) FileStatInfo_t[dirinfo->dirSize];
@@ -1001,7 +986,7 @@ int Listdir(DirInfo_t* dirinfo) {
         return -LIBCURVE_ERROR::FAILED;
     }
 
-    for (int i = 0; i < dirinfo->dirSize; i++) {
+    for (uint64_t i = 0; i < dirinfo->dirSize; i++) {
         dirinfo->fileStat[i].id = fileStat[i].id;
         dirinfo->fileStat[i].parentid = fileStat[i].parentid;
         dirinfo->fileStat[i].filetype = fileStat[i].filetype;
@@ -1011,13 +996,13 @@ int Listdir(DirInfo_t* dirinfo) {
         memcpy(dirinfo->fileStat[i].owner, fileStat[i].owner, NAME_MAX_SIZE);
         memset(dirinfo->fileStat[i].filename, 0, NAME_MAX_SIZE);
         memcpy(dirinfo->fileStat[i].filename, fileStat[i].filename,
-                NAME_MAX_SIZE);
+               NAME_MAX_SIZE);
     }
 
     return ret;
 }
 
-void CloseDir(DirInfo_t* dirinfo) {
+void CloseDir(DirInfo_t *dirinfo) {
     if (dirinfo != nullptr) {
         if (dirinfo->fileStat != nullptr) {
             delete[] dirinfo->fileStat;
@@ -1027,24 +1012,24 @@ void CloseDir(DirInfo_t* dirinfo) {
     }
 }
 
-int Mkdir(const char* dirpath, const C_UserInfo_t* userinfo) {
+int Mkdir(const char *dirpath, const C_UserInfo_t *userinfo) {
     if (globalclient == nullptr) {
         LOG(ERROR) << "not inited!";
         return -LIBCURVE_ERROR::FAILED;
     }
 
     return globalclient->Mkdir(dirpath,
-            UserInfo(userinfo->owner, userinfo->password));
+                               UserInfo(userinfo->owner, userinfo->password));
 }
 
-int Rmdir(const char* dirpath, const C_UserInfo_t* userinfo) {
+int Rmdir(const char *dirpath, const C_UserInfo_t *userinfo) {
     if (globalclient == nullptr) {
         LOG(ERROR) << "not inited!";
         return -LIBCURVE_ERROR::FAILED;
     }
 
     return globalclient->Rmdir(dirpath,
-            UserInfo(userinfo->owner, userinfo->password));
+                               UserInfo(userinfo->owner, userinfo->password));
 }
 
 int Close(int fd) {
@@ -1056,11 +1041,11 @@ int Close(int fd) {
     return globalclient->Close(fd);
 }
 
-int StatFile4Qemu(const char* filename, FileStatInfo* finfo) {
+int StatFile4Qemu(const char *filename, FileStatInfo *finfo) {
     curve::client::UserInfo_t userinfo;
     std::string realname;
-    bool ret = curve::client::ServiceHelper::GetUserInfoFromFilename(filename,
-               &realname, &userinfo.owner);
+    bool ret = curve::client::ServiceHelper::GetUserInfoFromFilename(
+        filename, &realname, &userinfo.owner);
     if (!ret) {
         LOG(ERROR) << "get user info from filename failed!";
         return -LIBCURVE_ERROR::FAILED;
@@ -1074,8 +1059,8 @@ int StatFile4Qemu(const char* filename, FileStatInfo* finfo) {
     return globalclient->StatFile(realname, userinfo, finfo);
 }
 
-int StatFile(const char* filename,
-    const C_UserInfo_t* cuserinfo, FileStatInfo* finfo) {
+int StatFile(const char *filename, const C_UserInfo_t *cuserinfo,
+             FileStatInfo *finfo) {
     if (globalclient == nullptr) {
         LOG(ERROR) << "not inited!";
         return -LIBCURVE_ERROR::FAILED;
@@ -1085,8 +1070,8 @@ int StatFile(const char* filename,
     return globalclient->StatFile(filename, userinfo, finfo);
 }
 
-int ChangeOwner(const char* filename,
-    const char* newOwner, const C_UserInfo_t* cuserinfo) {
+int ChangeOwner(const char *filename, const char *newOwner,
+                const C_UserInfo_t *cuserinfo) {
     if (globalclient == nullptr) {
         LOG(ERROR) << "not inited!";
         return -LIBCURVE_ERROR::FAILED;
@@ -1096,11 +1081,9 @@ int ChangeOwner(const char* filename,
     return globalclient->ChangeOwner(filename, newOwner, userinfo);
 }
 
-void UnInit() {
-    GlobalUnInit();
-}
+void UnInit() { GlobalUnInit(); }
 
-int GetClusterId(char* buf, int len) {
+int GetClusterId(char *buf, int len) {
     if (globalclient == nullptr) {
         LOG(ERROR) << "not inited!";
         return -LIBCURVE_ERROR::FAILED;
@@ -1109,7 +1092,7 @@ int GetClusterId(char* buf, int len) {
     return globalclient->GetClusterId(buf, len);
 }
 
-int GlobalInit(const char* path) {
+int GlobalInit(const char *path) {
     int ret = 0;
     if (globalclientinited_) {
         LOG(INFO) << "global cient already inited!";
@@ -1146,74 +1129,74 @@ void GlobalUnInit() {
     }
 }
 
-const char* LibCurveErrorName(LIBCURVE_ERROR err) {
+const char *LibCurveErrorName(LIBCURVE_ERROR err) {
     switch (err) {
-        case LIBCURVE_ERROR::OK:
-            return "OK";
-        case LIBCURVE_ERROR::EXISTS:
-            return "EXISTS";
-        case LIBCURVE_ERROR::FAILED:
-            return "FAILED";
-        case LIBCURVE_ERROR::DISABLEIO:
-            return "DISABLEIO";
-        case LIBCURVE_ERROR::AUTHFAIL:
-            return "AUTHFAIL";
-        case LIBCURVE_ERROR::DELETING:
-            return "DELETING";
-        case LIBCURVE_ERROR::NOTEXIST:
-            return "NOTEXIST";
-        case LIBCURVE_ERROR::UNDER_SNAPSHOT:
-            return "UNDER_SNAPSHOT";
-        case LIBCURVE_ERROR::NOT_UNDERSNAPSHOT:
-            return "NOT_UNDERSNAPSHOT";
-        case LIBCURVE_ERROR::DELETE_ERROR:
-            return "DELETE_ERROR";
-        case LIBCURVE_ERROR::NOT_ALLOCATE:
-            return "NOT_ALLOCATE";
-        case LIBCURVE_ERROR::NOT_SUPPORT:
-            return "NOT_SUPPORT";
-        case LIBCURVE_ERROR::NOT_EMPTY:
-            return "NOT_EMPTY";
-        case LIBCURVE_ERROR::NO_SHRINK_BIGGER_FILE:
-            return "NO_SHRINK_BIGGER_FILE";
-        case LIBCURVE_ERROR::SESSION_NOTEXISTS:
-            return "SESSION_NOTEXISTS";
-        case LIBCURVE_ERROR::FILE_OCCUPIED:
-            return "FILE_OCCUPIED";
-        case LIBCURVE_ERROR::PARAM_ERROR:
-            return "PARAM_ERROR";
-        case LIBCURVE_ERROR::INTERNAL_ERROR:
-            return "INTERNAL_ERROR";
-        case LIBCURVE_ERROR::CRC_ERROR:
-            return "CRC_ERROR";
-        case LIBCURVE_ERROR::INVALID_REQUEST:
-            return "INVALID_REQUEST";
-        case LIBCURVE_ERROR::DISK_FAIL:
-            return "DISK_FAIL";
-        case LIBCURVE_ERROR::NO_SPACE:
-            return "NO_SPACE";
-        case LIBCURVE_ERROR::NOT_ALIGNED:
-            return "NOT_ALIGNED";
-        case LIBCURVE_ERROR::BAD_FD:
-            return "BAD_FD";
-        case LIBCURVE_ERROR::LENGTH_NOT_SUPPORT:
-            return "LENGTH_NOT_SUPPORT";
-        case LIBCURVE_ERROR::SESSION_NOT_EXIST:
-            return "SESSION_NOT_EXIST";
-        case LIBCURVE_ERROR::STATUS_NOT_MATCH:
-            return "STATUS_NOT_MATCH";
-        case LIBCURVE_ERROR::DELETE_BEING_CLONED:
-            return "DELETE_BEING_CLONED";
-        case LIBCURVE_ERROR::CLIENT_NOT_SUPPORT_SNAPSHOT:
-            return "CLIENT_NOT_SUPPORT_SNAPSHOT";
-        case LIBCURVE_ERROR::SNAPSTHO_FROZEN:
-            return "SNAPSTHO_FROZEN";
-        case LIBCURVE_ERROR::RETRY_UNTIL_SUCCESS:
-            return "RETRY_UNTIL_SUCCESS";
-        case LIBCURVE_ERROR::EPOCH_TOO_OLD:
-            return "EPOCH_TOO_OLD";
-        case LIBCURVE_ERROR::UNKNOWN:
-            break;
+    case LIBCURVE_ERROR::OK:
+        return "OK";
+    case LIBCURVE_ERROR::EXISTS:
+        return "EXISTS";
+    case LIBCURVE_ERROR::FAILED:
+        return "FAILED";
+    case LIBCURVE_ERROR::DISABLEIO:
+        return "DISABLEIO";
+    case LIBCURVE_ERROR::AUTHFAIL:
+        return "AUTHFAIL";
+    case LIBCURVE_ERROR::DELETING:
+        return "DELETING";
+    case LIBCURVE_ERROR::NOTEXIST:
+        return "NOTEXIST";
+    case LIBCURVE_ERROR::UNDER_SNAPSHOT:
+        return "UNDER_SNAPSHOT";
+    case LIBCURVE_ERROR::NOT_UNDERSNAPSHOT:
+        return "NOT_UNDERSNAPSHOT";
+    case LIBCURVE_ERROR::DELETE_ERROR:
+        return "DELETE_ERROR";
+    case LIBCURVE_ERROR::NOT_ALLOCATE:
+        return "NOT_ALLOCATE";
+    case LIBCURVE_ERROR::NOT_SUPPORT:
+        return "NOT_SUPPORT";
+    case LIBCURVE_ERROR::NOT_EMPTY:
+        return "NOT_EMPTY";
+    case LIBCURVE_ERROR::NO_SHRINK_BIGGER_FILE:
+        return "NO_SHRINK_BIGGER_FILE";
+    case LIBCURVE_ERROR::SESSION_NOTEXISTS:
+        return "SESSION_NOTEXISTS";
+    case LIBCURVE_ERROR::FILE_OCCUPIED:
+        return "FILE_OCCUPIED";
+    case LIBCURVE_ERROR::PARAM_ERROR:
+        return "PARAM_ERROR";
+    case LIBCURVE_ERROR::INTERNAL_ERROR:
+        return "INTERNAL_ERROR";
+    case LIBCURVE_ERROR::CRC_ERROR:
+        return "CRC_ERROR";
+    case LIBCURVE_ERROR::INVALID_REQUEST:
+        return "INVALID_REQUEST";
+    case LIBCURVE_ERROR::DISK_FAIL:
+        return "DISK_FAIL";
+    case LIBCURVE_ERROR::NO_SPACE:
+        return "NO_SPACE";
+    case LIBCURVE_ERROR::NOT_ALIGNED:
+        return "NOT_ALIGNED";
+    case LIBCURVE_ERROR::BAD_FD:
+        return "BAD_FD";
+    case LIBCURVE_ERROR::LENGTH_NOT_SUPPORT:
+        return "LENGTH_NOT_SUPPORT";
+    case LIBCURVE_ERROR::SESSION_NOT_EXIST:
+        return "SESSION_NOT_EXIST";
+    case LIBCURVE_ERROR::STATUS_NOT_MATCH:
+        return "STATUS_NOT_MATCH";
+    case LIBCURVE_ERROR::DELETE_BEING_CLONED:
+        return "DELETE_BEING_CLONED";
+    case LIBCURVE_ERROR::CLIENT_NOT_SUPPORT_SNAPSHOT:
+        return "CLIENT_NOT_SUPPORT_SNAPSHOT";
+    case LIBCURVE_ERROR::SNAPSTHO_FROZEN:
+        return "SNAPSTHO_FROZEN";
+    case LIBCURVE_ERROR::RETRY_UNTIL_SUCCESS:
+        return "RETRY_UNTIL_SUCCESS";
+    case LIBCURVE_ERROR::EPOCH_TOO_OLD:
+        return "EPOCH_TOO_OLD";
+    case LIBCURVE_ERROR::UNKNOWN:
+        break;
     }
 
     static thread_local char message[64];

--- a/src/client/mds_client.cpp
+++ b/src/client/mds_client.cpp
@@ -249,6 +249,8 @@ LIBCURVE_ERROR MDSClient::OpenFile(const std::string &filename,
                                    FileEpoch_t *fEpoch,
                                    LeaseSession *lease) {
     auto task = RPCTaskDefine {
+        (void)addrindex;
+        (void)rpctimeoutMS;
         OpenFileResponse response;
         mdsClientMetric_.openFile.qps.count << 1;
         LatencyGuard lg(&mdsClientMetric_.openFile.latency);
@@ -311,6 +313,8 @@ LIBCURVE_ERROR MDSClient::CreateFile(const std::string &filename,
                                      bool normalFile, uint64_t stripeUnit,
                                      uint64_t stripeCount) {
     auto task = RPCTaskDefine {
+        (void)addrindex;
+        (void)rpctimeoutMS;
         CreateFileResponse response;
         mdsClientMetric_.createFile.qps.count << 1;
         LatencyGuard lg(&mdsClientMetric_.createFile.latency);
@@ -346,6 +350,8 @@ LIBCURVE_ERROR MDSClient::CloseFile(const std::string &filename,
                                     const UserInfo_t &userinfo,
                                     const std::string &sessionid) {
     auto task = RPCTaskDefine {
+        (void)addrindex;
+        (void)rpctimeoutMS;
         CloseFileResponse response;
         mdsClientMetric_.closeFile.qps.count << 1;
         LatencyGuard lg(&mdsClientMetric_.closeFile.latency);
@@ -380,6 +386,8 @@ LIBCURVE_ERROR MDSClient::GetFileInfo(const std::string &filename,
                                       const UserInfo_t &uinfo, FInfo_t *fi,
                                       FileEpoch_t *fEpoch) {
     auto task = RPCTaskDefine {
+        (void)addrindex;
+        (void)rpctimeoutMS;
         GetFileInfoResponse response;
         mdsClientMetric_.getFile.qps.count << 1;
         LatencyGuard lg(&mdsClientMetric_.getFile.latency);
@@ -416,6 +424,8 @@ LIBCURVE_ERROR MDSClient::IncreaseEpoch(const std::string& filename,
     FileEpoch_t *fEpoch,
     std::list<CopysetPeerInfo<ChunkServerID>> *csLocs) {
     auto task = RPCTaskDefine {
+        (void)addrindex;
+        (void)rpctimeoutMS;
         IncreaseFileEpochResponse response;
         mdsClientMetric_.increaseEpoch.qps.count << 1;
         LatencyGuard lg(&mdsClientMetric_.increaseEpoch.latency);
@@ -474,6 +484,8 @@ LIBCURVE_ERROR MDSClient::CreateSnapShot(const std::string& filename,
                                          const UserInfo_t& userinfo,
                                          uint64_t* seq) {
     auto task = RPCTaskDefine {
+        (void)addrindex;
+        (void)rpctimeoutMS;
         CreateSnapShotResponse response;
         MDSClientBase::CreateSnapShot(filename, userinfo, &response, cntl,
                                       channel);
@@ -533,6 +545,8 @@ LIBCURVE_ERROR MDSClient::DeleteSnapShot(const std::string &filename,
                                          const UserInfo_t &userinfo,
                                          uint64_t seq) {
     auto task = RPCTaskDefine {
+        (void)addrindex;
+        (void)rpctimeoutMS;
         DeleteSnapShotResponse response;
         MDSClientBase::DeleteSnapShot(filename, userinfo, seq, &response, cntl,
                                       channel);
@@ -565,6 +579,8 @@ LIBCURVE_ERROR MDSClient::ListSnapShot(const std::string &filename,
                                        const std::vector<uint64_t> *seq,
                                        std::map<uint64_t, FInfo> *snapif) {
     auto task = RPCTaskDefine {
+        (void)addrindex;
+        (void)rpctimeoutMS;
         ListSnapShotFileInfoResponse response;
         MDSClientBase::ListSnapShot(filename, userinfo, seq, &response, cntl,
                                     channel);
@@ -597,7 +613,7 @@ LIBCURVE_ERROR MDSClient::ListSnapShot(const std::string &filename,
             snapif->insert(std::make_pair(tempInfo.seqnum, tempInfo));
         }
 
-        if (response.fileinfo_size() != seq->size()) {
+        if (response.fileinfo_size() != static_cast<int>(seq->size())) {
             LOG(WARNING) << "some snapshot info not found!";
             return LIBCURVE_ERROR::NOTEXIST;
         }
@@ -613,6 +629,8 @@ LIBCURVE_ERROR MDSClient::GetSnapshotSegmentInfo(const std::string &filename,
                                                  uint64_t seq, uint64_t offset,
                                                  SegmentInfo *segInfo) {
     auto task = RPCTaskDefine {
+        (void)addrindex;
+        (void)rpctimeoutMS;
         GetOrAllocateSegmentResponse response;
         MDSClientBase::GetSnapshotSegmentInfo(filename, userinfo, seq, offset,
                                               &response, cntl, channel);
@@ -676,6 +694,8 @@ LIBCURVE_ERROR MDSClient::RefreshSession(const std::string &filename,
                                          LeaseRefreshResult *resp,
                                          LeaseSession *lease) {
     auto task = RPCTaskDefine {
+        (void)addrindex;
+        (void)rpctimeoutMS;
         ReFreshSessionResponse response;
         mdsClientMetric_.refreshSession.qps.count << 1;
         LatencyGuard lg(&mdsClientMetric_.refreshSession.latency);
@@ -750,6 +770,8 @@ LIBCURVE_ERROR MDSClient::CheckSnapShotStatus(const std::string &filename,
                                               uint64_t seq,
                                               FileStatus *filestatus) {
     auto task = RPCTaskDefine {
+        (void)addrindex;
+        (void)rpctimeoutMS;
         CheckSnapShotStatusResponse response;
         MDSClientBase::CheckSnapShotStatus(filename, userinfo, seq, &response,
                                            cntl, channel);
@@ -785,6 +807,8 @@ MDSClient::GetServerList(const LogicPoolID &logicalpooid,
                          const std::vector<CopysetID> &copysetidvec,
                          std::vector<CopysetInfo<ChunkServerID>> *cpinfoVec) {
     auto task = RPCTaskDefine {
+        (void)addrindex;
+        (void)rpctimeoutMS;
         GetChunkServerListInCopySetsResponse response;
         mdsClientMetric_.getServerList.qps.count << 1;
         LatencyGuard lg(&mdsClientMetric_.getServerList.latency);
@@ -848,6 +872,8 @@ MDSClient::GetServerList(const LogicPoolID &logicalpooid,
 
 LIBCURVE_ERROR MDSClient::GetClusterInfo(ClusterContext *clsctx) {
     auto task = RPCTaskDefine {
+        (void)addrindex;
+        (void)rpctimeoutMS;
         curve::mds::topology::GetClusterInfoResponse response;
         MDSClientBase::GetClusterInfo(&response, cntl, channel);
 
@@ -873,6 +899,8 @@ LIBCURVE_ERROR MDSClient::CreateCloneFile(
     const UserInfo_t &userinfo, uint64_t size, uint64_t sn, uint32_t chunksize,
     uint64_t stripeUnit, uint64_t stripeCount, FInfo *fileinfo) {
     auto task = RPCTaskDefine {
+        (void)addrindex;
+        (void)rpctimeoutMS;
         CreateCloneFileResponse response;
         MDSClientBase::CreateCloneFile(source, destination, userinfo, size, sn,
                                        chunksize, stripeUnit, stripeCount,
@@ -928,6 +956,8 @@ LIBCURVE_ERROR MDSClient::SetCloneFileStatus(const std::string &filename,
                                              const UserInfo_t &userinfo,
                                              uint64_t fileID) {
     auto task = RPCTaskDefine {
+        (void)addrindex;
+        (void)rpctimeoutMS;
         SetCloneFileStatusResponse response;
         MDSClientBase::SetCloneFileStatus(filename, filestatus, userinfo,
                                           fileID, &response, cntl, channel);
@@ -960,6 +990,8 @@ LIBCURVE_ERROR MDSClient::GetOrAllocateSegment(bool allocate, uint64_t offset,
                                                const FileEpoch_t *fEpoch,
                                                SegmentInfo *segInfo) {
     auto task = RPCTaskDefine {
+        (void)addrindex;
+        (void)rpctimeoutMS;
         GetOrAllocateSegmentResponse response;
         mdsClientMetric_.getOrAllocateSegment.qps.count << 1;
         LatencyGuard lg(&mdsClientMetric_.getOrAllocateSegment.latency);
@@ -1023,6 +1055,8 @@ LIBCURVE_ERROR MDSClient::GetOrAllocateSegment(bool allocate, uint64_t offset,
 LIBCURVE_ERROR MDSClient::DeAllocateSegment(const FInfo *fileInfo,
                                             uint64_t offset) {
     auto task = RPCTaskDefine {
+        (void)addrindex;
+        (void)rpctimeoutMS;
         DeAllocateSegmentResponse response;
         mdsClientMetric_.deAllocateSegment.qps.count << 1;
         LatencyGuard lg(&mdsClientMetric_.deAllocateSegment.latency);
@@ -1063,6 +1097,8 @@ LIBCURVE_ERROR MDSClient::RenameFile(const UserInfo_t &userinfo,
                                      uint64_t originId,
                                      uint64_t destinationId) {
     auto task = RPCTaskDefine {
+        (void)addrindex;
+        (void)rpctimeoutMS;
         RenameFileResponse response;
         mdsClientMetric_.renameFile.qps.count << 1;
         LatencyGuard lg(&mdsClientMetric_.renameFile.latency);
@@ -1102,6 +1138,8 @@ LIBCURVE_ERROR MDSClient::RenameFile(const UserInfo_t &userinfo,
 LIBCURVE_ERROR MDSClient::Extend(const std::string &filename,
                                  const UserInfo_t &userinfo, uint64_t newsize) {
     auto task = RPCTaskDefine {
+        (void)addrindex;
+        (void)rpctimeoutMS;
         ExtendFileResponse response;
         mdsClientMetric_.extendFile.qps.count << 1;
         LatencyGuard lg(&mdsClientMetric_.extendFile.latency);
@@ -1135,6 +1173,8 @@ LIBCURVE_ERROR MDSClient::DeleteFile(const std::string &filename,
                                      const UserInfo_t &userinfo,
                                      bool deleteforce, uint64_t fileid) {
     auto task = RPCTaskDefine {
+        (void)addrindex;
+        (void)rpctimeoutMS;
         DeleteFileResponse response;
         mdsClientMetric_.deleteFile.qps.count << 1;
         LatencyGuard lg(&mdsClientMetric_.deleteFile.latency);
@@ -1173,6 +1213,8 @@ LIBCURVE_ERROR MDSClient::RecoverFile(const std::string &filename,
                                       const UserInfo_t &userinfo,
                                       uint64_t fileid) {
     auto task = RPCTaskDefine {
+        (void)addrindex;
+        (void)rpctimeoutMS;
         RecoverFileResponse response;
         mdsClientMetric_.recoverFile.qps.count << 1;
         LatencyGuard lg(&mdsClientMetric_.recoverFile.latency);
@@ -1205,6 +1247,8 @@ LIBCURVE_ERROR MDSClient::ChangeOwner(const std::string &filename,
                                       const std::string &newOwner,
                                       const UserInfo_t &userinfo) {
     auto task = RPCTaskDefine {
+        (void)addrindex;
+        (void)rpctimeoutMS;
         ChangeOwnerResponse response;
         mdsClientMetric_.changeOwner.qps.count << 1;
         LatencyGuard lg(&mdsClientMetric_.changeOwner.latency);
@@ -1244,6 +1288,8 @@ LIBCURVE_ERROR MDSClient::Listdir(const std::string &dirpath,
                                   const UserInfo_t &userinfo,
                                   std::vector<FileStatInfo> *filestatVec) {
     auto task = RPCTaskDefine {
+        (void)addrindex;
+        (void)rpctimeoutMS;
         ListDirResponse response;
         mdsClientMetric_.listDir.qps.count << 1;
         LatencyGuard lg(&mdsClientMetric_.listDir.latency);
@@ -1306,6 +1352,8 @@ LIBCURVE_ERROR MDSClient::GetChunkServerInfo(const PeerAddr &csAddr,
     }
 
     auto task = RPCTaskDefine {
+        (void)addrindex;
+        (void)rpctimeoutMS;
         curve::mds::topology::GetChunkServerInfoResponse response;
 
         mdsClientMetric_.getChunkServerId.qps.count << 1;
@@ -1366,6 +1414,8 @@ LIBCURVE_ERROR
 MDSClient::ListChunkServerInServer(const std::string &serverIp,
                                    std::vector<ChunkServerID> *csIds) {
     auto task = RPCTaskDefine {
+        (void)addrindex;
+        (void)rpctimeoutMS;
         curve::mds::topology::ListChunkServerResponse response;
 
         mdsClientMetric_.listChunkserverInServer.qps.count << 1;

--- a/src/client/mds_client_base.cpp
+++ b/src/client/mds_client_base.cpp
@@ -377,7 +377,6 @@ void MDSClientBase::GetOrAllocateSegment(bool allocate,
 
     // convert the user offset to seg  offset
     uint64_t segmentsize = fi->segmentsize;
-    uint64_t chunksize = fi->chunksize;
     uint64_t seg_offset = (offset / segmentsize) * segmentsize;
     request.set_filename(fi->fullPathName);
     request.set_offset(seg_offset);

--- a/src/client/metacache.cpp
+++ b/src/client/metacache.cpp
@@ -214,8 +214,7 @@ void MetaCache::UpdateCopysetInfoIfMatchCurrentLeader(
     CopysetID copysetId,
     const PeerAddr& leaderAddr) {
     std::vector<CopysetInfo<ChunkServerID>> copysetInfos;
-    int ret =
-        mdsclient_->GetServerList(logicPoolId, {copysetId}, &copysetInfos);
+    (void)mdsclient_->GetServerList(logicPoolId, {copysetId}, &copysetInfos);
 
     bool needUpdate = (!copysetInfos.empty()) &&
                       (copysetInfos[0].HasPeerInCopyset(leaderAddr));

--- a/src/client/metacache_struct.h
+++ b/src/client/metacache_struct.h
@@ -55,7 +55,7 @@ template <typename T> struct CURVE_CACHELINE_ALIGNMENT CopysetPeerInfo {
 
     CopysetPeerInfo() = default;
 
-    CopysetPeerInfo(const CopysetPeerInfo&) = default;
+    CopysetPeerInfo(const CopysetPeerInfo &) = default;
     CopysetPeerInfo &operator=(const CopysetPeerInfo &other) = default;
 
     CopysetPeerInfo(const T &cid, const PeerAddr &internal,
@@ -160,7 +160,7 @@ template <typename T> struct CURVE_CACHELINE_ALIGNMENT CopysetInfo {
 
     bool GetCurrentLeaderID(T *id) const {
         if (leaderindex_ >= 0) {
-            if (csinfos_.size() < leaderindex_) {
+            if (static_cast<int>(csinfos_.size()) < leaderindex_) {
                 return false;
             } else {
                 *id = csinfos_[leaderindex_].peerID;
@@ -212,7 +212,8 @@ template <typename T> struct CURVE_CACHELINE_ALIGNMENT CopysetInfo {
      */
     int GetLeaderInfo(T *peerid, EndPoint *ep) {
         // 第一次获取leader,如果当前leader信息没有确定，返回-1，由外部主动发起更新leader
-        if (leaderindex_ < 0 || leaderindex_ >= csinfos_.size()) {
+        if (leaderindex_ < 0 ||
+            leaderindex_ >= static_cast<int>(csinfos_.size())) {
             LOG(INFO) << "GetLeaderInfo pool " << lpid_ << ", copyset " << cpid_
                       << " has no leader";
 

--- a/src/client/request_sender.cpp
+++ b/src/client/request_sender.cpp
@@ -80,6 +80,7 @@ int RequestSender::ReadChunk(const ChunkIDInfo& idinfo,
                              uint64_t appliedindex,
                              const RequestSourceInfo& sourceInfo,
                              ClientClosure *done) {
+    (void)sn;
     brpc::ClosureGuard doneGuard(done);
     brpc::Controller *cntl = new brpc::Controller();
     ChunkResponse *response = new ChunkResponse();

--- a/src/client/splitor.cpp
+++ b/src/client/splitor.cpp
@@ -143,8 +143,6 @@ bool Splitor::AssignInternal(IOTracker* iotracker, MetaCache* metaCache,
                              MDSClient* mdsclient, const FInfo_t* fileInfo,
                              const FileEpoch_t* fEpoch,
                              ChunkIndex chunkidx) {
-    const auto maxSplitSizeBytes = 1024 * iosplitopt_.fileIOSplitMaxSizeKB;
-
     lldiv_t res = std::div(
         static_cast<long long>(chunkidx) * fileInfo->chunksize,  // NOLINT
         static_cast<long long>(fileInfo->segmentsize));          // NOLINT
@@ -369,7 +367,6 @@ int Splitor::SplitForStripe(IOTracker* iotracker, MetaCache* metaCache,
 
     uint64_t cur = offset;
     uint64_t left = length;
-    uint64_t curChunkIndex = 0;
 
     while (left > 0) {
         uint64_t blockIndex = cur / stripeUnit;
@@ -427,11 +424,11 @@ uint64_t Splitor::ProcessUnalignedRequests(const off_t currentOffset,
     uint64_t alignedEndOffset =
         common::align_down(currentEndOff, iosplitopt_.alignment.cloneVolume);
 
-    if (currentOffset == alignedStartOffset &&
+    if (static_cast<uint64_t>(currentOffset) == alignedStartOffset &&
         currentEndOff == alignedEndOffset) {
         padding->aligned = true;
     } else {
-        if (currentOffset == alignedStartOffset) {
+        if (static_cast<uint64_t>(currentOffset) == alignedStartOffset) {
             padding->aligned = false;
             padding->type = RequestContext::Padding::Right;
             padding->offset = alignedEndOffset;

--- a/src/client/unstable_helper.cpp
+++ b/src/client/unstable_helper.cpp
@@ -24,15 +24,14 @@
 namespace curve {
 namespace client {
 
-UnstableState UnstableHelper::GetCurrentUnstableState(
-    ChunkServerID csId,
-    const butil::EndPoint& csEndPoint) {
-
+UnstableState
+UnstableHelper::GetCurrentUnstableState(ChunkServerID csId,
+                                        const butil::EndPoint &csEndPoint) {
     std::string ip = butil::ip2str(csEndPoint.ip).c_str();
 
     mtx_.lock();
     // 如果当前ip已经超过阈值，则直接返回chunkserver unstable
-    int unstabled = serverUnstabledChunkservers_[ip].size();
+    uint32_t unstabled = serverUnstabledChunkservers_[ip].size();
     if (unstabled >= option_.serverUnstableThreshold) {
         serverUnstabledChunkservers_[ip].emplace(csId);
         mtx_.unlock();

--- a/src/common/concurrent/dlock.h
+++ b/src/common/concurrent/dlock.h
@@ -32,8 +32,8 @@
 namespace curve {
 namespace common {
 
-using curve::kvstorage::KVStorageClient;
 using curve::common::Uncopyable;
+using curve::kvstorage::KVStorageClient;
 
 struct DLockOpts {
     std::string pfx;
@@ -47,19 +47,19 @@ struct DLockOpts {
 
 class DLock : public Uncopyable {
  public:
-    explicit DLock(const DLockOpts &opts) : opts_(opts), locker_(0) {}
+    explicit DLock(const DLockOpts &opts) : locker_(0), opts_(opts) {}
     virtual ~DLock();
 
     /**
      * @brief Init the etcd Mutex
-     * 
+     *
      * @return lock leaseid
      */
     virtual int64_t Init();
 
     /**
      * @brief lock the object
-     * 
+     *
      * @return error code EtcdErrCode
      */
     virtual int Lock();
@@ -97,8 +97,8 @@ class DLock : public Uncopyable {
     const DLockOpts &opts_;
 };
 
-}   // namespace common
-}   // namespace curve
+}  // namespace common
+}  // namespace curve
 
 
 #endif  // SRC_COMMON_CONCURRENT_DLOCK_H_

--- a/src/common/fs_util.h
+++ b/src/common/fs_util.h
@@ -20,8 +20,8 @@
  * Author: charisu
  */
 
-#ifndef  SRC_COMMON_FS_UTIL_H_
-#define  SRC_COMMON_FS_UTIL_H_
+#ifndef SRC_COMMON_FS_UTIL_H_
+#define SRC_COMMON_FS_UTIL_H_
 
 #include <glog/logging.h>
 #include <string>
@@ -32,8 +32,8 @@ namespace curve {
 namespace common {
 
 // 计算path2相对于path1的相对路径
-inline std::string CalcRelativePath(const std::string& path1,
-                                    const std::string& path2) {
+inline std::string CalcRelativePath(const std::string &path1,
+                                    const std::string &path2) {
     if (path1.empty() || path2.empty()) {
         return "";
     }
@@ -41,7 +41,7 @@ inline std::string CalcRelativePath(const std::string& path1,
     std::vector<std::string> dirs2;
     SplitString(path1, "/", &dirs1);
     SplitString(path2, "/", &dirs2);
-    int unmatchedIndex = 0;
+    size_t unmatchedIndex = 0;
     while (unmatchedIndex < dirs1.size() && unmatchedIndex < dirs2.size()) {
         if (dirs1[unmatchedIndex] != dirs2[unmatchedIndex]) {
             break;
@@ -52,13 +52,13 @@ inline std::string CalcRelativePath(const std::string& path1,
     if (unmatchedIndex == dirs1.size()) {
         rpath.append(".");
     }
-    for (int i = 0; i < dirs1.size() - unmatchedIndex; ++i) {
+    for (int i = 0; i < static_cast<int>(dirs1.size() - unmatchedIndex); ++i) {
         if (i > 0) {
             rpath.append("/");
         }
         rpath.append("..");
     }
-    for (int i = unmatchedIndex; i < dirs2.size(); ++i) {
+    for (size_t i = unmatchedIndex; i < dirs2.size(); ++i) {
         rpath.append("/");
         rpath.append(dirs2[i]);
     }
@@ -66,8 +66,7 @@ inline std::string CalcRelativePath(const std::string& path1,
 }
 
 // Check whether the path2 is the subpath of path1
-inline bool IsSubPath(const std::string& path1,
-                      const std::string& path2) {
+inline bool IsSubPath(const std::string &path1, const std::string &path2) {
     return StringStartWith(CalcRelativePath(path1, path2), "./");
 }
 
@@ -75,4 +74,3 @@ inline bool IsSubPath(const std::string& path1,
 }  // namespace curve
 
 #endif  // SRC_COMMON_FS_UTIL_H_
-

--- a/src/common/s3_adapter.h
+++ b/src/common/s3_adapter.h
@@ -22,6 +22,7 @@
 
 #ifndef SRC_COMMON_S3_ADAPTER_H_
 #define SRC_COMMON_S3_ADAPTER_H_
+#include <cstdint>
 #include <map>
 #include <list>
 #include <string>
@@ -54,7 +55,7 @@
 #include <aws/core/utils/memory/stl/AWSStringStream.h>    //NOLINT
 #include <aws/s3/model/BucketLocationConstraint.h>        //NOLINT
 #include <aws/s3/model/CreateBucketConfiguration.h>       //NOLINT
-#include <aws/core/utils/threading/Executor.h>            // NOLINT
+#include <aws/core/utils/threading/Executor.h>            //NOLINT
 #include "src/common/configuration.h"
 #include "src/common/throttle.h"
 
@@ -116,7 +117,7 @@ struct GetObjectAsyncContext : public Aws::Client::AsyncCallerContext {
     size_t len;
     GetObjectAsyncCallBack cb;
     int retCode;
-    int retry;
+    uint32_t retry;
     size_t actualLen;
 };
 
@@ -144,9 +145,7 @@ class S3Adapter {
         s3Client_ = nullptr;
         throttle_ = nullptr;
     }
-    virtual ~S3Adapter() {
-        Deinit();
-    }
+    virtual ~S3Adapter() { Deinit(); }
     /**
      * 初始化S3Adapter
      */
@@ -360,10 +359,15 @@ class FakeS3Adapter : public S3Adapter {
 
     int PutObject(const Aws::String &key, const char *buffer,
                   const size_t bufferSize) override {
+        (void)key;
+        (void)buffer;
+        (void)bufferSize;
         return 0;
     }
 
     int PutObject(const Aws::String &key, const std::string &data) override {
+        (void)key;
+        (void)data;
         return 0;
     }
 
@@ -374,6 +378,8 @@ class FakeS3Adapter : public S3Adapter {
     }
 
     int GetObject(const Aws::String &key, std::string *data) override {
+        (void)key;
+        (void)data;
         // just return 4M data
         data->resize(4 * 1024 * 1024, '1');
         return 0;
@@ -381,6 +387,8 @@ class FakeS3Adapter : public S3Adapter {
 
     int GetObject(const std::string &key, char *buf, off_t offset,
                   size_t len) override {
+        (void)key;
+        (void)offset;
         // juset return len data
         memset(buf, '1', len);
         return 0;
@@ -393,13 +401,20 @@ class FakeS3Adapter : public S3Adapter {
         context->cb(this, context);
     }
 
-    int DeleteObject(const Aws::String &key) override { return 0; }
-
-    int DeleteObjects(const std::list<Aws::String> &keyList) override {
+    int DeleteObject(const Aws::String &key) override {
+        (void)key;
         return 0;
     }
 
-    bool ObjectExist(const Aws::String &key) override { return true; }
+    int DeleteObjects(const std::list<Aws::String> &keyList) override {
+        (void)keyList;
+        return 0;
+    }
+
+    bool ObjectExist(const Aws::String &key) override {
+        (void)key;
+        return true;
+    }
 };
 
 

--- a/src/fs/ext4_filesystem_impl.cpp
+++ b/src/fs/ext4_filesystem_impl.cpp
@@ -337,7 +337,7 @@ int Ext4FileSystemImpl::Write(int fd,
                               butil::IOBuf buf,
                               uint64_t offset,
                               int length) {
-    if (length != buf.size()) {
+    if (length != static_cast<int>(buf.size())) {
         LOG(ERROR) << "IOBuf::pcut_into_file_descriptor failed, fd: " << fd
                    << ", data size doesn't equal to length, data size: "
                    << buf.size() << ", length: " << length;
@@ -345,7 +345,6 @@ int Ext4FileSystemImpl::Write(int fd,
     }
 
     int remainLength = length;
-    int relativeOffset = 0;
     int retryTimes = 0;
 
     while (remainLength > 0) {
@@ -380,6 +379,9 @@ int Ext4FileSystemImpl::Sync(int fd) {
 int Ext4FileSystemImpl::Append(int fd,
                                const char *buf,
                                int length) {
+    (void)fd;
+    (void)buf;
+    (void)length;
     // TODO(yyk)
     return 0;
 }

--- a/src/fs/local_filesystem.cpp
+++ b/src/fs/local_filesystem.cpp
@@ -32,6 +32,7 @@ namespace fs {
 std::shared_ptr<LocalFileSystem> LocalFsFactory::CreateFs(
     FileSystemType type,
     const std::string& deviceID) {
+    (void)deviceID;
     std::shared_ptr<LocalFileSystem> localFs;
     if (type == FileSystemType::EXT4) {
         localFs = Ext4FileSystemImpl::getInstance();

--- a/src/mds/copyset/copyset_manager.cpp
+++ b/src/mds/copyset/copyset_manager.cpp
@@ -57,7 +57,7 @@ bool CopysetManager::GenCopyset(const ClusterInfo& cluster,
     }
 
     int numChunkServers = cluster.GetClusterSize();
-    if (*scatterWidth > (numChunkServers - 1)) {
+    if (static_cast<int32_t>(*scatterWidth) > (numChunkServers - 1)) {
         // It's impossible that scatterWidth is lager than cluster size
         return false;
     }

--- a/src/mds/copyset/copyset_policy.cpp
+++ b/src/mds/copyset/copyset_policy.cpp
@@ -131,6 +131,8 @@ void CopysetZoneShufflePolicy::GetMinCopySetFromScatterWidth(
 int CopysetZoneShufflePolicy::GetMaxPermutationNum(int numCopysets,
     int numChunkServers,
     int numReplicas) {
+    (void)numChunkServers;
+    (void)numReplicas;
     return numCopysets;
 }
 

--- a/src/mds/heartbeat/chunkserver_healthy_checker.cpp
+++ b/src/mds/heartbeat/chunkserver_healthy_checker.cpp
@@ -90,7 +90,6 @@ bool ChunkserverHealthyChecker::ChunkServerStateNeedUpdate(
         return false;
     }
 
-    bool shouldOffline = true;
     if (OnlineState::OFFLINE != info.state) {
         LOG(WARNING) << "chunkserver " << info.csId << " is offline. "
                 << timePass / milliseconds(1) << "ms from last heartbeat";

--- a/src/mds/heartbeat/heartbeat_service.cpp
+++ b/src/mds/heartbeat/heartbeat_service.cpp
@@ -36,6 +36,7 @@ void HeartbeatServiceImpl::ChunkServerHeartbeat(
     const ::curve::mds::heartbeat::ChunkServerHeartbeatRequest *request,
     ::curve::mds::heartbeat::ChunkServerHeartbeatResponse *response,
     ::google::protobuf::Closure *done) {
+    (void)controller;
     brpc::ClosureGuard doneGuard(done);
     heartbeatManager_->ChunkServerHeartbeat(*request, response);
 }

--- a/src/mds/nameserver2/allocstatistic/alloc_statistic.h
+++ b/src/mds/nameserver2/allocstatistic/alloc_statistic.h
@@ -32,12 +32,12 @@
 #include "src/common/concurrent/concurrent.h"
 #include "src/common/interruptible_sleeper.h"
 
-using ::curve::mds::topology::PoolIdType;
 using ::curve::common::Atomic;
+using ::curve::common::InterruptibleSleeper;
 using ::curve::common::Mutex;
 using ::curve::common::RWLock;
 using ::curve::common::Thread;
-using ::curve::common::InterruptibleSleeper;
+using ::curve::mds::topology::PoolIdType;
 
 namespace curve {
 namespace mds {
@@ -49,7 +49,8 @@ using ::curve::kvstorage::EtcdClientImp;
  * The statistics are divided into two parts:
  * part1:
  *     1. statistics of the allocation amount before the designated revision
- *     2. record the segment allocation amount of each revision since mds started
+ *     2. record the segment allocation amount of each revision since mds
+ * started
  *     3. combine the data in 1 and 2
  * part2: the background periodically persists the merged data in part1
  *
@@ -76,17 +77,12 @@ class AllocStatistic {
      * @param[in] client Etcd client
      */
     AllocStatistic(uint64_t periodicPersistInterMs, uint64_t retryInterMs,
-        std::shared_ptr<EtcdClientImp> client) :
-        client_(client),
-        currentValueAvalible_(false),
-        segmentAllocFromEtcdOK_(false),
-        stop_(true),
-        periodicPersistInterMs_(periodicPersistInterMs),
-        retryInterMs_(retryInterMs) {}
+                   std::shared_ptr<EtcdClientImp> client)
+        : client_(client), segmentAllocFromEtcdOK_(false),
+          currentValueAvalible_(false), retryInterMs_(retryInterMs),
+          periodicPersistInterMs_(periodicPersistInterMs), stop_(true) {}
 
-    ~AllocStatistic() {
-        Stop();
-    }
+    ~AllocStatistic() { Stop(); }
 
     /**
      * @brief Init Obtains the allocated segment information and information in
@@ -97,7 +93,7 @@ class AllocStatistic {
      */
     int Init();
 
-   /**
+    /**
      * @brief Run 1. get all the segments under the specified revision
      *            2. persist the statistics of allocated segment size in memory
      *               under each logicalPool regularly
@@ -138,11 +134,10 @@ class AllocStatistic {
      * @param[in] changeSize Segment reduction
      * @param[in] revision Version corresponding to this change
      */
-    virtual void DeAllocSpace(
-        PoolIdType, int64_t changeSize, int64_t revision);
+    virtual void DeAllocSpace(PoolIdType, int64_t changeSize, int64_t revision);
 
  private:
-     /**
+    /**
      * @brief CalculateSegmentAlloc Get all the segment records of the
      *                         specified revision from Etcd
      */
@@ -154,14 +149,15 @@ class AllocStatistic {
      */
     void PeriodicPersist();
 
-     /**
+    /**
      * @brief HandleResult Dealing with the situation that error occur when
      *                     obtaining all segment records of specified revision
      */
     bool HandleResult(int res);
 
     /**
-     * @brief DoMerge For each logicalPool, merge the change amount and data read in Etcd //NOLINT
+     * @brief DoMerge For each logicalPool, merge the change amount and data
+     * read in Etcd //NOLINT
      */
     void DoMerge();
 
@@ -201,7 +197,8 @@ class AllocStatistic {
     std::map<PoolIdType, int64_t> existSegmentAllocValues_;
     RWLock existSegmentAllocValuesLock_;
 
-    // At the beginning, stores allocation data of the segment before specified revision //NOLINT
+    // At the beginning, stores allocation data of the segment before specified
+    // revision
     // Later, stores the merged value
     std::map<PoolIdType, int64_t> segmentAlloc_;
     RWLock segmentAllocLock_;
@@ -230,7 +227,8 @@ class AllocStatistic {
 
     InterruptibleSleeper sleeper_;
 
-    // thread for periodically persisting allocated segment size of each logical pool //NOLINT
+    // thread for periodically persisting allocated segment size of each logical
+    // pool
     Thread periodicPersist_;
 
     // thread for calculating allocated segment size under specified revision
@@ -240,4 +238,3 @@ class AllocStatistic {
 }  // namespace curve
 
 #endif  // SRC_MDS_NAMESERVER2_ALLOCSTATISTIC_ALLOC_STATISTIC_H_
-

--- a/src/mds/nameserver2/allocstatistic/alloc_statistic_helper.cpp
+++ b/src/mds/nameserver2/allocstatistic/alloc_statistic_helper.cpp
@@ -32,22 +32,21 @@
 namespace curve {
 namespace mds {
 
-using ::curve::common::SEGMENTALLOCSIZEKEYEND;
 using ::curve::common::SEGMENTALLOCSIZEKEY;
-using ::curve::common::SEGMENTINFOKEYPREFIX;
+using ::curve::common::SEGMENTALLOCSIZEKEYEND;
 using ::curve::common::SEGMENTINFOKEYEND;
+using ::curve::common::SEGMENTINFOKEYPREFIX;
 const int GETBUNDLE = 1000;
 int AllocStatisticHelper::GetExistSegmentAllocValues(
     std::map<PoolIdType, int64_t> *out,
     const std::shared_ptr<EtcdClientImp> &client) {
     // Obtain the segmentSize value of corresponding logical pools from Etcd
     std::vector<std::string> allocVec;
-    int res = client->List(
-        SEGMENTALLOCSIZEKEY, SEGMENTALLOCSIZEKEYEND, &allocVec);
+    int res =
+        client->List(SEGMENTALLOCSIZEKEY, SEGMENTALLOCSIZEKEYEND, &allocVec);
     if (res != EtcdErrCode::EtcdOK) {
         LOG(ERROR) << "list [" << SEGMENTALLOCSIZEKEY << ","
-                   << SEGMENTALLOCSIZEKEYEND << ") fail, errorCode: "
-                   << res;
+                   << SEGMENTALLOCSIZEKEYEND << ") fail, errorCode: " << res;
         return -1;
     }
 
@@ -55,8 +54,8 @@ int AllocStatisticHelper::GetExistSegmentAllocValues(
     for (auto &item : allocVec) {
         PoolIdType lid;
         uint64_t alloc;
-        bool res = NameSpaceStorageCodec::DecodeSegmentAllocValue(
-            item, &lid, &alloc);
+        bool res =
+            NameSpaceStorageCodec::DecodeSegmentAllocValue(item, &lid, &alloc);
         if (false == res) {
             LOG(ERROR) << "decode segment alloc value: " << item << " fail";
             continue;
@@ -83,8 +82,9 @@ int AllocStatisticHelper::CalculateSegmentAlloc(
 
         // get segments in bundles from Etcd, GETBUNDLE is the number of items
         // to fetch
-        int res = client->ListWithLimitAndRevision(
-           startKey, SEGMENTINFOKEYEND, GETBUNDLE, revision, &values, &lastKey);
+        int res = client->ListWithLimitAndRevision(startKey, SEGMENTINFOKEYEND,
+                                                   GETBUNDLE, revision, &values,
+                                                   &lastKey);
         if (res != EtcdErrCode::EtcdOK) {
             LOG(ERROR) << "list [" << startKey << "," << SEGMENTINFOKEYEND
                        << ") at revision: " << revision
@@ -94,17 +94,17 @@ int AllocStatisticHelper::CalculateSegmentAlloc(
         }
 
         // decode the obtained value
-        int startPos = 1;
+        size_t startPos = 1;
         if (startKey == SEGMENTINFOKEYPREFIX) {
             startPos = 0;
         }
-        for ( ; startPos < values.size(); startPos++) {
+        for (; startPos < values.size(); startPos++) {
             PageFileSegment segment;
-            bool res = NameSpaceStorageCodec::DecodeSegment(
-                values[startPos], &segment);
+            bool res = NameSpaceStorageCodec::DecodeSegment(values[startPos],
+                                                            &segment);
             if (false == res) {
-                LOG(ERROR) << "decode segment item{"
-                          << values[startPos] << "} fail";
+                LOG(ERROR) << "decode segment item{" << values[startPos]
+                           << "} fail";
                 return -1;
             } else {
                 (*out)[segment.logicalpoolid()] += segment.segmentsize();

--- a/src/mds/nameserver2/chunk_allocator.cpp
+++ b/src/mds/nameserver2/chunk_allocator.cpp
@@ -63,7 +63,7 @@ bool ChunkSegmentAllocatorImpl::AllocateChunkSegment(FileType type,
             return false;
         }
         auto logicalpoolId = copysets[0].logicalPoolId;
-        for (auto i = 0; i < copysets.size(); i++) {
+        for (size_t i = 0; i < copysets.size(); i++) {
             if (copysets[i].logicalPoolId !=  logicalpoolId) {
                 LOG(ERROR) << "Allocate Copysets id not same, copysets["
                             << i << "] = "

--- a/src/mds/nameserver2/clean_core.cpp
+++ b/src/mds/nameserver2/clean_core.cpp
@@ -172,7 +172,6 @@ StatusCode CleanCore::CleanDiscardSegment(
     const DiscardSegmentInfo& discardSegmentInfo, TaskProgress* progress) {
     const FileInfo& fileInfo = discardSegmentInfo.fileinfo();
     const PageFileSegment& segment = discardSegmentInfo.pagefilesegment();
-    const LogicalPoolID logicalPoolId = segment.logicalpoolid();
     const SeqNum seq = fileInfo.seqnum();
 
     LOG(INFO) << "Start CleanDiscardSegment, filename = " << fileInfo.filename()

--- a/src/mds/nameserver2/curvefs.cpp
+++ b/src/mds/nameserver2/curvefs.cpp
@@ -453,6 +453,7 @@ StatusCode CurveFS::GetAllocatedSize(const std::string& fileName,
 StatusCode CurveFS::GetFileAllocSize(const std::string& fileName,
                                      const FileInfo& fileInfo,
                                      AllocatedSize* allocSize) {
+    (void)fileName;
     std::vector<PageFileSegment> segments;
     auto listSegmentRet = storage_->ListSegment(fileInfo.id(), &segments);
 
@@ -470,6 +471,7 @@ StatusCode CurveFS::GetFileAllocSize(const std::string& fileName,
 StatusCode CurveFS::GetDirAllocSize(const std::string& fileName,
                                     const FileInfo& fileInfo,
                                     AllocatedSize* allocSize) {
+    (void)fileInfo;
     std::vector<FileInfo> files;
     StatusCode ret = ReadDir(fileName, &files);
     if (ret != StatusCode::kOK) {
@@ -1955,6 +1957,7 @@ StatusCode CurveFS::CheckPathOwnerInternal(const std::string &filename,
                               const std::string &signature,
                               std::string *lastEntry,
                               uint64_t *parentID) {
+    (void)signature;
     std::vector<std::string> paths;
     ::curve::common::SplitString(filename, "/", &paths);
 
@@ -2247,6 +2250,7 @@ bool CurveFS::CheckSignature(const std::string& owner,
 
 StatusCode CurveFS::ListClient(bool listAllClient,
                                std::vector<ClientInfo>* clientInfos) {
+    (void)listAllClient;
     std::set<butil::EndPoint> allClients = fileRecordManager_->ListAllClient();
 
     for (const auto &c : allClients) {

--- a/src/mds/schedule/copySetScheduler.cpp
+++ b/src/mds/schedule/copySetScheduler.cpp
@@ -208,12 +208,12 @@ void CopySetScheduler::StatsCopysetDistribute(
     for (auto &item : distribute) {
         num += item.second.size();
 
-        if (max == -1 || item.second.size() > max) {
+        if (max == -1 || static_cast<int>(item.second.size()) > max) {
             max = item.second.size();
             maxcsId = item.first;
         }
 
-        if (min == -1 || item.second.size() < min) {
+        if (min == -1 || static_cast<int>(item.second.size()) < min) {
             min = item.second.size();
             mincsId = item.first;
         }
@@ -357,7 +357,7 @@ bool CopySetScheduler::CopySetSatisfiyBasicMigrationCond(
     }
 
     // the replica num of copyset is not standard
-    if (info.peers.size() !=
+    if (static_cast<int>(info.peers.size()) !=
         topo_->GetStandardReplicaNumInLogicalPool(info.id.first)) {
         return false;
     }

--- a/src/mds/schedule/operatorTemplate.h
+++ b/src/mds/schedule/operatorTemplate.h
@@ -98,6 +98,7 @@ OperatorT<IdType, CopySetInfoT, CopySetConfT>::OperatorT(
     EpochType startEpoch, const CopySetKey &id, OperatorPriority pri,
     const steady_clock::time_point &timeLimit,
     std::shared_ptr<OperatorStep> step) {
+    (void)timeLimit;
     this->startEpoch = startEpoch;
     this->copysetID.first = id.first;
     this->copysetID.second = id.second;

--- a/src/mds/schedule/rapidLeaderScheduler.cpp
+++ b/src/mds/schedule/rapidLeaderScheduler.cpp
@@ -149,7 +149,7 @@ ChunkServerIdType RapidLeaderScheduler::SelectTargetPeer(
 
     // the replica with least leader number
     int possibleSelected = MinLeaderNumInCopySetPeers(info, stat);
-    if (possibleSelected == curChunkServerId) {
+    if (possibleSelected == static_cast<int>(curChunkServerId)) {
         return selected;
     }
 

--- a/src/mds/schedule/scheduleMetricsTemplate.h
+++ b/src/mds/schedule/scheduleMetricsTemplate.h
@@ -242,6 +242,9 @@ void ScheduleMetricsT<
     TopoCopySetInfoT>::RemoveUpdateOperatorsMap(const Operator &op,
                                                 std::string type,
                                                 IdType target) {
+    (void)type;
+    (void)target;
+
     auto findOp = operators.find(op.copysetID);
     if (findOp == operators.end()) {
         return;
@@ -306,7 +309,7 @@ void ScheduleMetricsT<IdType, CopySetInfoT, CopySetConfT, TopologyT,
         if (peerId == out.GetLeader()) {
             copysetLeaderPeer = hostPort;
         }
-        if (count == members.size()) {
+        if (count == static_cast<int>(members.size())) {
             copysetPeers += hostPort;
         } else {
             copysetPeers += hostPort + ",";

--- a/src/mds/schedule/scheduler.cpp
+++ b/src/mds/schedule/scheduler.cpp
@@ -116,7 +116,7 @@ ChunkServerIdType Scheduler::SelectBestPlacementChunkServer(
                    << " invalid";
         return UNINTIALIZE_ID;
     }
-    if (excludeZones.size() >= standardZoneNum) {
+    if (static_cast<int>(excludeZones.size()) >= standardZoneNum) {
         excludeZones.clear();
     }
 
@@ -210,7 +210,7 @@ ChunkServerIdType Scheduler::SelectRedundantReplicaToRemove(
                    " replicaNum must >=0, please check";
         return UNINTIALIZE_ID;
     }
-    if (copySetInfo.peers.size() <= standardReplicaNum) {
+    if (static_cast<int>(copySetInfo.peers.size()) <= standardReplicaNum) {
         LOG(ERROR) << "topoAdapter cannot select redundent replica for "
                    << copySetInfo.CopySetInfoStr() << ", beacuse replicaNum "
                    << copySetInfo.peers.size()
@@ -242,7 +242,7 @@ ChunkServerIdType Scheduler::SelectRedundantReplicaToRemove(
 
     // 1. alarm if the zone number is lass than the standard
     // TODO(lixiaocui): adjust by adding or deleting replica in this case
-    if (zoneList.size() < standardZoneNum) {
+    if (static_cast<int>(zoneList.size()) < standardZoneNum) {
         LOG(ERROR) << "topoAdapter find " << copySetInfo.CopySetInfoStr()
                    << " replicas distribute in "
                    << zoneList.size() << " zones, less than standard zoneNum "
@@ -265,7 +265,7 @@ ChunkServerIdType Scheduler::SelectRedundantReplicaToRemove(
     std::vector<ChunkServerIdType> candidateChunkServer;
     for (auto item : zoneList) {
         if (item.second.size() == 1) {
-            if (zoneList.size() == standardZoneNum) {
+            if (static_cast<int>(zoneList.size()) == standardZoneNum) {
                 continue;
             }
         }

--- a/src/mds/schedule/scheduler_helper.cpp
+++ b/src/mds/schedule/scheduler_helper.cpp
@@ -139,7 +139,7 @@ bool SchedulerHelper::SatisfyZoneAndScatterWidthLimit(
         zoneList[targetZone] += 1;
     }
 
-    if (zoneList.size() < minZone) {
+    if (static_cast<int>(zoneList.size()) < minZone) {
         return false;
     }
 

--- a/src/mds/schedule/topoAdapter.h
+++ b/src/mds/schedule/topoAdapter.h
@@ -148,7 +148,7 @@ struct CopySetInfo {
 struct ChunkServerInfo {
  public:
     ChunkServerInfo() :
-        leaderCount(0), diskCapacity(0), diskUsed(0), startUpTime(0) {}
+        startUpTime(0), leaderCount(0), diskCapacity(0), diskUsed(0) {}
     ChunkServerInfo(const PeerInfo &info, OnlineState state,
                     DiskState diskState, ChunkServerStatus status,
                     uint32_t leaderCount, uint64_t capacity, uint64_t used,

--- a/src/mds/server/mds.cpp
+++ b/src/mds/server/mds.cpp
@@ -244,7 +244,7 @@ void MDS::InitEtcdClient(const EtcdConf& etcdConf,
     auto res = etcdClient_->Init(etcdConf, etcdTimeout, retryTimes);
     LOG_IF(FATAL, res != EtcdErrCode::EtcdOK)
         << "init etcd client err! "
-        << "etcdaddr: " << std::string{etcdConf.Endpoints, etcdConf.len}
+        << "etcdaddr: " << std::string(etcdConf.Endpoints, etcdConf.len)
         << ", etcdaddr len: " << etcdConf.len
         << ", etcdtimeout: " << etcdConf.DialTimeout
         << ", operation timeout: " << etcdTimeout
@@ -258,7 +258,7 @@ void MDS::InitEtcdClient(const EtcdConf& etcdConf,
         << "Run mds err. Check if etcd is running.";
 
     LOG(INFO) << "init etcd client ok! "
-            << "etcdaddr: " << std::string{etcdConf.Endpoints, etcdConf.len}
+            << "etcdaddr: " << std::string(etcdConf.Endpoints, etcdConf.len)
             << ", etcdaddr len: " << etcdConf.len
             << ", etcdtimeout: " << etcdConf.DialTimeout
             << ", operation timeout: " << etcdTimeout
@@ -510,7 +510,6 @@ void MDS::InitCurveFSOptions(CurveFSOption *curveFSOptions) {
         "mds.curvefs.minFileLength", &curveFSOptions->minFileLength);
     conf_->GetValueFatalIfFail(
         "mds.curvefs.maxFileLength", &curveFSOptions->maxFileLength);
-    FileRecordOptions fileRecordOptions;
     InitFileRecordOptions(&curveFSOptions->fileRecordOptions);
 
     RootAuthOption authOptions;

--- a/src/mds/topology/topology_chunk_allocator.h
+++ b/src/mds/topology/topology_chunk_allocator.h
@@ -49,18 +49,18 @@ enum class ChoosePoolPolicy {
 class ChunkFilePoolAllocHelp {
  public:
     ChunkFilePoolAllocHelp()
-    : ChunkFilePoolPoolWalReserve(0),
-      useChunkFilepool(false),
-      useChunkFilePoolAsWalPool(false) {}
+        : useChunkFilepool(false), useChunkFilePoolAsWalPool(false),
+          ChunkFilePoolPoolWalReserve(0) {}
     ~ChunkFilePoolAllocHelp() {}
-    void UpdateChunkFilePoolAllocConfig(bool useChunkFilepool_,
-        bool useChunkFilePoolAsWalPool_,
-        uint32_t useChunkFilePoolAsWalPoolReserve_)  {
+    void
+    UpdateChunkFilePoolAllocConfig(bool useChunkFilepool_,
+                                   bool useChunkFilePoolAsWalPool_,
+                                   uint32_t useChunkFilePoolAsWalPoolReserve_) {
         useChunkFilepool.store(useChunkFilepool_, std::memory_order_release);
         useChunkFilePoolAsWalPool.store(useChunkFilePoolAsWalPool_,
-            std::memory_order_release);
+                                        std::memory_order_release);
         ChunkFilePoolPoolWalReserve.store(useChunkFilePoolAsWalPoolReserve_,
-            std::memory_order_release);
+                                          std::memory_order_release);
     }
     bool GetUseChunkFilepool() {
         return useChunkFilepool.load(std::memory_order_acquire);
@@ -68,8 +68,8 @@ class ChunkFilePoolAllocHelp {
     // After removing the reserved space, the remaining percentage
     uint32_t GetAvailable() {
         if (useChunkFilePoolAsWalPool.load(std::memory_order_acquire)) {
-            return 100 - ChunkFilePoolPoolWalReserve.load(
-                    std::memory_order_acquire);
+            return 100 -
+                   ChunkFilePoolPoolWalReserve.load(std::memory_order_acquire);
         } else {
             return 100;
         }
@@ -80,7 +80,7 @@ class ChunkFilePoolAllocHelp {
     std::atomic<bool> useChunkFilepool;
     std::atomic<bool> useChunkFilePoolAsWalPool;
     // Reserve extra space for walpool
-    std::atomic<uint32_t>  ChunkFilePoolPoolWalReserve;
+    std::atomic<uint32_t> ChunkFilePoolPoolWalReserve;
 };
 
 class TopologyChunkAllocator {
@@ -88,18 +88,14 @@ class TopologyChunkAllocator {
     TopologyChunkAllocator() {}
     virtual ~TopologyChunkAllocator() {}
     virtual bool AllocateChunkRandomInSingleLogicalPool(
-        ::curve::mds::FileType fileType,
-        uint32_t chunkNumer,
-        ChunkSizeType chunkSize,
-        std::vector<CopysetIdInfo> *infos) = 0;
+        ::curve::mds::FileType fileType, uint32_t chunkNumer,
+        ChunkSizeType chunkSize, std::vector<CopysetIdInfo> *infos) = 0;
     virtual bool AllocateChunkRoundRobinInSingleLogicalPool(
-        ::curve::mds::FileType fileType,
-        uint32_t chunkNumer,
-        ChunkSizeType chunkSize,
-        std::vector<CopysetIdInfo> *infos) = 0;
+        ::curve::mds::FileType fileType, uint32_t chunkNumer,
+        ChunkSizeType chunkSize, std::vector<CopysetIdInfo> *infos) = 0;
     virtual void GetRemainingSpaceInLogicalPool(
-        const std::vector<PoolIdType>& logicalPools,
-        std::map<PoolIdType, double>* remianingSpace) = 0;
+        const std::vector<PoolIdType> &logicalPools,
+        std::map<PoolIdType, double> *remianingSpace) = 0;
     virtual void UpdateChunkFilePoolAllocConfig(
         bool useChunkFilepool_, bool useChunkFilePoolAsWalPool_,
         uint32_t useChunkFilePoolAsWalPoolReserve_) = 0;
@@ -107,18 +103,18 @@ class TopologyChunkAllocator {
 
 class TopologyChunkAllocatorImpl : public TopologyChunkAllocator {
  public:
-    TopologyChunkAllocatorImpl(std::shared_ptr<Topology> topology,
+    TopologyChunkAllocatorImpl(
+        std::shared_ptr<Topology> topology,
         std::shared_ptr<AllocStatistic> allocStatistic,
         std::shared_ptr<TopologyStat> topologyStat,
         std::shared_ptr<ChunkFilePoolAllocHelp> ChunkFilePoolAllocHelp,
         const TopologyOption &option)
-        : topology_(topology),
-        allocStatistic_(allocStatistic),
-        topoStat_(topologyStat),
-        chunkFilePoolAllocHelp_(ChunkFilePoolAllocHelp),
-        available_(option.PoolUsagePercentLimit),
-        policy_(static_cast<ChoosePoolPolicy>(option.choosePoolPolicy)),
-        enableLogicalPoolStatus_(option.enableLogicalPoolStatus) {
+        : topology_(topology), allocStatistic_(allocStatistic),
+          available_(option.PoolUsagePercentLimit),
+          topoStat_(topologyStat),
+          chunkFilePoolAllocHelp_(ChunkFilePoolAllocHelp),
+          policy_(static_cast<ChoosePoolPolicy>(option.choosePoolPolicy)),
+          enableLogicalPoolStatus_(option.enableLogicalPoolStatus) {
         std::srand(std::time(nullptr));
     }
     ~TopologyChunkAllocatorImpl() {}
@@ -136,10 +132,8 @@ class TopologyChunkAllocatorImpl : public TopologyChunkAllocator {
      * @retval false if failed
      */
     bool AllocateChunkRandomInSingleLogicalPool(
-        curve::mds::FileType fileType,
-        uint32_t chunkNumber,
-        ChunkSizeType chunkSize,
-        std::vector<CopysetIdInfo> *infos) override;
+        curve::mds::FileType fileType, uint32_t chunkNumber,
+        ChunkSizeType chunkSize, std::vector<CopysetIdInfo> *infos) override;
 
     /**
      * @brief allocate chunks by round robin in a single logical pool
@@ -153,20 +147,18 @@ class TopologyChunkAllocatorImpl : public TopologyChunkAllocator {
      * @retval false if failed
      */
     bool AllocateChunkRoundRobinInSingleLogicalPool(
-        curve::mds::FileType fileType,
-        uint32_t chunkNumber,
-        ChunkSizeType chunkSize,
-        std::vector<CopysetIdInfo> *infos) override;
+        curve::mds::FileType fileType, uint32_t chunkNumber,
+        ChunkSizeType chunkSize, std::vector<CopysetIdInfo> *infos) override;
     void GetRemainingSpaceInLogicalPool(
-        const std::vector<PoolIdType>& logicalPools,
-        std::map<PoolIdType, double>* remianingSpace) override;
-    void UpdateChunkFilePoolAllocConfig(bool useChunkFilepool_,
-            bool useChunkFilePoolAsWalPool_,
-            uint32_t useChunkFilePoolAsWalPoolReserve_) override {
-              chunkFilePoolAllocHelp_->UpdateChunkFilePoolAllocConfig(
-                useChunkFilepool_, useChunkFilePoolAsWalPool_,
-                useChunkFilePoolAsWalPoolReserve_);
-        }
+        const std::vector<PoolIdType> &logicalPools,
+        std::map<PoolIdType, double> *remianingSpace) override;
+    void UpdateChunkFilePoolAllocConfig(
+        bool useChunkFilepool_, bool useChunkFilePoolAsWalPool_,
+        uint32_t useChunkFilePoolAsWalPoolReserve_) override {
+        chunkFilePoolAllocHelp_->UpdateChunkFilePoolAllocConfig(
+            useChunkFilepool_, useChunkFilePoolAsWalPool_,
+            useChunkFilePoolAsWalPoolReserve_);
+    }
 
  private:
     /**
@@ -179,7 +171,7 @@ class TopologyChunkAllocatorImpl : public TopologyChunkAllocator {
      * @retval false if failed
      */
     bool ChooseSingleLogicalPool(curve::mds::FileType fileType,
-        PoolIdType *poolOut);
+                                 PoolIdType *poolOut);
 
  private:
     std::shared_ptr<Topology> topology_;
@@ -230,10 +222,8 @@ class AllocateChunkPolicy {
      * @retval false if failed
      */
     static bool AllocateChunkRandomInSingleLogicalPool(
-        std::vector<CopySetIdType> copySetIds,
-        PoolIdType logicalPoolId,
-        uint32_t chunkNumber,
-        std::vector<CopysetIdInfo> *infos);
+        std::vector<CopySetIdType> copySetIds, PoolIdType logicalPoolId,
+        uint32_t chunkNumber, std::vector<CopysetIdInfo> *infos);
 
     /**
      * @brief allocate chunks by round robin in a single logical pool
@@ -253,10 +243,8 @@ class AllocateChunkPolicy {
      * @retval false if failed
      */
     static bool AllocateChunkRoundRobinInSingleLogicalPool(
-        std::vector<CopySetIdType> copySetIds,
-        PoolIdType logicalPoolId,
-        uint32_t *nextIndex,
-        uint32_t chunkNumber,
+        std::vector<CopySetIdType> copySetIds, PoolIdType logicalPoolId,
+        uint32_t *nextIndex, uint32_t chunkNumber,
         std::vector<CopysetIdInfo> *infos);
 
     /**
@@ -281,11 +269,10 @@ class AllocateChunkPolicy {
      * @retval true if succeeded
      * @retval false if failed
      */
-    static bool ChooseSingleLogicalPoolRandom(
-        const std::vector<PoolIdType> &pools,
-        PoolIdType *poolIdOut);
+    static bool
+    ChooseSingleLogicalPoolRandom(const std::vector<PoolIdType> &pools,
+                                  PoolIdType *poolIdOut);
 };
-
 
 
 }  // namespace topology

--- a/src/mds/topology/topology_item.cpp
+++ b/src/mds/topology/topology_item.cpp
@@ -24,6 +24,7 @@
 
 #include <string>
 #include <vector>
+#include <memory>
 
 #include "json/json.h"
 #include "src/common/string_util.h"
@@ -47,51 +48,57 @@ bool ClusterInformation::ParseFromString(const std::string &value) {
 }
 
 bool LogicalPool::TransRedundanceAndPlaceMentPolicyFromJsonStr(
-    const std::string &jsonStr,
-    LogicalPoolType type,
+    const std::string &jsonStr, LogicalPoolType type,
     RedundanceAndPlaceMentPolicy *rap) {
-    Json::Reader reader;
+    Json::CharReaderBuilder builder;
+    std::unique_ptr<Json::CharReader> reader(builder.newCharReader());
     Json::Value rapJson;
-    if (!reader.parse(jsonStr, rapJson)) {
+    JSONCPP_STRING errormsg;
+    if (!reader->parse(jsonStr.data(), jsonStr.data() + jsonStr.length(),
+                       &rapJson, &errormsg)) {
         return false;
     }
 
     switch (type) {
-        case LogicalPoolType::PAGEFILE: {
-            if (!rapJson["replicaNum"].isNull()) {
-                rap->pageFileRAP.replicaNum = rapJson["replicaNum"].asInt();
-            } else {
-                return false;
-            }
-            if (!rapJson["copysetNum"].isNull()) {
-                rap->pageFileRAP.copysetNum = rapJson["copysetNum"].asInt();
-            } else {
-                return false;
-            }
-            if (!rapJson["zoneNum"].isNull()) {
-                rap->pageFileRAP.zoneNum = rapJson["zoneNum"].asInt();
-            } else {
-                return false;
-            }
-            break;
-        }
-        case LogicalPoolType::APPENDFILE: {
-            // TODO(xuchaojie): it is not done.
+    case LogicalPoolType::PAGEFILE: {
+        if (!rapJson["replicaNum"].isNull()) {
+            rap->pageFileRAP.replicaNum = rapJson["replicaNum"].asInt();
+        } else {
             return false;
         }
-        case LogicalPoolType::APPENDECFILE: {
-            // TODO(xuchaojie): it is not done.
+        if (!rapJson["copysetNum"].isNull()) {
+            rap->pageFileRAP.copysetNum = rapJson["copysetNum"].asInt();
+        } else {
             return false;
         }
-        default: {
+        if (!rapJson["zoneNum"].isNull()) {
+            rap->pageFileRAP.zoneNum = rapJson["zoneNum"].asInt();
+        } else {
             return false;
         }
+        break;
+    }
+    case LogicalPoolType::APPENDFILE: {
+        // TODO(xuchaojie): it is not done.
+        return false;
+    }
+    case LogicalPoolType::APPENDECFILE: {
+        // TODO(xuchaojie): it is not done.
+        return false;
+    }
+    default: {
+        return false;
+    }
     }
     return true;
 }
 
-bool LogicalPool::TransUserPolicyFromJsonStr(
-    const std::string &jsonStr, LogicalPoolType type, UserPolicy *policy) {
+bool LogicalPool::TransUserPolicyFromJsonStr(const std::string &jsonStr,
+                                             LogicalPoolType type,
+                                             UserPolicy *policy) {
+    (void)jsonStr;
+    (void)type;
+    (void)policy;
     // TODO(xuchaojie): to finish it.
     return true;
 }
@@ -99,32 +106,30 @@ bool LogicalPool::TransUserPolicyFromJsonStr(
 bool LogicalPool::SetRedundanceAndPlaceMentPolicyByJson(
     const std::string &jsonStr) {
     return LogicalPool::TransRedundanceAndPlaceMentPolicyFromJsonStr(
-               jsonStr,
-               GetLogicalPoolType(),
-               &rap_);
+        jsonStr, GetLogicalPoolType(), &rap_);
 }
 
 std::string LogicalPool::GetRedundanceAndPlaceMentPolicyJsonStr() const {
     std::string rapStr;
     Json::Value rapJson;
     switch (GetLogicalPoolType()) {
-        case LogicalPoolType::PAGEFILE : {
-            rapJson["replicaNum"] = rap_.pageFileRAP.replicaNum;
-            rapJson["copysetNum"] = rap_.pageFileRAP.copysetNum;
-            rapJson["zoneNum"] = rap_.pageFileRAP.zoneNum;
-            rapStr = rapJson.toStyledString();
-            break;
-        }
-        case LogicalPoolType::APPENDFILE : {
-            // TODO(xuchaojie): fix it
-            break;
-        }
-        case LogicalPoolType::APPENDECFILE : {
-            // TODO(xuchaojie): fix it
-            break;
-        }
-        default:
-            break;
+    case LogicalPoolType::PAGEFILE: {
+        rapJson["replicaNum"] = rap_.pageFileRAP.replicaNum;
+        rapJson["copysetNum"] = rap_.pageFileRAP.copysetNum;
+        rapJson["zoneNum"] = rap_.pageFileRAP.zoneNum;
+        rapStr = rapJson.toStyledString();
+        break;
+    }
+    case LogicalPoolType::APPENDFILE: {
+        // TODO(xuchaojie): fix it
+        break;
+    }
+    case LogicalPoolType::APPENDECFILE: {
+        // TODO(xuchaojie): fix it
+        break;
+    }
+    default:
+        break;
     }
     return rapStr;
 }
@@ -132,9 +137,7 @@ std::string LogicalPool::GetRedundanceAndPlaceMentPolicyJsonStr() const {
 
 bool LogicalPool::SetUserPolicyByJson(const std::string &jsonStr) {
     return LogicalPool::TransUserPolicyFromJsonStr(
-               jsonStr,
-               GetLogicalPoolType(),
-               &policy_);
+        jsonStr, GetLogicalPoolType(), &policy_);
 }
 
 std::string LogicalPool::GetUserPolicyJsonStr() const {
@@ -145,20 +148,20 @@ std::string LogicalPool::GetUserPolicyJsonStr() const {
 uint16_t LogicalPool::GetReplicaNum() const {
     uint16_t ret = 0;
     switch (GetLogicalPoolType()) {
-        case LogicalPoolType::PAGEFILE : {
-            ret = rap_.pageFileRAP.replicaNum;
-            break;
-        }
-        case LogicalPoolType::APPENDFILE : {
-            // TODO(xuchaojie): fix it
-            break;
-        }
-        case LogicalPoolType::APPENDECFILE : {
-            // TODO(xuchaojie): fix it
-            break;
-        }
-        default:
-            break;
+    case LogicalPoolType::PAGEFILE: {
+        ret = rap_.pageFileRAP.replicaNum;
+        break;
+    }
+    case LogicalPoolType::APPENDFILE: {
+        // TODO(xuchaojie): fix it
+        break;
+    }
+    case LogicalPoolType::APPENDECFILE: {
+        // TODO(xuchaojie): fix it
+        break;
+    }
+    default:
+        break;
     }
     return ret;
 }
@@ -187,10 +190,8 @@ bool LogicalPool::ParseFromString(const std::string &value) {
     name_ = data.logicalpoolname();
     physicalPoolId_ = data.physicalpoolid();
     type_ = data.type();
-    SetRedundanceAndPlaceMentPolicyByJson(
-        data.redundanceandplacementpolicy());
-    SetUserPolicyByJson(
-        data.userpolicy());
+    SetRedundanceAndPlaceMentPolicyByJson(data.redundanceandplacementpolicy());
+    SetUserPolicyByJson(data.userpolicy());
     initialScatterWidth_ = data.initialscatterwidth();
     createTime_ = data.createtime();
     status_ = data.status();
@@ -309,13 +310,17 @@ std::string CopySetInfo::GetCopySetMembersStr() const {
 }
 
 bool CopySetInfo::SetCopySetMembersByJson(const std::string &jsonStr) {
-    Json::Reader reader;
+    Json::CharReaderBuilder builder;
+    std::unique_ptr<Json::CharReader> reader(builder.newCharReader());
     Json::Value copysetMemJson;
-    if (!reader.parse(jsonStr, copysetMemJson)) {
+    JSONCPP_STRING errormsg;
+    if (!reader->parse(jsonStr.data(), jsonStr.data() + jsonStr.length(),
+                       &copysetMemJson, &errormsg)) {
         return false;
     }
+
     peers_.clear();
-    for (int i = 0; i < copysetMemJson.size(); i++) {
+    for (int i = 0; i < static_cast<int>(copysetMemJson.size()); i++) {
         if (copysetMemJson[i].isInt()) {
             peers_.insert(copysetMemJson[i].asInt());
         } else {
@@ -355,16 +360,13 @@ bool CopySetInfo::ParseFromString(const std::string &value) {
         peers_.insert(data.chunkserverids(i));
     }
     lastScanSec_ = data.has_lastscansec() ? data.lastscansec() : 0;
-    lastScanConsistent_ = data.has_lastscanconsistent() ?
-                          data.lastscanconsistent() : true;
+    lastScanConsistent_ =
+        data.has_lastscanconsistent() ? data.lastscanconsistent() : true;
     return ret;
 }
 
-bool SplitPeerId(
-    const std::string &peerId,
-    std::string *ip,
-    uint32_t *port,
-    uint32_t *idx) {
+bool SplitPeerId(const std::string &peerId, std::string *ip, uint32_t *port,
+                 uint32_t *idx) {
     std::vector<std::string> items;
     curve::common::SplitString(peerId, ":", &items);
     if (3 == items.size()) {

--- a/src/mds/topology/topology_service_manager.cpp
+++ b/src/mds/topology/topology_service_manager.cpp
@@ -347,6 +347,7 @@ void TopologyServiceManager::GetChunkServer(
 void TopologyServiceManager::GetChunkServerInCluster(
     const GetChunkServerInClusterRequest *request,
     GetChunkServerInClusterResponse *response) {
+    (void)request;
     response->set_statuscode(kTopoErrCodeSuccess);
     auto chunkserverIds = topology_->GetChunkServerInCluster();
     for (const auto id : chunkserverIds) {
@@ -863,6 +864,7 @@ void TopologyServiceManager::GetPhysicalPool(const PhysicalPoolRequest *request,
 void TopologyServiceManager::ListPhysicalPool(
     const ListPhysicalPoolRequest *request,
     ListPhysicalPoolResponse *response) {
+    (void)request;
     response->set_statuscode(kTopoErrCodeSuccess);
     auto poolList = topology_->GetPhysicalPoolInCluster();
     for (PoolIdType id : poolList) {
@@ -1570,6 +1572,7 @@ void TopologyServiceManager::GetCopyset(const GetCopysetRequest* request,
 void TopologyServiceManager::GetClusterInfo(
     const GetClusterInfoRequest* request,
     GetClusterInfoResponse* response) {
+    (void)request;
     ClusterInformation info;
     if (topology_->GetClusterInfo(&info)) {
         response->set_statuscode(kTopoErrCodeSuccess);
@@ -1599,6 +1602,7 @@ void TopologyServiceManager::SetCopysetsAvailFlag(
 void TopologyServiceManager::ListUnAvailCopySets(
           const ListUnAvailCopySetsRequest* request,
           ListUnAvailCopySetsResponse* response) {
+    (void)request;
     std::vector<CopySetKey> copysets =
                     topology_->GetCopySetsInCluster();
     for (const CopySetKey& copyset : copysets) {

--- a/src/mds/topology/topology_storge_etcd.cpp
+++ b/src/mds/topology/topology_storge_etcd.cpp
@@ -45,7 +45,7 @@ bool TopologyStorageEtcd::LoadLogicalPool(
         LOG(ERROR) << "etcd list err:" << errCode;
         return false;
     }
-    for (int i = 0; i < out.size(); i++) {
+    for (size_t i = 0; i < out.size(); i++) {
         LogicalPool data;
         errCode = codec_->DecodeLogicalPoolData(out[i], &data);
         if (!errCode) {
@@ -82,7 +82,7 @@ bool TopologyStorageEtcd::LoadPhysicalPool(
         LOG(ERROR) << "etcd list err:" << errCode;
         return false;
     }
-    for (int i = 0; i < out.size(); i++) {
+    for (size_t i = 0; i < out.size(); i++) {
         PhysicalPool data;
         errCode = codec_->DecodePhysicalPoolData(out[i], &data);
         if (!errCode) {
@@ -118,7 +118,7 @@ bool TopologyStorageEtcd::LoadZone(
         LOG(ERROR) << "etcd list err:" << errCode;
         return false;
     }
-    for (int i = 0; i < out.size(); i++) {
+    for (size_t i = 0; i < out.size(); i++) {
         Zone data;
         errCode = codec_->DecodeZoneData(out[i], &data);
         if (!errCode) {
@@ -154,7 +154,7 @@ bool TopologyStorageEtcd::LoadServer(
         LOG(ERROR) << "etcd list err:" << errCode;
         return false;
     }
-    for (int i = 0; i < out.size(); i++) {
+    for (size_t i = 0; i < out.size(); i++) {
         Server data;
         errCode = codec_->DecodeServerData(out[i], &data);
         if (!errCode) {
@@ -190,7 +190,7 @@ bool TopologyStorageEtcd::LoadChunkServer(
         LOG(ERROR) << "etcd list err:" << errCode;
         return false;
     }
-    for (int i = 0; i < out.size(); i++) {
+    for (size_t i = 0; i < out.size(); i++) {
         ChunkServer data;
         errCode = codec_->DecodeChunkServerData(out[i], &data);
         if (!errCode) {
@@ -228,7 +228,7 @@ bool TopologyStorageEtcd::LoadCopySet(
         LOG(ERROR) << "etcd list err:" << errCode;
         return false;
     }
-    for (int i = 0; i < out.size(); i++) {
+    for (size_t i = 0; i < out.size(); i++) {
         CopySetInfo data;
         errCode = codec_->DecodeCopySetData(out[i], &data);
         if (!errCode) {

--- a/src/snapshotcloneserver/clone/clone_closure.h
+++ b/src/snapshotcloneserver/clone/clone_closure.h
@@ -34,60 +34,38 @@
 #include "src/common/concurrent/name_lock.h"
 #include "src/common/concurrent/dlock.h"
 
-using ::google::protobuf::RpcController;
-using ::google::protobuf::Closure;
-using ::curve::common::NameLockGuard;
 using ::curve::common::DLock;
+using ::curve::common::NameLockGuard;
+using ::google::protobuf::Closure;
+using ::google::protobuf::RpcController;
 
 namespace curve {
 namespace snapshotcloneserver {
 
 class CloneClosure : public Closure {
  public:
-    CloneClosure(brpc::Controller* bcntl = nullptr,
-                 Closure* done = nullptr)
-        : bcntl_(bcntl),
-          done_(done),
-          requestId_(""),
-          taskId_(""),
-          dlock_(nullptr),
-          retCode_(kErrCodeInternalError) {}
+    explicit CloneClosure(brpc::Controller *bcntl = nullptr,
+                          Closure *done = nullptr)
+        : dlock_(nullptr), bcntl_(bcntl), done_(done), requestId_(""),
+          taskId_(""), retCode_(kErrCodeInternalError) {}
 
-    brpc::Controller * GetController() {
-        return bcntl_;
-    }
+    brpc::Controller *GetController() { return bcntl_; }
 
-    void SetRequestId(const UUID &requestId) {
-        requestId_ = requestId;
-    }
+    void SetRequestId(const UUID &requestId) { requestId_ = requestId; }
 
-    void SetTaskId(const TaskIdType &taskId) {
-        taskId_ = taskId;
-    }
+    void SetTaskId(const TaskIdType &taskId) { taskId_ = taskId; }
 
-    TaskIdType GetTaskId() {
-        return taskId_;
-    }
+    TaskIdType GetTaskId() { return taskId_; }
 
-    void SetErrCode(int retCode) {
-        retCode_ = retCode;
-    }
+    void SetErrCode(int retCode) { retCode_ = retCode; }
 
-    int GetErrCode() {
-        return retCode_;
-    }
+    int GetErrCode() { return retCode_; }
 
-    void SetDestFileLock(std::shared_ptr<NameLock> lock) {
-        lock_ = lock;
-    }
+    void SetDestFileLock(std::shared_ptr<NameLock> lock) { lock_ = lock; }
 
-    void SetDLock(std::shared_ptr<DLock> lock) {
-        dlock_ = lock;
-    }
+    void SetDLock(std::shared_ptr<DLock> lock) { dlock_ = lock; }
 
-    std::shared_ptr<DLock> GetDLock() {
-        return dlock_;
-    }
+    std::shared_ptr<DLock> GetDLock() { return dlock_; }
 
     void SetDestFileName(const std::string &destFileName) {
         destFileName_ = destFileName;
@@ -100,9 +78,8 @@ class CloneClosure : public Closure {
                 bcntl_->http_response().set_status_code(
                     brpc::HTTP_STATUS_INTERNAL_SERVER_ERROR);
                 butil::IOBufBuilder os;
-                std::string msg = BuildErrorMessage(retCode_,
-                                                    requestId_,
-                                                    taskId_);
+                std::string msg =
+                    BuildErrorMessage(retCode_, requestId_, taskId_);
                 os << msg;
                 os.move_to(bcntl_->response_attachment());
             } else {
@@ -137,7 +114,7 @@ class CloneClosure : public Closure {
     std::shared_ptr<DLock> dlock_;
     std::string destFileName_;
     brpc::Controller *bcntl_;
-    Closure* done_;
+    Closure *done_;
     UUID requestId_;
     TaskIdType taskId_;
     int retCode_;

--- a/src/snapshotcloneserver/clone/clone_core.cpp
+++ b/src/snapshotcloneserver/clone/clone_core.cpp
@@ -174,7 +174,7 @@ int CloneCoreImpl::CloneOrRecoverPre(const UUID &source,
             return kErrCodeInternalError;
     }
 
-    //是否为快照
+    // 是否为快照
     SnapshotInfo snapInfo;
     CloneFileType fileType;
 
@@ -290,6 +290,7 @@ int CloneCoreImpl::FlattenPre(
     const std::string &user,
     const TaskIdType &taskId,
     CloneInfo *cloneInfo) {
+    (void)user;
     int ret = metaStore_->GetCloneInfo(taskId, cloneInfo);
     if (ret < 0) {
         return kErrCodeFileNotExist;
@@ -868,6 +869,8 @@ int CloneCoreImpl::CompleteCloneMeta(
     std::shared_ptr<CloneTaskInfo> task,
     const FInfo &fInfo,
     const CloneSegmentMap &segInfos) {
+    (void)fInfo;
+    (void)segInfos;
     std::string origin =
         cloneTempDir_ + "/" + task->GetCloneInfo().GetTaskId();
     std::string user = task->GetCloneInfo().GetUser();
@@ -1077,6 +1080,7 @@ int CloneCoreImpl::ContinueAsyncRecoverChunkPartAndWaitSomeChunkEnd(
 int CloneCoreImpl::ChangeOwner(
     std::shared_ptr<CloneTaskInfo> task,
     const FInfo &fInfo) {
+    (void)fInfo;
     std::string user = task->GetCloneInfo().GetUser();
     std::string origin =
         cloneTempDir_ + "/" + task->GetCloneInfo().GetTaskId();
@@ -1171,6 +1175,8 @@ int CloneCoreImpl::CompleteCloneFile(
     std::shared_ptr<CloneTaskInfo> task,
     const FInfo &fInfo,
     const CloneSegmentMap &segInfos) {
+    (void)fInfo;
+    (void)segInfos;
     std::string fileName;
     if (IsLazy(task)) {
         fileName = task->GetCloneInfo().GetDest();
@@ -1542,7 +1548,7 @@ void CloneCoreImpl::HandleCleanCloneOrRecoverTask(
     if (CloneStatus::errorCleaning == task->GetCloneInfo().GetStatus()) {
         // 错误情况下可能未清除镜像被克隆标志
         if (IsFile(task)) {
-            //重新发送
+            // 重新发送
             std::string source = task->GetCloneInfo().GetSrc();
             NameLockGuard lockGuard(cloneRef_->GetLock(), source);
             if (cloneRef_->GetRef(source) == 0) {

--- a/src/snapshotcloneserver/common/snapshotclone_info.h
+++ b/src/snapshotcloneserver/common/snapshotclone_info.h
@@ -247,7 +247,7 @@ class CloneInfo {
 
 std::ostream& operator<<(std::ostream& os, const CloneInfo &cloneInfo);
 
-//快照处理状态
+// 快照处理状态
 enum class Status{
     done = 0,
     pending,
@@ -257,7 +257,7 @@ enum class Status{
     error
 };
 
-//快照信息
+// 快照信息
 class SnapshotInfo {
  public:
     SnapshotInfo()
@@ -427,7 +427,7 @@ class SnapshotInfo {
     uint32_t chunkSize_;
     // 文件的segment大小
     uint64_t segmentSize_;
-    //文件大小
+    // 文件大小
     uint64_t fileLength_;
     // stripe size
     uint64_t stripeUnit_;

--- a/src/snapshotcloneserver/common/snapshotclone_meta_store_etcd.cpp
+++ b/src/snapshotcloneserver/common/snapshotclone_meta_store_etcd.cpp
@@ -304,7 +304,7 @@ int SnapshotCloneMetaStoreEtcd::LoadSnapshotInfos() {
         LOG(ERROR) << "etcd list err:" << errCode;
         return -1;
     }
-    for (int i = 0; i < out.size(); i++) {
+    for (size_t i = 0; i < out.size(); i++) {
         SnapshotInfo data;
         errCode = codec_->DecodeSnapshotData(out[i], &data);
         if (!errCode) {
@@ -327,7 +327,7 @@ int SnapshotCloneMetaStoreEtcd::LoadCloneInfos() {
         LOG(ERROR) << "etcd list err:" << errCode;
         return -1;
     }
-    for (int i = 0; i < out.size(); i++) {
+    for (size_t i = 0; i < out.size(); i++) {
         CloneInfo data;
         errCode = codec_->DecodeCloneInfoData(out[i], &data);
         if (!errCode) {

--- a/src/snapshotcloneserver/common/task_tracker.h
+++ b/src/snapshotcloneserver/common/task_tracker.h
@@ -23,8 +23,11 @@
 #ifndef SRC_SNAPSHOTCLONESERVER_COMMON_TASK_TRACKER_H_
 #define SRC_SNAPSHOTCLONESERVER_COMMON_TASK_TRACKER_H_
 
-#include "src/common/snapshotclone/snapshotclone_define.h"
 #include "src/common/task_tracker.h"
+
+#include <memory>
+
+#include "src/common/snapshotclone/snapshotclone_define.h"
 
 using ::curve::common::TaskTracker;
 using ::curve::common::ContextTaskTracker;

--- a/src/snapshotcloneserver/snapshot/snapshot_core.cpp
+++ b/src/snapshotcloneserver/snapshot/snapshot_core.cpp
@@ -73,7 +73,7 @@ int SnapshotCoreImpl::CreateSnapshotPre(const std::string &file,
             snapshotNum--;
         }
     }
-    if (snapshotNum >= maxSnapshotLimit_) {
+    if (snapshotNum >= static_cast<int>(maxSnapshotLimit_)) {
         LOG(ERROR) << "Snapshot count reach the max limit.";
         return kErrCodeSnapshotCountReachLimit;
     }

--- a/src/snapshotcloneserver/snapshotclone_service.cpp
+++ b/src/snapshotcloneserver/snapshotclone_service.cpp
@@ -41,6 +41,8 @@ void SnapshotCloneServiceImpl::default_method(RpcController* cntl,
                     const HttpRequest* req,
                     HttpResponse* resp,
                     Closure* done) {
+    (void)req;
+    (void)resp;
     brpc::ClosureGuard done_guard(done);
     brpc::Controller* bcntl =
         static_cast<brpc::Controller*>(cntl);
@@ -913,7 +915,7 @@ void SnapshotCloneServiceImpl::HandleGetCloneRefStatusAction(
     if (refStatus == CloneRefStatus::kNeedCheck) {
         mainObj[kTotalCountStr] = cloneInfos.size();
         Json::Value listObj;
-        for (int i = 0; i < cloneInfos.size(); i++) {
+        for (size_t i = 0; i < cloneInfos.size(); i++) {
             Json::Value cloneTaskObj;
             cloneTaskObj[kUserStr] = cloneInfos[i].GetUser();
             cloneTaskObj[kFileStr] = cloneInfos[i].GetDest();

--- a/src/tools/copyset_check_core.cpp
+++ b/src/tools/copyset_check_core.cpp
@@ -19,8 +19,9 @@
  * Created Date: 2019-10-30
  * Author: charisu
  */
-#include <math.h>
 #include "src/tools/copyset_check_core.h"
+#include <math.h>
+#include <cstdint>
 
 DEFINE_uint64(margin, 1000, "The threshold of the gap between peers");
 DEFINE_uint64(replicasNum, 3, "the number of replicas that required");
@@ -404,7 +405,7 @@ int CopysetCheckCore::CheckCopysetsOnServer(const ServerIdType& serverId,
     std::vector<Thread> threadpool;
     std::map<std::string, std::pair<int, butil::IOBuf>> queryCsResult;
     uint32_t index = 0;
-    for (int i = 0; i < FLAGS_rpcConcurrentNum; i++) {
+    for (uint64_t i = 0; i < FLAGS_rpcConcurrentNum; i++) {
         threadpool.emplace_back(Thread(
                         &CopysetCheckCore::ConcurrentCheckCopysetsOnServer,
                         this, std::ref(chunkservers), &index,
@@ -751,7 +752,7 @@ CheckResult CopysetCheckCore::CheckPeerOnlineStatus(
     }
     if (notOnlineNum > 0) {
         uint32_t majority = peers.size() / 2 + 1;
-        if (notOnlineNum < majority) {
+        if (notOnlineNum < static_cast<int>(majority)) {
             return CheckResult::kMinorityPeerNotOnline;
         } else {
             return CheckResult::kMajorityPeerNotOnline;
@@ -928,6 +929,7 @@ int CopysetCheckCore::ListMayBrokenVolumes(
 
 void CopysetCheckCore::GetCopysetInfos(const char* key,
                                 std::vector<CopysetInfo>* copysets) {
+    (void)key;
     for (auto iter = copysets_[kMajorityPeerNotOnline].begin();
                     iter != copysets_[kMajorityPeerNotOnline].end(); ++iter) {
         std::string gid = *iter;

--- a/src/tools/copyset_tool.cpp
+++ b/src/tools/copyset_tool.cpp
@@ -84,7 +84,7 @@ int CopysetTool::Init() {
 }
 
 void PrintCopysets(const std::vector<CopysetInfo>& copysets) {
-    for (int i = 0; i < copysets.size(); ++i) {
+    for (size_t i = 0; i < copysets.size(); ++i) {
         if (i != 0) {
             std::cout << ",";
         }

--- a/src/tools/curve_cli.cpp
+++ b/src/tools/curve_cli.cpp
@@ -269,6 +269,8 @@ int CurveCli::DoSnapshot() {
 
 int CurveCli::DoSnapshot(uint32_t lgPoolId, uint32_t copysetId,
                          const curve::common::Peer& peer) {
+    (void)lgPoolId;
+    (void)copysetId;
     braft::cli::CliOptions opt;
     opt.timeout_ms = FLAGS_timeout_ms;
     opt.max_retry = FLAGS_max_retry;

--- a/src/tools/curve_meta_tool.cpp
+++ b/src/tools/curve_meta_tool.cpp
@@ -121,7 +121,7 @@ int CurveMetaTool::PrintChunkMeta(const std::string& chunkFileName) {
     memset(buf.get(), 0, FLAGS_pageSize);
     int rc = localFS_->Read(fd, buf.get(), 0, FLAGS_pageSize);
     localFS_->Close(fd);
-    if (rc != FLAGS_pageSize) {
+    if (rc != static_cast<int64_t>(FLAGS_pageSize)) {
         if (rc < 0) {
             std::cout << "Fail to read metaPage from "
                   << chunkFileName << ", " << berror() << std::endl;
@@ -157,7 +157,7 @@ int CurveMetaTool::PrintSnapshotMeta(const std::string& snapFileName) {
     memset(buf.get(), 0, FLAGS_pageSize);
     int rc = localFS_->Read(fd, buf.get(), 0, FLAGS_pageSize);
     localFS_->Close(fd);
-    if (rc != FLAGS_pageSize) {
+    if (rc != static_cast<int64_t>(FLAGS_pageSize)) {
         if (rc < 0) {
             std::cout << "Fail to read metaPage from "
                   << snapFileName << ", " << berror() << std::endl;

--- a/src/tools/mds_client.cpp
+++ b/src/tools/mds_client.cpp
@@ -960,7 +960,7 @@ int MDSClient::GetMetric(const std::string& metricName, std::string* value) {
 
 bool MDSClient::ChangeMDServer() {
     currentMdsIndex_++;
-    if (currentMdsIndex_ > mdsAddrVec_.size() - 1) {
+    if (currentMdsIndex_ > static_cast<int>(mdsAddrVec_.size() - 1)) {
         currentMdsIndex_ = 0;
     }
     if (channel_.Init(mdsAddrVec_[currentMdsIndex_].c_str(),

--- a/src/tools/namespace_tool_core.cpp
+++ b/src/tools/namespace_tool_core.cpp
@@ -203,7 +203,7 @@ int NameSpaceToolCore::UpdateFileThrottle(const std::string& fileName,
     params.set_limit(limit);
     params.set_type(type);
     if (burst >= 0) {
-        if (burst < limit) {
+        if (burst < static_cast<int64_t>(limit)) {
             std::cout << "burst should greater equal to limit" << std::endl;
             return -1;
         }
@@ -253,7 +253,7 @@ int NameSpaceToolCore::QueryChunkCopyset(const std::string& fileName,
         return -1;
     }
     uint64_t chunkIndex = (offset - segOffset) / segment.chunksize();
-    if (chunkIndex >= segment.chunks_size()) {
+    if (static_cast<int64_t>(chunkIndex) >= segment.chunks_size()) {
         std::cout << "ChunkIndex exceed chunks num in segment!" << std::endl;
         return -1;
     }

--- a/src/tools/snapshot_clone_client.cpp
+++ b/src/tools/snapshot_clone_client.cpp
@@ -104,8 +104,7 @@ std::vector<std::string> SnapshotCloneClient::GetActiveAddrs() {
 void SnapshotCloneClient::GetOnlineStatus(
                                 std::map<std::string, bool>* onlineStatus) {
     onlineStatus->clear();
-    int result = 0;
-    for (const auto item : dummyServerMap_) {
+    for (const auto &item : dummyServerMap_) {
         std::string listenAddr;
         int res = GetListenAddrFromDummyPort(item.second, &listenAddr);
         // 如果获取到的监听地址与记录的mds地址不一致，也认为不在线

--- a/src/tools/status_tool.cpp
+++ b/src/tools/status_tool.cpp
@@ -856,7 +856,7 @@ int PrintChunkserverOnlineStatus(
     int i = 0;
     for (ChunkServerIdType csId :  offlineRecover) {
         i++;
-        if (i == offlineRecover.size()) {
+        if (i == static_cast<int>(offlineRecover.size())) {
             std::cout << csId;
         } else {
             std::cout << csId << ", ";

--- a/src/tools/status_tool.h
+++ b/src/tools/status_tool.h
@@ -49,13 +49,13 @@
 #include "src/tools/snapshot_clone_client.h"
 #include "src/common/uri_parser.h"
 
+using curve::mds::topology::ChunkServerInfo;
 using curve::mds::topology::ChunkServerStatus;
 using curve::mds::topology::DiskState;
+using curve::mds::topology::LogicalPoolInfo;
 using curve::mds::topology::OnlineState;
 using curve::mds::topology::PhysicalPoolInfo;
-using curve::mds::topology::LogicalPoolInfo;
 using curve::mds::topology::PoolIdType;
-using curve::mds::topology::ChunkServerInfo;
 
 namespace curve {
 namespace tool {
@@ -99,14 +99,11 @@ class StatusTool : public CurveTool {
                std::shared_ptr<CopysetCheckCore> copysetCheckCore,
                std::shared_ptr<VersionTool> versionTool,
                std::shared_ptr<MetricClient> metricClient,
-               std::shared_ptr<SnapshotCloneClient> snapshotClient) :
-                  mdsClient_(mdsClient), etcdClient_(etcdClient),
-                  copysetCheckCore_(copysetCheckCore),
-                  versionTool_(versionTool),
-                  metricClient_(metricClient),
-                  snapshotClient_(snapshotClient),
-                  mdsInited_(false), etcdInited_(false),
-                  noSnapshotServer_(false) {}
+               std::shared_ptr<SnapshotCloneClient> snapshotClient)
+        : mdsClient_(mdsClient), copysetCheckCore_(copysetCheckCore),
+          etcdClient_(etcdClient), metricClient_(metricClient),
+          snapshotClient_(snapshotClient), versionTool_(versionTool),
+          mdsInited_(false), etcdInited_(false), noSnapshotServer_(false) {}
     ~StatusTool() = default;
 
     /**
@@ -128,7 +125,7 @@ class StatusTool : public CurveTool {
      *  @param command：执行的命令
      *  @return true / false
      */
-    static bool SupportCommand(const std::string& command);
+    static bool SupportCommand(const std::string &command);
 
     /**
      *  @brief 判断集群是否健康
@@ -136,16 +133,16 @@ class StatusTool : public CurveTool {
     bool IsClusterHeatlhy();
 
  private:
-    int Init(const std::string& command);
+    int Init(const std::string &command);
     int SpaceCmd();
     int StatusCmd();
     int ChunkServerListCmd();
     int ServerListCmd();
     int LogicalPoolListCmd();
     int ChunkServerStatusCmd();
-    int GetPoolsInCluster(std::vector<PhysicalPoolInfo>* phyPools,
-                          std::vector<LogicalPoolInfo>* lgPools);
-    int GetSpaceInfo(SpaceInfo* spaceInfo);
+    int GetPoolsInCluster(std::vector<PhysicalPoolInfo> *phyPools,
+                          std::vector<LogicalPoolInfo> *lgPools);
+    int GetSpaceInfo(SpaceInfo *spaceInfo);
     int PrintClusterStatus();
     int PrintMdsStatus();
     int PrintEtcdStatus();
@@ -153,9 +150,9 @@ class StatusTool : public CurveTool {
     int PrintClientStatus();
     int ClientListCmd();
     int ScanStatusCmd();
-    void PrintCsLeftSizeStatistics(const std::string& name,
-                        const std::map<PoolIdType,
-                        std::vector<uint64_t>>& poolLeftSize);
+    void PrintCsLeftSizeStatistics(
+        const std::string &name,
+        const std::map<PoolIdType, std::vector<uint64_t>> &poolLeftSize);
     int PrintSnapshotCloneStatus();
 
     /**
@@ -163,7 +160,7 @@ class StatusTool : public CurveTool {
      *  @param command：执行的命令
      *  @return 需要返回true，否则返回false
      */
-    bool CommandNeedEtcd(const std::string& command);
+    bool CommandNeedEtcd(const std::string &command);
 
 
     /**
@@ -171,22 +168,22 @@ class StatusTool : public CurveTool {
      *  @param command：执行的命令
      *  @return 需要返回true，否则返回false
      */
-    bool CommandNeedMds(const std::string& command);
+    bool CommandNeedMds(const std::string &command);
 
     /**
      *  @brief 判断命令是否需要snapshot clone server
      *  @param command：执行的命令
      *  @return 需要返回true，否则返回false
      */
-    bool CommandNeedSnapshotClone(const std::string& command);
+    bool CommandNeedSnapshotClone(const std::string &command);
 
     /**
      *  @brief 打印在线状态
      *  @param name : 在线状态对应的名字
      *  @param onlineStatus 在线状态的map
      */
-    void PrintOnlineStatus(const std::string& name,
-                           const std::map<std::string, bool>& onlineStatus);
+    void PrintOnlineStatus(const std::string &name,
+                           const std::map<std::string, bool> &onlineStatus);
 
     /**
      *  @brief 获取并打印mds version信息
@@ -197,7 +194,7 @@ class StatusTool : public CurveTool {
      *  @brief 检查服务是否健康
      *  @param name 服务名
      */
-    bool CheckServiceHealthy(const ServiceName& name);
+    bool CheckServiceHealthy(const ServiceName &name);
 
  private:
     // 向mds发送RPC的client

--- a/src/tools/version_tool.h
+++ b/src/tools/version_tool.h
@@ -49,9 +49,8 @@ class VersionTool {
     explicit VersionTool(std::shared_ptr<MDSClient> mdsClient,
                          std::shared_ptr<MetricClient> metricClient,
                          std::shared_ptr<SnapshotCloneClient> snapshotClient)
-                                 : mdsClient_(mdsClient),
-                                   metricClient_(metricClient),
-                                   snapshotClient_(snapshotClient) {}
+        : mdsClient_(mdsClient), snapshotClient_(snapshotClient),
+          metricClient_(metricClient) {}
     virtual ~VersionTool() {}
 
     /**
@@ -59,43 +58,45 @@ class VersionTool {
      *  @param[out] version 版本
      *  @return 成功返回0，失败返回-1
      */
-    virtual int GetAndCheckMdsVersion(std::string* version,
-                                      std::vector<std::string>* failedList);
+    virtual int GetAndCheckMdsVersion(std::string *version,
+                                      std::vector<std::string> *failedList);
 
     /**
      *  @brief 获取chunkserver的版本并检查版本一致性
      *  @param[out] version 版本
      *  @return 成功返回0，失败返回-1
      */
-    virtual int GetAndCheckChunkServerVersion(std::string* version,
-                                       std::vector<std::string>* failedList);
+    virtual int
+    GetAndCheckChunkServerVersion(std::string *version,
+                                  std::vector<std::string> *failedList);
 
     /**
      *  @brief 获取snapshot clone server的版本
      *  @param[out] version 版本
      *  @return 成功返回0，失败返回-1
      */
-    virtual int GetAndCheckSnapshotCloneVersion(std::string* version,
-                                        std::vector<std::string>* failedList);
+    virtual int
+    GetAndCheckSnapshotCloneVersion(std::string *version,
+                                    std::vector<std::string> *failedList);
 
     /**
      *  @brief 获取client的版本
      *  @param[out] versionMap process->版本->地址的映射表
      *  @return 成功返回0，失败返回-1
      */
-    virtual int GetClientVersion(ClientVersionMapType* versionMap);
+    virtual int GetClientVersion(ClientVersionMapType *versionMap);
 
     /**
      *  @brief 打印每个version对应的地址
      *  @param versionMap version到地址列表的map
      */
-    static void PrintVersionMap(const VersionMapType& versionMap);
+    static void PrintVersionMap(const VersionMapType &versionMap);
 
     /**
      *  @brief 打印访问失败的地址
      *  @param failedList 访问失败的地址列表
      */
-    static void PrintFailedList(const std::vector<std::string>& failedList);
+    static void PrintFailedList(const std::vector<std::string> &failedList);
 
  private:
     /**
@@ -104,17 +105,17 @@ class VersionTool {
      *  @param[out] versionMap version到地址的map
      *  @param[out] failedList 查询version失败的地址列表
      */
-    void GetVersionMap(const std::vector<std::string>& addrVec,
-                       VersionMapType* versionMap,
-                       std::vector<std::string>* failedList);
+    void GetVersionMap(const std::vector<std::string> &addrVec,
+                       VersionMapType *versionMap,
+                       std::vector<std::string> *failedList);
 
     /**
      *  @brief 获取addrVec对应地址的version，并把version和地址对应关系存在map中
      *  @param addrVec 地址列表
      *  @param[out] processMap 不同的process对应的client的地址列表
      */
-    void FetchClientProcessMap(const std::vector<std::string>& addrVec,
-                               ProcessMapType* processMap);
+    void FetchClientProcessMap(const std::vector<std::string> &addrVec,
+                               ProcessMapType *processMap);
 
     /**
      *  @brief 从启动server的命令行获取对应的程序的名字
@@ -129,7 +130,7 @@ class VersionTool {
      *  @param addrVec 地址列表
      *  @return 进程的名字
      */
-    std::string GetProcessNameFromCmd(const std::string& cmd);
+    std::string GetProcessNameFromCmd(const std::string &cmd);
 
  private:
     // 向mds发送RPC的client

--- a/test/chunkserver/chunk_service_test.cpp
+++ b/test/chunkserver/chunk_service_test.cpp
@@ -159,7 +159,6 @@ TEST_F(ChunkserverTest, normal_read_write_test) {
     };
     WaitpidGuard waitpidGuard(pid1, pid2, pid3);
 
-    const uint32_t kMaxChunkSize = 16 * 1024 * 1024;
     PeerId leader;
     LogicPoolID logicPoolId = 1;
     CopysetID copysetId = 100001;

--- a/test/chunkserver/chunk_service_test2.cpp
+++ b/test/chunkserver/chunk_service_test2.cpp
@@ -164,7 +164,6 @@ TEST_F(ChunkService2Test, illegial_parameters_test) {
     CopysetID copysetId = 100001;
     uint64_t chunkId = 1;
     uint64_t sn = 1;
-    char ch = 'a';
     char expectData[kOpRequestAlignSize + 1];
     ::memset(expectData, 'a', kOpRequestAlignSize);
     expectData[kOpRequestAlignSize] = '\0';

--- a/test/chunkserver/chunkserver_test.cpp
+++ b/test/chunkserver/chunkserver_test.cpp
@@ -34,11 +34,9 @@
 
 #include "test/client/fake/fakeMDS.h"
 
-uint32_t segment_size = 1 * 1024 * 1024 * 1024ul;   // NOLINT
-uint32_t chunk_size = 16 * 1024 * 1024;   // NOLINT
-std::string mdsMetaServerAddr = "127.0.0.1:9301";   // NOLINT
-
-char* confPath = "conf/client.conf";
+uint32_t segment_size = 1 * 1024 * 1024 * 1024ul;  // NOLINT
+uint32_t chunk_size = 16 * 1024 * 1024;            // NOLINT
+std::string mdsMetaServerAddr = "127.0.0.1:9301";  // NOLINT
 
 butil::AtExitManager atExitManager;
 
@@ -53,17 +51,17 @@ struct ChunkServerPackage {
     char **argv;
 };
 
-void* run_chunkserver_thread(void *arg) {
+void *run_chunkserver_thread(void *arg) {
     ChunkServerPackage *package = reinterpret_cast<ChunkServerPackage *>(arg);
     package->chunkserver->Run(package->argc, package->argv);
 
     return NULL;
 }
 
-using curve::fs::LocalFsFactory;
 using curve::fs::FileSystemType;
+using curve::fs::LocalFsFactory;
 
-static int ExecCmd(const std::string& cmd) {
+static int ExecCmd(const std::string &cmd) {
     LOG(INFO) << "executing command: " << cmd;
 
     return system(cmd.c_str());
@@ -73,7 +71,6 @@ class ChunkserverTest : public ::testing::Test {
  public:
     void SetUp() {
         std::string filename = "test.img";
-        size_t filesize =  10uL * 1024 * 1024 * 1024;
 
         mds_ = new FakeMDS(filename);
 
@@ -87,8 +84,7 @@ class ChunkserverTest : public ::testing::Test {
     }
 
  private:
-    FakeMDS* mds_;
-    int fd_;
+    FakeMDS *mds_;
 };
 
 TEST(ChunkserverCommonTest, GroupIdTest) {
@@ -111,25 +107,26 @@ TEST(ChunkserverCommonTest, GroupIdTest) {
 
 TEST(ChunkServerGflagTest, test_load_gflag) {
     int argc = 1;
-    char *argvv[] = {""};
+    char *argvv[] = {const_cast<char *>("")};
     char **argv = argvv;
     gflags::ParseCommandLineFlags(&argc, &argv, true);
     google::CommandLineFlagInfo info;
     ASSERT_TRUE(GetCommandLineFlagInfo("chunkservertest", &info));
     ASSERT_TRUE(info.is_default);
     ASSERT_EQ("testdefault", FLAGS_chunkservertest);
-    ASSERT_FALSE(
-        GetCommandLineFlagInfo("chunkservertest", &info) && !info.is_default);
+    ASSERT_FALSE(GetCommandLineFlagInfo("chunkservertest", &info) &&
+                 !info.is_default);
 
-    char *argvj[] = {"", "-chunkservertest=test1"};
+    char *argvj[] = {const_cast<char *>(""),
+                     const_cast<char *>("-chunkservertest=test1")};
     argv = argvj;
     argc = 2;
     gflags::ParseCommandLineFlags(&argc, &argv, true);
     ASSERT_TRUE(GetCommandLineFlagInfo("chunkservertest", &info));
     ASSERT_FALSE(info.is_default);
     ASSERT_EQ("test1", FLAGS_chunkservertest);
-    ASSERT_TRUE(
-        GetCommandLineFlagInfo("chunkservertest", &info) && !info.is_default);
+    ASSERT_TRUE(GetCommandLineFlagInfo("chunkservertest", &info) &&
+                !info.is_default);
 }
 }  // namespace chunkserver
 }  // namespace curve

--- a/test/chunkserver/clone/op_request_test.cpp
+++ b/test/chunkserver/clone/op_request_test.cpp
@@ -668,7 +668,7 @@ TEST_F(OpRequestTest, ReadChunkTest) {
             .WillOnce(
                 DoAll(SetArgPointee<1>(info), Return(CSErrorCode::Success)));
 
-        char chunkData[length];  // NOLINT
+        char *chunkData = new char[length];
         memset(chunkData, 'a', length);
         EXPECT_CALL(*datastore_, ReadChunk(_, _, _, offset, length))
             .WillOnce(DoAll(SetArrayArgument<2>(chunkData, chunkData + length),
@@ -687,6 +687,7 @@ TEST_F(OpRequestTest, ReadChunkTest) {
         }
 
         ASSERT_TRUE(closure->isDone_);
+        delete[] chunkData;
     }
 
     /**
@@ -704,7 +705,7 @@ TEST_F(OpRequestTest, ReadChunkTest) {
             .WillOnce(
                 DoAll(SetArgPointee<1>(info), Return(CSErrorCode::Success)));
         // 读chunk文件
-        char chunkData[length];  // NOLINT
+        char *chunkData = new char[length];
         memset(chunkData, 'a', length);
         EXPECT_CALL(*datastore_, ReadChunk(_, _, _, offset, length))
             .WillOnce(DoAll(SetArrayArgument<2>(chunkData, chunkData + length),
@@ -723,6 +724,7 @@ TEST_F(OpRequestTest, ReadChunkTest) {
                    cntl->response_attachment().to_string().c_str(),  // NOLINT
                    length),
             0);
+        delete[] chunkData;
     }
 
     /**
@@ -741,7 +743,7 @@ TEST_F(OpRequestTest, ReadChunkTest) {
             .WillOnce(
                 DoAll(SetArgPointee<1>(info), Return(CSErrorCode::Success)));
         // 读chunk文件
-        char chunkData[length];  // NOLINT
+        char *chunkData = new char[length];
         memset(chunkData, 'a', length);
         EXPECT_CALL(*datastore_, ReadChunk(_, _, _, offset, length))
             .WillOnce(DoAll(SetArrayArgument<2>(chunkData, chunkData + length),
@@ -762,6 +764,7 @@ TEST_F(OpRequestTest, ReadChunkTest) {
                              .c_str(),  // NOLINT
                          length),
                   0);
+        delete[] chunkData;
     }
 
     /**
@@ -879,7 +882,7 @@ TEST_F(OpRequestTest, ReadChunkTest) {
             .WillOnce(DoAll(SetArgPointee<1>(info),
                             Return(CSErrorCode::Success)));
         // 读chunk文件
-        char chunkData[length];  // NOLINT
+        char *chunkData = new char[length];
         memset(chunkData, 'a', length);
         EXPECT_CALL(*datastore_, ReadChunk(_, _, _, offset, length))
             .WillOnce(DoAll(SetArrayArgument<2>(chunkData,
@@ -899,6 +902,7 @@ TEST_F(OpRequestTest, ReadChunkTest) {
         ASSERT_EQ(memcmp(chunkData,
                          closure->cntl_->response_attachment().to_string().c_str(),  //NOLINT
                          length), 0);
+        delete[] chunkData;
     }
     /**
      * 测试OnApply

--- a/test/chunkserver/conf_epoch_file_test.cpp
+++ b/test/chunkserver/conf_epoch_file_test.cpp
@@ -33,20 +33,20 @@ namespace curve {
 namespace chunkserver {
 
 using ::testing::_;
-using ::testing::Invoke;
-using ::testing::Return;
 using ::testing::AnyNumber;
-using ::testing::Matcher;
-using ::testing::DoAll;
-using ::testing::SetArgPointee;
-using ::testing::SetArrayArgument;
-using ::testing::SetArgReferee;
-using ::testing::InSequence;
 using ::testing::AtLeast;
+using ::testing::DoAll;
+using ::testing::InSequence;
+using ::testing::Invoke;
+using ::testing::Matcher;
+using ::testing::Return;
 using ::testing::SaveArgPointee;
+using ::testing::SetArgPointee;
+using ::testing::SetArgReferee;
+using ::testing::SetArrayArgument;
 
-using curve::fs::MockLocalFileSystem;
 using curve::fs::FileSystemType;
+using curve::fs::MockLocalFileSystem;
 
 TEST(ConfEpochFileTest, load_save) {
     LogicPoolID logicPoolID = 123;
@@ -65,9 +65,7 @@ TEST(ConfEpochFileTest, load_save) {
         LogicPoolID loadLogicPoolID;
         CopysetID loadCopysetID;
         uint64_t loadEpoch;
-        ASSERT_EQ(0, confEpochFile.Load(path,
-                                        &loadLogicPoolID,
-                                        &loadCopysetID,
+        ASSERT_EQ(0, confEpochFile.Load(path, &loadLogicPoolID, &loadCopysetID,
                                         &loadEpoch));
         ASSERT_EQ(logicPoolID, loadLogicPoolID);
         ASSERT_EQ(copysetID, loadCopysetID);
@@ -78,22 +76,20 @@ TEST(ConfEpochFileTest, load_save) {
 
     // load: open failed
     {
-        std::shared_ptr<MockLocalFileSystem> fs
-            = std::make_shared<MockLocalFileSystem>();
+        std::shared_ptr<MockLocalFileSystem> fs =
+            std::make_shared<MockLocalFileSystem>();
         ConfEpochFile confEpochFile(fs);
         LogicPoolID loadLogicPoolID;
         CopysetID loadCopysetID;
         uint64_t loadEpoch;
         EXPECT_CALL(*fs, Open(_, _)).Times(1).WillOnce(Return(-1));
-        ASSERT_EQ(-1, confEpochFile.Load(path,
-                                        &loadLogicPoolID,
-                                        &loadCopysetID,
-                                        &loadEpoch));
+        ASSERT_EQ(-1, confEpochFile.Load(path, &loadLogicPoolID, &loadCopysetID,
+                                         &loadEpoch));
     }
     // load: open success, read failed
     {
-        std::shared_ptr<MockLocalFileSystem> fs
-            = std::make_shared<MockLocalFileSystem>();
+        std::shared_ptr<MockLocalFileSystem> fs =
+            std::make_shared<MockLocalFileSystem>();
         ConfEpochFile confEpochFile(fs);
         LogicPoolID loadLogicPoolID;
         CopysetID loadCopysetID;
@@ -101,118 +97,111 @@ TEST(ConfEpochFileTest, load_save) {
         EXPECT_CALL(*fs, Open(_, _)).Times(1).WillOnce(Return(10));
         EXPECT_CALL(*fs, Read(_, _, _, _)).Times(1).WillOnce(Return(-1));
         EXPECT_CALL(*fs, Close(_)).Times(1).WillOnce(Return(0));
-        ASSERT_EQ(-1, confEpochFile.Load(path,
-                                         &loadLogicPoolID,
-                                         &loadCopysetID,
+        ASSERT_EQ(-1, confEpochFile.Load(path, &loadLogicPoolID, &loadCopysetID,
                                          &loadEpoch));
     }
     // load: open success, read success, decode success, crc32c right
     {
-        char *json = "{\"logicPoolId\":123,\"copysetId\":1345,\"epoch\":0,\"checksum\":599727352}";  // NOLINT
+        const char *json = "{\"logicPoolId\":123,\"copysetId\":1345,\"epoch\":"
+                           "0,\"checksum\":599727352}";  // NOLINT
         std::string jsonStr(json);
-        std::shared_ptr<MockLocalFileSystem> fs
-            = std::make_shared<MockLocalFileSystem>();
+        std::shared_ptr<MockLocalFileSystem> fs =
+            std::make_shared<MockLocalFileSystem>();
         ConfEpochFile confEpochFile(fs);
         LogicPoolID loadLogicPoolID;
         CopysetID loadCopysetID;
         uint64_t loadEpoch;
         EXPECT_CALL(*fs, Open(_, _)).Times(1).WillOnce(Return(10));
-        EXPECT_CALL(*fs, Read(_, _, _, _)).Times(1)
+        EXPECT_CALL(*fs, Read(_, _, _, _))
+            .Times(1)
             .WillOnce(DoAll(SetArrayArgument<1>(json, json + jsonStr.size()),
                             Return(jsonStr.size())));
         EXPECT_CALL(*fs, Close(_)).Times(1).WillOnce(Return(0));
-        ASSERT_EQ(0, confEpochFile.Load(path,
-                                         &loadLogicPoolID,
-                                         &loadCopysetID,
-                                         &loadEpoch));
+        ASSERT_EQ(0, confEpochFile.Load(path, &loadLogicPoolID, &loadCopysetID,
+                                        &loadEpoch));
     }
     // load: open success, read success, decode failed, crc32c right
     {
-        char *json = "{\"logicPoolId";
+        const char *json = "{\"logicPoolId";
         std::string jsonStr(json);
-        std::shared_ptr<MockLocalFileSystem> fs
-            = std::make_shared<MockLocalFileSystem>();
+        std::shared_ptr<MockLocalFileSystem> fs =
+            std::make_shared<MockLocalFileSystem>();
         ConfEpochFile confEpochFile(fs);
         LogicPoolID loadLogicPoolID;
         CopysetID loadCopysetID;
         uint64_t loadEpoch;
         EXPECT_CALL(*fs, Open(_, _)).Times(1).WillOnce(Return(10));
-        EXPECT_CALL(*fs, Read(_, _, _, _)).Times(1)
+        EXPECT_CALL(*fs, Read(_, _, _, _))
+            .Times(1)
             .WillOnce(DoAll(SetArrayArgument<1>(json, json + jsonStr.size()),
                             Return(jsonStr.size())));
         EXPECT_CALL(*fs, Close(_)).Times(1).WillOnce(Return(0));
-        ASSERT_EQ(-1, confEpochFile.Load(path,
-                                         &loadLogicPoolID,
-                                         &loadCopysetID,
+        ASSERT_EQ(-1, confEpochFile.Load(path, &loadLogicPoolID, &loadCopysetID,
                                          &loadEpoch));
     }
     // load: open success, read success, decode success, crc32c not right
     {
-        char *json = "{\"logicPoolId\":123,\"copysetId\":1345,\"epoch\":0,\"checksum\":123}";  // NOLINT
+        const char *json = "{\"logicPoolId\":123,\"copysetId\":1345,\"epoch\":"
+                           "0,\"checksum\":123}";  // NOLINT
         std::string jsonStr(json);
-        std::shared_ptr<MockLocalFileSystem> fs
-            = std::make_shared<MockLocalFileSystem>();
+        std::shared_ptr<MockLocalFileSystem> fs =
+            std::make_shared<MockLocalFileSystem>();
         ConfEpochFile confEpochFile(fs);
         LogicPoolID loadLogicPoolID;
         CopysetID loadCopysetID;
         uint64_t loadEpoch;
         EXPECT_CALL(*fs, Open(_, _)).Times(1).WillOnce(Return(10));
-        EXPECT_CALL(*fs, Read(_, _, _, _)).Times(1)
+        EXPECT_CALL(*fs, Read(_, _, _, _))
+            .Times(1)
             .WillOnce(DoAll(SetArrayArgument<1>(json, json + jsonStr.size()),
                             Return(jsonStr.size())));
         EXPECT_CALL(*fs, Close(_)).Times(1).WillOnce(Return(0));
-        ASSERT_EQ(-1, confEpochFile.Load(path,
-                                        &loadLogicPoolID,
-                                        &loadCopysetID,
-                                        &loadEpoch));
+        ASSERT_EQ(-1, confEpochFile.Load(path, &loadLogicPoolID, &loadCopysetID,
+                                         &loadEpoch));
     }
     // save: open failed
     {
-        std::shared_ptr<MockLocalFileSystem> fs
-            = std::make_shared<MockLocalFileSystem>();
+        std::shared_ptr<MockLocalFileSystem> fs =
+            std::make_shared<MockLocalFileSystem>();
         ConfEpochFile confEpochFile(fs);
-        LogicPoolID loadLogicPoolID;
-        CopysetID loadCopysetID;
-        uint64_t loadEpoch;
+        LogicPoolID loadLogicPoolID = 0;
+        CopysetID loadCopysetID = 0;
+        uint64_t loadEpoch = 0;
         EXPECT_CALL(*fs, Open(_, _)).Times(1).WillOnce(Return(-1));
-        ASSERT_EQ(-1, confEpochFile.Save(path,
-                                         loadLogicPoolID,
-                                         loadCopysetID,
+        ASSERT_EQ(-1, confEpochFile.Save(path, loadLogicPoolID, loadCopysetID,
                                          loadEpoch));
     }
     // save: open success, write failed
     {
-        std::shared_ptr<MockLocalFileSystem> fs
-            = std::make_shared<MockLocalFileSystem>();
+        std::shared_ptr<MockLocalFileSystem> fs =
+            std::make_shared<MockLocalFileSystem>();
         ConfEpochFile confEpochFile(fs);
-        LogicPoolID loadLogicPoolID;
-        CopysetID loadCopysetID;
-        uint64_t loadEpoch;
+        LogicPoolID loadLogicPoolID = 0;
+        CopysetID loadCopysetID = 0;
+        uint64_t loadEpoch = 0;
         EXPECT_CALL(*fs, Open(_, _)).Times(1).WillOnce(Return(10));
-        EXPECT_CALL(*fs, Write(_, Matcher<const char*>(_), _, _)).Times(1)
+        EXPECT_CALL(*fs, Write(_, Matcher<const char *>(_), _, _))
+            .Times(1)
             .WillOnce(Return(-1));
         EXPECT_CALL(*fs, Close(_)).Times(1).WillOnce(Return(0));
-        ASSERT_EQ(-1, confEpochFile.Save(path,
-                                         loadLogicPoolID,
-                                         loadCopysetID,
+        ASSERT_EQ(-1, confEpochFile.Save(path, loadLogicPoolID, loadCopysetID,
                                          loadEpoch));
     }
     // save: open success, write success, fsync failed
     {
-        char *json = "{\"logicPoolId\":123,\"copysetId\":1345,\"epoch\":0,\"checksum\":599727352}";  // NOLINT
+        const char *json = "{\"logicPoolId\":123,\"copysetId\":1345,\"epoch\":"
+                           "0,\"checksum\":599727352}";  // NOLINT
         std::string jsonStr(json);
-        std::shared_ptr<MockLocalFileSystem> fs
-            = std::make_shared<MockLocalFileSystem>();
+        std::shared_ptr<MockLocalFileSystem> fs =
+            std::make_shared<MockLocalFileSystem>();
         ConfEpochFile confEpochFile(fs);
         EXPECT_CALL(*fs, Open(_, _)).Times(1).WillOnce(Return(10));
-        EXPECT_CALL(*fs, Write(_, Matcher<const char*>(_), _, _)).Times(1)
+        EXPECT_CALL(*fs, Write(_, Matcher<const char *>(_), _, _))
+            .Times(1)
             .WillOnce(Return(jsonStr.size()));
         EXPECT_CALL(*fs, Close(_)).Times(1).WillOnce(Return(0));
         EXPECT_CALL(*fs, Fsync(_)).Times(1).WillOnce(Return(-1));
-        ASSERT_EQ(-1, confEpochFile.Save(path,
-                                         logicPoolID,
-                                         copysetID,
-                                         epoch));
+        ASSERT_EQ(-1, confEpochFile.Save(path, logicPoolID, copysetID, epoch));
     }
 }
 

--- a/test/chunkserver/copyset_node_test.cpp
+++ b/test/chunkserver/copyset_node_test.cpp
@@ -160,7 +160,6 @@ class CopysetNodeTest : public ::testing::Test {
 TEST_F(CopysetNodeTest, error_test) {
     std::shared_ptr<LocalFileSystem>
         fs(LocalFsFactory::CreateFs(FileSystemType::EXT4, ""));    //NOLINT
-    const uint32_t kMaxChunkSize = 16 * 1024 * 1024;
     std::string rmCmd("rm -f ");
     rmCmd += kCurveConfEpochFilename;
 
@@ -173,7 +172,7 @@ TEST_F(CopysetNodeTest, error_test) {
         files.push_back("test-1.txt");
         files.push_back("test-2.txt");
 
-        char *json = "{\"logicPoolId\":123,\"copysetId\":1345,\"epoch\":0,\"checksum\":774340440}";  // NOLINT
+        const char *json = "{\"logicPoolId\":123,\"copysetId\":1345,\"epoch\":0,\"checksum\":774340440}";  // NOLINT
         std::string jsonStr(json);
 
         CopysetNode copysetNode(logicPoolID, copysetID, conf);
@@ -235,7 +234,7 @@ TEST_F(CopysetNodeTest, error_test) {
         files.push_back("test-1.txt");
         files.push_back("test-2.txt");
 
-        char *json = "{\"logicPoolId\":123,\"copysetId\":1345,\"epoch\":0,\"checksum\":774340440}";  // NOLINT
+        const char *json = "{\"logicPoolId\":123,\"copysetId\":1345,\"epoch\":0,\"checksum\":774340440}";  // NOLINT
         std::string jsonStr(json);
 
         CopysetNode copysetNode(logicPoolID, copysetID, conf);
@@ -270,7 +269,7 @@ TEST_F(CopysetNodeTest, error_test) {
         files.push_back("test-1.txt");
         files.push_back("test-2.txt");
 
-        char *json = "{\"logicPoolId\":123,\"copysetId\":1345,\"epoch\":0,\"checksum\":774340440}";  // NOLINT
+        const char *json = "{\"logicPoolId\":123,\"copysetId\":1345,\"epoch\":0,\"checksum\":774340440}";  // NOLINT
         std::string jsonStr(json);
 
         CopysetNode copysetNode(logicPoolID, copysetID, conf);
@@ -590,7 +589,6 @@ TEST_F(CopysetNodeTest, error_test) {
 TEST_F(CopysetNodeTest, get_conf_change) {
     std::shared_ptr<LocalFileSystem>
         fs(LocalFsFactory::CreateFs(FileSystemType::EXT4, ""));    //NOLINT
-    const uint32_t kMaxChunkSize = 16 * 1024 * 1024;
     std::string rmCmd("rm -f ");
     rmCmd += kCurveConfEpochFilename;
 
@@ -794,7 +792,6 @@ TEST_F(CopysetNodeTest, get_conf_change) {
 TEST_F(CopysetNodeTest, get_hash) {
     std::shared_ptr<LocalFileSystem>
         fs(LocalFsFactory::CreateFs(FileSystemType::EXT4, ""));    //NOLINT
-    const uint32_t kMaxChunkSize = 16 * 1024 * 1024;
     std::string rmCmd("rm -f ");
     rmCmd += kCurveConfEpochFilename;
 

--- a/test/chunkserver/datastore/datastore_mock_unittest.cpp
+++ b/test/chunkserver/datastore/datastore_mock_unittest.cpp
@@ -669,8 +669,8 @@ TEST_F(CSDataStore_test, WriteChunkTest1) {
     SequenceNum sn = 1;
     off_t offset = 0;
     size_t length = PAGE_SIZE;
-    char buf[length];  // NOLINT
-    memset(buf, 0, sizeof(buf));
+    char *buf = new char[length];
+    memset(buf, 0, length);
     // create new chunk and open it
     string chunk3Path = string(baseDir) + "/" +
                         FileNameOperator::GenerateChunkFileName(id);
@@ -733,6 +733,7 @@ TEST_F(CSDataStore_test, WriteChunkTest1) {
         .Times(1);
     EXPECT_CALL(*lfs_, Close(4))
         .Times(1);
+    delete[] buf;
 }
 
 /**
@@ -751,8 +752,8 @@ TEST_F(CSDataStore_test, WriteChunkTest2) {
     SequenceNum sn = 3;
     off_t offset = 0;
     size_t length = PAGE_SIZE;
-    char buf[length];  // NOLINT
-    memset(buf, 0, sizeof(buf));
+    char *buf = new char[length];
+    memset(buf, 0, length);
 
     // sn<chunk.sn  sn>chunk.correctedsn
     EXPECT_EQ(CSErrorCode::BackwardRequestError,
@@ -789,6 +790,7 @@ TEST_F(CSDataStore_test, WriteChunkTest2) {
         .Times(1);
     EXPECT_CALL(*lfs_, Close(3))
         .Times(1);
+    delete[] buf;
 }
 
 /**
@@ -812,8 +814,8 @@ TEST_F(CSDataStore_test, WriteChunkTest3) {
     SequenceNum sn = 3;
     off_t offset = 0;
     size_t length = PAGE_SIZE;
-    char buf[length];  // NOLINT
-    memset(buf, 0, sizeof(buf));
+    char *buf = new char[length];
+    memset(buf, 0, length);
 
     // sn>chunk.sn  sn<chunk.correctedsn
     EXPECT_EQ(CSErrorCode::BackwardRequestError,
@@ -850,6 +852,7 @@ TEST_F(CSDataStore_test, WriteChunkTest3) {
         .Times(1);
     EXPECT_CALL(*lfs_, Close(3))
         .Times(1);
+    delete[] buf;
 }
 
 /**
@@ -867,8 +870,8 @@ TEST_F(CSDataStore_test, WriteChunkTest4) {
     SequenceNum sn = 2;
     off_t offset = 0;
     size_t length = PAGE_SIZE;
-    char buf[length];  // NOLINT
-    memset(buf, 0, sizeof(buf));
+    char *buf = new char[length];
+    memset(buf, 0, length);
 
     // will write data
     EXPECT_CALL(*lfs_,
@@ -930,6 +933,7 @@ TEST_F(CSDataStore_test, WriteChunkTest4) {
         .Times(1);
     EXPECT_CALL(*lfs_, Close(3))
         .Times(1);
+    delete[] buf;
 }
 
 /**
@@ -954,8 +958,8 @@ TEST_F(CSDataStore_test, WriteChunkTest6) {
     SequenceNum sn = 3;
     off_t offset = 0;
     size_t length = PAGE_SIZE;
-    char buf[length];  // NOLINT
-    memset(buf, 0, sizeof(buf));
+    char *buf = new char[length];
+    memset(buf, 0, length);
     // will update metapage
     EXPECT_CALL(*lfs_, Write(3, Matcher<const char*>(NotNull()), 0, PAGE_SIZE))
         .Times(1);
@@ -982,6 +986,7 @@ TEST_F(CSDataStore_test, WriteChunkTest6) {
         .Times(1);
     EXPECT_CALL(*lfs_, Close(3))
         .Times(1);
+    delete[] buf;
 }
 
 /**
@@ -1000,8 +1005,8 @@ TEST_F(CSDataStore_test, WriteChunkTest7) {
     SequenceNum sn = 3;
     off_t offset = 0;
     size_t length = PAGE_SIZE;
-    char buf[length];  // NOLINT
-    memset(buf, 0, sizeof(buf));
+    char *buf = new char[length];
+    memset(buf, 0, length);
     // will Open snapshot file, snap sn equals 2
     string snapPath = string(baseDir) + "/" +
         FileNameOperator::GenerateSnapshotName(id, 2);
@@ -1079,6 +1084,7 @@ TEST_F(CSDataStore_test, WriteChunkTest7) {
         .Times(1);
     EXPECT_CALL(*lfs_, Close(4))
         .Times(1);
+    delete[] buf;
 }
 
 /**
@@ -1096,8 +1102,8 @@ TEST_F(CSDataStore_test, WriteChunkTest9) {
     SequenceNum sn = 2;
     off_t offset = 0;
     size_t length = PAGE_SIZE;
-    char buf[length];  // NOLINT
-    memset(buf, 0, sizeof(buf));
+    char *buf = new char[length];
+    memset(buf, 0, length);
     // will not create snapshot
     // will copy on write
     EXPECT_CALL(*lfs_, Read(1, NotNull(), PAGE_SIZE + offset, length))
@@ -1131,6 +1137,7 @@ TEST_F(CSDataStore_test, WriteChunkTest9) {
         .Times(1);
     EXPECT_CALL(*lfs_, Close(3))
         .Times(1);
+    delete[] buf;
 }
 
 /**
@@ -1155,8 +1162,8 @@ TEST_F(CSDataStore_test, WriteChunkTest10) {
     SequenceNum sn = 3;
     off_t offset = 0;
     size_t length = PAGE_SIZE;
-    char buf[length];  // NOLINT
-    memset(buf, 0, sizeof(buf));
+    char *buf = new char[length];
+    memset(buf, 0, length);
     // will update metapage
     EXPECT_CALL(*lfs_, Write(1, Matcher<const char*>(NotNull()), 0, PAGE_SIZE))
         .Times(1);
@@ -1184,6 +1191,7 @@ TEST_F(CSDataStore_test, WriteChunkTest10) {
         .Times(1);
     EXPECT_CALL(*lfs_, Close(3))
         .Times(1);
+    delete[] buf;
 }
 
 /**
@@ -1208,8 +1216,8 @@ TEST_F(CSDataStore_test, WriteChunkTest11) {
     SequenceNum sn = 4;
     off_t offset = 0;
     size_t length = PAGE_SIZE;
-    char buf[length];  // NOLINT
-    memset(buf, 0, sizeof(buf));
+    char *buf = new char[length];
+    memset(buf, 0, length);
 
     // sn>chunk.sn, sn>chunk.correctedsn
     EXPECT_EQ(CSErrorCode::SnapshotConflictError,
@@ -1231,6 +1239,7 @@ TEST_F(CSDataStore_test, WriteChunkTest11) {
         .Times(1);
     EXPECT_CALL(*lfs_, Close(3))
         .Times(1);
+    delete[] buf;
 }
 
 /**
@@ -1255,8 +1264,8 @@ TEST_F(CSDataStore_test, WriteChunkTest13) {
     SequenceNum correctedSn = 0;
     off_t offset = 0;
     size_t length = PAGE_SIZE;
-    char buf[length];  // NOLINT
-    memset(buf, 0, sizeof(buf));
+    char *buf = new char[length];
+    memset(buf, 0, length);
     CSChunkInfo info;
     // 创建 clone chunk
     {
@@ -1417,6 +1426,7 @@ TEST_F(CSDataStore_test, WriteChunkTest13) {
         .Times(1);
     EXPECT_CALL(*lfs_, Close(4))
         .Times(1);
+    delete[] buf;
 }
 
 /**
@@ -1441,8 +1451,8 @@ TEST_F(CSDataStore_test, WriteChunkTest14) {
     SequenceNum correctedSn = 3;
     off_t offset = 0;
     size_t length = PAGE_SIZE;
-    char buf[length];  // NOLINT
-    memset(buf, 0, sizeof(buf));
+    char *buf = new char[length];
+    memset(buf, 0, length);
     CSChunkInfo info;
     // 创建 clone chunk
     {
@@ -1612,6 +1622,7 @@ TEST_F(CSDataStore_test, WriteChunkTest14) {
         .Times(1);
     EXPECT_CALL(*lfs_, Close(4))
         .Times(1);
+    delete[] buf;
 }
 
 /**
@@ -1646,8 +1657,8 @@ TEST_F(CSDataStore_test, WriteChunkTest15) {
     SequenceNum sn = 2;
     off_t offset = 0;
     size_t length = PAGE_SIZE;
-    char buf[length];  // NOLINT
-    memset(buf, 0, sizeof(buf));
+    char *buf = new char[length];
+    memset(buf, 0, length);
     // will not create snapshot
     // will not copy on write
     EXPECT_CALL(*lfs_, Write(2, Matcher<const char*>(NotNull()), _, _))
@@ -1671,6 +1682,7 @@ TEST_F(CSDataStore_test, WriteChunkTest15) {
         .Times(1);
     EXPECT_CALL(*lfs_, Close(3))
         .Times(1);
+    delete[] buf;
 }
 
 /**
@@ -1705,8 +1717,8 @@ TEST_F(CSDataStore_test, WriteChunkTest16) {
     SequenceNum sn = 3;
     off_t offset = 0;
     size_t length = PAGE_SIZE;
-    char buf[length];  // NOLINT
-    memset(buf, 0, sizeof(buf));
+    char *buf = new char[length];
+    memset(buf, 0, length);
     // will not create snapshot
     // will not copy on write
     EXPECT_CALL(*lfs_, Write(2, Matcher<const char*>(NotNull()), _, _))
@@ -1733,6 +1745,7 @@ TEST_F(CSDataStore_test, WriteChunkTest16) {
         .Times(1);
     EXPECT_CALL(*lfs_, Close(3))
         .Times(1);
+    delete[] buf;
 }
 
 /**
@@ -1749,8 +1762,8 @@ TEST_F(CSDataStore_test, WriteChunkErrorTest1) {
     SequenceNum sn = 3;
     off_t offset = 0;
     size_t length = PAGE_SIZE;
-    char buf[length];  // NOLINT
-    memset(buf, 0, sizeof(buf));
+    char *buf = new char[length];
+    memset(buf, 0, length);
     string snapPath = string(baseDir) + "/" +
         FileNameOperator::GenerateSnapshotName(id, 2);
 
@@ -1817,6 +1830,7 @@ TEST_F(CSDataStore_test, WriteChunkErrorTest1) {
         .Times(1);
     EXPECT_CALL(*lfs_, Close(3))
         .Times(1);
+    delete[] buf;
 }
 
 /**
@@ -1834,8 +1848,8 @@ TEST_F(CSDataStore_test, WriteChunkErrorTest2) {
     SequenceNum sn = 3;
     off_t offset = 0;
     size_t length = PAGE_SIZE;
-    char buf[length];  // NOLINT
-    memset(buf, 0, sizeof(buf));
+    char *buf = new char[length];
+    memset(buf, 0, length);
     // will Open snapshot file, snap sn equals 2
     string snapPath = string(baseDir) + "/" +
         FileNameOperator::GenerateSnapshotName(id, 2);
@@ -1879,6 +1893,7 @@ TEST_F(CSDataStore_test, WriteChunkErrorTest2) {
         .Times(1);
     EXPECT_CALL(*lfs_, Close(4))
         .Times(1);
+    delete[] buf;
 }
 
 /**
@@ -1896,8 +1911,8 @@ TEST_F(CSDataStore_test, WriteChunkErrorTest3) {
     SequenceNum sn = 3;
     off_t offset = 0;
     size_t length = PAGE_SIZE;
-    char buf[length];  // NOLINT
-    memset(buf, 0, sizeof(buf));
+    char *buf = new char[length];
+    memset(buf, 0, length);
     // will Open snapshot file, snap sn equals 2
     string snapPath = string(baseDir) + "/" +
         FileNameOperator::GenerateSnapshotName(id, 2);
@@ -2011,6 +2026,7 @@ TEST_F(CSDataStore_test, WriteChunkErrorTest3) {
         .Times(1);
     EXPECT_CALL(*lfs_, Close(4))
         .Times(1);
+    delete[] buf;
 }
 
 /**
@@ -2028,8 +2044,8 @@ TEST_F(CSDataStore_test, WriteChunkErrorTest4) {
     SequenceNum sn = 3;
     off_t offset = 0;
     size_t length = PAGE_SIZE;
-    char buf[length];  // NOLINT
-    memset(buf, 0, sizeof(buf));
+    char *buf = new char[length];
+    memset(buf, 0, length);
     // will Open snapshot file, snap sn equals 2
     string snapPath = string(baseDir) + "/" +
         FileNameOperator::GenerateSnapshotName(id, 2);
@@ -2093,6 +2109,7 @@ TEST_F(CSDataStore_test, WriteChunkErrorTest4) {
         .Times(1);
     EXPECT_CALL(*lfs_, Close(4))
         .Times(1);
+    delete[] buf;
 }
 
 /**
@@ -2109,8 +2126,8 @@ TEST_F(CSDataStore_test, WriteChunkErrorTest5) {
     SequenceNum sn = 1;
     off_t offset = 0;
     size_t length = PAGE_SIZE;
-    char buf[length];  // NOLINT
-    memset(buf, 0, sizeof(buf));
+    char *buf = new char[length];
+    memset(buf, 0, length);
     // create new chunk and open it
     string chunk3Path = string(baseDir) + "/" +
                         FileNameOperator::GenerateChunkFileName(id);
@@ -2211,6 +2228,7 @@ TEST_F(CSDataStore_test, WriteChunkErrorTest5) {
         .Times(1);
     EXPECT_CALL(*lfs_, Close(3))
         .Times(1);
+    delete[] buf;
 }
 
 /*
@@ -2233,8 +2251,8 @@ TEST_F(CSDataStore_test, WriteChunkErrorTest6) {
     SequenceNum correctedSn = 0;
     off_t offset = 0;
     size_t length = PAGE_SIZE;
-    char buf[length];  // NOLINT
-    memset(buf, 0, sizeof(buf));
+    char *buf = new char[length];
+    memset(buf, 0, length);
     CSChunkInfo info;
     // 创建 clone chunk
     {
@@ -2333,6 +2351,7 @@ TEST_F(CSDataStore_test, WriteChunkErrorTest6) {
         .Times(1);
     EXPECT_CALL(*lfs_, Close(4))
         .Times(1);
+    delete[] buf;
 }
 
 /**
@@ -2349,8 +2368,8 @@ TEST_F(CSDataStore_test, ReadChunkTest1) {
     SequenceNum sn = 2;
     off_t offset = PAGE_SIZE;
     size_t length = PAGE_SIZE;
-    char buf[length];  // NOLINT
-    memset(buf, 0, sizeof(buf));
+    char *buf = new char[length];
+    memset(buf, 0, length);
     // test chunk not exists
     EXPECT_EQ(CSErrorCode::ChunkNotExistError,
               dataStore->ReadChunk(id,
@@ -2365,6 +2384,7 @@ TEST_F(CSDataStore_test, ReadChunkTest1) {
         .Times(1);
     EXPECT_CALL(*lfs_, Close(3))
         .Times(1);
+    delete[] buf;
 }
 
 /**
@@ -2381,8 +2401,8 @@ TEST_F(CSDataStore_test, ReadChunkTest2) {
     SequenceNum sn = 2;
     off_t offset = CHUNK_SIZE;
     size_t length = PAGE_SIZE;
-    char buf[length];  // NOLINT
-    memset(buf, 0, sizeof(buf));
+    char *buf = new char[length];
+    memset(buf, 0, length);
     // test read out of range
     EXPECT_EQ(CSErrorCode::InvalidArgError,
               dataStore->ReadChunk(id,
@@ -2415,6 +2435,7 @@ TEST_F(CSDataStore_test, ReadChunkTest2) {
         .Times(1);
     EXPECT_CALL(*lfs_, Close(3))
         .Times(1);
+    delete[] buf;
 }
 
 /**
@@ -2431,8 +2452,8 @@ TEST_F(CSDataStore_test, ReadChunkTest3) {
     SequenceNum sn = 2;
     off_t offset = PAGE_SIZE;
     size_t length = PAGE_SIZE;
-    char buf[length];  // NOLINT
-    memset(buf, 0, sizeof(buf));
+    char *buf = new char[length];
+    memset(buf, 0, length);
     // test chunk exists
     EXPECT_CALL(*lfs_, Read(1, NotNull(), offset + PAGE_SIZE, length))
         .Times(1);
@@ -2449,6 +2470,7 @@ TEST_F(CSDataStore_test, ReadChunkTest3) {
         .Times(1);
     EXPECT_CALL(*lfs_, Close(3))
         .Times(1);
+    delete[] buf;
 }
 
 /**
@@ -2502,8 +2524,8 @@ TEST_F(CSDataStore_test, ReadChunkTest4) {
     // case1: 读取未写过区域
     off_t offset = 1 * PAGE_SIZE;
     size_t length = PAGE_SIZE;
-    char buf[2 * length];  // NOLINT
-    memset(buf, 0, sizeof(buf));
+    char *buf = new char[2 * length];
+    memset(buf, 0, 2 * length);
     EXPECT_CALL(*lfs_, Read(_, _, _, _))
         .Times(0);
     EXPECT_EQ(CSErrorCode::PageNerverWrittenError,
@@ -2561,8 +2583,8 @@ TEST_F(CSDataStore_test, ReadChunkErrorTest1) {
     SequenceNum sn = 2;
     off_t offset = PAGE_SIZE;
     size_t length = PAGE_SIZE;
-    char buf[length];  // NOLINT
-    memset(buf, 0, sizeof(buf));
+    char *buf = new char[length];
+    memset(buf, 0, length);
     // test read chunk failed
     EXPECT_CALL(*lfs_, Read(1, NotNull(), offset + PAGE_SIZE, length))
         .WillOnce(Return(-UT_ERRNO));
@@ -2579,6 +2601,7 @@ TEST_F(CSDataStore_test, ReadChunkErrorTest1) {
         .Times(1);
     EXPECT_CALL(*lfs_, Close(3))
         .Times(1);
+    delete[] buf;
 }
 
 /**
@@ -2595,8 +2618,8 @@ TEST_F(CSDataStore_test, ReadSnapshotChunkTest1) {
     SequenceNum sn = 2;
     off_t offset = PAGE_SIZE;
     size_t length = PAGE_SIZE;
-    char buf[length];  // NOLINT
-    memset(buf, 0, sizeof(buf));
+    char *buf = new char[length];
+    memset(buf, 0, length);
     // test chunk not exists
     EXPECT_EQ(CSErrorCode::ChunkNotExistError,
               dataStore->ReadSnapshotChunk(id,
@@ -2611,6 +2634,7 @@ TEST_F(CSDataStore_test, ReadSnapshotChunkTest1) {
         .Times(1);
     EXPECT_CALL(*lfs_, Close(3))
         .Times(1);
+    delete[] buf;
 }
 
 /**
@@ -2627,8 +2651,8 @@ TEST_F(CSDataStore_test, ReadSnapshotChunkTest2) {
     SequenceNum sn = 2;
     off_t offset = CHUNK_SIZE;
     size_t length = 2 * PAGE_SIZE;
-    char buf[length];  // NOLINT
-    memset(buf, 0, sizeof(buf));
+    char *buf = new char[length];
+    memset(buf, 0, length);
     // test out of range
     EXPECT_EQ(CSErrorCode::InvalidArgError,
               dataStore->ReadSnapshotChunk(id,
@@ -2672,6 +2696,7 @@ TEST_F(CSDataStore_test, ReadSnapshotChunkTest2) {
         .Times(1);
     EXPECT_CALL(*lfs_, Close(3))
         .Times(1);
+    delete[] buf;
 }
 
 /**
@@ -2688,8 +2713,8 @@ TEST_F(CSDataStore_test, ReadSnapshotChunkTest3) {
     SequenceNum sn = 2;
     off_t offset = PAGE_SIZE;
     size_t length = PAGE_SIZE * 2;
-    char writeBuf[length];  // NOLINT
-    memset(writeBuf, 0, sizeof(writeBuf));
+    char *writeBuf = new char[length];
+    memset(writeBuf, 0, length);
     // data in [PAGE_SIZE, 2*PAGE_SIZE) will be cow
     EXPECT_CALL(*lfs_, Read(1, NotNull(), offset + PAGE_SIZE, length))
         .Times(1);
@@ -2715,8 +2740,8 @@ TEST_F(CSDataStore_test, ReadSnapshotChunkTest3) {
     sn = 1;
     offset = CHUNK_SIZE;
     length = PAGE_SIZE * 4;
-    char readBuf[length];  // NOLINT
-    memset(readBuf, 0, sizeof(readBuf));
+    char *readBuf = new char[length];
+    memset(readBuf, 0, length);
     EXPECT_EQ(CSErrorCode::InvalidArgError,
               dataStore->ReadSnapshotChunk(id,
                                            sn,
@@ -2746,6 +2771,8 @@ TEST_F(CSDataStore_test, ReadSnapshotChunkTest3) {
         .Times(1);
     EXPECT_CALL(*lfs_, Close(3))
         .Times(1);
+    delete[] writeBuf;
+    delete[] readBuf;
 }
 
 /**
@@ -2762,8 +2789,8 @@ TEST_F(CSDataStore_test, ReadSnapshotChunkTest4) {
     SequenceNum sn = 3;
     off_t offset = PAGE_SIZE;
     size_t length = PAGE_SIZE;
-    char buf[length];  // NOLINT
-    memset(buf, 0, sizeof(buf));
+    char *buf = new char[length];
+    memset(buf, 0, length);
     // test sn not exists
     EXPECT_EQ(CSErrorCode::ChunkNotExistError,
               dataStore->ReadSnapshotChunk(id,
@@ -2778,6 +2805,7 @@ TEST_F(CSDataStore_test, ReadSnapshotChunkTest4) {
         .Times(1);
     EXPECT_CALL(*lfs_, Close(3))
         .Times(1);
+    delete[] buf;
 }
 
 /**
@@ -2794,8 +2822,8 @@ TEST_F(CSDataStore_test, ReadSnapshotChunkErrorTest1) {
     SequenceNum sn = 2;
     off_t offset = PAGE_SIZE;
     size_t length = PAGE_SIZE * 2;
-    char writeBuf[length];  // NOLINT
-    memset(writeBuf, 0, sizeof(writeBuf));
+    char *writeBuf = new char[length];
+    memset(writeBuf, 0, length);
     // data in [PAGE_SIZE, 2*PAGE_SIZE) will be cow
     EXPECT_CALL(*lfs_, Read(1, NotNull(), offset + PAGE_SIZE, length))
         .Times(1);
@@ -2821,8 +2849,8 @@ TEST_F(CSDataStore_test, ReadSnapshotChunkErrorTest1) {
     sn = 1;
     offset = 0;
     length = PAGE_SIZE * 4;
-    char readBuf[length];  // NOLINT
-    memset(readBuf, 0, sizeof(readBuf));
+    char *readBuf = new char[length];
+    memset(readBuf, 0, length);
     // read chunk failed
     EXPECT_CALL(*lfs_, Read(1, NotNull(), PAGE_SIZE, PAGE_SIZE))
         .WillOnce(Return(-UT_ERRNO));
@@ -2853,6 +2881,8 @@ TEST_F(CSDataStore_test, ReadSnapshotChunkErrorTest1) {
         .Times(1);
     EXPECT_CALL(*lfs_, Close(3))
         .Times(1);
+    delete[] writeBuf;
+    delete[] readBuf;
 }
 
 /**
@@ -2869,8 +2899,8 @@ TEST_F(CSDataStore_test, ReadSnapshotChunkErrorTest2) {
     SequenceNum sn = 2;
     off_t offset = PAGE_SIZE;
     size_t length = 2 * PAGE_SIZE;
-    char buf[length];  // NOLINT
-    memset(buf, 0, sizeof(buf));
+    char *buf = new char[length];
+    memset(buf, 0, length);
     // test in range
     offset = PAGE_SIZE;
     EXPECT_CALL(*lfs_, Read(1, NotNull(), offset + PAGE_SIZE, length))
@@ -2888,6 +2918,7 @@ TEST_F(CSDataStore_test, ReadSnapshotChunkErrorTest2) {
         .Times(1);
     EXPECT_CALL(*lfs_, Close(3))
         .Times(1);
+    delete[] buf;
 }
 
 /**
@@ -3040,7 +3071,6 @@ TEST_F(CSDataStore_test, DeleteChunkTest4) {
     EXPECT_TRUE(dataStore->Initialize());
 
     ChunkID id = 2;
-    SequenceNum sn = 2;
 
     // case1
     {
@@ -3811,8 +3841,8 @@ TEST_F(CSDataStore_test, PasteChunkTest1) {
     SequenceNum correctedSn = 2;
     off_t offset = 0;
     size_t length = PAGE_SIZE;
-    char buf[length];  // NOLINT
-    memset(buf, 0, sizeof(buf));
+    char *buf = new char[length];
+    memset(buf, 0, length);
     CSChunkInfo info;
     // 创建 clone chunk
     {
@@ -4013,6 +4043,7 @@ TEST_F(CSDataStore_test, PasteChunkTest1) {
         .Times(1);
     EXPECT_CALL(*lfs_, Close(4))
         .Times(1);
+    delete[] buf;
 }
 
 /*
@@ -4032,8 +4063,8 @@ TEST_F(CSDataStore_test, PasteChunkErrorTest1) {
     SequenceNum correctedSn = 2;
     off_t offset = 0;
     size_t length = PAGE_SIZE;
-    char buf[length];  // NOLINT
-    memset(buf, 0, sizeof(buf));
+    char *buf = new char[length];
+    memset(buf, 0, length);
     CSChunkInfo info;
     // 创建 clone chunk
     {
@@ -4118,6 +4149,7 @@ TEST_F(CSDataStore_test, PasteChunkErrorTest1) {
         .Times(1);
     EXPECT_CALL(*lfs_, Close(4))
         .Times(1);
+    delete[] buf;
 }
 
 /*
@@ -4156,8 +4188,6 @@ TEST_F(CSDataStore_test, GetHashErrorTest2) {
 
     ChunkID id = 1;
     std::string hash;
-    off_t offset = 0;
-    size_t length = PAGE_SIZE + CHUNK_SIZE;
     // test read chunk failed
     EXPECT_CALL(*lfs_, Read(1, NotNull(), 0, 4096))
         .WillOnce(Return(-UT_ERRNO));
@@ -4203,10 +4233,9 @@ TEST_F(CSDataStore_test, CloneChunkUnAlignedTest) {
     ChunkID id = 3;
     SequenceNum sn = 2;
     SequenceNum correctedSn = 3;
-    off_t offset = 0;
     size_t length = PAGE_SIZE;
-    char buf[length];  // NOLINT
-    memset(buf, 0, sizeof(buf));
+    char *buf = new char[length];
+    memset(buf, 0, length);
     CSChunkInfo info;
     // 创建 clone chunk
     {
@@ -4370,6 +4399,7 @@ TEST_F(CSDataStore_test, CloneChunkUnAlignedTest) {
         .Times(1);
     EXPECT_CALL(*lfs_, Close(4))
         .Times(1);
+    delete[] buf;
 }
 
 TEST_F(CSDataStore_test, CloneChunkAlignedTest) {
@@ -4382,8 +4412,8 @@ TEST_F(CSDataStore_test, CloneChunkAlignedTest) {
     SequenceNum correctedSn = 3;
     off_t offset = 0;
     size_t length = PAGE_SIZE;
-    char buf[length];  // NOLINT
-    memset(buf, 0, sizeof(buf));
+    char *buf = new char[length];
+    memset(buf, 0, length);
     CSChunkInfo info;
     // 创建 clone chunk
     {
@@ -4468,6 +4498,7 @@ TEST_F(CSDataStore_test, CloneChunkAlignedTest) {
         .Times(1);
     EXPECT_CALL(*lfs_, Close(4))
         .Times(1);
+    delete[] buf;
 }
 
 TEST_F(CSDataStore_test, NormalChunkAlignmentTest) {
@@ -4477,10 +4508,9 @@ TEST_F(CSDataStore_test, NormalChunkAlignmentTest) {
 
     ChunkID id = 2;
     SequenceNum sn = 2;
-    off_t offset = 0;
     size_t length = 512;
-    char buf[length];  // NOLINT
-    memset(buf, 0, sizeof(buf));
+    char *buf = new char[length];
+    memset(buf, 0, length);
 
     // write unaligned test
     {
@@ -4546,6 +4576,7 @@ TEST_F(CSDataStore_test, NormalChunkAlignmentTest) {
         .Times(1);
     EXPECT_CALL(*lfs_, Close(3))
         .Times(1);
+    delete[] buf;
 }
 
 }  // namespace chunkserver

--- a/test/chunkserver/heartbeat_test_common.cpp
+++ b/test/chunkserver/heartbeat_test_common.cpp
@@ -26,7 +26,7 @@
 uint32_t segment_size = 1 * 1024 * 1024 * 1024ul;   // NOLINT
 uint32_t chunk_size = 16 * 1024 * 1024;   // NOLINT
 
-static char* confPath[3] = {
+static const char* confPath[3] = {
     "./8200/chunkserver.conf",
     "./8201/chunkserver.conf",
     "./8202/chunkserver.conf",
@@ -73,10 +73,6 @@ void HeartbeatTestCommon::CleanPeer(
                 req->copysetinfos(i);
 
             std::string peersStr = info.peers(0).address();
-
-            if (info.has_configchangeinfo()) {
-                const ConfigChangeInfo& cxInfo = info.configchangeinfo();
-            }
 
             {
                 // answer with cleaning peer response

--- a/test/chunkserver/heartbeat_test_main.cpp
+++ b/test/chunkserver/heartbeat_test_main.cpp
@@ -31,7 +31,7 @@
 #include "test/chunkserver/heartbeat_test_common.h"
 #include "test/integration/common/config_generator.h"
 
-static char *param[3][15] = {
+static const char *param[3][15] = {
     {
         "heartbeat_test",
         "-chunkServerIp=127.0.0.1",
@@ -135,7 +135,7 @@ int main(int argc, char *argv[]) {
              * RunChunkServer内部会调用LOG(), 有较低概率因不兼容fork()而卡死
              */
             return RunChunkServer(i, sizeof(param[i]) / sizeof(char *),
-                                  param[i]);
+                                  const_cast<char **>(param[i]));
         }
     }
 
@@ -172,8 +172,8 @@ int main(int argc, char *argv[]) {
             /*
              * RunChunkServer内部会调用LOG(), 有较低概率因不兼容fork()而卡死
              */
-            ret =
-                RunChunkServer(1, sizeof(param[1]) / sizeof(char *), param[1]);
+            ret = RunChunkServer(1, sizeof(param[1]) / sizeof(char *),
+                                 const_cast<char **>(param[1]));
             return ret;
         }
         sleep(2);

--- a/test/chunkserver/multiple_copysets_io_test.cpp
+++ b/test/chunkserver/multiple_copysets_io_test.cpp
@@ -145,7 +145,7 @@ int64_t chunk_size = 0;
 int64_t nr_chunks = 0;
 int64_t nr_copysets = 0;
 int64_t chunks_per_copyset = 0;
-ThreadInfo thread_infos[8] = {0};
+ThreadInfo thread_infos[8] = {};
 
 LogicPoolID poolId = 10000;
 CopysetID copysetIdBase = 100;
@@ -791,7 +791,7 @@ int main(int argc, char *argv[]) {
 
     clock_gettime(CLOCK_REALTIME, &t1);
 
-    ThreadInfo total_info = {0};
+    ThreadInfo total_info = {};
     total_info.io_time = time_diff(t0, t1);
     total_info.iodepth = FLAGS_iodepth;
     threads_stats(FLAGS_thread_num, &total_info);

--- a/test/chunkserver/op_request_test.cpp
+++ b/test/chunkserver/op_request_test.cpp
@@ -735,11 +735,7 @@ TEST(ChunkOpRequestTest, OnApplyErrorTest) {
 TEST(ChunkOpRequestTest, OnApplyFromLogTest) {
     LogicPoolID logicPoolId = 1;
     CopysetID copysetId = 10001;
-    uint64_t chunkId = 12345;
-    size_t offset = 0;
-    uint32_t size = 16;
     uint64_t sn = 1;
-    uint64_t appliedIndex = 12;
     uint32_t followScanRpcTimeoutMs = 1000;
 
     Configuration conf;

--- a/test/chunkserver/raftlog/test_curve_segment.cpp
+++ b/test/chunkserver/raftlog/test_curve_segment.cpp
@@ -135,7 +135,7 @@ TEST_F(CurveSegmentTest, open_segment) {
 
     // create and open
     std::string path = kRaftLogDataDir;
-    butil::string_appendf(&path, "/" CURVE_SEGMENT_OPEN_PATTERN, 1);
+    butil::string_appendf(&path, "/" CURVE_SEGMENT_OPEN_PATTERN, 1L);
     ASSERT_EQ(0, prepare_segment(path));
     ASSERT_EQ(0, seg1->create());
     ASSERT_TRUE(seg1->is_open());
@@ -191,7 +191,7 @@ TEST_F(CurveSegmentTest, closed_segment) {
 
     // create and open
     std::string path = kRaftLogDataDir;
-    butil::string_appendf(&path, "/" CURVE_SEGMENT_OPEN_PATTERN, 1);
+    butil::string_appendf(&path, "/" CURVE_SEGMENT_OPEN_PATTERN, 1L);
     ASSERT_EQ(0, prepare_segment(path));
     ASSERT_EQ(0, seg1->create());
     ASSERT_TRUE(seg1->is_open());

--- a/test/chunkserver/raftlog/test_curve_segment_log_storage.cpp
+++ b/test/chunkserver/raftlog/test_curve_segment_log_storage.cpp
@@ -155,13 +155,13 @@ TEST_F(CurveSegmentLogStorageTest, basic_test) {
 
     // append entry
     std::string path = kRaftLogDataDir;
-    butil::string_appendf(&path, "/" CURVE_SEGMENT_OPEN_PATTERN, 1);
+    butil::string_appendf(&path, "/" CURVE_SEGMENT_OPEN_PATTERN, 1L);
     ASSERT_EQ(0,  prepare_segment(path));
     path = kRaftLogDataDir;
-    butil::string_appendf(&path, "/" CURVE_SEGMENT_OPEN_PATTERN, 2049);
+    butil::string_appendf(&path, "/" CURVE_SEGMENT_OPEN_PATTERN, 2049L);
     ASSERT_EQ(0,  prepare_segment(path));
     path = kRaftLogDataDir;
-    butil::string_appendf(&path, "/" CURVE_SEGMENT_OPEN_PATTERN, 4097);
+    butil::string_appendf(&path, "/" CURVE_SEGMENT_OPEN_PATTERN, 4097L);
     ASSERT_EQ(0,  prepare_segment(path));
     append_entries(storage, 1000, 5);
 
@@ -200,7 +200,7 @@ TEST_F(CurveSegmentLogStorageTest, basic_test) {
 
     // append
     path = kRaftLogDataDir;
-    butil::string_appendf(&path, "/" CURVE_SEGMENT_OPEN_PATTERN, 6145);
+    butil::string_appendf(&path, "/" CURVE_SEGMENT_OPEN_PATTERN, 6145L);
     ASSERT_EQ(0,  prepare_segment(path));
     for (int i = 5001; i <= 7000; i++) {
         int64_t index = i;
@@ -273,10 +273,10 @@ TEST_F(CurveSegmentLogStorageTest, append_close_load_append) {
 
     // append entry
     std::string path = kRaftLogDataDir;
-    butil::string_appendf(&path, "/" CURVE_SEGMENT_OPEN_PATTERN, 1);
+    butil::string_appendf(&path, "/" CURVE_SEGMENT_OPEN_PATTERN, 1L);
     ASSERT_EQ(0,  prepare_segment(path));
     path = kRaftLogDataDir;
-    butil::string_appendf(&path, "/" CURVE_SEGMENT_OPEN_PATTERN, 2049);
+    butil::string_appendf(&path, "/" CURVE_SEGMENT_OPEN_PATTERN, 2049L);
     ASSERT_EQ(0,  prepare_segment(path));
     append_entries(storage, 600, 5);
     ASSERT_EQ(countWalSegmentFile(), storage->GetStatus().walSegmentFileCount);
@@ -293,7 +293,7 @@ TEST_F(CurveSegmentLogStorageTest, append_close_load_append) {
 
     // append entry
     path = kRaftLogDataDir;
-    butil::string_appendf(&path, "/" CURVE_SEGMENT_OPEN_PATTERN, 4097);
+    butil::string_appendf(&path, "/" CURVE_SEGMENT_OPEN_PATTERN, 4097L);
     ASSERT_EQ(0,  prepare_segment(path));
     braft::IOMetric metric;
     for (int i = 600; i < 1000; i++) {
@@ -349,7 +349,7 @@ TEST_F(CurveSegmentLogStorageTest, data_lost) {
 
     // append entry
     std::string path = kRaftLogDataDir;
-    butil::string_appendf(&path, "/" CURVE_SEGMENT_OPEN_PATTERN, 1);
+    butil::string_appendf(&path, "/" CURVE_SEGMENT_OPEN_PATTERN, 1L);
     ASSERT_EQ(0,  prepare_segment(path));
     append_entries(storage, 100, 5);
     ASSERT_EQ(countWalSegmentFile(), storage->GetStatus().walSegmentFileCount);
@@ -393,7 +393,7 @@ TEST_F(CurveSegmentLogStorageTest, compatibility) {
 
     // append entry
     std::string path = kRaftLogDataDir;
-    butil::string_appendf(&path, "/" CURVE_SEGMENT_OPEN_PATTERN, 3001);
+    butil::string_appendf(&path, "/" CURVE_SEGMENT_OPEN_PATTERN, 3001L);
     ASSERT_EQ(0,  prepare_segment(path));
     braft::IOMetric metric;
     for (int i = 600; i < 1000; i++) {
@@ -451,13 +451,13 @@ TEST_F(CurveSegmentLogStorageTest, basic_test_without_direct) {
 
     // append entry
     std::string path = kRaftLogDataDir;
-    butil::string_appendf(&path, "/" CURVE_SEGMENT_OPEN_PATTERN, 1);
+    butil::string_appendf(&path, "/" CURVE_SEGMENT_OPEN_PATTERN, 1L);
     ASSERT_EQ(0,  prepare_segment(path));
     path = kRaftLogDataDir;
-    butil::string_appendf(&path, "/" CURVE_SEGMENT_OPEN_PATTERN, 2049);
+    butil::string_appendf(&path, "/" CURVE_SEGMENT_OPEN_PATTERN, 2049L);
     ASSERT_EQ(0,  prepare_segment(path));
     path = kRaftLogDataDir;
-    butil::string_appendf(&path, "/" CURVE_SEGMENT_OPEN_PATTERN, 4097);
+    butil::string_appendf(&path, "/" CURVE_SEGMENT_OPEN_PATTERN, 4097L);
     ASSERT_EQ(0,  prepare_segment(path));
     append_entries(storage, 1000, 5);
 
@@ -496,7 +496,7 @@ TEST_F(CurveSegmentLogStorageTest, basic_test_without_direct) {
 
     // append
     path = kRaftLogDataDir;
-    butil::string_appendf(&path, "/" CURVE_SEGMENT_OPEN_PATTERN, 6145);
+    butil::string_appendf(&path, "/" CURVE_SEGMENT_OPEN_PATTERN, 6145L);
     ASSERT_EQ(0,  prepare_segment(path));
     for (int i = 5001; i <= 7000; i++) {
         int64_t index = i;

--- a/test/chunkserver/trash_test.cpp
+++ b/test/chunkserver/trash_test.cpp
@@ -512,7 +512,7 @@ TEST_F(TrashTest, recycle_wal_failed) {
                             "curve_log_inprogress_10088"))
         .WillOnce(Return(-1));
 
-    //失败的情况下不应删除
+    // 失败的情况下不应删除
     EXPECT_CALL(*lfs, Delete("./runlog/trash_test0/trash/4294967493.55555"))
         .Times(0);
 

--- a/test/client/client_mdsclient_metacache_unittest.cpp
+++ b/test/client/client_mdsclient_metacache_unittest.cpp
@@ -55,10 +55,11 @@
 
 uint32_t chunk_size = 4 * 1024 * 1024;
 uint32_t segment_size = 1 * 1024 * 1024 * 1024;
-std::string mdsMetaServerAddr = "127.0.0.1:29104";  // NOLINT
-std::string configpath = "./test/client/configs/client_mdsclient_metacache.conf";  // NOLINT
+std::string mdsMetaServerAddr = "127.0.0.1:29104";              // NOLINT
+std::string configpath =                                        // NOLINT
+    "./test/client/configs/client_mdsclient_metacache.conf";    // NOLINT
 
-extern curve::client::FileClient* globalclient;
+extern curve::client::FileClient *globalclient;
 
 namespace curve {
 namespace client {
@@ -190,7 +191,6 @@ TEST_F(MDSClientTest, Createfile) {
 
 TEST_F(MDSClientTest, MkDir) {
     std::string dirpath = "/1";
-    size_t len = 4 * 1024 * 1024;
     // set response file exist
     ::curve::mds::CreateFileResponse response;
     response.set_statuscode(::curve::mds::StatusCode::kFileExists);
@@ -244,7 +244,6 @@ TEST_F(MDSClientTest, MkDir) {
 
 TEST_F(MDSClientTest, Closefile) {
     std::string filename = "/1_userinfo_";
-    size_t len = 4 * 1024 * 1024;
     // file not exist
     ::curve::mds::CloseFileResponse response;
     response.set_statuscode(::curve::mds::StatusCode::kFileNotExists);
@@ -289,7 +288,6 @@ TEST_F(MDSClientTest, Closefile) {
 
 TEST_F(MDSClientTest, Openfile) {
     std::string filename = "/1_userinfo_";
-    size_t len = 4 * 1024 * 1024;
     /**
      * set openfile response
      */
@@ -635,7 +633,6 @@ TEST_F(MDSClientTest, Extendfile) {
 TEST_F(MDSClientTest, Deletefile) {
     LOG(INFO) << "Deletefile=======================================";
     std::string filename1 = "/1_userinfo_";
-    uint64_t newsize = 10 * 1024 * 1024 * 1024ul;
 
     // set response file exist
     ::curve::mds::DeleteFileResponse response;
@@ -723,7 +720,6 @@ TEST_F(MDSClientTest, Deletefile) {
 
 TEST_F(MDSClientTest, Rmdir) {
     std::string filename1 = "/1/";
-    uint64_t newsize = 10 * 1024 * 1024 * 1024ul;
 
     // set response dir not exist
     ::curve::mds::DeleteFileResponse response;
@@ -895,9 +891,9 @@ TEST_F(MDSClientTest, GetFileInfo) {
     curvefsservice.SetGetFileInfoFakeReturn(fakeret2);
     curvefsservice.CleanRetryTimes();
 
-    ASSERT_EQ(LIBCURVE_ERROR::FAILED,
-              mdsclient_.GetFileInfo(filename.c_str(), userinfo,
-                  finfo, &fEpoch));
+    ASSERT_EQ(
+        LIBCURVE_ERROR::FAILED,
+        mdsclient_.GetFileInfo(filename.c_str(), userinfo, finfo, &fEpoch));
 
     delete fakeret;
     delete fakeret2;
@@ -912,16 +908,17 @@ TEST_F(MDSClientTest, GetOrAllocateSegment) {
     fi.chunksize = 4 * 1024 * 1024;
     fi.segmentsize = 1 * 1024 * 1024 * 1024ul;
 
-    std::chrono::system_clock::time_point start, end;
-    auto startTimer = [&start]() { start = std::chrono::system_clock::now(); };
-    auto endTimer = [&end]() { end = std::chrono::system_clock::now(); };
-    auto checkTimer = [&start, &end](uint64_t min, uint64_t max) {
-        auto elpased =
-            std::chrono::duration_cast<std::chrono::milliseconds>(end - start)
-                .count();
-        ASSERT_GE(elpased, min);
-        ASSERT_LE(elpased, max);
-    };
+    // std::chrono::system_clock::time_point start, end;
+    // auto startTimer = [&start]() { start = std::chrono::system_clock::now();
+    // }; auto endTimer = [&end]() { end = std::chrono::system_clock::now(); };
+    // auto checkTimer = [&start, &end](uint64_t min, uint64_t max) {
+    //     auto elpased =
+    //         std::chrono::duration_cast<std::chrono::milliseconds>(end -
+    //         start)
+    //             .count();
+    //     ASSERT_GE(elpased, min);
+    //     ASSERT_LE(elpased, max);
+    // };
 
     // TEST CASE: GetOrAllocateSegment failed, block until response ok
     // curve::mds::GetOrAllocateSegmentResponse resp;
@@ -1102,8 +1099,8 @@ TEST_F(MDSClientTest, GetServerList) {
     response_1.set_statuscode(0);
     uint32_t chunkserveridc = 1;
 
-    ::curve::common::ChunkServerLocation* cslocs;
-    ::curve::mds::topology::CopySetServerInfo* csinfo;
+    ::curve::common::ChunkServerLocation *cslocs;
+    ::curve::mds::topology::CopySetServerInfo *csinfo;
     for (int j = 0; j < 256; j++) {
         csinfo = response_1.add_csinfo();
         csinfo->set_copysetid(j);
@@ -1264,8 +1261,8 @@ TEST_F(MDSClientTest, GetLeaderTest) {
     response_1.set_statuscode(0);
     uint32_t chunkserveridc = 1;
 
-    ::curve::common::ChunkServerLocation* cslocs;
-    ::curve::mds::topology::CopySetServerInfo* csinfo;
+    ::curve::common::ChunkServerLocation *cslocs;
+    ::curve::mds::topology::CopySetServerInfo *csinfo;
     csinfo = response_1.add_csinfo();
     csinfo->set_copysetid(1234);
     for (int i = 0; i < 4; i++) {
@@ -1707,7 +1704,6 @@ TEST_F(MDSClientTest, ListDir) {
 
     curvefsservice.SetListDir(fakeret);
 
-    int arrsize;
     std::vector<FileStatInfo> filestatVec;
     int ret = globalclient->Listdir(filename1, userinfo, &filestatVec);
     ASSERT_EQ(ret, -1 * LIBCURVE_ERROR::NOTEXIST);
@@ -1736,7 +1732,6 @@ TEST_F(MDSClientTest, ListDir) {
     curvefsservice.SetListDir(fakeret1);
     ASSERT_EQ(LIBCURVE_ERROR::OK,
               globalclient->Listdir(filename1, userinfo, &filestatVec));
-    int arraysize = 0;
     C_UserInfo_t cuserinfo;
     memcpy(cuserinfo.owner, "test", 5);
     FileStatInfo *filestat = new FileStatInfo[5];
@@ -1823,7 +1818,7 @@ TEST_F(MDSClientTest, ListDir) {
 TEST(LibcurveInterface, InvokeWithOutInit) {
     CurveAioContext aioctx;
     UserInfo_t userinfo;
-    C_UserInfo_t *ui;
+    C_UserInfo_t *ui = nullptr;
 
     FileClient fc;
     ASSERT_EQ(-LIBCURVE_ERROR::FAILED, fc.Create("", userinfo, 0));
@@ -1930,8 +1925,7 @@ class ServiceHelperGetLeaderTest : public MDSClientTest {
         }
     }
 
-    GetLeaderResponse2
-    MakeResponse(const curve::client::PeerAddr &addr) {
+    GetLeaderResponse2 MakeResponse(const curve::client::PeerAddr &addr) {
         GetLeaderResponse2 response;
         curve::common::Peer *peer = new curve::common::Peer();
         peer->set_address(addr.ToString());
@@ -2003,8 +1997,7 @@ TEST_F(ServiceHelperGetLeaderTest, NormalTest) {
 
     // 测试第二次拉取新的leader，直接跳过第一个chunkserver，查找第2，3两个
     int32_t currentLeaderIndex = 0;
-    curve::client::PeerAddr currentLeader =
-        internalAddrs[currentLeaderIndex];
+    curve::client::PeerAddr currentLeader = internalAddrs[currentLeaderIndex];
 
     response = MakeResponse(currentLeader);
     fakeret1 = FakeReturn(nullptr, static_cast<void *>(&response));
@@ -2369,8 +2362,8 @@ TEST_F(MDSClientRefreshSessionTest, NoStartDummyServerTest) {
 }  // namespace client
 }  // namespace curve
 
-const std::vector<std::string> clientConf {
-    std::string("mds.listen.addr=") + mdsMetaServerAddr,
+const std::vector<std::string> clientConf{
+    std::string("mds.listen.addr=") + std::string(mdsMetaServerAddr),
     std::string("global.logPath=./runlog/"),
     std::string("chunkserver.rpcTimeoutMS=1000"),
     std::string("chunkserver.opMaxRetry=3"),
@@ -2383,7 +2376,7 @@ const std::vector<std::string> clientConf {
     std::string("throttle.enable=true"),
 };
 
-int main(int argc, char* argv[]) {
+int main(int argc, char *argv[]) {
     ::testing::InitGoogleTest(&argc, argv);
     ::testing::InitGoogleMock(&argc, argv);
 
@@ -2393,8 +2386,8 @@ int main(int argc, char* argv[]) {
 
     std::unique_ptr<curve::CurveCluster> cluster(new curve::CurveCluster());
 
-    cluster->PrepareConfig<curve::ClientConfigGenerator>(
-        configpath, clientConf);
+    cluster->PrepareConfig<curve::ClientConfigGenerator>(configpath,
+                                                         clientConf);
 
     return RUN_ALL_TESTS();
 }

--- a/test/client/client_session_unittest.cpp
+++ b/test/client/client_session_unittest.cpp
@@ -159,8 +159,6 @@ TEST(ClientSession, LeaseTaskTest) {
         }
     }
 
-    auto iomanager = fileinstance.GetIOManager4File();
-
     curve::client::LeaseExecutor* lease = fileinstance.GetLeaseExecutor();
 
     // 5. set refresh AuthFail

--- a/test/client/fake/fakeMDS.cpp
+++ b/test/client/fake/fakeMDS.cpp
@@ -293,7 +293,7 @@ bool FakeMDS::StartService() {
     /**
      * set get snap allocate info
      */
-    FakeReturn* snapfakeret = new FakeReturn(nullptr, static_cast<void*>(getallocateresponse));      // NOLINT
+    // FakeReturn* snapfakeret = new FakeReturn(nullptr, static_cast<void*>(getallocateresponse));      // NOLINT
     fakecurvefsservice_.SetGetSnapshotSegmentInfo(fakeret);
 
     /**
@@ -328,7 +328,6 @@ bool FakeMDS::StartService() {
     /**
      * set list physical pool response
      */
-    ListPhysicalPoolResponse* listphypoolresp = new ListPhysicalPoolResponse();
     FakeReturn* fakeListPPRet = new FakeReturn(nullptr, response);
     faketopologyservice_.fakelistpoolret_ = fakeListPPRet;
 

--- a/test/client/fake/fakeMDS.h
+++ b/test/client/fake/fakeMDS.h
@@ -204,6 +204,7 @@ class FakeMDSCurveFSService : public curve::mds::CurveFSService {
             LOG(INFO) << "request filename = " << request->filename();
             ASSERT_EQ(request->filename()[0], '/');
         };
+        (void)checkFullpath;
 
         fiu_do_on("test/client/fake/fakeMDS.GetOrAllocateSegment",
                  checkFullpath());

--- a/test/client/fake/mock_schedule.cpp
+++ b/test/client/fake/mock_schedule.cpp
@@ -43,9 +43,7 @@ int Schedule::ScheduleRequest(
     const std::vector<curve::client::RequestContext*>& reqlist) {
     // LOG(INFO) << "ENTER MOCK ScheduleRequest";
     char fakedate[10] = {'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'k'};
-    curve::client::OpType type = curve::client::OpType::UNKNOWN;
     int processed = 0;
-    int totallength = 0;
     std::vector<datastruct> datavec;
 
     if (enableScheduleFailed) {
@@ -71,9 +69,10 @@ int Schedule::ScheduleRequest(
 
         auto req = iter->done_->GetReqCtx();
         if (iter->optype_ == curve::client::OpType::READ_SNAP) {
-            char buf[iter->rawlength_];  // NOLINT
+            char *buf = new char[iter->rawlength_];
             memset(buf, fakedate[processed % 10], iter->rawlength_);
             iter->readData_.append(buf, iter->rawlength_);
+            delete[] buf;
         }
 
         if (iter->optype_ == curve::client::OpType::GET_CHUNK_INFO) {
@@ -82,9 +81,10 @@ int Schedule::ScheduleRequest(
         }
 
         if (iter->optype_ == curve::client::OpType::READ) {
-            char buffer[iter->rawlength_];  // NOLINT
+            char *buffer = new char[iter->rawlength_];
             memset(buffer, fakedate[processed % 10], iter->rawlength_);
             iter->readData_.append(buffer, iter->rawlength_);
+            delete[] buffer;
 
             // LOG(ERROR)  << "request split"
             //            << ", off = " << iter->offset_
@@ -96,7 +96,6 @@ int Schedule::ScheduleRequest(
         }
 
         if (iter->optype_ == curve::client::OpType::WRITE) {
-            type = curve::client::OpType::WRITE;
             writeData.append(iter->writeData_);
         }
         processed++;

--- a/test/client/iotracker_splitor_unittest.cpp
+++ b/test/client/iotracker_splitor_unittest.cpp
@@ -339,7 +339,6 @@ TEST_F(IOTrackerSplitorTest, AsyncStartRead) {
     mockschuler->DelegateToFake();
 
     curve::client::IOManager4File* iomana = fileinstance_->GetIOManager4File();
-    MetaCache* mc = fileinstance_->GetIOManager4File()->GetMetaCache();
     iomana->SetRequestScheduler(mockschuler);
 
     CurveAioContext aioctx;
@@ -374,7 +373,6 @@ TEST_F(IOTrackerSplitorTest, AsyncStartWrite) {
     mockschuler->DelegateToFake();
 
     curve::client::IOManager4File* iomana = fileinstance_->GetIOManager4File();
-    MetaCache* mc = fileinstance_->GetIOManager4File()->GetMetaCache();
     iomana->SetRequestScheduler(mockschuler);
 
     CurveAioContext aioctx;
@@ -420,7 +418,6 @@ TEST_F(IOTrackerSplitorTest, StartRead) {
     mockschuler->DelegateToFake();
 
     curve::client::IOManager4File* iomana = fileinstance_->GetIOManager4File();
-    MetaCache* mc = fileinstance_->GetIOManager4File()->GetMetaCache();
     iomana->SetRequestScheduler(mockschuler);
 
     uint64_t offset = 4 * 1024 * 1024 - 4 * 1024;
@@ -451,7 +448,6 @@ TEST_F(IOTrackerSplitorTest, StartWrite) {
     mockschuler->DelegateToFake();
 
     curve::client::IOManager4File* iomana = fileinstance_->GetIOManager4File();
-    MetaCache* mc = fileinstance_->GetIOManager4File()->GetMetaCache();
     iomana->SetRequestScheduler(mockschuler);
 
     uint64_t offset = 4 * 1024 * 1024 - 4 * 1024;
@@ -518,7 +514,6 @@ TEST_F(IOTrackerSplitorTest, ManagerAsyncStartWrite) {
     MockRequestScheduler* mockschuler = new MockRequestScheduler;
     mockschuler->DelegateToFake();
 
-    MetaCache* mc = fileinstance_->GetIOManager4File()->GetMetaCache();
     auto ioctxmana = fileinstance_->GetIOManager4File();
     ioctxmana->SetRequestScheduler(mockschuler);
 
@@ -656,7 +651,6 @@ TEST_F(IOTrackerSplitorTest, ManagerStartRead) {
     MockRequestScheduler* mockschuler = new MockRequestScheduler;
     mockschuler->DelegateToFake();
 
-    MetaCache* mc = fileinstance_->GetIOManager4File()->GetMetaCache();
     auto ioctxmana = fileinstance_->GetIOManager4File();
     ioctxmana->SetRequestScheduler(mockschuler);
 
@@ -687,7 +681,6 @@ TEST_F(IOTrackerSplitorTest, ManagerStartWrite) {
     MockRequestScheduler* mockschuler = new MockRequestScheduler;
     mockschuler->DelegateToFake();
 
-    MetaCache* mc = fileinstance_->GetIOManager4File()->GetMetaCache();
     auto ioctxmana = fileinstance_->GetIOManager4File();
     ioctxmana->SetRequestScheduler(mockschuler);
 
@@ -781,7 +774,6 @@ TEST_F(IOTrackerSplitorTest, BoundaryTEST) {
     MockRequestScheduler* mockschuler = new MockRequestScheduler;
     mockschuler->DelegateToFake();
 
-    MetaCache* mc = fileinstance_->GetIOManager4File()->GetMetaCache();
     auto ioctxmana = fileinstance_->GetIOManager4File();
     ioctxmana->SetRequestScheduler(mockschuler);
 
@@ -1179,7 +1171,6 @@ TEST_F(IOTrackerSplitorTest, StartReadNotAllocateSegment) {
     mockschuler->DelegateToFake();
 
     curve::client::IOManager4File* iomana = fileinstance_->GetIOManager4File();
-    MetaCache* mc = fileinstance_->GetIOManager4File()->GetMetaCache();
     iomana->SetRequestScheduler(mockschuler);
 
     uint64_t offset = 1 * 1024 * 1024 * 1024 + 4 * 1024 * 1024 - 4 * 1024;
@@ -1207,7 +1198,6 @@ TEST_F(IOTrackerSplitorTest, AsyncStartReadNotAllocateSegment) {
     mockschuler->DelegateToFake();
 
     curve::client::IOManager4File* iomana = fileinstance_->GetIOManager4File();
-    MetaCache* mc = fileinstance_->GetIOManager4File()->GetMetaCache();
     iomana->SetRequestScheduler(mockschuler);
 
     CurveAioContext aioctx;

--- a/test/client/libcbd_ext4_test.cpp
+++ b/test/client/libcbd_ext4_test.cpp
@@ -42,7 +42,7 @@ TEST(TestLibcbdExt4, InitTest) {
 
     memset(&opt, 0, sizeof(opt));
 
-    opt.datahome = ".";
+    opt.datahome = const_cast<char*>(".");
     ret = cbd_lib_init(&opt);
     ASSERT_EQ(ret, 0);
 
@@ -67,7 +67,7 @@ TEST(TestLibcbdExt4, ReadWriteTest) {
     memset(&opt, 0, sizeof(opt));
     memset(buf, 'a', BUFSIZE);
 
-    opt.datahome = ".";
+    opt.datahome = const_cast<char*>(".");
     ret = cbd_lib_init(&opt);
     ASSERT_EQ(ret, 0);
 
@@ -122,7 +122,7 @@ TEST(TestLibcbdExt4, AioReadWriteTest) {
     memset(&opt, 0, sizeof(opt));
     memset(buf, 'a', BUFSIZE);
 
-    opt.datahome = ".";
+    opt.datahome = const_cast<char*>(".");
     ret = cbd_lib_init(&opt);
     ASSERT_EQ(ret, 0);
 
@@ -175,7 +175,7 @@ TEST(TestLibcbdExt4, IncreaseEpochTest) {
 
     memset(&opt, 0, sizeof(opt));
 
-    opt.datahome = ".";
+    opt.datahome = const_cast<char*>(".");
     ret = cbd_lib_init(&opt);
     ASSERT_EQ(ret, 0);
 

--- a/test/client/libcbd_libcurve_test.cpp
+++ b/test/client/libcbd_libcurve_test.cpp
@@ -133,7 +133,7 @@ TEST_F(TestLibcbdLibcurve, InitTest) {
     globalclientinited_ = false;
     memset(&opt, 0, sizeof(opt));
     // testing with no conf specified
-    opt.conf = "";
+    opt.conf = const_cast<char*>("");
     ret = cbd_lib_init(&opt);
     ASSERT_NE(ret, 0);
     ret = cbd_lib_fini();

--- a/test/client/libcurve_interface_unittest.cpp
+++ b/test/client/libcurve_interface_unittest.cpp
@@ -113,7 +113,7 @@ TEST(TestLibcurveInterface, InterfaceTest) {
     ASSERT_EQ(GetClusterId(clusterId, 1), -LIBCURVE_ERROR::FAILED);
 
     // libcurve file operation
-    int temp = Create(filename.c_str(), &userinfo, FLAGS_test_disk_size);
+    (void)Create(filename.c_str(), &userinfo, FLAGS_test_disk_size);
 
     int fd = Open(filename.c_str(), &userinfo);
 
@@ -895,7 +895,6 @@ TEST(TestLibcurveInterface, ResumeTimeoutBackoff) {
 
     ASSERT_NE(fd, -1);
 
-    CliServiceFake *cliservice = mds.GetCliService();
     std::vector<FakeChunkService *> chunkservice = mds.GetFakeChunkService();
 
     char *buffer = new char[8 * 1024];

--- a/test/client/mds_failover_test.cpp
+++ b/test/client/mds_failover_test.cpp
@@ -66,7 +66,6 @@ TEST(MDSChangeTest, MDSFailoverTest) {
 
     rpcexcutor.SetOption(metaopt.rpcRetryOpt);
 
-    int currentWorkMDSIndex = 1;
     int mds0RetryTimes = 0;
     int mds1RetryTimes = 0;
     int mds2RetryTimes = 0;

--- a/test/client/metacache_test.cpp
+++ b/test/client/metacache_test.cpp
@@ -91,7 +91,6 @@ TEST_F(MetaCacheTest, TestCleanChunksInSegment) {
         InsertMetaCache(fileLength, segmentSize, chunkSize);
 
         uint64_t totalChunks = fileLength / chunkSize;
-        uint64_t totalSegments = fileLength / segmentSize;
         uint64_t chunksInSegment = segmentSize / chunkSize;
 
         ASSERT_EQ(totalChunks,

--- a/test/client/snapshot_service_unittest.cpp
+++ b/test/client/snapshot_service_unittest.cpp
@@ -565,7 +565,6 @@ TEST(SnapInstance, DeleteChunkSnapshotTest) {
 
     SnapshotClient cl;
     ASSERT_TRUE(!cl.Init(opt));
-    auto max_split_size_kb = 1024 * 64;
     MockRequestScheduler* mocksch = new MockRequestScheduler;
     mocksch->DelegateToFake();
 

--- a/test/common/count_down_event_test.cpp
+++ b/test/common/count_down_event_test.cpp
@@ -85,7 +85,6 @@ TEST(CountDownEventTest, basic) {
         t1.join();
     }
     {
-        int i = 0;
         CountDownEvent cond(0);
         cond.WaitFor(1000);
     }

--- a/test/common/dlock_test.cpp
+++ b/test/common/dlock_test.cpp
@@ -46,7 +46,7 @@ class TestDLock : public ::testing::Test {
         system("rm -fr testDLock.etcd");
         client_ = std::make_shared<EtcdClientImp>();
         char endpoints[] = "127.0.0.1:2375";
-        EtcdConf conf = { endpoints, strlen(endpoints), 1000 };
+        EtcdConf conf = {endpoints, static_cast<int>(strlen(endpoints)), 1000};
         ASSERT_EQ(EtcdErrCode::EtcdDeadlineExceeded,
                   client_->Init(conf, 200, 3));
 

--- a/test/common/rw_lock_test.cpp
+++ b/test/common/rw_lock_test.cpp
@@ -80,6 +80,7 @@ TEST(RWLockTest, basic_test) {
         for (uint64_t i = 0; i < 10000; ++i) {
             ReadLockGuard readLockGuard(rwlock);
             auto j = writeCnt + i;
+            (void)j;
         }
     };
     {
@@ -149,6 +150,7 @@ TEST(BthreadRWLockTest, basic_test) {
         for (uint64_t i = 0; i < 10000; ++i) {
             ReadLockGuard readLockGuard(rwlock);
             auto j = writeCnt + i;
+            (void)j;
         }
     };
     {

--- a/test/common/task_thread_pool_test.cpp
+++ b/test/common/task_thread_pool_test.cpp
@@ -35,11 +35,13 @@ using curve::common::CountDownEvent;
 
 void TestAdd1(int a, double b, CountDownEvent *cond) {
     double c = a + b;
+    (void)c;
     cond->Signal();
 }
 
 int TestAdd2(int a, double b, CountDownEvent *cond) {
     double c = a + b;
+    (void)c;
     cond->Signal();
     return 0;
 }

--- a/test/integration/chunkserver/chunkserver_basic_test.cpp
+++ b/test/integration/chunkserver/chunkserver_basic_test.cpp
@@ -49,7 +49,7 @@ const ChunkSizeType CHUNK_SIZE = 16 * kMB;
 
 const char* kFakeMdsAddr = "127.0.0.1:9079";
 
-static char *chunkServerParams[1][16] = {
+static const char *chunkServerParams[1][16] = {
     { "chunkserver", "-chunkServerIp=127.0.0.1",
       "-chunkServerPort=" BASIC_TEST_CHUNK_SERVER_PORT,
       "-chunkServerStoreUri=local://./" BASIC_TEST_CHUNK_SERVER_PORT "/",
@@ -103,7 +103,7 @@ class ChunkServerIoTest : public testing::Test {
         ASSERT_TRUE(cg1_.Generate());
 
         paramsIndexs_[PeerCluster::PeerToId(peer1_)] = 0;
-        params_.push_back(chunkServerParams[0]);
+        params_.push_back(const_cast<char**>(chunkServerParams[0]));
 
         // 初始化chunkfilepool，这里会预先分配一些chunk
         lfs_ = LocalFsFactory::CreateFs(FileSystemType::EXT4, "");
@@ -157,9 +157,7 @@ class ChunkServerIoTest : public testing::Test {
 
     void TestBasicIO(std::shared_ptr<ChunkServiceVerify> verify) {
         uint64_t chunkId = 1;
-        off_t offset = 0;
         int length = kOpRequestAlignSize;
-        int ret = 0;
         const SequenceNum sn1 = 1;
         std::string data(length * 4, 0);
         // Now we will zeroing chunk file, even though it fill '0' in start
@@ -214,9 +212,7 @@ class ChunkServerIoTest : public testing::Test {
         const SequenceNum sn1 = 1;
         const SequenceNum sn2 = 2;
         const SequenceNum sn3 = 3;
-        off_t offset = 0;
         int length = kOpRequestAlignSize;
-        int ret = 0;
         std::string data(length * 4, 0);
         std::string chunkData1a(kChunkSize, 0);  // chunk1版本1预期数据
         std::string chunkData1b(kChunkSize, 0);  // chunk1版本2预期数据

--- a/test/integration/chunkserver/chunkserver_clone_recover.cpp
+++ b/test/integration/chunkserver/chunkserver_clone_recover.cpp
@@ -778,7 +778,6 @@ TEST_F(CSCloneRecoverTest, CloneFromCurveByReadChunkWhenLazyAlloc) {
     // 1. chunk文件不存在
     ChunkServiceVerify verify(&opConf_);
     ChunkID cloneChunk1 = 331;
-    SequenceNum sn0 = 0;
     SequenceNum sn1 = 1;
     SequenceNum sn2 = 2;
     string sourceFile = CURVEFS_FILENAME;
@@ -1006,7 +1005,6 @@ TEST_F(CSCloneRecoverTest, RecoverFromS3ByReadChunk) {
     // 1. 创建克隆文件
     ChunkServiceVerify verify(&opConf_);
     ChunkID cloneChunk1 = 339;
-    ChunkID cloneChunk2 = 340;
     SequenceNum sn2 = 2;
     SequenceNum sn3 = 3;
     SequenceNum sn4 = 4;
@@ -1074,7 +1072,6 @@ TEST_F(CSCloneRecoverTest, RecoverFromS3ByRecoverChunk) {
     // 1. 创建克隆文件
     ChunkServiceVerify verify(&opConf_);
     ChunkID cloneChunk1 = 341;
-    ChunkID cloneChunk2 = 342;
     SequenceNum sn2 = 2;
     SequenceNum sn3 = 3;
     SequenceNum sn4 = 4;

--- a/test/integration/chunkserver/chunkserver_concurrent_test.cpp
+++ b/test/integration/chunkserver/chunkserver_concurrent_test.cpp
@@ -45,7 +45,7 @@ using curve::common::Thread;
 
 const char* kFakeMdsAddr = "127.0.0.1:9329";
 
-static char *chunkConcurrencyParams1[1][16] = {
+static const char *chunkConcurrencyParams1[1][16] = {
     {
         "chunkserver",
         "-chunkServerIp=127.0.0.1",
@@ -66,7 +66,7 @@ static char *chunkConcurrencyParams1[1][16] = {
     },
 };
 
-static char *chunkConcurrencyParams2[1][16] = {
+static const char *chunkConcurrencyParams2[1][16] = {
     {
         "chunkserver",
         "-chunkServerIp=127.0.0.1",
@@ -121,7 +121,7 @@ class ChunkServerConcurrentNotFromFilePoolTest : public testing::Test {
 
         paramsIndexs[PeerCluster::PeerToId(peer1)] = 0;
 
-        params.push_back(chunkConcurrencyParams1[0]);
+        params.push_back(const_cast<char**>(chunkConcurrencyParams1[0]));
     }
     virtual void TearDown() {
         std::string rmdir1("rm -fr ");
@@ -192,7 +192,7 @@ class ChunkServerConcurrentFromFilePoolTest : public testing::Test {
 
         paramsIndexs[PeerCluster::PeerToId(peer1)] = 0;
 
-        params.push_back(chunkConcurrencyParams2[0]);
+        params.push_back(const_cast<char**>(chunkConcurrencyParams2[0]));
 
         // 初始化FilePool，这里会预先分配一些chunk
         lfs = LocalFsFactory::CreateFs(FileSystemType::EXT4, "");
@@ -1401,7 +1401,6 @@ TEST_F(ChunkServerConcurrentFromFilePoolTest, DeleteMultiChunk) {
 TEST_F(ChunkServerConcurrentFromFilePoolTest, CreateCloneMultiChunk) {
     const int kThreadNum = 10;
     ChunkID chunkIdRange = kChunkNum;
-    const int sn = 1;
 
     // 1. 启动一个成员的复制组
     PeerCluster cluster("InitShutdown-cluster",

--- a/test/integration/chunkserver/datastore/datastore_restart_test.cpp
+++ b/test/integration/chunkserver/datastore/datastore_restart_test.cpp
@@ -156,8 +156,8 @@ class ExecWrite : public ExecStep {
     }
 
     void Dump() override {
-        printf("WriteChunk, id = %llu, sn = %llu, offset = %llu, "
-                "size = %llu, data = %c.\n",
+        printf("WriteChunk, id = %lu, sn = %lu, offset = %lu, "
+                "size = %lu, data = %c.\n",
                 id_, sn_, data_.offset, data_.length, data_.data);
     }
 
@@ -182,8 +182,8 @@ class ExecPaste : public ExecStep {
     }
 
     void Dump() override {
-        printf("PasteChunk, id = %llu, offset = %llu, "
-                "size = %llu, data = %c.\n",
+        printf("PasteChunk, id = %lu, offset = %lu, "
+                "size = %lu, data = %c.\n",
                 id_, data_.offset, data_.length, data_.data);
     }
 
@@ -204,7 +204,7 @@ class ExecDelete : public ExecStep {
     }
 
     void Dump() override {
-        printf("DeleteChunk, id = %llu, sn = %llu.\n", id_, sn_);
+        printf("DeleteChunk, id = %lu, sn = %lu.\n", id_, sn_);
     }
 
  private:
@@ -226,7 +226,7 @@ class ExecDeleteSnapshot : public ExecStep {
 
     void Dump() override {
         printf("DeleteSnapshotChunkOrCorrectSn, "
-               "id = %llu, correctedSn = %llu.\n", id_, correctedSn_);
+               "id = %lu, correctedSn = %lu.\n", id_, correctedSn_);
     }
 
  private:
@@ -251,8 +251,8 @@ class ExecCreateClone : public ExecStep {
     }
 
     void Dump() override {
-        printf("CreateCloneChunk, id = %llu, sn = %llu, correctedSn = %llu, "
-               "chunk size = %llu, location = %s.\n",
+        printf("CreateCloneChunk, id = %lu, sn = %lu, correctedSn = %lu, "
+               "chunk size = %u, location = %s.\n",
                id_, sn_, correctedSn_, size_, location_.c_str());
     }
 

--- a/test/integration/chunkserver/datastore/datastore_stress_test.cpp
+++ b/test/integration/chunkserver/datastore/datastore_stress_test.cpp
@@ -64,8 +64,7 @@ TEST_F(StressTestSuit, StressTest) {
 
     auto RunStress = [&](int threadNum, int rwPercent, int ioNum) {
         uint64_t beginTime = TimeUtility::GetTimeofDayUs();
-        const int kThreadNum = threadNum;
-        Thread threads[kThreadNum];
+        Thread *threads = new Thread[threadNum];
         int readThreadNum = threadNum * rwPercent / 100;
         int ioNumAvg = ioNum / threadNum;
         int idRange = 100;
@@ -77,17 +76,18 @@ TEST_F(StressTestSuit, StressTest) {
             threads[i] = std::thread(RunWrite, idRange, ioNumAvg);
         }
 
-        for (auto& t : threads) {
-            t.join();
+        for (int i = 0; i < threadNum; ++i) {
+            threads[i].join();
         }
 
         uint64_t endTime = TimeUtility::GetTimeofDayUs();
         uint64_t iops = ioNum * 1000000L / (endTime - beginTime);
-        printf("Total time used: %llu us\n", endTime - beginTime);
+        printf("Total time used: %lu us\n", endTime - beginTime);
         printf("Thread number: %d\n", threadNum);
         printf("read write percent: %d\n", rwPercent);
         printf("io num: %d\n", ioNum);
-        printf("iops: %llu\n", iops);
+        printf("iops: %lu\n", iops);
+        delete[] threads;
     };
 
     printf("===============TEST WRITE==================\n");

--- a/test/integration/client/unstable_chunkserver_exception_test.cpp
+++ b/test/integration/client/unstable_chunkserver_exception_test.cpp
@@ -311,9 +311,9 @@ TEST_F(UnstableCSModuleException, TestCommonReadAndWrite) {
 
     ::Create(filename.c_str(), &info, 10ull * 1024 * 1024 * 1024);
     int fd = ::Open(filename.c_str(), &info);
-    int ret = ::Read(fd, readBuff.get(), offset, length);
+    (void)::Read(fd, readBuff.get(), offset, length);
     LOG(INFO) << "Read finish, here";
-    ret = ::Write(fd, readBuff.get(), offset, length);
+    (void)::Write(fd, readBuff.get(), offset, length);
     LOG(INFO) << "Write finish, here";
 
     ::Close(fd);

--- a/test/integration/cluster_common/cluster.cpp
+++ b/test/integration/cluster_common/cluster.cpp
@@ -772,7 +772,6 @@ int CurveCluster::ProbePort(const std::string &ipPort, int64_t timeoutMs,
     addr.sin_port = htons(port);
     addr.sin_addr.s_addr = inet_addr(res[0].c_str());
 
-    bool satisfy = false;
     uint64_t start = ::curve::common::TimeUtility::GetTimeofDayMs();
     while (::curve::common::TimeUtility::GetTimeofDayMs() - start < timeoutMs) {
         int connectRes =

--- a/test/integration/common/peer_cluster.cpp
+++ b/test/integration/common/peer_cluster.cpp
@@ -52,8 +52,8 @@ PeerCluster::PeerCluster(const std::string &clusterName,
     clusterName_(clusterName),
     snapshotIntervalS_(1),
     electionTimeoutMs_(1000),
-    params_(params),
     paramsIndexs_(paramsIndexs),
+    params_(params),
     isFakeMdsStart_(false) {
     logicPoolID_ = logicPoolID;
     copysetID_ = copysetID;

--- a/test/integration/raft/raft_config_change_test.cpp
+++ b/test/integration/raft/raft_config_change_test.cpp
@@ -44,7 +44,7 @@ const char kRaftConfigChangeTestLogDir[] = "./runlog/RaftConfigChange";
 const char* kFakeMdsAddr = "127.0.0.1:9080";
 const uint32_t kOpRequestAlignSize = 4096;
 
-static char* raftConfigParam[5][16] = {
+static const char* raftConfigParam[5][16] = {
     {
         "chunkserver",
         "-chunkServerIp=127.0.0.1",
@@ -224,11 +224,11 @@ class RaftConfigChangeTest : public testing::Test {
         paramsIndexs[PeerCluster::PeerToId(peer4)] = 3;
         paramsIndexs[PeerCluster::PeerToId(peer5)] = 4;
 
-        params.push_back(raftConfigParam[0]);
-        params.push_back(raftConfigParam[1]);
-        params.push_back(raftConfigParam[2]);
-        params.push_back(raftConfigParam[3]);
-        params.push_back(raftConfigParam[4]);
+        params.push_back(const_cast<char**>(raftConfigParam[0]));
+        params.push_back(const_cast<char**>(raftConfigParam[1]));
+        params.push_back(const_cast<char**>(raftConfigParam[2]));
+        params.push_back(const_cast<char**>(raftConfigParam[3]));
+        params.push_back(const_cast<char**>(raftConfigParam[4]));
     }
     virtual void TearDown() {
         // wait for process exit
@@ -1415,7 +1415,6 @@ TEST_F(RaftConfigChangeTest, ThreeNodeHangPeerAndThenAddNewFollowerFromInstallSn
     braft::cli::CliOptions options;
     options.max_retry = 3;
     options.timeout_ms = confChangeTimeoutMs;
-    const int kMaxLoop = 10;
     butil::Status st = AddPeer(logicPoolId, copysetId, conf, peer4, options);
     ASSERT_TRUE(st.ok());
 

--- a/test/integration/raft/raft_log_replication_test.cpp
+++ b/test/integration/raft/raft_log_replication_test.cpp
@@ -46,7 +46,7 @@ const uint32_t kOpRequestAlignSize = 4096;
 const char kRaftLogRepTestLogDir[] = "./runlog/RaftLogRep";
 const char* kFakeMdsAddr = "127.0.0.1:9070";
 
-static char* raftLogParam[5][16] = {
+static const char* raftLogParam[5][16] = {
     {
         "chunkserver",
         "-chunkServerIp=127.0.0.1",
@@ -224,11 +224,11 @@ class RaftLogReplicationTest : public testing::Test {
         paramsIndexs[PeerCluster::PeerToId(peer4)] = 3;
         paramsIndexs[PeerCluster::PeerToId(peer5)] = 4;
 
-        params.push_back(raftLogParam[0]);
-        params.push_back(raftLogParam[1]);
-        params.push_back(raftLogParam[2]);
-        params.push_back(raftLogParam[3]);
-        params.push_back(raftLogParam[4]);
+        params.push_back(const_cast<char**>(raftLogParam[0]));
+        params.push_back(const_cast<char**>(raftLogParam[1]));
+        params.push_back(const_cast<char**>(raftLogParam[2]));
+        params.push_back(const_cast<char**>(raftLogParam[3]));
+        params.push_back(const_cast<char**>(raftLogParam[4]));
     }
     virtual void TearDown() {
         std::string rmdir1("rm -fr ");

--- a/test/integration/raft/raft_snapshot_test.cpp
+++ b/test/integration/raft/raft_snapshot_test.cpp
@@ -45,7 +45,7 @@ const char* kFakeMdsAddr = "127.0.0.1:9320";
 
 const uint32_t kOpRequestAlignSize = 4096;
 
-static char *raftVoteParam[4][16] = {
+static const char *raftVoteParam[4][16] = {
     {
         "chunkserver",
         "-chunkServerIp=127.0.0.1",
@@ -190,10 +190,10 @@ class RaftSnapshotTest : public testing::Test {
         paramsIndexs_[PeerCluster::PeerToId(peer3_)] = 2;
         paramsIndexs_[PeerCluster::PeerToId(peer4_)] = 3;
 
-        params_.push_back(raftVoteParam[0]);
-        params_.push_back(raftVoteParam[1]);
-        params_.push_back(raftVoteParam[2]);
-        params_.push_back(raftVoteParam[3]);
+        params_.push_back(const_cast<char**>(raftVoteParam[0]));
+        params_.push_back(const_cast<char**>(raftVoteParam[1]));
+        params_.push_back(const_cast<char**>(raftVoteParam[2]));
+        params_.push_back(const_cast<char**>(raftVoteParam[3]));
 
         // 配置默认raft client option
         defaultCliOpt_.max_retry = 3;

--- a/test/integration/raft/raft_vote_test.cpp
+++ b/test/integration/raft/raft_vote_test.cpp
@@ -45,7 +45,7 @@ const char* kFakeMdsAddr = "127.0.0.1:9089";
 
 const uint32_t kOpRequestAlignSize = 4096;
 
-static char* raftVoteParam[3][16] = {
+static const char* raftVoteParam[3][16] = {
     {
         "chunkserver",
         "-chunkServerIp=127.0.0.1",
@@ -159,9 +159,9 @@ class RaftVoteTest : public testing::Test {
         paramsIndexs[PeerCluster::PeerToId(peer2)] = 1;
         paramsIndexs[PeerCluster::PeerToId(peer3)] = 2;
 
-        params.push_back(raftVoteParam[0]);
-        params.push_back(raftVoteParam[1]);
-        params.push_back(raftVoteParam[2]);
+        params.push_back(const_cast<char**>(raftVoteParam[0]));
+        params.push_back(const_cast<char**>(raftVoteParam[1]));
+        params.push_back(const_cast<char**>(raftVoteParam[2]));
     }
     virtual void TearDown() {
         std::string rmdir1("rm -fr ");

--- a/test/kvstorageclient/etcdclient_test.cpp
+++ b/test/kvstorageclient/etcdclient_test.cpp
@@ -54,7 +54,7 @@ class TestEtcdClinetImp : public ::testing::Test {
 
         client_ = std::make_shared<EtcdClientImp>();
         char endpoints[] = "127.0.0.1:2377";
-        EtcdConf conf = { endpoints, strlen(endpoints), 1000 };
+        EtcdConf conf = {endpoints, static_cast<int>(strlen(endpoints)), 1000};
         ASSERT_EQ(EtcdErrCode::EtcdDeadlineExceeded,
                   client_->Init(conf, 200, 3));
 
@@ -204,13 +204,15 @@ TEST_F(TestEtcdClinetImp, test_EtcdClientInterface) {
     }
 
     // 5. rename file: rename file9 ~ file10, file10本来不存在
-    Operation op1{ OpType::OpDelete, const_cast<char *>(keyMap[9].c_str()),
-                   const_cast<char *>(fileInfo9.c_str()), keyMap[9].size(),
-                   fileInfo9.size() };
-    Operation op2{ OpType::OpPut, const_cast<char *>(fileKey10.c_str()),
-                   const_cast<char *>(fileInfo10.c_str()), fileKey10.size(),
-                   fileInfo10.size() };
-    std::vector<Operation> ops{ op1, op2 };
+    Operation op1{OpType::OpDelete, const_cast<char *>(keyMap[9].c_str()),
+                  const_cast<char *>(fileInfo9.c_str()),
+                  static_cast<int>(keyMap[9].size()),
+                  static_cast<int>(fileInfo9.size())};
+    Operation op2{OpType::OpPut, const_cast<char *>(fileKey10.c_str()),
+                  const_cast<char *>(fileInfo10.c_str()),
+                  static_cast<int>(fileKey10.size()),
+                  static_cast<int>(fileInfo10.size())};
+    std::vector<Operation> ops{op1, op2};
     ASSERT_EQ(EtcdErrCode::EtcdOK, client_->TxnN(ops));
     // cannot get file9
     std::string out;
@@ -222,12 +224,14 @@ TEST_F(TestEtcdClinetImp, test_EtcdClientInterface) {
     ASSERT_EQ(fileName10, fileinfo.filename());
 
     // 6. snapshot of keyMap[6]
-    Operation op3{ OpType::OpPut, const_cast<char *>(keyMap[6].c_str()),
-                   const_cast<char *>(fileInfo6.c_str()), keyMap[6].size(),
-                   fileInfo6.size() };
-    Operation op4{ OpType::OpPut, const_cast<char *>(snapshotKey6.c_str()),
-                   const_cast<char *>(snapshotInfo6.c_str()),
-                   snapshotKey6.size(), snapshotInfo6.size() };
+    Operation op3{OpType::OpPut, const_cast<char *>(keyMap[6].c_str()),
+                  const_cast<char *>(fileInfo6.c_str()),
+                  static_cast<int>(keyMap[6].size()),
+                  static_cast<int>(fileInfo6.size())};
+    Operation op4{OpType::OpPut, const_cast<char *>(snapshotKey6.c_str()),
+                  const_cast<char *>(snapshotInfo6.c_str()),
+                  static_cast<int>(snapshotKey6.size()),
+                  static_cast<int>(snapshotInfo6.size())};
     ops.clear();
     ops.emplace_back(op3);
     ops.emplace_back(op4);
@@ -256,8 +260,9 @@ TEST_F(TestEtcdClinetImp, test_EtcdClientInterface) {
     ASSERT_EQ("200", out);
 
     // 8. rename file: rename file7 ~ file8
-    Operation op8{ OpType::OpDelete, const_cast<char *>(keyMap[7].c_str()), "",
-                   keyMap[7].size(), 0 };
+    Operation op8{OpType::OpDelete, const_cast<char *>(keyMap[7].c_str()),
+                  const_cast<char *>(""), static_cast<int>(keyMap[7].size()),
+                  0};
     FileInfo newFileInfo7;
     newFileInfo7.CopyFrom(fileInfo7);
     newFileInfo7.set_parentid(fileInfo8.parentid());
@@ -267,10 +272,11 @@ TEST_F(TestEtcdClinetImp, test_EtcdClientInterface) {
                                                   newFileInfo7.filename());
     std::string encodeNewFileInfo7;
     ASSERT_TRUE(newFileInfo7.SerializeToString(&encodeNewFileInfo7));
-    Operation op9{ OpType::OpPut,
-                   const_cast<char *>(encodeNewFileInfo7Key.c_str()),
-                   const_cast<char *>(encodeNewFileInfo7.c_str()),
-                   encodeNewFileInfo7Key.size(), encodeNewFileInfo7.size() };
+    Operation op9{OpType::OpPut,
+                  const_cast<char *>(encodeNewFileInfo7Key.c_str()),
+                  const_cast<char *>(encodeNewFileInfo7.c_str()),
+                  static_cast<int>(encodeNewFileInfo7Key.size()),
+                  static_cast<int>(encodeNewFileInfo7.size())};
     ops.clear();
     ops.emplace_back(op8);
     ops.emplace_back(op9);
@@ -300,9 +306,10 @@ TEST_F(TestEtcdClinetImp, test_EtcdClientInterface) {
     ASSERT_EQ(EtcdErrCode::EtcdDeadlineExceeded, client_->TxnN(ops));
 
     client_->SetTimeout(5000);
-    Operation op5{ OpType(5), const_cast<char *>(snapshotKey6.c_str()),
-                   const_cast<char *>(snapshotInfo6.c_str()),
-                   snapshotKey6.size(), snapshotInfo6.size() };
+    Operation op5{OpType(5), const_cast<char *>(snapshotKey6.c_str()),
+                  const_cast<char *>(snapshotInfo6.c_str()),
+                  static_cast<int>(snapshotKey6.size()),
+                  static_cast<int>(snapshotInfo6.size())};
     ops.clear();
     ops.emplace_back(op3);
     ops.emplace_back(op5);
@@ -384,7 +391,7 @@ TEST_F(TestEtcdClinetImp, test_CampaignLeader) {
     int dialtTimeout = 10000;
     int retryTimes = 3;
     char endpoints[] = "127.0.0.1:2377";
-    EtcdConf conf = { endpoints, strlen(endpoints), 20000 };
+    EtcdConf conf = {endpoints, static_cast<int>(strlen(endpoints)), 20000};
     std::string leaderName1("leader1");
     std::string leaderName2("leader2");
     uint64_t leaderOid;

--- a/test/mds/nameserver2/chunk_allocator_test.cpp
+++ b/test/mds/nameserver2/chunk_allocator_test.cpp
@@ -28,13 +28,13 @@
 #include "src/mds/nameserver2/chunk_allocator.h"
 #include "src/mds/common/mds_define.h"
 
-using ::testing::Return;
-using ::testing::_;
-using ::testing::DoAll;
-using ::testing::SetArgPointee;
-using ::testing::AtLeast;
 using ::curve::mds::topology::CopysetIdInfo;
 using ::curve::mds::topology::PoolIdType;
+using ::testing::_;
+using ::testing::AtLeast;
+using ::testing::DoAll;
+using ::testing::Return;
+using ::testing::SetArgPointee;
 
 namespace curve {
 namespace mds {
@@ -42,7 +42,7 @@ namespace mds {
 const uint64_t DefaultChunkSize = 16 * kMB;
 const uint64_t DefaultSegmentSize = kGB * 1;
 
-class ChunkAllocatorTest: public ::testing::Test {
+class ChunkAllocatorTest : public ::testing::Test {
  protected:
     void SetUp() override {
         mockChunkIDGenerator_ = std::make_shared<MockChunkIDGenerator>();
@@ -59,20 +59,25 @@ class ChunkAllocatorTest: public ::testing::Test {
 
 TEST_F(ChunkAllocatorTest, testcase1) {
     auto impl = std::make_shared<ChunkSegmentAllocatorImpl>(
-                                mockTopologyChunkAllocator_,
-                                mockChunkIDGenerator_);
+        mockTopologyChunkAllocator_, mockChunkIDGenerator_);
     // test segment pointer == nullptr
     ASSERT_EQ(impl->AllocateChunkSegment(FileType::INODE_PAGEFILE,
-        DefaultSegmentSize, DefaultChunkSize, 0, nullptr), false);
+                                         DefaultSegmentSize, DefaultChunkSize,
+                                         0, nullptr),
+              false);
 
     // test offset not align with segmentsize
     PageFileSegment segment;
     ASSERT_EQ(impl->AllocateChunkSegment(FileType::INODE_PAGEFILE,
-        DefaultSegmentSize, DefaultChunkSize, 1, &segment), false);
+                                         DefaultSegmentSize, DefaultChunkSize,
+                                         1, &segment),
+              false);
 
     // test  chunkSize not align with segmentsize
     ASSERT_EQ(impl->AllocateChunkSegment(FileType::INODE_PAGEFILE,
-        DefaultSegmentSize, DefaultChunkSize - 1, 0, &segment), false);
+                                         DefaultSegmentSize,
+                                         DefaultChunkSize - 1, 0, &segment),
+              false);
 
     // test  topologyAdmin_AllocateChunkRoundRobinInSingleLogicalPool
     // return false
@@ -80,12 +85,14 @@ TEST_F(ChunkAllocatorTest, testcase1) {
         PageFileSegment segment;
 
         EXPECT_CALL(*mockTopologyChunkAllocator_,
-            AllocateChunkRoundRobinInSingleLogicalPool(_, _,  _, _))
+                    AllocateChunkRoundRobinInSingleLogicalPool(_, _, _, _))
             .Times(1)
             .WillOnce(Return(false));
 
         ASSERT_EQ(impl->AllocateChunkSegment(FileType::INODE_PAGEFILE,
-            DefaultSegmentSize, DefaultChunkSize, 0, &segment), false);
+                                             DefaultSegmentSize,
+                                             DefaultChunkSize, 0, &segment),
+                  false);
     }
 
     // test topologyAdmin_ Allocate return size error
@@ -94,13 +101,14 @@ TEST_F(ChunkAllocatorTest, testcase1) {
 
         std::vector<CopysetIdInfo> copysetInfos;
         EXPECT_CALL(*mockTopologyChunkAllocator_,
-            AllocateChunkRoundRobinInSingleLogicalPool(_, _,  _, _))
+                    AllocateChunkRoundRobinInSingleLogicalPool(_, _, _, _))
             .Times(1)
-            .WillOnce(DoAll(SetArgPointee<3>(copysetInfos),
-            Return(true)));
+            .WillOnce(DoAll(SetArgPointee<3>(copysetInfos), Return(true)));
 
         ASSERT_EQ(impl->AllocateChunkSegment(FileType::INODE_PAGEFILE,
-            DefaultSegmentSize, DefaultChunkSize, 0, &segment), false);
+                                             DefaultSegmentSize,
+                                             DefaultChunkSize, 0, &segment),
+                  false);
     }
 
     // test   GenChunkID error
@@ -108,23 +116,25 @@ TEST_F(ChunkAllocatorTest, testcase1) {
         PoolIdType logicalPoolID = 1;
         PageFileSegment segment;
         std::vector<CopysetIdInfo> copysetInfos;
-        for (int i = 0; i != DefaultSegmentSize/DefaultChunkSize; i++) {
-            CopysetIdInfo info = {logicalPoolID, i};
+        for (int i = 0; i != DefaultSegmentSize / DefaultChunkSize; i++) {
+            CopysetIdInfo info = {logicalPoolID,
+                                  static_cast<topology::CopySetIdType>(i)};
             copysetInfos.push_back(info);
         }
 
         EXPECT_CALL(*mockTopologyChunkAllocator_,
-            AllocateChunkRoundRobinInSingleLogicalPool(_, _,  _, _))
+                    AllocateChunkRoundRobinInSingleLogicalPool(_, _, _, _))
             .Times(1)
-            .WillOnce(DoAll(SetArgPointee<3>(copysetInfos),
-            Return(true)));
+            .WillOnce(DoAll(SetArgPointee<3>(copysetInfos), Return(true)));
 
         EXPECT_CALL(*mockChunkIDGenerator_, GenChunkID(_))
-        .Times(1)
-        .WillOnce(Return(false));
+            .Times(1)
+            .WillOnce(Return(false));
 
         ASSERT_EQ(impl->AllocateChunkSegment(FileType::INODE_PAGEFILE,
-            DefaultSegmentSize, DefaultChunkSize, 0, &segment), false);
+                                             DefaultSegmentSize,
+                                             DefaultChunkSize, 0, &segment),
+                  false);
     }
 
     // test ok
@@ -132,46 +142,49 @@ TEST_F(ChunkAllocatorTest, testcase1) {
         PoolIdType logicalPoolID = 1;
         PageFileSegment segment;
         std::vector<CopysetIdInfo> copysetInfos;
-        for (int i = 0; i != DefaultSegmentSize/DefaultChunkSize; i++) {
-            CopysetIdInfo info = {logicalPoolID, i};
+        for (int i = 0; i != DefaultSegmentSize / DefaultChunkSize; i++) {
+            CopysetIdInfo info = {logicalPoolID,
+                                  static_cast<topology::CopySetIdType>(i)};
             copysetInfos.push_back(info);
         }
 
         EXPECT_CALL(*mockTopologyChunkAllocator_,
-            AllocateChunkRoundRobinInSingleLogicalPool(_, _,  _, _))
+                    AllocateChunkRoundRobinInSingleLogicalPool(_, _, _, _))
             .Times(1)
-            .WillOnce(DoAll(SetArgPointee<3>(copysetInfos),
-            Return(true)));
+            .WillOnce(DoAll(SetArgPointee<3>(copysetInfos), Return(true)));
 
         EXPECT_CALL(*mockChunkIDGenerator_, GenChunkID(_))
-        .Times(1)
-        .WillOnce(Return(false));
+            .Times(1)
+            .WillOnce(Return(false));
 
         ASSERT_EQ(impl->AllocateChunkSegment(FileType::INODE_PAGEFILE,
-            DefaultSegmentSize, DefaultChunkSize, 0, &segment), false);
+                                             DefaultSegmentSize,
+                                             DefaultChunkSize, 0, &segment),
+                  false);
     }
 
     // test logicalid not same
     {
         PageFileSegment segment;
-        PoolIdType logicalPoolID = 1;
         std::vector<CopysetIdInfo> copysetInfos;
 
-        uint64_t segmentSize = DefaultChunkSize*2;
+        uint64_t segmentSize = DefaultChunkSize * 2;
 
-        for (int i = 0; i != segmentSize/DefaultChunkSize; i++) {
-            CopysetIdInfo info = {i, i};
+        for (int i = 0; i != segmentSize / DefaultChunkSize; i++) {
+            CopysetIdInfo info = {static_cast<topology::PoolIdType>(i),
+                                  static_cast<topology::CopySetIdType>(i)};
             copysetInfos.push_back(info);
         }
 
         EXPECT_CALL(*mockTopologyChunkAllocator_,
-            AllocateChunkRoundRobinInSingleLogicalPool(_, _,  _, _))
+                    AllocateChunkRoundRobinInSingleLogicalPool(_, _, _, _))
             .Times(1)
-            .WillOnce(DoAll(SetArgPointee<3>(copysetInfos),
-            Return(true)));
+            .WillOnce(DoAll(SetArgPointee<3>(copysetInfos), Return(true)));
 
         ASSERT_EQ(impl->AllocateChunkSegment(FileType::INODE_PAGEFILE,
-            segmentSize, DefaultChunkSize, 0, &segment), false);
+                                             segmentSize, DefaultChunkSize, 0,
+                                             &segment),
+                  false);
     }
 
 
@@ -181,39 +194,41 @@ TEST_F(ChunkAllocatorTest, testcase1) {
         PoolIdType logicalPoolID = 1;
         std::vector<CopysetIdInfo> copysetInfos;
 
-        uint64_t segmentSize = DefaultChunkSize*2;
+        uint64_t segmentSize = DefaultChunkSize * 2;
 
-        for (int i = 0; i != segmentSize/DefaultChunkSize; i++) {
-            CopysetIdInfo info = {logicalPoolID, i};
+        for (int i = 0; i != segmentSize / DefaultChunkSize; i++) {
+            CopysetIdInfo info = {logicalPoolID,
+                                  static_cast<topology::CopySetIdType>(i)};
             copysetInfos.push_back(info);
         }
 
         EXPECT_CALL(*mockTopologyChunkAllocator_,
-            AllocateChunkRoundRobinInSingleLogicalPool(_, _,  _, _))
+                    AllocateChunkRoundRobinInSingleLogicalPool(_, _, _, _))
             .Times(1)
-            .WillOnce(DoAll(SetArgPointee<3>(copysetInfos),
-            Return(true)));
+            .WillOnce(DoAll(SetArgPointee<3>(copysetInfos), Return(true)));
 
         EXPECT_CALL(*mockChunkIDGenerator_, GenChunkID(_))
-        .Times(AtLeast(segmentSize/DefaultChunkSize))
-        .WillRepeatedly(DoAll(SetArgPointee<0>(1), Return(true)));
+            .Times(AtLeast(segmentSize / DefaultChunkSize))
+            .WillRepeatedly(DoAll(SetArgPointee<0>(1), Return(true)));
 
         ASSERT_EQ(impl->AllocateChunkSegment(FileType::INODE_PAGEFILE,
-            segmentSize, DefaultChunkSize, 0, &segment), true);
+                                             segmentSize, DefaultChunkSize, 0,
+                                             &segment),
+                  true);
 
         PageFileSegment expectSegment;
         expectSegment.set_chunksize(DefaultChunkSize);
         expectSegment.set_segmentsize(segmentSize);
         expectSegment.set_startoffset(0);
         expectSegment.set_logicalpoolid(logicalPoolID);
-        for (uint32_t i = 0; i < segmentSize/DefaultChunkSize ; i++) {
-            PageFileChunkInfo* chunkinfo =  expectSegment.add_chunks();
+        for (uint32_t i = 0; i < segmentSize / DefaultChunkSize; i++) {
+            PageFileChunkInfo *chunkinfo = expectSegment.add_chunks();
             chunkinfo->set_chunkid(1);
             chunkinfo->set_copysetid(i);
             LOG(INFO) << "chunkid = " << 1 << ", copysetid = " << i;
         }
         ASSERT_EQ(segment.SerializeAsString(),
-            expectSegment.SerializeAsString());
+                  expectSegment.SerializeAsString());
     }
 }
 }  // namespace mds

--- a/test/mds/nameserver2/curvefs_test.cpp
+++ b/test/mds/nameserver2/curvefs_test.cpp
@@ -1512,7 +1512,6 @@ TEST_F(CurveFSTest, testRenameFile) {
 
     // new file exist, rename success
     {
-        uint64_t fileId = 10;
         FileInfo fileInfo1;
         FileInfo fileInfo2;
         FileInfo fileInfo3;

--- a/test/mds/schedule/leaderScheduler_test.cpp
+++ b/test/mds/schedule/leaderScheduler_test.cpp
@@ -132,7 +132,6 @@ TEST_F(TestLeaderSchedule, test_copySet_has_candidate) {
     PeerInfo peer2(2, 2, 2, "192.168.10.2", 9000);
     PeerInfo peer3(3, 3, 3, "192.168.10.3", 9000);
     auto onlineState = ::curve::mds::topology::OnlineState::ONLINE;
-    auto offlineState = ::curve::mds::topology::OnlineState::OFFLINE;
     auto diskState = ::curve::mds::topology::DiskState::DISKNORMAL;
     auto statInfo = ::curve::mds::heartbeat::ChunkServerStatisticInfo();
     ChunkServerInfo csInfo1(
@@ -173,7 +172,6 @@ TEST_F(TestLeaderSchedule, test_cannot_get_chunkServerInfo) {
     PeerInfo peer2(2, 2, 2, "192.168.10.2", 9000);
     PeerInfo peer3(3, 3, 3, "192.168.10.3", 9000);
     auto onlineState = ::curve::mds::topology::OnlineState::ONLINE;
-    auto offlineState = ::curve::mds::topology::OnlineState::OFFLINE;
     auto diskState = ::curve::mds::topology::DiskState::DISKNORMAL;
     auto statInfo = ::curve::mds::heartbeat::ChunkServerStatisticInfo();
     ChunkServerInfo csInfo1(
@@ -218,7 +216,6 @@ TEST_F(TestLeaderSchedule, test_no_need_tranferLeaderOut) {
     PeerInfo peer2(2, 2, 2, "192.168.10.2", 9000);
     PeerInfo peer3(3, 3, 3, "192.168.10.3", 9000);
     auto onlineState = ::curve::mds::topology::OnlineState::ONLINE;
-    auto offlineState = ::curve::mds::topology::OnlineState::OFFLINE;
     auto diskState = ::curve::mds::topology::DiskState::DISKNORMAL;
     auto statInfo = ::curve::mds::heartbeat::ChunkServerStatisticInfo();
     ChunkServerInfo csInfo1(
@@ -265,7 +262,6 @@ TEST_F(TestLeaderSchedule, test_tranferLeaderout_normal) {
     PeerInfo peer5(5, 5, 5, "192.168.10.5", 9000);
     PeerInfo peer6(6, 6, 6, "192.168.10.6", 9000);
     auto onlineState = ::curve::mds::topology::OnlineState::ONLINE;
-    auto offlineState = ::curve::mds::topology::OnlineState::OFFLINE;
     auto diskState = ::curve::mds::topology::DiskState::DISKNORMAL;
     auto statInfo = ::curve::mds::heartbeat::ChunkServerStatisticInfo();
     ChunkServerInfo csInfo1(
@@ -361,7 +357,6 @@ TEST_F(TestLeaderSchedule, test_tranferLeaderout_pendding) {
     PeerInfo peer5(5, 5, 5, "192.168.10.5", 9000);
     PeerInfo peer6(6, 6, 6, "192.168.10.6", 9000);
     auto onlineState = ::curve::mds::topology::OnlineState::ONLINE;
-    auto offlineState = ::curve::mds::topology::OnlineState::OFFLINE;
     auto diskState = ::curve::mds::topology::DiskState::DISKNORMAL;
     auto statInfo = ::curve::mds::heartbeat::ChunkServerStatisticInfo();
     ChunkServerInfo csInfo1(
@@ -452,7 +447,6 @@ TEST_F(TestLeaderSchedule, test_transferLeaderIn_normal) {
     PeerInfo peer3(3, 3, 3, "192.168.10.3", 9000);
     PeerInfo peer4(3, 4, 4, "192.168.10.4", 9000);
     auto onlineState = ::curve::mds::topology::OnlineState::ONLINE;
-    auto offlineState = ::curve::mds::topology::OnlineState::OFFLINE;
     auto diskState = ::curve::mds::topology::DiskState::DISKNORMAL;
     auto statInfo = ::curve::mds::heartbeat::ChunkServerStatisticInfo();
     ChunkServerInfo csInfo1(
@@ -535,7 +529,6 @@ TEST_F(TestLeaderSchedule, test_transferLeaderIn_pendding) {
     PeerInfo peer3(3, 3, 3, "192.168.10.3", 9000);
     PeerInfo peer4(3, 4, 4, "192.168.10.4", 9000);
     auto onlineState = ::curve::mds::topology::OnlineState::ONLINE;
-    auto offlineState = ::curve::mds::topology::OnlineState::OFFLINE;
     auto diskState = ::curve::mds::topology::DiskState::DISKNORMAL;
     auto statInfo = ::curve::mds::heartbeat::ChunkServerStatisticInfo();
     ChunkServerInfo csInfo1(

--- a/test/mds/schedule/recoverScheduler_test.cpp
+++ b/test/mds/schedule/recoverScheduler_test.cpp
@@ -214,7 +214,6 @@ TEST_F(TestRecoverSheduler, test_all_chunkServer_online_offline) {
     ChunkServerIdType id1 = 1;
     ChunkServerIdType id2 = 2;
     ChunkServerIdType id3 = 3;
-    ChunkServerIdType id4 = 4;
     Operator op;
     EXPECT_CALL(*topoAdapter_, GetAvgScatterWidthInLogicalPool(_))
             .WillRepeatedly(Return(90));

--- a/test/mds/server/mds_test.cpp
+++ b/test/mds/server/mds_test.cpp
@@ -64,7 +64,7 @@ class MDSTest : public ::testing::Test {
         }
         // 一定时间内尝试init直到etcd完全起来
         auto client = std::make_shared<EtcdClientImp>();
-        EtcdConf conf = { kEtcdAddr, strlen(kEtcdAddr), 1000 };
+        EtcdConf conf = {kEtcdAddr, static_cast<int>(strlen(kEtcdAddr)), 1000};
         uint64_t now = ::curve::common::TimeUtility::GetTimeofDaySec();
         bool initSuccess = false;
         while (::curve::common::TimeUtility::GetTimeofDaySec() - now <= 5) {
@@ -176,7 +176,7 @@ TEST_F(MDSTest, common) {
     request1.set_token("123");
     request1.set_ip("127.0.0.1");
     request1.set_port(8888);
-    heartbeat::DiskState* diskState = new heartbeat::DiskState();
+    heartbeat::DiskState *diskState = new heartbeat::DiskState();
     diskState->set_errtype(0);
     diskState->set_errmsg("");
     request1.set_allocated_diskstate(diskState);

--- a/test/mds/snapshotcloneclient/test_snapshotclone_client.cpp
+++ b/test/mds/snapshotcloneclient/test_snapshotclone_client.cpp
@@ -90,7 +90,6 @@ TEST_F(TestSnapshotCloneClient, TestInitSuccess) {
 }
 
 TEST_F(TestSnapshotCloneClient, TestInitFalse) {
-    uint32_t port = listenAddr_.port;
     option.snapshotCloneAddr = "";
     client_->Init(option);
     ASSERT_FALSE(client_->GetInitStatus());
@@ -107,7 +106,6 @@ TEST_F(TestSnapshotCloneClient, TestGetCloneRefStatusFalseNotInit) {
 }
 
 TEST_F(TestSnapshotCloneClient, TestGetCloneRefStatusFalseConnectFail) {
-    uint32_t port = listenAddr_.port;
     option.snapshotCloneAddr = "aa";
     client_->Init(option);
     ASSERT_TRUE(client_->GetInitStatus());
@@ -122,7 +120,6 @@ TEST_F(TestSnapshotCloneClient, TestGetCloneRefStatusFalseConnectFail) {
 }
 
 TEST_F(TestSnapshotCloneClient, TestGetCloneRefStatusFalseCallFail) {
-    uint32_t port = listenAddr_.port;
     option.snapshotCloneAddr = "127.0.0.1:" + std::to_string(0);
     client_->Init(option);
     ASSERT_TRUE(client_->GetInitStatus());
@@ -216,7 +213,6 @@ TEST_F(TestSnapshotCloneClient, TestGetCloneRefStatusFalseInvalidStatus) {
                         butil::IOBufBuilder os;
                         Json::Value mainObj;
                         mainObj[kCodeStr] = std::to_string(kErrCodeSuccess);
-                        CloneRefStatus refStatus = CloneRefStatus::kNoRef;
                         mainObj[kRefStatusStr] = 4;
                         os << mainObj.toStyledString();
                         os.move_to(bcntl->response_attachment());

--- a/test/mds/topology/test_topology_service_manager.cpp
+++ b/test/mds/topology/test_topology_service_manager.cpp
@@ -840,7 +840,6 @@ TEST_F(TestTopologyServiceManager, test_RegistServer_PhysicalPoolNotFound) {
 
 TEST_F(TestTopologyServiceManager,
     test_RegistServer_ByNamePhysicalPoolNotFound) {
-    ServerIdType id = 0x31;
     PoolIdType physicalPoolId = 0x11;
     ZoneIdType zoneId = 0x21;
     PrepareAddPhysicalPool(physicalPoolId, "PhysicalPool1");
@@ -885,7 +884,6 @@ TEST_F(TestTopologyServiceManager, test_RegistServer_ZoneNotFound) {
 }
 
 TEST_F(TestTopologyServiceManager, test_RegistServer_ByNameZoneNotFound) {
-    ServerIdType id = 0x31;
     PoolIdType physicalPoolId = 0x11;
     ZoneIdType zoneId = 0x21;
     PrepareAddPhysicalPool(physicalPoolId, "PhysicalPool1");
@@ -946,7 +944,6 @@ TEST_F(TestTopologyServiceManager,
 
 TEST_F(TestTopologyServiceManager,
     test_RegistServer_InvalidParamMissingPhysicalPoolIdAndName) {
-    ServerIdType id = 0x31;
     PoolIdType physicalPoolId = 0x11;
     ZoneIdType zoneId = 0x21;
     PrepareAddPhysicalPool(physicalPoolId, "PhysicalPool1");
@@ -968,7 +965,6 @@ TEST_F(TestTopologyServiceManager,
 }
 
 TEST_F(TestTopologyServiceManager, test_RegistServer_AllocateIdFail) {
-    ServerIdType id = 0x31;
     PoolIdType physicalPoolId = 0x11;
     ZoneIdType zoneId = 0x21;
     PrepareAddPhysicalPool(physicalPoolId);
@@ -1476,7 +1472,6 @@ TEST_F(TestTopologyServiceManager, test_CreateZone_success) {
 
 TEST_F(TestTopologyServiceManager, test_CreateZone_AllocateIdFail) {
     PoolIdType physicalPoolId = 0x11;
-    ZoneIdType zoneId = 0x21;
     PrepareAddPhysicalPool(physicalPoolId, "poolname1");
 
     ZoneRequest request;

--- a/test/mds/topology/test_topology_stat.cpp
+++ b/test/mds/topology/test_topology_stat.cpp
@@ -114,7 +114,6 @@ TEST_F(TestTopologyStat, TestUpdateAndGetChunkServerStat) {
     cstat3.writeIOPS = 3;
     stat3.copysetStats.push_back(cstat3);
 
-    PoolIdType pPid = 2;
     EXPECT_CALL(*topology_, GetBelongPhysicalPoolId(_, _))
         .WillRepeatedly(DoAll(SetArgPointee<1>(2),
                             Return(kTopoErrCodeSuccess)));

--- a/test/snapshotcloneserver/test_clone_core.cpp
+++ b/test/snapshotcloneserver/test_clone_core.cpp
@@ -1223,7 +1223,6 @@ void TestCloneCoreImpl::MockCloneMetaSuccess(
     std::shared_ptr<CloneTaskInfo> task) {
     uint32_t chunksize = 1024 * 1024;
     uint64_t segmentsize = 2 * chunksize;
-    uint64_t filelength = 1 * segmentsize;
     SegmentInfo segInfoOut;
     segInfoOut.segmentsize = segmentsize;
     segInfoOut.chunksize = chunksize;

--- a/test/snapshotcloneserver/test_snapshot_core.cpp
+++ b/test/snapshotcloneserver/test_snapshot_core.cpp
@@ -989,7 +989,7 @@ TEST_F(TestSnapshotCoreImpl,
     std::vector<SnapshotInfo> snapInfos;
     SnapshotInfo info2(uuid2, user, fileName, desc2);
     info.SetSeqNum(seqNum);
-    info2.SetSeqNum(seqNum - 1);  //上一个快照
+    info2.SetSeqNum(seqNum - 1);  // 上一个快照
     info2.SetStatus(Status::done);
     snapInfos.push_back(info);
     snapInfos.push_back(info2);

--- a/test/tools/mds_client_test.cpp
+++ b/test/tools/mds_client_test.cpp
@@ -28,36 +28,36 @@
 #include "test/tools/mock/mock_topology_service.h"
 #include "test/tools/mock/mock_schedule_service.h"
 
-using curve::mds::topology::DiskState;
-using curve::mds::topology::OnlineState;
+using curve::mds::schedule::QueryChunkServerRecoverStatusRequest;
+using curve::mds::schedule::QueryChunkServerRecoverStatusResponse;
+using curve::mds::schedule::RapidLeaderScheduleResponse;
 using curve::mds::topology::AllocateStatus;
-using curve::mds::topology::LogicalPoolType;
-using curve::mds::topology::ListPhysicalPoolRequest;
-using curve::mds::topology::ListPhysicalPoolResponse;
-using curve::mds::topology::ListLogicalPoolRequest;
-using curve::mds::topology::ListLogicalPoolResponse;
+using curve::mds::topology::DiskState;
 using curve::mds::topology::GetChunkServerListInCopySetsRequest;
 using curve::mds::topology::GetChunkServerListInCopySetsResponse;
+using curve::mds::topology::GetCopysetRequest;
+using curve::mds::topology::GetCopysetResponse;
 using curve::mds::topology::GetCopySetsInChunkServerRequest;
 using curve::mds::topology::GetCopySetsInChunkServerResponse;
 using curve::mds::topology::GetCopySetsInClusterRequest;
 using curve::mds::topology::GetCopySetsInClusterResponse;
-using curve::mds::topology::GetCopysetRequest;
-using curve::mds::topology::GetCopysetResponse;
-using curve::mds::topology::SetCopysetsAvailFlagRequest;
-using curve::mds::topology::SetCopysetsAvailFlagResponse;
+using curve::mds::topology::ListLogicalPoolRequest;
+using curve::mds::topology::ListLogicalPoolResponse;
+using curve::mds::topology::ListPhysicalPoolRequest;
+using curve::mds::topology::ListPhysicalPoolResponse;
 using curve::mds::topology::ListUnAvailCopySetsRequest;
 using curve::mds::topology::ListUnAvailCopySetsResponse;
+using curve::mds::topology::LogicalPoolType;
+using curve::mds::topology::OnlineState;
+using curve::mds::topology::SetCopysetsAvailFlagRequest;
+using curve::mds::topology::SetCopysetsAvailFlagResponse;
 using curve::mds::topology::SetLogicalPoolScanStateRequest;
 using curve::mds::topology::SetLogicalPoolScanStateResponse;
-using curve::mds::schedule::RapidLeaderScheduleResponse;
-using curve::mds::schedule::QueryChunkServerRecoverStatusRequest;
-using curve::mds::schedule::QueryChunkServerRecoverStatusResponse;
 
 using ::testing::_;
-using ::testing::Return;
-using ::testing::Invoke;
 using ::testing::DoAll;
+using ::testing::Invoke;
+using ::testing::Return;
 using ::testing::SetArgPointee;
 
 DECLARE_string(mdsDummyPort);
@@ -67,11 +67,9 @@ namespace tool {
 
 const char mdsAddr[] = "127.0.0.1:9191,127.0.0.1:9192";
 
-template<typename Req, typename Resp>
-void callback(RpcController* controller,
-              const Req* request,
-              Resp* response,
-              Closure* done) {
+template <typename Req, typename Resp>
+void callback(RpcController *controller, const Req *request, Resp *response,
+              Closure *done) {
     brpc::ClosureGuard doneGuard(done);
 }
 
@@ -84,11 +82,11 @@ class ToolMDSClientTest : public ::testing::Test {
         topoService = new curve::mds::topology::MockTopologyService();
         scheduleService = new curve::mds::schedule::MockScheduleService();
         ASSERT_EQ(0, server->AddService(nameService,
-                                      brpc::SERVER_DOESNT_OWN_SERVICE));
+                                        brpc::SERVER_DOESNT_OWN_SERVICE));
         ASSERT_EQ(0, server->AddService(topoService,
-                                      brpc::SERVER_DOESNT_OWN_SERVICE));
+                                        brpc::SERVER_DOESNT_OWN_SERVICE));
         ASSERT_EQ(0, server->AddService(scheduleService,
-                                      brpc::SERVER_DOESNT_OWN_SERVICE));
+                                        brpc::SERVER_DOESNT_OWN_SERVICE));
         ASSERT_EQ(0, server->Start("127.0.0.1:9192", nullptr));
         brpc::StartDummyServerAt(9193);
 
@@ -96,13 +94,13 @@ class ToolMDSClientTest : public ::testing::Test {
         curve::mds::topology::ListPhysicalPoolResponse response;
         response.set_statuscode(kTopoErrCodeSuccess);
         EXPECT_CALL(*topoService, ListPhysicalPool(_, _, _, _))
-        .WillOnce(DoAll(SetArgPointee<2>(response),
+            .WillOnce(DoAll(
+                SetArgPointee<2>(response),
                 Invoke([](RpcController *controller,
                           const ListPhysicalPoolRequest *request,
-                          ListPhysicalPoolResponse *response,
-                          Closure *done){
-                          brpc::ClosureGuard doneGuard(done);
-                    })));
+                          ListPhysicalPoolResponse *response, Closure *done) {
+                    brpc::ClosureGuard doneGuard(done);
+                })));
         ASSERT_EQ(0, mdsClient.Init(mdsAddr, "9194,9193"));
     }
     void TearDown() {
@@ -118,7 +116,7 @@ class ToolMDSClientTest : public ::testing::Test {
         scheduleService = nullptr;
     }
 
-    void GetFileInfoForTest(uint64_t id, FileInfo* fileInfo) {
+    void GetFileInfoForTest(uint64_t id, FileInfo *fileInfo) {
         fileInfo->set_id(id);
         fileInfo->set_filename("test");
         fileInfo->set_parentid(0);
@@ -129,12 +127,11 @@ class ToolMDSClientTest : public ::testing::Test {
         fileInfo->set_ctime(1573546993000000);
     }
 
-    void GetCopysetInfoForTest(CopySetServerInfo* info,
-                                int num, uint32_t copysetId = 1) {
+    void GetCopysetInfoForTest(CopySetServerInfo *info, int num,
+                               uint32_t copysetId = 1) {
         info->Clear();
         for (int i = 0; i < num; ++i) {
-            curve::common::ChunkServerLocation *csLoc =
-                                                info->add_cslocs();
+            curve::common::ChunkServerLocation *csLoc = info->add_cslocs();
             csLoc->set_chunkserverid(i);
             csLoc->set_hostip("127.0.0.1");
             csLoc->set_port(9191 + i);
@@ -142,21 +139,21 @@ class ToolMDSClientTest : public ::testing::Test {
         info->set_copysetid(copysetId);
     }
 
-    void GetSegmentForTest(PageFileSegment* segment) {
+    void GetSegmentForTest(PageFileSegment *segment) {
         segment->set_logicalpoolid(1);
         segment->set_segmentsize(DefaultSegmentSize);
         segment->set_chunksize(kChunkSize);
         segment->set_startoffset(0);
     }
 
-    void GetPhysicalPoolInfoForTest(PoolIdType id, PhysicalPoolInfo* pool) {
+    void GetPhysicalPoolInfoForTest(PoolIdType id, PhysicalPoolInfo *pool) {
         pool->set_physicalpoolid(id);
         pool->set_physicalpoolname("testPool");
         pool->set_desc("physical pool for test");
     }
 
     void GetLogicalPoolForTest(PoolIdType id,
-                        curve::mds::topology::LogicalPoolInfo *lpInfo) {
+                               curve::mds::topology::LogicalPoolInfo *lpInfo) {
         lpInfo->set_logicalpoolid(id);
         lpInfo->set_logicalpoolname("defaultLogicalPool");
         lpInfo->set_physicalpoolid(1);
@@ -207,10 +204,10 @@ class ToolMDSClientTest : public ::testing::Test {
         csInfo->set_diskcapacity(1024);
         csInfo->set_diskused(512);
     }
-    brpc::Server* server;
-    curve::mds::MockNameService* nameService;
-    curve::mds::topology::MockTopologyService* topoService;
-    curve::mds::schedule::MockScheduleService* scheduleService;
+    brpc::Server *server;
+    curve::mds::MockNameService *nameService;
+    curve::mds::topology::MockTopologyService *topoService;
+    curve::mds::schedule::MockScheduleService *scheduleService;
     MDSClient mdsClient;
     const uint64_t kChunkSize = 16777216;
     const uint64_t DefaultSegmentSize = 1024 * 1024 * 1024;
@@ -237,42 +234,40 @@ TEST_F(ToolMDSClientTest, GetFileInfo) {
     EXPECT_CALL(*nameService, GetFileInfo(_, _, _, _))
         .Times(6)
         .WillRepeatedly(Invoke([](RpcController *controller,
-                          const curve::mds::GetFileInfoRequest *request,
-                          curve::mds::GetFileInfoResponse *response,
-                          Closure *done){
-                          brpc::ClosureGuard doneGuard(done);
-                          brpc::Controller *cntl =
-                            dynamic_cast<brpc::Controller *>(controller);
-                          cntl->SetFailed("test");
-                    }));
+                                  const curve::mds::GetFileInfoRequest *request,
+                                  curve::mds::GetFileInfoResponse *response,
+                                  Closure *done) {
+            brpc::ClosureGuard doneGuard(done);
+            brpc::Controller *cntl =
+                dynamic_cast<brpc::Controller *>(controller);
+            cntl->SetFailed("test");
+        }));
     ASSERT_EQ(-1, mdsClient.GetFileInfo(filename, &outFileInfo));
 
     // 返回码不为OK
     curve::mds::GetFileInfoResponse response;
     response.set_statuscode(curve::mds::StatusCode::kParaError);
     EXPECT_CALL(*nameService, GetFileInfo(_, _, _, _))
-        .WillOnce(DoAll(SetArgPointee<2>(response),
-                Invoke([](RpcController *controller,
-                          const curve::mds::GetFileInfoRequest *request,
-                          curve::mds::GetFileInfoResponse *response,
-                          Closure *done){
-                          brpc::ClosureGuard doneGuard(done);
-                    })));
+        .WillOnce(DoAll(
+            SetArgPointee<2>(response),
+            Invoke([](RpcController *controller,
+                      const curve::mds::GetFileInfoRequest *request,
+                      curve::mds::GetFileInfoResponse *response,
+                      Closure *done) { brpc::ClosureGuard doneGuard(done); })));
     ASSERT_EQ(-1, mdsClient.GetFileInfo(filename, &outFileInfo));
 
     // 正常情况
-    curve::mds::FileInfo * info = new curve::mds::FileInfo;
+    curve::mds::FileInfo *info = new curve::mds::FileInfo;
     GetFileInfoForTest(1, info);
     response.set_allocated_fileinfo(info);
     response.set_statuscode(curve::mds::StatusCode::kOK);
     EXPECT_CALL(*nameService, GetFileInfo(_, _, _, _))
-        .WillOnce(DoAll(SetArgPointee<2>(response),
-                Invoke([](RpcController *controller,
-                          const curve::mds::GetFileInfoRequest *request,
-                          curve::mds::GetFileInfoResponse *response,
-                          Closure *done){
-                          brpc::ClosureGuard doneGuard(done);
-                    })));
+        .WillOnce(DoAll(
+            SetArgPointee<2>(response),
+            Invoke([](RpcController *controller,
+                      const curve::mds::GetFileInfoRequest *request,
+                      curve::mds::GetFileInfoResponse *response,
+                      Closure *done) { brpc::ClosureGuard doneGuard(done); })));
     ASSERT_EQ(0, mdsClient.GetFileInfo(filename, &outFileInfo));
     ASSERT_EQ(info->DebugString(), outFileInfo.DebugString());
 }
@@ -283,48 +278,48 @@ TEST_F(ToolMDSClientTest, GetAllocatedSize) {
     // 发送RPC失败
     EXPECT_CALL(*nameService, GetAllocatedSize(_, _, _, _))
         .Times(6)
-        .WillRepeatedly(Invoke([](RpcController *controller,
-                          const curve::mds::GetAllocatedSizeRequest *request,
-                          curve::mds::GetAllocatedSizeResponse *response,
-                          Closure *done){
-                          brpc::ClosureGuard doneGuard(done);
-                          brpc::Controller *cntl =
-                            dynamic_cast<brpc::Controller *>(controller);
-                          cntl->SetFailed("test");
-                    }));
+        .WillRepeatedly(Invoke(
+            [](RpcController *controller,
+               const curve::mds::GetAllocatedSizeRequest *request,
+               curve::mds::GetAllocatedSizeResponse *response, Closure *done) {
+                brpc::ClosureGuard doneGuard(done);
+                brpc::Controller *cntl =
+                    dynamic_cast<brpc::Controller *>(controller);
+                cntl->SetFailed("test");
+            }));
     ASSERT_EQ(-1, mdsClient.GetAllocatedSize(filename, &allocSize));
 
     // 返回码不为OK
     curve::mds::GetAllocatedSizeResponse response;
     response.set_statuscode(curve::mds::StatusCode::kParaError);
     EXPECT_CALL(*nameService, GetAllocatedSize(_, _, _, _))
-        .WillOnce(DoAll(SetArgPointee<2>(response),
-                Invoke([](RpcController *controller,
-                          const curve::mds::GetAllocatedSizeRequest *request,
-                          curve::mds::GetAllocatedSizeResponse *response,
-                          Closure *done){
-                          brpc::ClosureGuard doneGuard(done);
-                    })));
+        .WillOnce(DoAll(
+            SetArgPointee<2>(response),
+            Invoke([](RpcController *controller,
+                      const curve::mds::GetAllocatedSizeRequest *request,
+                      curve::mds::GetAllocatedSizeResponse *response,
+                      Closure *done) { brpc::ClosureGuard doneGuard(done); })));
     ASSERT_EQ(-1, mdsClient.GetAllocatedSize(filename, &allocSize));
 
     // 正常情况
     response.set_allocatedsize(DefaultSegmentSize * 3);
     for (int i = 1; i <= 3; ++i) {
-        response.mutable_allocsizemap()->insert({i, DefaultSegmentSize});
+        response.mutable_allocsizemap()->insert(
+            {static_cast<::google::protobuf::uint32>(i), DefaultSegmentSize});
     }
     response.set_statuscode(curve::mds::StatusCode::kOK);
     EXPECT_CALL(*nameService, GetAllocatedSize(_, _, _, _))
-        .WillOnce(DoAll(SetArgPointee<2>(response),
-                Invoke([](RpcController *controller,
-                          const curve::mds::GetAllocatedSizeRequest *request,
-                          curve::mds::GetAllocatedSizeResponse *response,
-                          Closure *done){
-                          brpc::ClosureGuard doneGuard(done);
-                    })));
+        .WillOnce(DoAll(
+            SetArgPointee<2>(response),
+            Invoke([](RpcController *controller,
+                      const curve::mds::GetAllocatedSizeRequest *request,
+                      curve::mds::GetAllocatedSizeResponse *response,
+                      Closure *done) { brpc::ClosureGuard doneGuard(done); })));
     AllocMap allocMap;
     ASSERT_EQ(0, mdsClient.GetAllocatedSize(filename, &allocSize, &allocMap));
     ASSERT_EQ(DefaultSegmentSize * 3, allocSize);
-    AllocMap expected = {{1, DefaultSegmentSize}, {2, DefaultSegmentSize},
+    AllocMap expected = {{1, DefaultSegmentSize},
+                         {2, DefaultSegmentSize},
                          {3, DefaultSegmentSize}};
     ASSERT_EQ(expected, allocMap);
 }
@@ -336,28 +331,27 @@ TEST_F(ToolMDSClientTest, ListDir) {
     // 发送RPC失败
     EXPECT_CALL(*nameService, ListDir(_, _, _, _))
         .Times(6)
-        .WillRepeatedly(Invoke([](RpcController *controller,
-                          const curve::mds::ListDirRequest *request,
-                          curve::mds::ListDirResponse *response,
-                          Closure *done){
-                          brpc::ClosureGuard doneGuard(done);
-                          brpc::Controller *cntl =
-                            dynamic_cast<brpc::Controller *>(controller);
-                          cntl->SetFailed("test");
-                    }));
+        .WillRepeatedly(
+            Invoke([](RpcController *controller,
+                      const curve::mds::ListDirRequest *request,
+                      curve::mds::ListDirResponse *response, Closure *done) {
+                brpc::ClosureGuard doneGuard(done);
+                brpc::Controller *cntl =
+                    dynamic_cast<brpc::Controller *>(controller);
+                cntl->SetFailed("test");
+            }));
     ASSERT_EQ(-1, mdsClient.ListDir(fileName, &fileInfoVec));
 
     // 返回码不为OK
     curve::mds::ListDirResponse response;
     response.set_statuscode(curve::mds::StatusCode::kParaError);
     EXPECT_CALL(*nameService, ListDir(_, _, _, _))
-        .WillOnce(DoAll(SetArgPointee<2>(response),
-                Invoke([](RpcController *controller,
-                          const curve::mds::ListDirRequest *request,
-                          curve::mds::ListDirResponse *response,
-                          Closure *done){
-                          brpc::ClosureGuard doneGuard(done);
-                    })));
+        .WillOnce(DoAll(
+            SetArgPointee<2>(response),
+            Invoke([](RpcController *controller,
+                      const curve::mds::ListDirRequest *request,
+                      curve::mds::ListDirResponse *response,
+                      Closure *done) { brpc::ClosureGuard doneGuard(done); })));
     ASSERT_EQ(-1, mdsClient.ListDir(fileName, &fileInfoVec));
     // 正常情况
     response.set_statuscode(curve::mds::StatusCode::kOK);
@@ -366,13 +360,12 @@ TEST_F(ToolMDSClientTest, ListDir) {
         GetFileInfoForTest(i, fileInfo);
     }
     EXPECT_CALL(*nameService, ListDir(_, _, _, _))
-        .WillOnce(DoAll(SetArgPointee<2>(response),
-                Invoke([](RpcController *controller,
-                          const curve::mds::ListDirRequest *request,
-                          curve::mds::ListDirResponse *response,
-                          Closure *done){
-                          brpc::ClosureGuard doneGuard(done);
-                    })));
+        .WillOnce(DoAll(
+            SetArgPointee<2>(response),
+            Invoke([](RpcController *controller,
+                      const curve::mds::ListDirRequest *request,
+                      curve::mds::ListDirResponse *response,
+                      Closure *done) { brpc::ClosureGuard doneGuard(done); })));
     ASSERT_EQ(0, mdsClient.ListDir(fileName, &fileInfoVec));
     for (int i = 0; i < 5; i++) {
         FileInfo expected;
@@ -389,72 +382,69 @@ TEST_F(ToolMDSClientTest, GetSegmentInfo) {
     // 发送RPC失败
     EXPECT_CALL(*nameService, GetOrAllocateSegment(_, _, _, _))
         .Times(6)
-        .WillRepeatedly(Invoke([](RpcController *controller,
-                        const curve::mds::GetOrAllocateSegmentRequest *request,
-                        curve::mds::GetOrAllocateSegmentResponse *response,
-                        Closure *done){
-                        brpc::ClosureGuard doneGuard(done);
-                        brpc::Controller *cntl =
-                            dynamic_cast<brpc::Controller *>(controller);
-                        cntl->SetFailed("test");
-                    }));
+        .WillRepeatedly(
+            Invoke([](RpcController *controller,
+                      const curve::mds::GetOrAllocateSegmentRequest *request,
+                      curve::mds::GetOrAllocateSegmentResponse *response,
+                      Closure *done) {
+                brpc::ClosureGuard doneGuard(done);
+                brpc::Controller *cntl =
+                    dynamic_cast<brpc::Controller *>(controller);
+                cntl->SetFailed("test");
+            }));
     ASSERT_EQ(GetSegmentRes::kOtherError,
-                    mdsClient.GetSegmentInfo(fileName, offset, &outSegment));
+              mdsClient.GetSegmentInfo(fileName, offset, &outSegment));
 
     // segment不存在
     curve::mds::GetOrAllocateSegmentResponse response;
     response.set_statuscode(curve::mds::StatusCode::kSegmentNotAllocated);
     EXPECT_CALL(*nameService, GetOrAllocateSegment(_, _, _, _))
-        .WillOnce(DoAll(SetArgPointee<2>(response),
-                        Invoke([](RpcController *controller,
-                        const curve::mds::GetOrAllocateSegmentRequest *request,
-                        curve::mds::GetOrAllocateSegmentResponse *response,
-                        Closure *done){
-                        brpc::ClosureGuard doneGuard(done);
-                    })));
+        .WillOnce(DoAll(
+            SetArgPointee<2>(response),
+            Invoke([](RpcController *controller,
+                      const curve::mds::GetOrAllocateSegmentRequest *request,
+                      curve::mds::GetOrAllocateSegmentResponse *response,
+                      Closure *done) { brpc::ClosureGuard doneGuard(done); })));
     ASSERT_EQ(GetSegmentRes::kSegmentNotAllocated,
-                    mdsClient.GetSegmentInfo(fileName, offset, &outSegment));
+              mdsClient.GetSegmentInfo(fileName, offset, &outSegment));
     // 文件不存在
     response.set_statuscode(curve::mds::StatusCode::kFileNotExists);
     EXPECT_CALL(*nameService, GetOrAllocateSegment(_, _, _, _))
-        .WillOnce(DoAll(SetArgPointee<2>(response),
-                        Invoke([](RpcController *controller,
-                        const curve::mds::GetOrAllocateSegmentRequest *request,
-                        curve::mds::GetOrAllocateSegmentResponse *response,
-                        Closure *done){
-                        brpc::ClosureGuard doneGuard(done);
-                    })));
+        .WillOnce(DoAll(
+            SetArgPointee<2>(response),
+            Invoke([](RpcController *controller,
+                      const curve::mds::GetOrAllocateSegmentRequest *request,
+                      curve::mds::GetOrAllocateSegmentResponse *response,
+                      Closure *done) { brpc::ClosureGuard doneGuard(done); })));
     ASSERT_EQ(GetSegmentRes::kFileNotExists,
-                    mdsClient.GetSegmentInfo(fileName, offset, &outSegment));
+              mdsClient.GetSegmentInfo(fileName, offset, &outSegment));
 
     // 其他错误
     response.set_statuscode(curve::mds::StatusCode::kParaError);
     EXPECT_CALL(*nameService, GetOrAllocateSegment(_, _, _, _))
-        .WillOnce(DoAll(SetArgPointee<2>(response),
-                        Invoke([](RpcController *controller,
-                        const curve::mds::GetOrAllocateSegmentRequest *request,
-                        curve::mds::GetOrAllocateSegmentResponse *response,
-                        Closure *done){
-                        brpc::ClosureGuard doneGuard(done);
-                    })));
+        .WillOnce(DoAll(
+            SetArgPointee<2>(response),
+            Invoke([](RpcController *controller,
+                      const curve::mds::GetOrAllocateSegmentRequest *request,
+                      curve::mds::GetOrAllocateSegmentResponse *response,
+                      Closure *done) { brpc::ClosureGuard doneGuard(done); })));
     ASSERT_EQ(GetSegmentRes::kOtherError,
-                    mdsClient.GetSegmentInfo(fileName, offset, &outSegment));
+              mdsClient.GetSegmentInfo(fileName, offset, &outSegment));
 
     // 正常情况
-    PageFileSegment* segment = new PageFileSegment();
+    PageFileSegment *segment = new PageFileSegment();
     GetSegmentForTest(segment);
     response.set_statuscode(curve::mds::StatusCode::kOK);
     response.set_allocated_pagefilesegment(segment);
     EXPECT_CALL(*nameService, GetOrAllocateSegment(_, _, _, _))
-        .WillOnce(DoAll(SetArgPointee<2>(response),
-                        Invoke([](RpcController *controller,
-                        const curve::mds::GetOrAllocateSegmentRequest *request,
-                        curve::mds::GetOrAllocateSegmentResponse *response,
-                        Closure *done){
-                        brpc::ClosureGuard doneGuard(done);
-                    })));
+        .WillOnce(DoAll(
+            SetArgPointee<2>(response),
+            Invoke([](RpcController *controller,
+                      const curve::mds::GetOrAllocateSegmentRequest *request,
+                      curve::mds::GetOrAllocateSegmentResponse *response,
+                      Closure *done) { brpc::ClosureGuard doneGuard(done); })));
     ASSERT_EQ(GetSegmentRes::kOK,
-                    mdsClient.GetSegmentInfo(fileName, offset, &outSegment));
+              mdsClient.GetSegmentInfo(fileName, offset, &outSegment));
     ASSERT_EQ(segment->DebugString(), outSegment.DebugString());
 }
 
@@ -464,89 +454,85 @@ TEST_F(ToolMDSClientTest, DeleteFile) {
     // 发送RPC失败
     EXPECT_CALL(*nameService, DeleteFile(_, _, _, _))
         .Times(6)
-        .WillRepeatedly(Invoke([](RpcController *controller,
-                        const curve::mds::DeleteFileRequest *request,
-                        curve::mds::DeleteFileResponse *response,
-                        Closure *done){
-                        brpc::ClosureGuard doneGuard(done);
-                        brpc::Controller *cntl =
-                            dynamic_cast<brpc::Controller *>(controller);
-                        cntl->SetFailed("test");
-                    }));
+        .WillRepeatedly(
+            Invoke([](RpcController *controller,
+                      const curve::mds::DeleteFileRequest *request,
+                      curve::mds::DeleteFileResponse *response, Closure *done) {
+                brpc::ClosureGuard doneGuard(done);
+                brpc::Controller *cntl =
+                    dynamic_cast<brpc::Controller *>(controller);
+                cntl->SetFailed("test");
+            }));
     ASSERT_EQ(-1, mdsClient.DeleteFile(fileName));
 
     // 返回码不为OK
     curve::mds::DeleteFileResponse response;
     response.set_statuscode(curve::mds::StatusCode::kParaError);
     EXPECT_CALL(*nameService, DeleteFile(_, _, _, _))
-        .WillOnce(DoAll(SetArgPointee<2>(response),
-                        Invoke([](RpcController *controller,
-                        const curve::mds::DeleteFileRequest *request,
-                        curve::mds::DeleteFileResponse *response,
-                        Closure *done){
-                        brpc::ClosureGuard doneGuard(done);
-                    })));
+        .WillOnce(DoAll(
+            SetArgPointee<2>(response),
+            Invoke([](RpcController *controller,
+                      const curve::mds::DeleteFileRequest *request,
+                      curve::mds::DeleteFileResponse *response,
+                      Closure *done) { brpc::ClosureGuard doneGuard(done); })));
     ASSERT_EQ(-1, mdsClient.DeleteFile(fileName));
 
     // 正常情况
     response.set_statuscode(curve::mds::StatusCode::kOK);
     EXPECT_CALL(*nameService, DeleteFile(_, _, _, _))
-        .WillOnce(DoAll(SetArgPointee<2>(response),
-                        Invoke([](RpcController *controller,
-                        const curve::mds::DeleteFileRequest *request,
-                        curve::mds::DeleteFileResponse *response,
-                        Closure *done){
-                        brpc::ClosureGuard doneGuard(done);
-                    })));
+        .WillOnce(DoAll(
+            SetArgPointee<2>(response),
+            Invoke([](RpcController *controller,
+                      const curve::mds::DeleteFileRequest *request,
+                      curve::mds::DeleteFileResponse *response,
+                      Closure *done) { brpc::ClosureGuard doneGuard(done); })));
     ASSERT_EQ(0, mdsClient.DeleteFile(fileName));
 }
 
 TEST_F(ToolMDSClientTest, CreateFile) {
     std::string fileName = "/test";
     uint64_t length = 10 * DefaultSegmentSize;
-    uint64_t stripeUnit = 32 * 1024 *1024;
+    uint64_t stripeUnit = 32 * 1024 * 1024;
     uint64_t stripeCount = 32;
     // 发送RPC失败
     EXPECT_CALL(*nameService, CreateFile(_, _, _, _))
         .Times(6)
-        .WillRepeatedly(Invoke([](RpcController *controller,
-                        const curve::mds::CreateFileRequest *request,
-                        curve::mds::CreateFileResponse *response,
-                        Closure *done){
-                        brpc::ClosureGuard doneGuard(done);
-                        brpc::Controller *cntl =
-                            dynamic_cast<brpc::Controller *>(controller);
-                        cntl->SetFailed("test");
-                    }));
-    ASSERT_EQ(-1, mdsClient.CreateFile(fileName, length,
-                             stripeUnit, stripeCount));
+        .WillRepeatedly(
+            Invoke([](RpcController *controller,
+                      const curve::mds::CreateFileRequest *request,
+                      curve::mds::CreateFileResponse *response, Closure *done) {
+                brpc::ClosureGuard doneGuard(done);
+                brpc::Controller *cntl =
+                    dynamic_cast<brpc::Controller *>(controller);
+                cntl->SetFailed("test");
+            }));
+    ASSERT_EQ(-1,
+              mdsClient.CreateFile(fileName, length, stripeUnit, stripeCount));
 
     // 返回码不为OK
     curve::mds::CreateFileResponse response;
     response.set_statuscode(curve::mds::StatusCode::kParaError);
     EXPECT_CALL(*nameService, CreateFile(_, _, _, _))
-        .WillOnce(DoAll(SetArgPointee<2>(response),
-                        Invoke([](RpcController *controller,
-                        const curve::mds::CreateFileRequest *request,
-                        curve::mds::CreateFileResponse *response,
-                        Closure *done){
-                        brpc::ClosureGuard doneGuard(done);
-                    })));
-    ASSERT_EQ(-1, mdsClient.CreateFile(fileName, length,
-                                       stripeUnit, stripeCount));
+        .WillOnce(DoAll(
+            SetArgPointee<2>(response),
+            Invoke([](RpcController *controller,
+                      const curve::mds::CreateFileRequest *request,
+                      curve::mds::CreateFileResponse *response,
+                      Closure *done) { brpc::ClosureGuard doneGuard(done); })));
+    ASSERT_EQ(-1,
+              mdsClient.CreateFile(fileName, length, stripeUnit, stripeCount));
 
     // 正常情况
     response.set_statuscode(curve::mds::StatusCode::kOK);
     EXPECT_CALL(*nameService, CreateFile(_, _, _, _))
-        .WillOnce(DoAll(SetArgPointee<2>(response),
-                        Invoke([](RpcController *controller,
-                        const curve::mds::CreateFileRequest *request,
-                        curve::mds::CreateFileResponse *response,
-                        Closure *done){
-                        brpc::ClosureGuard doneGuard(done);
-                    })));
-    ASSERT_EQ(0, mdsClient.CreateFile(fileName, length,
-                                     stripeUnit, stripeCount));
+        .WillOnce(DoAll(
+            SetArgPointee<2>(response),
+            Invoke([](RpcController *controller,
+                      const curve::mds::CreateFileRequest *request,
+                      curve::mds::CreateFileResponse *response,
+                      Closure *done) { brpc::ClosureGuard doneGuard(done); })));
+    ASSERT_EQ(0,
+              mdsClient.CreateFile(fileName, length, stripeUnit, stripeCount));
 }
 
 TEST_F(ToolMDSClientTest, ExtendVolume_success) {
@@ -555,13 +541,12 @@ TEST_F(ToolMDSClientTest, ExtendVolume_success) {
     curve::mds::ExtendFileResponse response;
     response.set_statuscode(curve::mds::StatusCode::kOK);
     EXPECT_CALL(*nameService, ExtendFile(_, _, _, _))
-        .WillOnce(DoAll(SetArgPointee<2>(response),
-                        Invoke([](RpcController *controller,
-                        const curve::mds::ExtendFileRequest *request,
-                        curve::mds::ExtendFileResponse *response,
-                        Closure *done){
-                        brpc::ClosureGuard doneGuard(done);
-                    })));
+        .WillOnce(DoAll(
+            SetArgPointee<2>(response),
+            Invoke([](RpcController *controller,
+                      const curve::mds::ExtendFileRequest *request,
+                      curve::mds::ExtendFileResponse *response,
+                      Closure *done) { brpc::ClosureGuard doneGuard(done); })));
     ASSERT_EQ(0, mdsClient.ExtendVolume(fileName, length));
 }
 
@@ -572,15 +557,15 @@ TEST_F(ToolMDSClientTest, ExtendVolume_Fail) {
     // 发送RPC失败
     EXPECT_CALL(*nameService, ExtendFile(_, _, _, _))
         .Times(6)
-        .WillRepeatedly(Invoke([](RpcController *controller,
-                        const curve::mds::ExtendFileRequest *request,
-                        curve::mds::ExtendFileResponse *response,
-                        Closure *done){
-                        brpc::ClosureGuard doneGuard(done);
-                        brpc::Controller *cntl =
-                            dynamic_cast<brpc::Controller *>(controller);
-                        cntl->SetFailed("test");
-                    }));
+        .WillRepeatedly(
+            Invoke([](RpcController *controller,
+                      const curve::mds::ExtendFileRequest *request,
+                      curve::mds::ExtendFileResponse *response, Closure *done) {
+                brpc::ClosureGuard doneGuard(done);
+                brpc::Controller *cntl =
+                    dynamic_cast<brpc::Controller *>(controller);
+                cntl->SetFailed("test");
+            }));
     ASSERT_EQ(-1, mdsClient.ExtendVolume(fileName, length));
 
     return;
@@ -589,13 +574,12 @@ TEST_F(ToolMDSClientTest, ExtendVolume_Fail) {
     curve::mds::ExtendFileResponse response;
     response.set_statuscode(curve::mds::StatusCode::kParaError);
     EXPECT_CALL(*nameService, ExtendFile(_, _, _, _))
-        .WillOnce(DoAll(SetArgPointee<2>(response),
-                        Invoke([](RpcController *controller,
-                        const curve::mds::ExtendFileRequest *request,
-                        curve::mds::ExtendFileResponse *response,
-                        Closure *done){
-                        brpc::ClosureGuard doneGuard(done);
-                    })));
+        .WillOnce(DoAll(
+            SetArgPointee<2>(response),
+            Invoke([](RpcController *controller,
+                      const curve::mds::ExtendFileRequest *request,
+                      curve::mds::ExtendFileResponse *response,
+                      Closure *done) { brpc::ClosureGuard doneGuard(done); })));
     ASSERT_EQ(-1, mdsClient.ExtendVolume(fileName, length));
 }
 
@@ -607,31 +591,30 @@ TEST_F(ToolMDSClientTest, GetChunkServerListInCopySets) {
     // 发送rpc失败
     EXPECT_CALL(*topoService, GetChunkServerListInCopySets(_, _, _, _))
         .Times(6)
-        .WillRepeatedly(Invoke([](RpcController *controller,
-                        const GetChunkServerListInCopySetsRequest *request,
-                        GetChunkServerListInCopySetsResponse *response,
-                        Closure *done){
-                        brpc::ClosureGuard doneGuard(done);
-                        brpc::Controller *cntl =
-                            dynamic_cast<brpc::Controller *>(controller);
-                        cntl->SetFailed("test");
-                    }));
-    ASSERT_EQ(-1, mdsClient.GetChunkServerListInCopySet(
-                                logicalPoolId, copysetId, &csLocs));
+        .WillRepeatedly(Invoke(
+            [](RpcController *controller,
+               const GetChunkServerListInCopySetsRequest *request,
+               GetChunkServerListInCopySetsResponse *response, Closure *done) {
+                brpc::ClosureGuard doneGuard(done);
+                brpc::Controller *cntl =
+                    dynamic_cast<brpc::Controller *>(controller);
+                cntl->SetFailed("test");
+            }));
+    ASSERT_EQ(-1, mdsClient.GetChunkServerListInCopySet(logicalPoolId,
+                                                        copysetId, &csLocs));
 
     // 返回码不为OK
     GetChunkServerListInCopySetsResponse response;
     response.set_statuscode(curve::mds::topology::kTopoErrCodeInitFail);
     EXPECT_CALL(*topoService, GetChunkServerListInCopySets(_, _, _, _))
-        .WillOnce(DoAll(SetArgPointee<2>(response),
-                        Invoke([](RpcController *controller,
-                        const GetChunkServerListInCopySetsRequest *request,
-                        GetChunkServerListInCopySetsResponse *response,
-                        Closure *done){
-                        brpc::ClosureGuard doneGuard(done);
-                    })));
-    ASSERT_EQ(-1, mdsClient.GetChunkServerListInCopySet(
-                                logicalPoolId, copysetId, &csLocs));
+        .WillOnce(DoAll(
+            SetArgPointee<2>(response),
+            Invoke([](RpcController *controller,
+                      const GetChunkServerListInCopySetsRequest *request,
+                      GetChunkServerListInCopySetsResponse *response,
+                      Closure *done) { brpc::ClosureGuard doneGuard(done); })));
+    ASSERT_EQ(-1, mdsClient.GetChunkServerListInCopySet(logicalPoolId,
+                                                        copysetId, &csLocs));
 
     // 正常情况
     response.set_statuscode(kTopoErrCodeSuccess);
@@ -640,15 +623,14 @@ TEST_F(ToolMDSClientTest, GetChunkServerListInCopySets) {
     auto infoPtr = response.add_csinfo();
     infoPtr->CopyFrom(csInfo);
     EXPECT_CALL(*topoService, GetChunkServerListInCopySets(_, _, _, _))
-        .WillOnce(DoAll(SetArgPointee<2>(response),
-                        Invoke([](RpcController *controller,
-                        const GetChunkServerListInCopySetsRequest *request,
-                        GetChunkServerListInCopySetsResponse *response,
-                        Closure *done){
-                        brpc::ClosureGuard doneGuard(done);
-                    })));
-    ASSERT_EQ(0, mdsClient.GetChunkServerListInCopySet(
-                                logicalPoolId, copysetId, &csLocs));
+        .WillOnce(DoAll(
+            SetArgPointee<2>(response),
+            Invoke([](RpcController *controller,
+                      const GetChunkServerListInCopySetsRequest *request,
+                      GetChunkServerListInCopySetsResponse *response,
+                      Closure *done) { brpc::ClosureGuard doneGuard(done); })));
+    ASSERT_EQ(0, mdsClient.GetChunkServerListInCopySet(logicalPoolId, copysetId,
+                                                       &csLocs));
     ASSERT_EQ(csInfo.cslocs_size(), csLocs.size());
     for (uint32_t i = 0; i < csLocs.size(); ++i) {
         ASSERT_EQ(csInfo.cslocs(i).DebugString(), csLocs[i].DebugString());
@@ -668,15 +650,14 @@ TEST_F(ToolMDSClientTest, GetChunkServerListInCopySets) {
     std::vector<CopySetIdType> copysets = {100, 101, 102};
     std::vector<CopySetServerInfo> csServerInfos;
     EXPECT_CALL(*topoService, GetChunkServerListInCopySets(_, _, _, _))
-        .WillOnce(DoAll(SetArgPointee<2>(response),
-                        Invoke([](RpcController *controller,
-                        const GetChunkServerListInCopySetsRequest *request,
-                        GetChunkServerListInCopySetsResponse *response,
-                        Closure *done){
-                        brpc::ClosureGuard doneGuard(done);
-                    })));
-    ASSERT_EQ(0, mdsClient.GetChunkServerListInCopySets(
-                                logicalPoolId, copysets, &csServerInfos));
+        .WillOnce(DoAll(
+            SetArgPointee<2>(response),
+            Invoke([](RpcController *controller,
+                      const GetChunkServerListInCopySetsRequest *request,
+                      GetChunkServerListInCopySetsResponse *response,
+                      Closure *done) { brpc::ClosureGuard doneGuard(done); })));
+    ASSERT_EQ(0, mdsClient.GetChunkServerListInCopySets(logicalPoolId, copysets,
+                                                        &csServerInfos));
     ASSERT_EQ(expected.size(), csServerInfos.size());
     for (uint32_t i = 0; i < expected.size(); ++i) {
         ASSERT_EQ(expected[i].DebugString(), csServerInfos[i].DebugString());
@@ -689,28 +670,28 @@ TEST_F(ToolMDSClientTest, ListPhysicalPoolsInCluster) {
     // 发送rpc失败
     EXPECT_CALL(*topoService, ListPhysicalPool(_, _, _, _))
         .Times(6)
-        .WillRepeatedly(Invoke([](RpcController *controller,
-                        const ListPhysicalPoolRequest *request,
-                        ListPhysicalPoolResponse *response,
-                        Closure *done){
-                        brpc::ClosureGuard doneGuard(done);
-                        brpc::Controller *cntl =
-                            dynamic_cast<brpc::Controller *>(controller);
-                        cntl->SetFailed("test");
-                    }));
+        .WillRepeatedly(
+            Invoke([](RpcController *controller,
+                      const ListPhysicalPoolRequest *request,
+                      ListPhysicalPoolResponse *response, Closure *done) {
+                brpc::ClosureGuard doneGuard(done);
+                brpc::Controller *cntl =
+                    dynamic_cast<brpc::Controller *>(controller);
+                cntl->SetFailed("test");
+            }));
     ASSERT_EQ(-1, mdsClient.ListPhysicalPoolsInCluster(&pools));
 
     // 返回码不为OK
     ListPhysicalPoolResponse response;
     response.set_statuscode(curve::mds::topology::kTopoErrCodeInitFail);
     EXPECT_CALL(*topoService, ListPhysicalPool(_, _, _, _))
-        .WillOnce(DoAll(SetArgPointee<2>(response),
-                        Invoke([](RpcController *controller,
-                        const ListPhysicalPoolRequest *request,
-                        ListPhysicalPoolResponse *response,
-                        Closure *done){
-                        brpc::ClosureGuard doneGuard(done);
-                    })));
+        .WillOnce(
+            DoAll(SetArgPointee<2>(response),
+                  Invoke([](RpcController *controller,
+                            const ListPhysicalPoolRequest *request,
+                            ListPhysicalPoolResponse *response, Closure *done) {
+                      brpc::ClosureGuard doneGuard(done);
+                  })));
     ASSERT_EQ(-1, mdsClient.ListPhysicalPoolsInCluster(&pools));
 
     // 正常情况
@@ -720,13 +701,13 @@ TEST_F(ToolMDSClientTest, ListPhysicalPoolsInCluster) {
         GetPhysicalPoolInfoForTest(i, poolInfo);
     }
     EXPECT_CALL(*topoService, ListPhysicalPool(_, _, _, _))
-        .WillOnce(DoAll(SetArgPointee<2>(response),
-                        Invoke([](RpcController *controller,
-                        const ListPhysicalPoolRequest *request,
-                        ListPhysicalPoolResponse *response,
-                        Closure *done){
-                        brpc::ClosureGuard doneGuard(done);
-                    })));
+        .WillOnce(
+            DoAll(SetArgPointee<2>(response),
+                  Invoke([](RpcController *controller,
+                            const ListPhysicalPoolRequest *request,
+                            ListPhysicalPoolResponse *response, Closure *done) {
+                      brpc::ClosureGuard doneGuard(done);
+                  })));
     ASSERT_EQ(0, mdsClient.ListPhysicalPoolsInCluster(&pools));
     ASSERT_EQ(3, pools.size());
     for (int i = 0; i < 3; ++i) {
@@ -743,28 +724,27 @@ TEST_F(ToolMDSClientTest, ListLogicalPoolsInPhysicalPool) {
     // 发送rpc失败
     EXPECT_CALL(*topoService, ListLogicalPool(_, _, _, _))
         .Times(6)
-        .WillRepeatedly(Invoke([](RpcController *controller,
-                        const ListLogicalPoolRequest *request,
-                        ListLogicalPoolResponse *response,
-                        Closure *done){
-                        brpc::ClosureGuard doneGuard(done);
-                        brpc::Controller *cntl =
-                            dynamic_cast<brpc::Controller *>(controller);
-                        cntl->SetFailed("test");
-                    }));
+        .WillRepeatedly(Invoke(
+            [](RpcController *controller, const ListLogicalPoolRequest *request,
+               ListLogicalPoolResponse *response, Closure *done) {
+                brpc::ClosureGuard doneGuard(done);
+                brpc::Controller *cntl =
+                    dynamic_cast<brpc::Controller *>(controller);
+                cntl->SetFailed("test");
+            }));
     ASSERT_EQ(-1, mdsClient.ListLogicalPoolsInPhysicalPool(poolId, &pools));
 
     // 返回码不为OK
     ListLogicalPoolResponse response;
     response.set_statuscode(curve::mds::topology::kTopoErrCodeInitFail);
     EXPECT_CALL(*topoService, ListLogicalPool(_, _, _, _))
-        .WillOnce(DoAll(SetArgPointee<2>(response),
-                        Invoke([](RpcController *controller,
-                        const ListLogicalPoolRequest *request,
-                        ListLogicalPoolResponse *response,
-                        Closure *done){
-                        brpc::ClosureGuard doneGuard(done);
-                    })));
+        .WillOnce(
+            DoAll(SetArgPointee<2>(response),
+                  Invoke([](RpcController *controller,
+                            const ListLogicalPoolRequest *request,
+                            ListLogicalPoolResponse *response, Closure *done) {
+                      brpc::ClosureGuard doneGuard(done);
+                  })));
     ASSERT_EQ(-1, mdsClient.ListLogicalPoolsInPhysicalPool(poolId, &pools));
 
     // 正常情况
@@ -774,13 +754,13 @@ TEST_F(ToolMDSClientTest, ListLogicalPoolsInPhysicalPool) {
         GetLogicalPoolForTest(i, poolInfo);
     }
     EXPECT_CALL(*topoService, ListLogicalPool(_, _, _, _))
-        .WillOnce(DoAll(SetArgPointee<2>(response),
-                        Invoke([](RpcController *controller,
-                        const ListLogicalPoolRequest *request,
-                        ListLogicalPoolResponse *response,
-                        Closure *done){
-                        brpc::ClosureGuard doneGuard(done);
-                    })));
+        .WillOnce(
+            DoAll(SetArgPointee<2>(response),
+                  Invoke([](RpcController *controller,
+                            const ListLogicalPoolRequest *request,
+                            ListLogicalPoolResponse *response, Closure *done) {
+                      brpc::ClosureGuard doneGuard(done);
+                  })));
     ASSERT_EQ(0, mdsClient.ListLogicalPoolsInPhysicalPool(poolId, &pools));
     ASSERT_EQ(3, pools.size());
     for (int i = 0; i < 3; ++i) {
@@ -796,28 +776,28 @@ TEST_F(ToolMDSClientTest, ListZoneInPhysicalPool) {
     // 发送rpc失败
     EXPECT_CALL(*topoService, ListPoolZone(_, _, _, _))
         .Times(6)
-        .WillRepeatedly(Invoke([](RpcController *controller,
-                    const curve::mds::topology::ListPoolZoneRequest *request,
-                    curve::mds::topology::ListPoolZoneResponse *response,
-                    Closure *done){
-                    brpc::ClosureGuard doneGuard(done);
-                    brpc::Controller *cntl =
-                            dynamic_cast<brpc::Controller *>(controller);
-                        cntl->SetFailed("test");
-                    }));
+        .WillRepeatedly(
+            Invoke([](RpcController *controller,
+                      const curve::mds::topology::ListPoolZoneRequest *request,
+                      curve::mds::topology::ListPoolZoneResponse *response,
+                      Closure *done) {
+                brpc::ClosureGuard doneGuard(done);
+                brpc::Controller *cntl =
+                    dynamic_cast<brpc::Controller *>(controller);
+                cntl->SetFailed("test");
+            }));
     ASSERT_EQ(-1, mdsClient.ListZoneInPhysicalPool(poolId, &zones));
 
     // 返回码不为OK
     curve::mds::topology::ListPoolZoneResponse response;
     response.set_statuscode(curve::mds::topology::kTopoErrCodeInitFail);
     EXPECT_CALL(*topoService, ListPoolZone(_, _, _, _))
-        .WillOnce(DoAll(SetArgPointee<2>(response),
-                    Invoke([](RpcController *controller,
-                    const curve::mds::topology::ListPoolZoneRequest *request,
-                    curve::mds::topology::ListPoolZoneResponse *response,
-                    Closure *done){
-                    brpc::ClosureGuard doneGuard(done);
-                    })));
+        .WillOnce(DoAll(
+            SetArgPointee<2>(response),
+            Invoke([](RpcController *controller,
+                      const curve::mds::topology::ListPoolZoneRequest *request,
+                      curve::mds::topology::ListPoolZoneResponse *response,
+                      Closure *done) { brpc::ClosureGuard doneGuard(done); })));
     ASSERT_EQ(-1, mdsClient.ListZoneInPhysicalPool(poolId, &zones));
     // 正常情况
     response.set_statuscode(kTopoErrCodeSuccess);
@@ -826,13 +806,12 @@ TEST_F(ToolMDSClientTest, ListZoneInPhysicalPool) {
         GetZoneInfoForTest(i, zoneInfo);
     }
     EXPECT_CALL(*topoService, ListPoolZone(_, _, _, _))
-        .WillOnce(DoAll(SetArgPointee<2>(response),
-                    Invoke([](RpcController *controller,
-                    const curve::mds::topology::ListPoolZoneRequest *request,
-                    curve::mds::topology::ListPoolZoneResponse *response,
-                    Closure *done){
-                    brpc::ClosureGuard doneGuard(done);
-                    })));
+        .WillOnce(DoAll(
+            SetArgPointee<2>(response),
+            Invoke([](RpcController *controller,
+                      const curve::mds::topology::ListPoolZoneRequest *request,
+                      curve::mds::topology::ListPoolZoneResponse *response,
+                      Closure *done) { brpc::ClosureGuard doneGuard(done); })));
     ASSERT_EQ(0, mdsClient.ListZoneInPhysicalPool(poolId, &zones));
     ASSERT_EQ(3, zones.size());
     for (int i = 0; i < 3; ++i) {
@@ -849,28 +828,29 @@ TEST_F(ToolMDSClientTest, ListServersInZone) {
     // 发送rpc失败
     EXPECT_CALL(*topoService, ListZoneServer(_, _, _, _))
         .Times(6)
-        .WillRepeatedly(Invoke([](RpcController *controller,
-                    const curve::mds::topology::ListZoneServerRequest *request,
-                    curve::mds::topology::ListZoneServerResponse *response,
-                    Closure *done){
-                    brpc::ClosureGuard doneGuard(done);
-                    brpc::Controller *cntl =
-                            dynamic_cast<brpc::Controller *>(controller);
-                        cntl->SetFailed("test");
-                    }));
+        .WillRepeatedly(Invoke(
+            [](RpcController *controller,
+               const curve::mds::topology::ListZoneServerRequest *request,
+               curve::mds::topology::ListZoneServerResponse *response,
+               Closure *done) {
+                brpc::ClosureGuard doneGuard(done);
+                brpc::Controller *cntl =
+                    dynamic_cast<brpc::Controller *>(controller);
+                cntl->SetFailed("test");
+            }));
     ASSERT_EQ(-1, mdsClient.ListServersInZone(zoneId, &servers));
 
     // 返回码不为OK
     curve::mds::topology::ListZoneServerResponse response;
     response.set_statuscode(curve::mds::topology::kTopoErrCodeInitFail);
     EXPECT_CALL(*topoService, ListZoneServer(_, _, _, _))
-        .WillOnce(DoAll(SetArgPointee<2>(response),
-                    Invoke([](RpcController *controller,
-                    const curve::mds::topology::ListZoneServerRequest *request,
-                    curve::mds::topology::ListZoneServerResponse *response,
-                    Closure *done){
-                    brpc::ClosureGuard doneGuard(done);
-                    })));
+        .WillOnce(DoAll(
+            SetArgPointee<2>(response),
+            Invoke(
+                [](RpcController *controller,
+                   const curve::mds::topology::ListZoneServerRequest *request,
+                   curve::mds::topology::ListZoneServerResponse *response,
+                   Closure *done) { brpc::ClosureGuard doneGuard(done); })));
     ASSERT_EQ(-1, mdsClient.ListServersInZone(zoneId, &servers));
 
     // 正常情况
@@ -880,13 +860,13 @@ TEST_F(ToolMDSClientTest, ListServersInZone) {
         GetServerInfoForTest(i, serverInfo);
     }
     EXPECT_CALL(*topoService, ListZoneServer(_, _, _, _))
-        .WillOnce(DoAll(SetArgPointee<2>(response),
-                    Invoke([](RpcController *controller,
-                    const curve::mds::topology::ListZoneServerRequest *request,
-                    curve::mds::topology::ListZoneServerResponse *response,
-                    Closure *done){
-                    brpc::ClosureGuard doneGuard(done);
-                    })));
+        .WillOnce(DoAll(
+            SetArgPointee<2>(response),
+            Invoke(
+                [](RpcController *controller,
+                   const curve::mds::topology::ListZoneServerRequest *request,
+                   curve::mds::topology::ListZoneServerResponse *response,
+                   Closure *done) { brpc::ClosureGuard doneGuard(done); })));
     ASSERT_EQ(0, mdsClient.ListServersInZone(zoneId, &servers));
     ASSERT_EQ(3, servers.size());
     for (int i = 0; i < 3; ++i) {
@@ -903,28 +883,29 @@ TEST_F(ToolMDSClientTest, ListChunkServersOnServer) {
     // 发送rpc失败
     EXPECT_CALL(*topoService, ListChunkServer(_, _, _, _))
         .Times(6)
-        .WillRepeatedly(Invoke([](RpcController *controller,
-                    const curve::mds::topology::ListChunkServerRequest *request,
-                    curve::mds::topology::ListChunkServerResponse *response,
-                    Closure *done){
-                    brpc::ClosureGuard doneGuard(done);
-                    brpc::Controller *cntl =
-                            dynamic_cast<brpc::Controller *>(controller);
-                        cntl->SetFailed("test");
-                    }));
+        .WillRepeatedly(Invoke(
+            [](RpcController *controller,
+               const curve::mds::topology::ListChunkServerRequest *request,
+               curve::mds::topology::ListChunkServerResponse *response,
+               Closure *done) {
+                brpc::ClosureGuard doneGuard(done);
+                brpc::Controller *cntl =
+                    dynamic_cast<brpc::Controller *>(controller);
+                cntl->SetFailed("test");
+            }));
     ASSERT_EQ(-1, mdsClient.ListChunkServersOnServer(serverId, &chunkservers));
 
     // 返回码不为OK
     curve::mds::topology::ListChunkServerResponse response;
     response.set_statuscode(curve::mds::topology::kTopoErrCodeInitFail);
     EXPECT_CALL(*topoService, ListChunkServer(_, _, _, _))
-        .WillOnce(DoAll(SetArgPointee<2>(response),
-                    Invoke([](RpcController *controller,
-                    const curve::mds::topology::ListChunkServerRequest *request,
-                    curve::mds::topology::ListChunkServerResponse *response,
-                    Closure *done){
-                    brpc::ClosureGuard doneGuard(done);
-                    })));
+        .WillOnce(DoAll(
+            SetArgPointee<2>(response),
+            Invoke(
+                [](RpcController *controller,
+                   const curve::mds::topology::ListChunkServerRequest *request,
+                   curve::mds::topology::ListChunkServerResponse *response,
+                   Closure *done) { brpc::ClosureGuard doneGuard(done); })));
     ASSERT_EQ(-1, mdsClient.ListChunkServersOnServer(serverId, &chunkservers));
 
     // 正常情况,两个chunkserver正常，一个chunkserver retired
@@ -934,13 +915,13 @@ TEST_F(ToolMDSClientTest, ListChunkServersOnServer) {
         GetChunkServerInfoForTest(i, csInfo, i == 2);
     }
     EXPECT_CALL(*topoService, ListChunkServer(_, _, _, _))
-        .WillOnce(DoAll(SetArgPointee<2>(response),
-                    Invoke([](RpcController *controller,
-                    const curve::mds::topology::ListChunkServerRequest *request,
-                    curve::mds::topology::ListChunkServerResponse *response,
-                    Closure *done){
-                    brpc::ClosureGuard doneGuard(done);
-                    })));
+        .WillOnce(DoAll(
+            SetArgPointee<2>(response),
+            Invoke(
+                [](RpcController *controller,
+                   const curve::mds::topology::ListChunkServerRequest *request,
+                   curve::mds::topology::ListChunkServerResponse *response,
+                   Closure *done) { brpc::ClosureGuard doneGuard(done); })));
     ASSERT_EQ(0, mdsClient.ListChunkServersOnServer(serverId, &chunkservers));
     ASSERT_EQ(2, chunkservers.size());
     for (int i = 0; i < 2; ++i) {
@@ -958,15 +939,16 @@ TEST_F(ToolMDSClientTest, GetChunkServerInfo) {
     // 发送rpc失败
     EXPECT_CALL(*topoService, GetChunkServer(_, _, _, _))
         .Times(12)
-        .WillRepeatedly(Invoke([](RpcController *controller,
-                const curve::mds::topology::GetChunkServerInfoRequest *request,
-                curve::mds::topology::GetChunkServerInfoResponse *response,
-                Closure *done){
+        .WillRepeatedly(Invoke(
+            [](RpcController *controller,
+               const curve::mds::topology::GetChunkServerInfoRequest *request,
+               curve::mds::topology::GetChunkServerInfoResponse *response,
+               Closure *done) {
                 brpc::ClosureGuard doneGuard(done);
                 brpc::Controller *cntl =
-                            dynamic_cast<brpc::Controller *>(controller);
-                        cntl->SetFailed("test");
-                    }));
+                    dynamic_cast<brpc::Controller *>(controller);
+                cntl->SetFailed("test");
+            }));
     ASSERT_EQ(-1, mdsClient.GetChunkServerInfo(csId, &chunkserver));
     ASSERT_EQ(-1, mdsClient.GetChunkServerInfo(csAddr, &chunkserver));
 
@@ -975,30 +957,32 @@ TEST_F(ToolMDSClientTest, GetChunkServerInfo) {
     response.set_statuscode(curve::mds::topology::kTopoErrCodeInitFail);
     EXPECT_CALL(*topoService, GetChunkServer(_, _, _, _))
         .Times(2)
-        .WillRepeatedly(DoAll(SetArgPointee<2>(response),
-                Invoke([](RpcController *controller,
-                const curve::mds::topology::GetChunkServerInfoRequest *request,
-                curve::mds::topology::GetChunkServerInfoResponse *response,
-                Closure *done){
-                    brpc::ClosureGuard doneGuard(done);
-                    })));
+        .WillRepeatedly(DoAll(
+            SetArgPointee<2>(response),
+            Invoke(
+                [](RpcController *controller,
+                   const curve::mds::topology::GetChunkServerInfoRequest
+                       *request,
+                   curve::mds::topology::GetChunkServerInfoResponse *response,
+                   Closure *done) { brpc::ClosureGuard doneGuard(done); })));
     ASSERT_EQ(-1, mdsClient.GetChunkServerInfo(csId, &chunkserver));
     ASSERT_EQ(-1, mdsClient.GetChunkServerInfo(csAddr, &chunkserver));
 
     // 正常情况
     response.set_statuscode(kTopoErrCodeSuccess);
-    ChunkServerInfo* csInfo = new ChunkServerInfo();
+    ChunkServerInfo *csInfo = new ChunkServerInfo();
     GetChunkServerInfoForTest(1, csInfo);
     response.set_allocated_chunkserverinfo(csInfo);
     EXPECT_CALL(*topoService, GetChunkServer(_, _, _, _))
         .Times(2)
-        .WillRepeatedly(DoAll(SetArgPointee<2>(response),
-                Invoke([](RpcController *controller,
-                const curve::mds::topology::GetChunkServerInfoRequest *request,
-                curve::mds::topology::GetChunkServerInfoResponse *response,
-                Closure *done){
-                    brpc::ClosureGuard doneGuard(done);
-                    })));
+        .WillRepeatedly(DoAll(
+            SetArgPointee<2>(response),
+            Invoke(
+                [](RpcController *controller,
+                   const curve::mds::topology::GetChunkServerInfoRequest
+                       *request,
+                   curve::mds::topology::GetChunkServerInfoResponse *response,
+                   Closure *done) { brpc::ClosureGuard doneGuard(done); })));
     ASSERT_EQ(0, mdsClient.GetChunkServerInfo(csId, &chunkserver));
     ASSERT_EQ(0, mdsClient.GetChunkServerInfo(csAddr, &chunkserver));
     ChunkServerInfo expected;
@@ -1022,15 +1006,15 @@ TEST_F(ToolMDSClientTest, GetCopySetsInChunkServer) {
     // 发送rpc失败
     EXPECT_CALL(*topoService, GetCopySetsInChunkServer(_, _, _, _))
         .Times(12)
-        .WillRepeatedly(Invoke([](RpcController *controller,
-                        const GetCopySetsInChunkServerRequest *request,
-                        GetCopySetsInChunkServerResponse *response,
-                        Closure *done){
-                        brpc::ClosureGuard doneGuard(done);
-                        brpc::Controller *cntl =
-                            dynamic_cast<brpc::Controller *>(controller);
-                        cntl->SetFailed("test");
-                    }));
+        .WillRepeatedly(Invoke(
+            [](RpcController *controller,
+               const GetCopySetsInChunkServerRequest *request,
+               GetCopySetsInChunkServerResponse *response, Closure *done) {
+                brpc::ClosureGuard doneGuard(done);
+                brpc::Controller *cntl =
+                    dynamic_cast<brpc::Controller *>(controller);
+                cntl->SetFailed("test");
+            }));
     ASSERT_EQ(-1, mdsClient.GetCopySetsInChunkServer(csId, &copysets));
     ASSERT_EQ(-1, mdsClient.GetCopySetsInChunkServer(csAddr, &copysets));
 
@@ -1039,13 +1023,12 @@ TEST_F(ToolMDSClientTest, GetCopySetsInChunkServer) {
     response.set_statuscode(curve::mds::topology::kTopoErrCodeInitFail);
     EXPECT_CALL(*topoService, GetCopySetsInChunkServer(_, _, _, _))
         .Times(2)
-        .WillRepeatedly(DoAll(SetArgPointee<2>(response),
-                Invoke([](RpcController *controller,
-                const GetCopySetsInChunkServerRequest *request,
-                GetCopySetsInChunkServerResponse *response,
-                Closure *done){
-                    brpc::ClosureGuard doneGuard(done);
-                    })));
+        .WillRepeatedly(DoAll(
+            SetArgPointee<2>(response),
+            Invoke([](RpcController *controller,
+                      const GetCopySetsInChunkServerRequest *request,
+                      GetCopySetsInChunkServerResponse *response,
+                      Closure *done) { brpc::ClosureGuard doneGuard(done); })));
     ASSERT_EQ(-1, mdsClient.GetCopySetsInChunkServer(csId, &copysets));
     ASSERT_EQ(-1, mdsClient.GetCopySetsInChunkServer(csAddr, &copysets));
 
@@ -1058,13 +1041,12 @@ TEST_F(ToolMDSClientTest, GetCopySetsInChunkServer) {
     }
     EXPECT_CALL(*topoService, GetCopySetsInChunkServer(_, _, _, _))
         .Times(2)
-        .WillRepeatedly(DoAll(SetArgPointee<2>(response),
-                Invoke([](RpcController *controller,
-                const GetCopySetsInChunkServerRequest *request,
-                GetCopySetsInChunkServerResponse *response,
-                Closure *done){
-                    brpc::ClosureGuard doneGuard(done);
-                    })));
+        .WillRepeatedly(DoAll(
+            SetArgPointee<2>(response),
+            Invoke([](RpcController *controller,
+                      const GetCopySetsInChunkServerRequest *request,
+                      GetCopySetsInChunkServerResponse *response,
+                      Closure *done) { brpc::ClosureGuard doneGuard(done); })));
     ASSERT_EQ(0, mdsClient.GetCopySetsInChunkServer(csId, &copysets));
     ASSERT_EQ(5, copysets.size());
     copysets.clear();
@@ -1089,15 +1071,15 @@ TEST_F(ToolMDSClientTest, GetCopySetsInCluster) {
     // 发送rpc失败
     EXPECT_CALL(*topoService, GetCopySetsInCluster(_, _, _, _))
         .Times(6)
-        .WillRepeatedly(Invoke([](RpcController *controller,
-                        const GetCopySetsInClusterRequest *request,
-                        GetCopySetsInClusterResponse *response,
-                        Closure *done){
-                        brpc::ClosureGuard doneGuard(done);
-                        brpc::Controller *cntl =
-                            dynamic_cast<brpc::Controller *>(controller);
-                        cntl->SetFailed("test");
-                    }));
+        .WillRepeatedly(
+            Invoke([](RpcController *controller,
+                      const GetCopySetsInClusterRequest *request,
+                      GetCopySetsInClusterResponse *response, Closure *done) {
+                brpc::ClosureGuard doneGuard(done);
+                brpc::Controller *cntl =
+                    dynamic_cast<brpc::Controller *>(controller);
+                cntl->SetFailed("test");
+            }));
     ASSERT_EQ(-1, mdsClient.GetCopySetsInCluster(&copysets));
 
     // 返回码不为OK
@@ -1105,13 +1087,12 @@ TEST_F(ToolMDSClientTest, GetCopySetsInCluster) {
     response.set_statuscode(curve::mds::topology::kTopoErrCodeInitFail);
     EXPECT_CALL(*topoService, GetCopySetsInCluster(_, _, _, _))
         .Times(1)
-        .WillRepeatedly(DoAll(SetArgPointee<2>(response),
-                Invoke([](RpcController *controller,
-                const GetCopySetsInClusterRequest *request,
-                GetCopySetsInClusterResponse *response,
-                Closure *done){
-                    brpc::ClosureGuard doneGuard(done);
-                    })));
+        .WillRepeatedly(DoAll(
+            SetArgPointee<2>(response),
+            Invoke([](RpcController *controller,
+                      const GetCopySetsInClusterRequest *request,
+                      GetCopySetsInClusterResponse *response,
+                      Closure *done) { brpc::ClosureGuard doneGuard(done); })));
     ASSERT_EQ(-1, mdsClient.GetCopySetsInCluster(&copysets));
 
     // 正常情况
@@ -1123,13 +1104,12 @@ TEST_F(ToolMDSClientTest, GetCopySetsInCluster) {
     }
     EXPECT_CALL(*topoService, GetCopySetsInCluster(_, _, _, _))
         .Times(1)
-        .WillRepeatedly(DoAll(SetArgPointee<2>(response),
-                Invoke([](RpcController *controller,
-                const GetCopySetsInClusterRequest *request,
-                GetCopySetsInClusterResponse *response,
-                Closure *done){
-                    brpc::ClosureGuard doneGuard(done);
-                    })));
+        .WillRepeatedly(DoAll(
+            SetArgPointee<2>(response),
+            Invoke([](RpcController *controller,
+                      const GetCopySetsInClusterRequest *request,
+                      GetCopySetsInClusterResponse *response,
+                      Closure *done) { brpc::ClosureGuard doneGuard(done); })));
     ASSERT_EQ(0, mdsClient.GetCopySetsInCluster(&copysets));
     ASSERT_EQ(5, copysets.size());
     copysets.clear();
@@ -1141,13 +1121,11 @@ TEST_F(ToolMDSClientTest, GetCopySetsInCluster) {
 
 TEST_F(ToolMDSClientTest, GetCopyset) {
     auto succCallback = callback<GetCopysetRequest, GetCopysetResponse>;
-    auto failCallback = [](RpcController* controller,
-                           const GetCopysetRequest* request,
-                           GetCopysetResponse* response,
-                           Closure* done) {
+    auto failCallback = [](RpcController *controller,
+                           const GetCopysetRequest *request,
+                           GetCopysetResponse *response, Closure *done) {
         brpc::ClosureGuard doneGuard(done);
-        brpc::Controller *cntl =
-            dynamic_cast<brpc::Controller*>(controller);
+        brpc::Controller *cntl = dynamic_cast<brpc::Controller *>(controller);
         cntl->SetFailed("fail");
     };
 
@@ -1168,8 +1146,8 @@ TEST_F(ToolMDSClientTest, GetCopyset) {
         CopysetInfo copysetInfo;
         EXPECT_CALL(*topoService, GetCopyset(_, _, _, _))
             .Times(6)
-            .WillRepeatedly(DoAll(SetArgPointee<2>(succResp),
-                                  Invoke(failCallback)));
+            .WillRepeatedly(
+                DoAll(SetArgPointee<2>(succResp), Invoke(failCallback)));
         ASSERT_EQ(mdsClient.GetCopyset(1, 1, &copysetInfo), -1);
     }
 
@@ -1177,8 +1155,7 @@ TEST_F(ToolMDSClientTest, GetCopyset) {
     {
         CopysetInfo copysetInfo;
         EXPECT_CALL(*topoService, GetCopyset(_, _, _, _))
-            .WillOnce(DoAll(SetArgPointee<2>(failResp),
-                            Invoke(succCallback)));
+            .WillOnce(DoAll(SetArgPointee<2>(failResp), Invoke(succCallback)));
         ASSERT_EQ(mdsClient.GetCopyset(1, 1, &copysetInfo), -1);
     }
 
@@ -1186,8 +1163,7 @@ TEST_F(ToolMDSClientTest, GetCopyset) {
     {
         CopysetInfo copysetInfo;
         EXPECT_CALL(*topoService, GetCopyset(_, _, _, _))
-            .WillOnce(DoAll(SetArgPointee<2>(succResp),
-                            Invoke(succCallback)));
+            .WillOnce(DoAll(SetArgPointee<2>(succResp), Invoke(succCallback)));
         ASSERT_EQ(mdsClient.GetCopyset(1, 1, &copysetInfo), 0);
         ASSERT_EQ(copysetInfo.logicalpoolid(), 1);
         ASSERT_EQ(copysetInfo.copysetid(), 1);
@@ -1201,15 +1177,15 @@ TEST_F(ToolMDSClientTest, RapidLeaderSchedule) {
     // 发送rpc失败
     EXPECT_CALL(*scheduleService, RapidLeaderSchedule(_, _, _, _))
         .Times(6)
-        .WillRepeatedly(Invoke([](RpcController *controller,
-                        const RapidLeaderScheduleRequst *request,
-                        RapidLeaderScheduleResponse *response,
-                        Closure *done){
-                        brpc::ClosureGuard doneGuard(done);
-                        brpc::Controller *cntl =
-                            dynamic_cast<brpc::Controller *>(controller);
-                        cntl->SetFailed("test");
-                    }));
+        .WillRepeatedly(
+            Invoke([](RpcController *controller,
+                      const RapidLeaderScheduleRequst *request,
+                      RapidLeaderScheduleResponse *response, Closure *done) {
+                brpc::ClosureGuard doneGuard(done);
+                brpc::Controller *cntl =
+                    dynamic_cast<brpc::Controller *>(controller);
+                cntl->SetFailed("test");
+            }));
     ASSERT_EQ(-1, mdsClient.RapidLeaderSchedule(1));
 
     // 返回码不为OK
@@ -1217,25 +1193,23 @@ TEST_F(ToolMDSClientTest, RapidLeaderSchedule) {
     response.set_statuscode(
         curve::mds::schedule::kScheduleErrCodeInvalidLogicalPool);
     EXPECT_CALL(*scheduleService, RapidLeaderSchedule(_, _, _, _))
-        .WillOnce(DoAll(SetArgPointee<2>(response),
-                        Invoke([](RpcController *controller,
-                        const RapidLeaderScheduleRequst *request,
-                        RapidLeaderScheduleResponse *response,
-                        Closure *done){
-                        brpc::ClosureGuard doneGuard(done);
-                    })));
+        .WillOnce(DoAll(
+            SetArgPointee<2>(response),
+            Invoke([](RpcController *controller,
+                      const RapidLeaderScheduleRequst *request,
+                      RapidLeaderScheduleResponse *response,
+                      Closure *done) { brpc::ClosureGuard doneGuard(done); })));
     ASSERT_EQ(-1, mdsClient.RapidLeaderSchedule(1));
 
     // 成功
     response.set_statuscode(curve::mds::schedule::kScheduleErrCodeSuccess);
     EXPECT_CALL(*scheduleService, RapidLeaderSchedule(_, _, _, _))
-        .WillOnce(DoAll(SetArgPointee<2>(response),
-                        Invoke([](RpcController *controller,
-                        const RapidLeaderScheduleRequst *request,
-                        RapidLeaderScheduleResponse *response,
-                        Closure *done){
-                        brpc::ClosureGuard doneGuard(done);
-                    })));
+        .WillOnce(DoAll(
+            SetArgPointee<2>(response),
+            Invoke([](RpcController *controller,
+                      const RapidLeaderScheduleRequst *request,
+                      RapidLeaderScheduleResponse *response,
+                      Closure *done) { brpc::ClosureGuard doneGuard(done); })));
     ASSERT_EQ(0, mdsClient.RapidLeaderSchedule(1));
 }
 
@@ -1251,9 +1225,9 @@ TEST_F(ToolMDSClientTest, SetLogicalPoolScanState) {
     // CASE 1: Send rpc failed
     {
         auto failCallback = [](RpcController *controller,
-                               const SetLogicalPoolScanStateRequest* request,
-                               SetLogicalPoolScanStateResponse* response,
-                               Closure* done) {
+                               const SetLogicalPoolScanStateRequest *request,
+                               SetLogicalPoolScanStateResponse *response,
+                               Closure *done) {
             brpc::ClosureGuard doneGuard(done);
             brpc::Controller *cntl =
                 dynamic_cast<brpc::Controller *>(controller);
@@ -1261,24 +1235,22 @@ TEST_F(ToolMDSClientTest, SetLogicalPoolScanState) {
         };
         EXPECT_CALL(*topoService, SetLogicalPoolScanState(_, _, _, _))
             .Times(6)
-            .WillRepeatedly(DoAll(SetArgPointee<2>(succResp),
-                                  Invoke(failCallback)));
+            .WillRepeatedly(
+                DoAll(SetArgPointee<2>(succResp), Invoke(failCallback)));
         ASSERT_EQ(-1, mdsClient.SetLogicalPoolScanState(1, true));
     }
 
     // CASE 2: Logical pool not found
     {
         EXPECT_CALL(*topoService, SetLogicalPoolScanState(_, _, _, _))
-            .WillOnce(DoAll(SetArgPointee<2>(failResp),
-                            Invoke(succCallback)));
+            .WillOnce(DoAll(SetArgPointee<2>(failResp), Invoke(succCallback)));
         ASSERT_EQ(-1, mdsClient.SetLogicalPoolScanState(1, true));
     }
 
     // CASE 3: Set success
     {
         EXPECT_CALL(*topoService, SetLogicalPoolScanState(_, _, _, _))
-            .WillOnce(DoAll(SetArgPointee<2>(succResp),
-                            Invoke(succCallback)));
+            .WillOnce(DoAll(SetArgPointee<2>(succResp), Invoke(succCallback)));
         ASSERT_EQ(0, mdsClient.SetLogicalPoolScanState(1, true));
     }
 }
@@ -1288,44 +1260,42 @@ TEST_F(ToolMDSClientTest, QueryChunkServerRecoverStatus) {
     // 发送rpc失败
     EXPECT_CALL(*scheduleService, QueryChunkServerRecoverStatus(_, _, _, _))
         .Times(6)
-        .WillRepeatedly(Invoke([](RpcController *controller,
-                        const QueryChunkServerRecoverStatusRequest *request,
-                        QueryChunkServerRecoverStatusResponse *response,
-                        Closure *done) {
-                        brpc::ClosureGuard doneGuard(done);
-                        brpc::Controller *cntl =
-                            dynamic_cast<brpc::Controller *>(controller);
-                        cntl->SetFailed("test");
-                    }));
+        .WillRepeatedly(Invoke(
+            [](RpcController *controller,
+               const QueryChunkServerRecoverStatusRequest *request,
+               QueryChunkServerRecoverStatusResponse *response, Closure *done) {
+                brpc::ClosureGuard doneGuard(done);
+                brpc::Controller *cntl =
+                    dynamic_cast<brpc::Controller *>(controller);
+                cntl->SetFailed("test");
+            }));
     ASSERT_EQ(-1, mdsClient.QueryChunkServerRecoverStatus(
-        std::vector<ChunkServerIdType>{}, &statusMap));
+                      std::vector<ChunkServerIdType>{}, &statusMap));
     // 1. QueryChunkServerRecoverStatus失败的情况
     QueryChunkServerRecoverStatusResponse response;
     response.set_statuscode(
         curve::mds::schedule::kScheduleErrInvalidQueryChunkserverID);
     EXPECT_CALL(*scheduleService, QueryChunkServerRecoverStatus(_, _, _, _))
-        .WillOnce(DoAll(SetArgPointee<2>(response),
-                        Invoke([](RpcController *controller,
-                        const QueryChunkServerRecoverStatusRequest *request,
-                        QueryChunkServerRecoverStatusResponse *response,
-                        Closure *done) {
-                        brpc::ClosureGuard doneGuard(done);
-                    })));
+        .WillOnce(DoAll(
+            SetArgPointee<2>(response),
+            Invoke([](RpcController *controller,
+                      const QueryChunkServerRecoverStatusRequest *request,
+                      QueryChunkServerRecoverStatusResponse *response,
+                      Closure *done) { brpc::ClosureGuard doneGuard(done); })));
     ASSERT_EQ(-1, mdsClient.QueryChunkServerRecoverStatus(
-        std::vector<ChunkServerIdType>{}, &statusMap));
+                      std::vector<ChunkServerIdType>{}, &statusMap));
 
     // 2. QueryChunkServerRecoverStatus成功的情况
     response.set_statuscode(curve::mds::schedule::kScheduleErrCodeSuccess);
     EXPECT_CALL(*scheduleService, QueryChunkServerRecoverStatus(_, _, _, _))
-        .WillOnce(DoAll(SetArgPointee<2>(response),
-                        Invoke([](RpcController *controller,
-                        const QueryChunkServerRecoverStatusRequest *request,
-                        QueryChunkServerRecoverStatusResponse *response,
-                        Closure *done) {
-                        brpc::ClosureGuard doneGuard(done);
-                    })));
+        .WillOnce(DoAll(
+            SetArgPointee<2>(response),
+            Invoke([](RpcController *controller,
+                      const QueryChunkServerRecoverStatusRequest *request,
+                      QueryChunkServerRecoverStatusResponse *response,
+                      Closure *done) { brpc::ClosureGuard doneGuard(done); })));
     ASSERT_EQ(0, mdsClient.QueryChunkServerRecoverStatus(
-        std::vector<ChunkServerIdType>{}, &statusMap));
+                     std::vector<ChunkServerIdType>{}, &statusMap));
 }
 
 TEST_F(ToolMDSClientTest, GetMetric) {
@@ -1365,14 +1335,14 @@ TEST_F(ToolMDSClientTest, GetMdsOnlineStatus) {
     std::map<std::string, bool> onlineStatus;
     // 9180在线，9999不在线
     value.set_value("{\"conf_name\":\"mds.listen.addr\","
-                        "\"conf_value\":\"127.0.0.1:9192\"}");
+                    "\"conf_value\":\"127.0.0.1:9192\"}");
     mdsClient.GetMdsOnlineStatus(&onlineStatus);
     std::map<std::string, bool> expected = {{"127.0.0.1:9191", false},
                                             {"127.0.0.1:9192", true}};
     ASSERT_EQ(expected, onlineStatus);
     // 9180的服务端口不一致
     value.set_value("{\"conf_name\":\"mds.listen.addr\","
-                        "\"conf_value\":\"127.0.0.1:9188\"}");
+                    "\"conf_value\":\"127.0.0.1:9188\"}");
     mdsClient.GetMdsOnlineStatus(&onlineStatus);
     expected = {{"127.0.0.1:9191", false}, {"127.0.0.1:9192", false}};
     ASSERT_EQ(expected, onlineStatus);
@@ -1389,28 +1359,27 @@ TEST_F(ToolMDSClientTest, ListClient) {
     // 发送rpc失败
     EXPECT_CALL(*nameService, ListClient(_, _, _, _))
         .Times(6)
-        .WillRepeatedly(Invoke([](RpcController *controller,
-                        const curve::mds::ListClientRequest *request,
-                        curve::mds::ListClientResponse *response,
-                        Closure *done){
-                        brpc::ClosureGuard doneGuard(done);
-                        brpc::Controller *cntl =
-                            dynamic_cast<brpc::Controller *>(controller);
-                        cntl->SetFailed("test");
-                    }));
+        .WillRepeatedly(
+            Invoke([](RpcController *controller,
+                      const curve::mds::ListClientRequest *request,
+                      curve::mds::ListClientResponse *response, Closure *done) {
+                brpc::ClosureGuard doneGuard(done);
+                brpc::Controller *cntl =
+                    dynamic_cast<brpc::Controller *>(controller);
+                cntl->SetFailed("test");
+            }));
     ASSERT_EQ(-1, mdsClient.ListClient(&clientAddrs));
 
     // 返回码不为OK
     curve::mds::ListClientResponse response;
     response.set_statuscode(curve::mds::StatusCode::kParaError);
     EXPECT_CALL(*nameService, ListClient(_, _, _, _))
-        .WillOnce(DoAll(SetArgPointee<2>(response),
-                        Invoke([](RpcController *controller,
-                        const curve::mds::ListClientRequest *request,
-                        curve::mds::ListClientResponse *response,
-                        Closure *done){
-                        brpc::ClosureGuard doneGuard(done);
-                    })));
+        .WillOnce(DoAll(
+            SetArgPointee<2>(response),
+            Invoke([](RpcController *controller,
+                      const curve::mds::ListClientRequest *request,
+                      curve::mds::ListClientResponse *response,
+                      Closure *done) { brpc::ClosureGuard doneGuard(done); })));
     ASSERT_EQ(-1, mdsClient.ListClient(&clientAddrs));
 
     // 正常情况
@@ -1421,19 +1390,18 @@ TEST_F(ToolMDSClientTest, ListClient) {
         clientInfo->set_port(8888 + i);
     }
     EXPECT_CALL(*nameService, ListClient(_, _, _, _))
-        .WillOnce(DoAll(SetArgPointee<2>(response),
-                        Invoke([](RpcController *controller,
-                        const curve::mds::ListClientRequest *request,
-                        curve::mds::ListClientResponse *response,
-                        Closure *done){
-                        brpc::ClosureGuard doneGuard(done);
-                    })));
+        .WillOnce(DoAll(
+            SetArgPointee<2>(response),
+            Invoke([](RpcController *controller,
+                      const curve::mds::ListClientRequest *request,
+                      curve::mds::ListClientResponse *response,
+                      Closure *done) { brpc::ClosureGuard doneGuard(done); })));
     ASSERT_EQ(0, mdsClient.ListClient(&clientAddrs));
     ASSERT_EQ(response.clientinfos_size(), clientAddrs.size());
     for (int i = 0; i < 5; i++) {
-        const auto& clientInfo = response.clientinfos(i);
-        std::string expected = clientInfo.ip() + ":" +
-                               std::to_string(clientInfo.port());
+        const auto &clientInfo = response.clientinfos(i);
+        std::string expected =
+            clientInfo.ip() + ":" + std::to_string(clientInfo.port());
         ASSERT_EQ(expected, clientAddrs[i]);
     }
 }
@@ -1445,28 +1413,28 @@ TEST_F(ToolMDSClientTest, ListVolumesOnCopyset) {
     // send rpc fail
     EXPECT_CALL(*nameService, ListVolumesOnCopysets(_, _, _, _))
         .Times(6)
-        .WillRepeatedly(Invoke([](RpcController *controller,
-                        const curve::mds::ListVolumesOnCopysetsRequest *request,
-                        curve::mds::ListVolumesOnCopysetsResponse *response,
-                        Closure *done){
-                        brpc::ClosureGuard doneGuard(done);
-                        brpc::Controller *cntl =
-                            dynamic_cast<brpc::Controller *>(controller);
-                        cntl->SetFailed("test");
-                    }));
+        .WillRepeatedly(
+            Invoke([](RpcController *controller,
+                      const curve::mds::ListVolumesOnCopysetsRequest *request,
+                      curve::mds::ListVolumesOnCopysetsResponse *response,
+                      Closure *done) {
+                brpc::ClosureGuard doneGuard(done);
+                brpc::Controller *cntl =
+                    dynamic_cast<brpc::Controller *>(controller);
+                cntl->SetFailed("test");
+            }));
     ASSERT_EQ(-1, mdsClient.ListVolumesOnCopyset(copysets, &fileNames));
 
     // return code not ok
     curve::mds::ListVolumesOnCopysetsResponse response;
     response.set_statuscode(curve::mds::StatusCode::kParaError);
     EXPECT_CALL(*nameService, ListVolumesOnCopysets(_, _, _, _))
-        .WillOnce(DoAll(SetArgPointee<2>(response),
-                        Invoke([](RpcController *controller,
-                        const curve::mds::ListVolumesOnCopysetsRequest *request,
-                        curve::mds::ListVolumesOnCopysetsResponse *response,
-                        Closure *done){
-                        brpc::ClosureGuard doneGuard(done);
-                    })));
+        .WillOnce(DoAll(
+            SetArgPointee<2>(response),
+            Invoke([](RpcController *controller,
+                      const curve::mds::ListVolumesOnCopysetsRequest *request,
+                      curve::mds::ListVolumesOnCopysetsResponse *response,
+                      Closure *done) { brpc::ClosureGuard doneGuard(done); })));
     ASSERT_EQ(-1, mdsClient.ListVolumesOnCopyset(copysets, &fileNames));
 
     // normal
@@ -1476,13 +1444,12 @@ TEST_F(ToolMDSClientTest, ListVolumesOnCopyset) {
         *fileName = "file" + std::to_string(i);
     }
     EXPECT_CALL(*nameService, ListVolumesOnCopysets(_, _, _, _))
-        .WillOnce(DoAll(SetArgPointee<2>(response),
-                        Invoke([](RpcController *controller,
-                        const curve::mds::ListVolumesOnCopysetsRequest *request,
-                        curve::mds::ListVolumesOnCopysetsResponse *response,
-                        Closure *done){
-                        brpc::ClosureGuard doneGuard(done);
-                    })));
+        .WillOnce(DoAll(
+            SetArgPointee<2>(response),
+            Invoke([](RpcController *controller,
+                      const curve::mds::ListVolumesOnCopysetsRequest *request,
+                      curve::mds::ListVolumesOnCopysetsResponse *response,
+                      Closure *done) { brpc::ClosureGuard doneGuard(done); })));
     ASSERT_EQ(0, mdsClient.ListVolumesOnCopyset(copysets, &fileNames));
     ASSERT_EQ(response.filenames_size(), fileNames.size());
     for (int i = 0; i < 5; i++) {
@@ -1500,40 +1467,38 @@ TEST_F(ToolMDSClientTest, SetCopysetsAvailFlag) {
     // send rpc fail
     EXPECT_CALL(*topoService, SetCopysetsAvailFlag(_, _, _, _))
         .Times(6)
-        .WillRepeatedly(Invoke([](RpcController *controller,
-                        const SetCopysetsAvailFlagRequest *request,
-                        SetCopysetsAvailFlagResponse *response,
-                        Closure *done){
-                        brpc::ClosureGuard doneGuard(done);
-                        brpc::Controller *cntl =
-                            dynamic_cast<brpc::Controller *>(controller);
-                        cntl->SetFailed("test");
-                    }));
+        .WillRepeatedly(
+            Invoke([](RpcController *controller,
+                      const SetCopysetsAvailFlagRequest *request,
+                      SetCopysetsAvailFlagResponse *response, Closure *done) {
+                brpc::ClosureGuard doneGuard(done);
+                brpc::Controller *cntl =
+                    dynamic_cast<brpc::Controller *>(controller);
+                cntl->SetFailed("test");
+            }));
     ASSERT_EQ(-1, mdsClient.SetCopysetsAvailFlag(copysets, false));
 
     // return code not ok
     SetCopysetsAvailFlagResponse response;
     response.set_statuscode(curve::mds::topology::kTopoErrCodeStorgeFail);
     EXPECT_CALL(*topoService, SetCopysetsAvailFlag(_, _, _, _))
-        .WillOnce(DoAll(SetArgPointee<2>(response),
-                        Invoke([](RpcController *controller,
-                        const SetCopysetsAvailFlagRequest *request,
-                        SetCopysetsAvailFlagResponse *response,
-                        Closure *done){
-                        brpc::ClosureGuard doneGuard(done);
-                    })));
+        .WillOnce(DoAll(
+            SetArgPointee<2>(response),
+            Invoke([](RpcController *controller,
+                      const SetCopysetsAvailFlagRequest *request,
+                      SetCopysetsAvailFlagResponse *response,
+                      Closure *done) { brpc::ClosureGuard doneGuard(done); })));
     ASSERT_EQ(-1, mdsClient.SetCopysetsAvailFlag(copysets, false));
 
     // normal
     response.set_statuscode(kTopoErrCodeSuccess);
     EXPECT_CALL(*topoService, SetCopysetsAvailFlag(_, _, _, _))
-        .WillOnce(DoAll(SetArgPointee<2>(response),
-                        Invoke([](RpcController *controller,
-                        const SetCopysetsAvailFlagRequest *request,
-                        SetCopysetsAvailFlagResponse *response,
-                        Closure *done){
-                        brpc::ClosureGuard doneGuard(done);
-                    })));
+        .WillOnce(DoAll(
+            SetArgPointee<2>(response),
+            Invoke([](RpcController *controller,
+                      const SetCopysetsAvailFlagRequest *request,
+                      SetCopysetsAvailFlagResponse *response,
+                      Closure *done) { brpc::ClosureGuard doneGuard(done); })));
     ASSERT_EQ(0, mdsClient.SetCopysetsAvailFlag(copysets, false));
 }
 
@@ -1542,28 +1507,27 @@ TEST_F(ToolMDSClientTest, ListUnAvailCopySets) {
     // send rpc fail
     EXPECT_CALL(*topoService, ListUnAvailCopySets(_, _, _, _))
         .Times(6)
-        .WillRepeatedly(Invoke([](RpcController *controller,
-                        const ListUnAvailCopySetsRequest *request,
-                        ListUnAvailCopySetsResponse *response,
-                        Closure *done){
-                        brpc::ClosureGuard doneGuard(done);
-                        brpc::Controller *cntl =
-                            dynamic_cast<brpc::Controller *>(controller);
-                        cntl->SetFailed("test");
-                    }));
+        .WillRepeatedly(
+            Invoke([](RpcController *controller,
+                      const ListUnAvailCopySetsRequest *request,
+                      ListUnAvailCopySetsResponse *response, Closure *done) {
+                brpc::ClosureGuard doneGuard(done);
+                brpc::Controller *cntl =
+                    dynamic_cast<brpc::Controller *>(controller);
+                cntl->SetFailed("test");
+            }));
     ASSERT_EQ(-1, mdsClient.ListUnAvailCopySets(&copysets));
 
     // return code not ok
     ListUnAvailCopySetsResponse response;
     response.set_statuscode(curve::mds::topology::kTopoErrCodeStorgeFail);
     EXPECT_CALL(*topoService, ListUnAvailCopySets(_, _, _, _))
-        .WillOnce(DoAll(SetArgPointee<2>(response),
-                        Invoke([](RpcController *controller,
-                        const ListUnAvailCopySetsRequest *request,
-                        ListUnAvailCopySetsResponse *response,
-                        Closure *done){
-                        brpc::ClosureGuard doneGuard(done);
-                    })));
+        .WillOnce(DoAll(
+            SetArgPointee<2>(response),
+            Invoke([](RpcController *controller,
+                      const ListUnAvailCopySetsRequest *request,
+                      ListUnAvailCopySetsResponse *response,
+                      Closure *done) { brpc::ClosureGuard doneGuard(done); })));
     ASSERT_EQ(-1, mdsClient.ListUnAvailCopySets(&copysets));
 
     // normal
@@ -1574,13 +1538,12 @@ TEST_F(ToolMDSClientTest, ListUnAvailCopySets) {
         cp->set_copysetid(i);
     }
     EXPECT_CALL(*topoService, ListUnAvailCopySets(_, _, _, _))
-        .WillOnce(DoAll(SetArgPointee<2>(response),
-                        Invoke([](RpcController *controller,
-                        const ListUnAvailCopySetsRequest *request,
-                        ListUnAvailCopySetsResponse *response,
-                        Closure *done){
-                        brpc::ClosureGuard doneGuard(done);
-                    })));
+        .WillOnce(DoAll(
+            SetArgPointee<2>(response),
+            Invoke([](RpcController *controller,
+                      const ListUnAvailCopySetsRequest *request,
+                      ListUnAvailCopySetsResponse *response,
+                      Closure *done) { brpc::ClosureGuard doneGuard(done); })));
     ASSERT_EQ(0, mdsClient.ListUnAvailCopySets(&copysets));
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Fix some warnings in code compilation.

This PR is a subtask of #1264. Due to the number of warnings, this task will be divided into several PRs.

OS: `Debian GNU/Linux 9 (stretch) x86_64`
GCC: `gcc (Debian 6.3.0-18+deb9u1) 6.3.0 20170516`

Fixed modules:
- [x] `//curvefs/...`
- [x] `//test/...`
- [x] `//src/...`
- [x] `//proto/...`
- [x] `//nebd/...`
- [x] `//include/...`
- [x] `//tools/...`

Fixed warnings:
- [x] `[-Wunused-parameter]`
- [x] `[-Wsign-compare]`
- [x] `[-Wnarrowing]`
- [x] `[-Wreorder]`
- [x] `[-Wunused-variable]`
- [x] `[-Wvla]`
- [x] `[-Wmissing-field-initializers]`
- [x] `[-Wwrite-strings]`
- [x] `[-Wunused-but-set-variable]`
- [x] `[-Wdeprecated-declarations]`
- [x] `[-Wformat=]`
- [x] `[-Wmaybe-uninitialized]`

Build result (Ignored submodule and external warnings):
```
root@be2939e66c7d:~/curve# bazel clean
INFO: Starting clean (this may take a while). Consider using --async if the clean takes more than several minutes.
root@be2939e66c7d:~/curve# bazel build //...

INFO: Analyzed 290 targets (190 packages loaded, 5106 targets configured).
INFO: Found 290 targets...
INFO: Elapsed time: 1277.986s, Critical Path: 37.67s
INFO: 3491 processes: 794 internal, 2697 processwrapper-sandbox.
INFO: Build completed successfully, 3491 total actions
INFO: Build completed successfully, 3491 total actions
```

Issue Number: #1264 <!-- replace xxx with issue number -->

Problem Summary:

### What is changed and how it works?

What's Changed: Relevant codes that cause warnings.

How it Works: By correcting corresponding codes.

Side effects(Breaking backward compatibility? Performance regression?): This may cause unknown bugs.

### Check List

- [x] Relevant documentation/comments are changed or added
- [x] I acknowledge that all my contributions will be made under the project's license
