### PR TITLE
[feat] chunkserver/datastore: add endianess in chunkfile/snapshotfile metapage

### DIFF
--- a/src/chunkserver/datastore/chunkserver_chunkfile.cpp
+++ b/src/chunkserver/datastore/chunkserver_chunkfile.cpp
@@ -119,7 +119,8 @@ void ChunkFileMetaPage::encode(char *buf) {
 
     // uint32_t crc 4 bytes need convert to network endianness
     uint32_t crc = ::curve::common::CRC32(buf, len);
-    uint32_t beCrc = htobe32(crc);
+    // uint32_t beCrc = htobe32(crc);
+    uint32_t beCrc = crc;
     memcpy(buf + len, &beCrc, sizeof(beCrc));
 
     LOG(INFO) << "calculate crc:" << crc;
@@ -175,7 +176,8 @@ CSErrorCode ChunkFileMetaPage::decode(const char *buf) {
     uint32_t crc = ::curve::common::CRC32(buf, len);
     uint32_t recordCrc;
     memcpy(&recordCrc, buf + len, sizeof(recordCrc));
-    uint32_t hostCrc = be32toh(recordCrc);
+    // uint32_t hostCrc = be32toh(recordCrc);
+    uint32_t hostCrc = recordCrc;
     LOG(INFO) << "calculate crc:" << crc;
     LOG(INFO) << "record crc(big endian):" << recordCrc;
     LOG(INFO) << "host crc:" << hostCrc;

--- a/src/chunkserver/datastore/chunkserver_chunkfile.cpp
+++ b/src/chunkserver/datastore/chunkserver_chunkfile.cpp
@@ -263,9 +263,9 @@ CSErrorCode CSChunkFile::Open(bool createFile) {
     if (createFile
         && !lfs_->FileExists(chunkFilePath)
         && metaPage_.sn > 0) {
-        std::unique_ptr<char[]> buf(new char[pageSize_]);
-        memset(buf.get(), 0, pageSize_);
-        metaPage_.version = FORMAT_VERSION_V3;
+        std::unique_ptr<char[]> buf(new char[metaPageSize_]);
+        memset(buf.get(), 0, metaPageSize_);
+        metaPage_.version = FORMAT_VERSION_V2;
         metaPage_.encode(buf.get());
 
         int rc = chunkFilePool_->GetFile(chunkFilePath, buf.get(), true);

--- a/src/chunkserver/datastore/chunkserver_chunkfile.cpp
+++ b/src/chunkserver/datastore/chunkserver_chunkfile.cpp
@@ -95,13 +95,7 @@ void ChunkFileMetaPage::encode(char *buf) {
     // long unsigned int loc_size 4/8 bytes need convert to big endian
     size_t loc_size = location.size();
     size_t be_loc_size;
-    if (sizeof(size_t) == 4) {
-        be_loc_size = htobe32(loc_size);
-    } else if (sizeof(size_t) == 8) {
-        be_loc_size = htobe64(loc_size);
-    } else {
-        be_loc_size = loc_size;
-    }
+    be_loc_size = htobe64(loc_size);
     memcpy(buf + len, &be_loc_size, sizeof(be_loc_size));
     len += sizeof(be_loc_size);
 
@@ -151,13 +145,7 @@ CSErrorCode ChunkFileMetaPage::decode(const char *buf) {
     // long unsigned int loc_size 4/8 bytes need convert to host endianness
     size_t loc_size;
     size_t host_loc_size;
-    if (sizeof(size_t) == 4) {
-        host_loc_size = be32toh(loc_size);
-    } else if (sizeof(size_t) == 8) {
-        host_loc_size = be64toh(loc_size);
-    } else {
-        host_loc_size = loc_size;
-    }
+    host_loc_size = be64toh(loc_size);
     loc_size = host_loc_size;
     memcpy(&loc_size, buf + len, sizeof(loc_size));
     len += sizeof(loc_size);

--- a/src/chunkserver/datastore/chunkserver_chunkfile.cpp
+++ b/src/chunkserver/datastore/chunkserver_chunkfile.cpp
@@ -75,13 +75,13 @@ ChunkFileMetaPage& ChunkFileMetaPage::operator =(
     return *this;
 }
 
-uint64_t SnapshotMetaPage::htonll(uint64_t val) {
+uint64_t ChunkFileMetaPage::htonll(uint64_t val) {
     if (1 == htonl(1))  // Judge the machine endianness
         return val;     // If equal Big Endianness
     return (((uint64_t)htonl(val)) << 32) + htonl(val >> 32);
 }
 
-uint64_t SnapshotMetaPage::ntohll(uint64_t val) {
+uint64_t ChunkFileMetaPage::ntohll(uint64_t val) {
     if (1 == htonl(1))
         return val;
     return (((uint64_t)ntohl(val)) << 32) + ntohl(val >> 32);

--- a/src/chunkserver/datastore/chunkserver_chunkfile.cpp
+++ b/src/chunkserver/datastore/chunkserver_chunkfile.cpp
@@ -128,6 +128,7 @@ void ChunkFileMetaPage::encode(char *buf) {
 
 CSErrorCode ChunkFileMetaPage::decode(const char *buf) {
     size_t len = 0;
+
     // uint8_t version 1 byte
     memcpy(&version, buf, sizeof(version));
     len += sizeof(version);
@@ -191,7 +192,7 @@ CSErrorCode ChunkFileMetaPage::decode(const char *buf) {
         LOG(ERROR) << "File format version incompatible."
                    << "file version: " << version << ", valid version: ["
                    << FORMAT_VERSION << ", " << FORMAT_VERSION_V2 << ", "
-                   << FORMAT_VERSION_V4 << "]";
+                   << FORMAT_VERSION_V3 << ", " << FORMAT_VERSION_V4 << "]";
         return CSErrorCode::IncompatibleError;
     } else if (version == FORMAT_VERSION) {
         version = FORMAT_VERSION_V3;

--- a/src/chunkserver/datastore/chunkserver_chunkfile.cpp
+++ b/src/chunkserver/datastore/chunkserver_chunkfile.cpp
@@ -19,13 +19,15 @@
  * File Created: Thursday, 6th September 2018 10:49:53 am
  * Author: yangyaokai
  */
+#include "src/chunkserver/datastore/chunkserver_chunkfile.h"
+
 #include <endian.h>
 #include <fcntl.h>
+
 #include <algorithm>
 #include <memory>
 
 #include "src/chunkserver/datastore/chunkserver_datastore.h"
-#include "src/chunkserver/datastore/chunkserver_chunkfile.h"
 #include "src/common/crc32.h"
 #include "src/common/curve_define.h"
 

--- a/src/chunkserver/datastore/chunkserver_chunkfile.cpp
+++ b/src/chunkserver/datastore/chunkserver_chunkfile.cpp
@@ -122,8 +122,8 @@ void ChunkFileMetaPage::encode(char *buf) {
     uint32_t beCrc = htobe32(crc);
     memcpy(buf + len, &beCrc, sizeof(beCrc));
 
-    LOG(ERROR) << "calculate crc:" << crc;
-    LOG(ERROR) << "big endian crc:" << beCrc;
+    LOG(INFO) << "calculate crc:" << crc;
+    LOG(INFO) << "big endian crc:" << beCrc;
 }
 
 CSErrorCode ChunkFileMetaPage::decode(const char *buf) {
@@ -176,9 +176,9 @@ CSErrorCode ChunkFileMetaPage::decode(const char *buf) {
     uint32_t recordCrc;
     memcpy(&recordCrc, buf + len, sizeof(recordCrc));
     uint32_t hostCrc = be32toh(recordCrc);
-    LOG(ERROR) << "calculate crc:" << crc;
-    LOG(ERROR) << "record crc(big endian):" << recordCrc;
-    LOG(ERROR) << "host crc:" << hostCrc;
+    LOG(INFO) << "calculate crc:" << crc;
+    LOG(INFO) << "record crc(big endian):" << recordCrc;
+    LOG(INFO) << "host crc:" << hostCrc;
     // check crc
     if (crc != hostCrc) {
         LOG(ERROR) << "Checking Crc32 failed.";
@@ -187,8 +187,8 @@ CSErrorCode ChunkFileMetaPage::decode(const char *buf) {
 
     // TODO(yyk) check version compatibility, currrent simple error handing,
     // need detailed implementation later
-    if (!(version == FORMAT_VERSION || version == FORMAT_VERSION_V2 ||
-          version == FORMAT_VERSION_V4)) {
+    if (version != FORMAT_VERSION && version != FORMAT_VERSION_V3 &&
+        version != FORMAT_VERSION_V2 && version != FORMAT_VERSION_V4) {
         LOG(ERROR) << "File format version incompatible."
                    << "file version: " << version << ", valid version: ["
                    << FORMAT_VERSION << ", " << FORMAT_VERSION_V2 << ", "

--- a/src/chunkserver/datastore/chunkserver_chunkfile.cpp
+++ b/src/chunkserver/datastore/chunkserver_chunkfile.cpp
@@ -117,14 +117,9 @@ void ChunkFileMetaPage::encode(char *buf) {
         len += bitmapBytes;
     }
 
-    // uint32_t crc 4 bytes need convert to network endianness
+    // uint32_t crc 4 bytes
     uint32_t crc = ::curve::common::CRC32(buf, len);
-    // uint32_t beCrc = htobe32(crc);
-    uint32_t beCrc = crc;
-    memcpy(buf + len, &beCrc, sizeof(beCrc));
-
-    LOG(INFO) << "calculate crc:" << crc;
-    LOG(INFO) << "big endian crc:" << beCrc;
+    memcpy(buf + len, &crc, sizeof(crc));
 }
 
 CSErrorCode ChunkFileMetaPage::decode(const char *buf) {
@@ -176,13 +171,9 @@ CSErrorCode ChunkFileMetaPage::decode(const char *buf) {
     uint32_t crc = ::curve::common::CRC32(buf, len);
     uint32_t recordCrc;
     memcpy(&recordCrc, buf + len, sizeof(recordCrc));
-    // uint32_t hostCrc = be32toh(recordCrc);
-    uint32_t hostCrc = recordCrc;
-    LOG(INFO) << "calculate crc:" << crc;
-    LOG(INFO) << "record crc(big endian):" << recordCrc;
-    LOG(INFO) << "host crc:" << hostCrc;
+
     // check crc
-    if (crc != hostCrc) {
+    if (crc != recordCrc) {
         LOG(ERROR) << "Checking Crc32 failed.";
         return CSErrorCode::CrcCheckError;
     }

--- a/src/chunkserver/datastore/chunkserver_chunkfile.cpp
+++ b/src/chunkserver/datastore/chunkserver_chunkfile.cpp
@@ -119,7 +119,10 @@ void ChunkFileMetaPage::encode(char *buf) {
 
     // uint32_t crc 4 bytes
     uint32_t crc = ::curve::common::CRC32(buf, len);
-    memcpy(buf + len, &crc, sizeof(crc));
+    uint32_t beCrc = crc;
+    memcpy(buf + len, &beCrc, sizeof(beCrc));
+
+    LOG(INFO) << "calculate crc:" << crc;
 }
 
 CSErrorCode ChunkFileMetaPage::decode(const char *buf) {
@@ -172,8 +175,11 @@ CSErrorCode ChunkFileMetaPage::decode(const char *buf) {
     uint32_t recordCrc;
     memcpy(&recordCrc, buf + len, sizeof(recordCrc));
 
+    uint32_t hostCrc = recordCrc;
+    LOG(INFO) << "calculate crc:" << crc;
+    LOG(INFO) << "host crc:" << hostCrc;
     // check crc
-    if (crc != recordCrc) {
+    if (crc != hostCrc) {
         LOG(ERROR) << "Checking Crc32 failed.";
         return CSErrorCode::CrcCheckError;
     }
@@ -194,7 +200,6 @@ CSErrorCode ChunkFileMetaPage::decode(const char *buf) {
     }
     return CSErrorCode::Success;
 }
-
 uint64_t CSChunkFile::syncChunkLimits_ = 2 * 1024 * 1024;
 uint64_t CSChunkFile::syncThreshold_ = 64 * 1024;
 

--- a/src/chunkserver/datastore/chunkserver_chunkfile.cpp
+++ b/src/chunkserver/datastore/chunkserver_chunkfile.cpp
@@ -19,6 +19,7 @@
  * File Created: Thursday, 6th September 2018 10:49:53 am
  * Author: yangyaokai
  */
+#include <arpa/inet.h>
 #include <fcntl.h>
 #include <algorithm>
 #include <memory>

--- a/src/chunkserver/datastore/chunkserver_chunkfile.h
+++ b/src/chunkserver/datastore/chunkserver_chunkfile.h
@@ -89,8 +89,6 @@ struct ChunkFileMetaPage {
     ChunkFileMetaPage(const ChunkFileMetaPage& metaPage);
     ChunkFileMetaPage& operator = (const ChunkFileMetaPage& metaPage);
 
-    uint64_t htonll(uint64_t val);
-    uint64_t ntohll(uint64_t val);
     void encode(char* buf);
     CSErrorCode decode(const char* buf);
 };

--- a/src/chunkserver/datastore/chunkserver_chunkfile.h
+++ b/src/chunkserver/datastore/chunkserver_chunkfile.h
@@ -89,6 +89,8 @@ struct ChunkFileMetaPage {
     ChunkFileMetaPage(const ChunkFileMetaPage& metaPage);
     ChunkFileMetaPage& operator = (const ChunkFileMetaPage& metaPage);
 
+    uint64_t htonll(uint64_t val);
+    uint64_t ntohll(uint64_t val);
     void encode(char* buf);
     CSErrorCode decode(const char* buf);
 };

--- a/src/chunkserver/datastore/chunkserver_snapshot.cpp
+++ b/src/chunkserver/datastore/chunkserver_snapshot.cpp
@@ -20,15 +20,19 @@
  * Author: yangyaokai
  */
 
-#include <endian.h>
-#include <memory>
-#include "src/chunkserver/datastore/chunkserver_datastore.h"
 #include "src/chunkserver/datastore/chunkserver_snapshot.h"
+
+#include <endian.h>
+
+#include <memory>
+
+#include "src/chunkserver/datastore/chunkserver_datastore.h"
+
 
 namespace curve {
 namespace chunkserver {
 
-void SnapshotMetaPage::encode(char *buf) {
+void SnapshotMetaPage::encode(char* buf) {
     size_t len = 0;
 
     // uint8_t version 1 byte
@@ -64,7 +68,7 @@ void SnapshotMetaPage::encode(char *buf) {
     LOG(INFO) << "calculate crc:" << crc;
 }
 
-CSErrorCode SnapshotMetaPage::decode(const char *buf) {
+CSErrorCode SnapshotMetaPage::decode(const char* buf) {
     size_t len = 0;
 
     // uint8_t version 1 byte
@@ -128,7 +132,7 @@ CSErrorCode SnapshotMetaPage::decode(const char *buf) {
     return CSErrorCode::Success;
 }
 
-SnapshotMetaPage::SnapshotMetaPage(const SnapshotMetaPage &metaPage) {
+SnapshotMetaPage::SnapshotMetaPage(const SnapshotMetaPage& metaPage) {
     version = metaPage.version;
     damaged = metaPage.damaged;
     sn = metaPage.sn;
@@ -138,7 +142,8 @@ SnapshotMetaPage::SnapshotMetaPage(const SnapshotMetaPage &metaPage) {
 }
 
 SnapshotMetaPage &
-SnapshotMetaPage::operator=(const SnapshotMetaPage &metaPage) {
+SnapshotMetaPage::operator=(
+    const SnapshotMetaPage& metaPage) {
     if (this == &metaPage)
         return *this;
     version = metaPage.version;
@@ -189,9 +194,7 @@ CSErrorCode CSSnapshot::Open(bool createFile) {
     // The existence of snapshot files may be caused by the following conditions
     // getchunk succeeded, but failed later in stat or loadmetapage,
     // when the download is opened again;
-     if (createFile
-        && !lfs_->FileExists(snapshotPath)
-        && metaPage_.sn > 0) {
+     if (createFile && !lfs_->FileExists(snapshotPath) && metaPage_.sn > 0) {
         std::unique_ptr<char[]> buf(new char[metaPageSize_]);
         memset(buf.get(), 0, metaPageSize_);
         metaPage_.encode(buf.get());
@@ -225,7 +228,7 @@ CSErrorCode CSSnapshot::Open(bool createFile) {
     return loadMetaPage();
 }
 
-CSErrorCode CSSnapshot::Read(char *buf, off_t offset, size_t length) {
+CSErrorCode CSSnapshot::Read(char* buf, off_t offset, size_t length) {
     // TODO(yyk) Do you need to compare the bit state of the offset?
     int rc = readData(buf, offset, length);
     if (rc < 0) {
@@ -253,7 +256,7 @@ std::shared_ptr<const Bitmap> CSSnapshot::GetPageStatus() const {
     return metaPage_.bitmap;
 }
 
-CSErrorCode CSSnapshot::Write(const char *buf, off_t offset, size_t length) {
+CSErrorCode CSSnapshot::Write(const char* buf, off_t offset, size_t length) {
     int rc = writeData(buf, offset, length);
     if (rc < 0) {
         LOG(ERROR) << "Write snapshot failed."

--- a/src/chunkserver/datastore/chunkserver_snapshot.cpp
+++ b/src/chunkserver/datastore/chunkserver_snapshot.cpp
@@ -51,7 +51,7 @@ void SnapshotMetaPage::encode(char *buf) {
     len += sizeof(beBits);
 
     // unsigned long bitmapBytes 4 bytes
-    // bitmap char  (bits + 8 - 1) / 3 bytes
+    // bitmap char  (bits + 8 - 1) / 8 bytes
     size_t bitmapBytes = (bits + 8 - 1) >> 3;
     memcpy(buf + len, bitmap->GetBitmap(), bitmapBytes);
     len += bitmapBytes;
@@ -61,8 +61,8 @@ void SnapshotMetaPage::encode(char *buf) {
     uint32_t beCrc = htobe32(crc);
     memcpy(buf + len, &beCrc, sizeof(beCrc));
 
-    LOG(ERROR) << "calculate crc:" << crc;
-    LOG(ERROR) << "big endian crc:" << beCrc;
+    LOG(INFO) << "calculate crc:" << crc;
+    LOG(INFO) << "big endian crc:" << beCrc;
 }
 
 CSErrorCode SnapshotMetaPage::decode(const char *buf) {
@@ -101,9 +101,9 @@ CSErrorCode SnapshotMetaPage::decode(const char *buf) {
     memcpy(&recordCrc, buf + len, sizeof(recordCrc));
     uint32_t hostCrc = be32toh(recordCrc);
 
-    LOG(ERROR) << "calculate crc:" << crc;
-    LOG(ERROR) << "record crc(big endian):" << recordCrc;
-    LOG(ERROR) << "host crc:" << hostCrc;
+    LOG(INFO) << "calculate crc:" << crc;
+    LOG(INFO) << "record crc(big endian):" << recordCrc;
+    LOG(INFO) << "host crc:" << hostCrc;
 
     // Verify crc, return an error code if the verification fails
     if (crc != hostCrc) {
@@ -130,6 +130,7 @@ CSErrorCode SnapshotMetaPage::decode(const char *buf) {
     }
     return CSErrorCode::Success;
 }
+
 SnapshotMetaPage::SnapshotMetaPage(const SnapshotMetaPage &metaPage) {
     version = metaPage.version;
     damaged = metaPage.damaged;

--- a/src/chunkserver/datastore/chunkserver_snapshot.cpp
+++ b/src/chunkserver/datastore/chunkserver_snapshot.cpp
@@ -87,9 +87,9 @@ CSErrorCode SnapshotMetaPage::decode(const char *buf) {
 
     // uint64_t sn 8 bytes need convert to host endianness in decode
     memcpy(&sn, buf + len, sizeof(sn));
-    uint64_t netSn = ntohll(sn);
-    sn = netSn;
-    len += sizeof(netSn);
+    uint64_t hostSn = ntohll(sn);
+    sn = hostSn;
+    len += sizeof(sn);
 
     // uint32_t bits 4 bytes need convert to host endianness in decode
     uint32_t bits = 0;
@@ -117,12 +117,15 @@ CSErrorCode SnapshotMetaPage::decode(const char *buf) {
 
     // TODO(yyk) judge version compatibility, simple processing at present,
     // detailed implementation later
-    if (version != FORMAT_VERSION) {
+    if (version != FORMAT_VERSION || version != FORMAT_VERSION_V3) {
         LOG(ERROR) << "File format version incompatible."
                    << "file version: " << static_cast<uint32_t>(version)
                    << ", format version: "
-                   << static_cast<uint32_t>(FORMAT_VERSION);
+                   << static_cast<uint32_t>(FORMAT_VERSION) << "/"
+                   << static_cast<uint32_t>(FORMAT_VERSION_V3);
         return CSErrorCode::IncompatibleError;
+    } else if (version != FORMAT_VERSION_V3) {
+        version = FORMAT_VERSION_V3;
     }
     return CSErrorCode::Success;
 }

--- a/src/chunkserver/datastore/chunkserver_snapshot.cpp
+++ b/src/chunkserver/datastore/chunkserver_snapshot.cpp
@@ -20,8 +20,8 @@
  * Author: yangyaokai
  */
 
-#include <memory>
 #include <arpa/inet.h>
+#include <memory>
 #include "src/chunkserver/datastore/chunkserver_datastore.h"
 #include "src/chunkserver/datastore/chunkserver_snapshot.h"
 

--- a/src/chunkserver/datastore/chunkserver_snapshot.cpp
+++ b/src/chunkserver/datastore/chunkserver_snapshot.cpp
@@ -58,7 +58,10 @@ void SnapshotMetaPage::encode(char *buf) {
 
     // uint32_t crc 4 bytes
     uint32_t crc = ::curve::common::CRC32(buf, len);
-    memcpy(buf + len, &crc, sizeof(crc));
+    uint32_t beCrc = crc;
+    memcpy(buf + len, &beCrc, sizeof(beCrc));
+
+    LOG(INFO) << "calculate crc:" << crc;
 }
 
 CSErrorCode SnapshotMetaPage::decode(const char *buf) {
@@ -96,8 +99,11 @@ CSErrorCode SnapshotMetaPage::decode(const char *buf) {
     uint32_t recordCrc;
     memcpy(&recordCrc, buf + len, sizeof(recordCrc));
 
-    // Verify crc, return an error code if the verification fails
-    if (crc != recordCrc) {
+    uint32_t hostCrc = recordCrc;
+    LOG(INFO) << "calculate crc:" << crc;
+    LOG(INFO) << "host crc:" << hostCrc;
+    // check crc
+    if (crc != hostCrc) {
         LOG(ERROR) << "Checking Crc32 failed.";
         return CSErrorCode::CrcCheckError;
     }

--- a/src/chunkserver/datastore/chunkserver_snapshot.cpp
+++ b/src/chunkserver/datastore/chunkserver_snapshot.cpp
@@ -58,7 +58,8 @@ void SnapshotMetaPage::encode(char *buf) {
 
     // uint32_t crc 4 bytes need convert to big endian
     uint32_t crc = ::curve::common::CRC32(buf, len);
-    uint32_t beCrc = htobe32(crc);
+    // uint32_t beCrc = htobe32(crc);
+    uint32_t beCrc = crc;
     memcpy(buf + len, &beCrc, sizeof(beCrc));
 
     LOG(INFO) << "calculate crc:" << crc;
@@ -99,7 +100,8 @@ CSErrorCode SnapshotMetaPage::decode(const char *buf) {
     uint32_t crc = ::curve::common::CRC32(buf, len);
     uint32_t recordCrc;
     memcpy(&recordCrc, buf + len, sizeof(recordCrc));
-    uint32_t hostCrc = be32toh(recordCrc);
+    // uint32_t hostCrc = be32toh(recordCrc);
+    uint32_t hostCrc = recordCrc;
 
     LOG(INFO) << "calculate crc:" << crc;
     LOG(INFO) << "record crc(big endian):" << recordCrc;

--- a/src/chunkserver/datastore/chunkserver_snapshot.cpp
+++ b/src/chunkserver/datastore/chunkserver_snapshot.cpp
@@ -21,49 +21,96 @@
  */
 
 #include <memory>
+#include <arpa/inet.h>
 #include "src/chunkserver/datastore/chunkserver_datastore.h"
 #include "src/chunkserver/datastore/chunkserver_snapshot.h"
 
 namespace curve {
 namespace chunkserver {
 
-void SnapshotMetaPage::encode(char* buf) {
+uint64_t SnapshotMetaPage::htonll(uint64_t val) {
+    if (1 == htonl(1))  // Judge the machine endianness
+        return val;     // If equal Big Endianness
+    return (((uint64_t)htonl(val)) << 32) + htonl(val >> 32);
+}
+
+uint64_t SnapshotMetaPage::ntohll(uint64_t val) {
+    if (1 == htonl(1))
+        return val;
+    return (((uint64_t)ntohl(val)) << 32) + ntohl(val >> 32);
+}
+
+void SnapshotMetaPage::encode(char *buf) {
     size_t len = 0;
+
+    // uint8_t version 1 byte
     memcpy(buf, &version, sizeof(version));
     len += sizeof(version);
+
+    // bool damaged 1 byte
     memcpy(buf + len, &damaged, sizeof(damaged));
     len += sizeof(damaged);
-    memcpy(buf + len, &sn, sizeof(sn));
-    len += sizeof(sn);
+
+    // uint64_t sn 8 bytes need convert to network endianness in encode
+    uint64_t u64NetSn = htonll(sn);
+    memcpy(buf + len, &u64NetSn, sizeof(u64NetSn));
+    len += sizeof(u64NetSn);
+
+    // uint32_t bits 4 bytes need convert to network endianness in encode
     uint32_t bits = bitmap->Size();
-    memcpy(buf + len, &bits, sizeof(bits));
-    len += sizeof(bits);
+    uint32_t netBits = htonl(bits);
+    memcpy(buf + len, &netBits, sizeof(netBits));
+    len += sizeof(netBits);
+
+    // unsigned long bitmapBytes 4 bytes
+    // bitmap char  (bits + 8 - 1) / 8 bytes
     size_t bitmapBytes = (bits + 8 - 1) / 8;
     memcpy(buf + len, bitmap->GetBitmap(), bitmapBytes);
     len += bitmapBytes;
+
+    // uint32_t crc 4 bytes need convert to network endianness in encode
     uint32_t crc = ::curve::common::CRC32(buf, len);
-    memcpy(buf + len, &crc, sizeof(crc));
+    uint32_t netCrc = htonl(crc);
+    memcpy(buf + len, &netCrc, sizeof(netCrc));
 }
 
-CSErrorCode SnapshotMetaPage::decode(const char* buf) {
+CSErrorCode SnapshotMetaPage::decode(const char *buf) {
     size_t len = 0;
+
+    // uint8_t version 1 byte
     memcpy(&version, buf, sizeof(version));
     len += sizeof(version);
+
+    // bool damaged 1 byte
     memcpy(&damaged, buf + len, sizeof(damaged));
     len += sizeof(damaged);
+
+    // uint64_t sn 8 bytes need convert to host endianness in decode
     memcpy(&sn, buf + len, sizeof(sn));
-    len += sizeof(sn);
+    uint64_t netSn = ntohll(sn);
+    sn = netSn;
+    len += sizeof(netSn);
+
+    // uint32_t bits 4 bytes need convert to host endianness in decode
     uint32_t bits = 0;
     memcpy(&bits, buf + len, sizeof(bits));
-    len += sizeof(bits);
-    bitmap = std::make_shared<Bitmap>(bits, buf + len);
+    uint32_t hostBits = ntohl(bits);
+    len += sizeof(hostBits);
+    bitmap = std::make_shared<Bitmap>(hostBits, buf + len);
+
+    // unsigned long bitmapBytes 4 bytes
+    // bitmap char  (bits + 8 - 1) / 8 bytes
     size_t bitmapBytes = (bitmap->Size() + 8 - 1) / 8;
     len += bitmapBytes;
-    uint32_t crc =  ::curve::common::CRC32(buf, len);
+
+    // uint32_t crc 4 bytes need convert to host endianness in decode
+    uint32_t crc = ::curve::common::CRC32(buf, len);
     uint32_t recordCrc;
     memcpy(&recordCrc, buf + len, sizeof(recordCrc));
+    uint32_t hostRecordCrc = ntohl(recordCrc);
+
     // Verify crc, return an error code if the verification fails
-    if (crc != recordCrc) {
+    if (crc != hostRecordCrc) {
         LOG(ERROR) << "Checking Crc32 failed.";
         return CSErrorCode::CrcCheckError;
     }
@@ -72,50 +119,42 @@ CSErrorCode SnapshotMetaPage::decode(const char* buf) {
     // detailed implementation later
     if (version != FORMAT_VERSION) {
         LOG(ERROR) << "File format version incompatible."
-                    << "file version: "
-                    << static_cast<uint32_t>(version)
-                    << ", format version: "
-                    << static_cast<uint32_t>(FORMAT_VERSION);
+                   << "file version: " << static_cast<uint32_t>(version)
+                   << ", format version: "
+                   << static_cast<uint32_t>(FORMAT_VERSION);
         return CSErrorCode::IncompatibleError;
     }
     return CSErrorCode::Success;
 }
 
-SnapshotMetaPage::SnapshotMetaPage(const SnapshotMetaPage& metaPage) {
+SnapshotMetaPage::SnapshotMetaPage(const SnapshotMetaPage &metaPage) {
     version = metaPage.version;
     damaged = metaPage.damaged;
     sn = metaPage.sn;
-    std::shared_ptr<Bitmap> newMap =
-        std::make_shared<Bitmap>(metaPage.bitmap->Size(),
-                                 metaPage.bitmap->GetBitmap());
+    std::shared_ptr<Bitmap> newMap = std::make_shared<Bitmap>(
+        metaPage.bitmap->Size(), metaPage.bitmap->GetBitmap());
     bitmap = newMap;
 }
 
-SnapshotMetaPage& SnapshotMetaPage::operator =(
-    const SnapshotMetaPage& metaPage) {
+SnapshotMetaPage &
+SnapshotMetaPage::operator=(const SnapshotMetaPage &metaPage) {
     if (this == &metaPage)
         return *this;
     version = metaPage.version;
     damaged = metaPage.damaged;
     sn = metaPage.sn;
-    std::shared_ptr<Bitmap> newMap =
-        std::make_shared<Bitmap>(metaPage.bitmap->Size(),
-                                 metaPage.bitmap->GetBitmap());
+    std::shared_ptr<Bitmap> newMap = std::make_shared<Bitmap>(
+        metaPage.bitmap->Size(), metaPage.bitmap->GetBitmap());
     bitmap = newMap;
     return *this;
 }
 
 CSSnapshot::CSSnapshot(std::shared_ptr<LocalFileSystem> lfs,
                        std::shared_ptr<FilePool> chunkFilePool,
-                       const ChunkOptions& options)
-    : fd_(-1),
-      chunkId_(options.id),
-      size_(options.chunkSize),
-      pageSize_(options.pageSize),
-      baseDir_(options.baseDir),
-      lfs_(lfs),
-      chunkFilePool_(chunkFilePool),
-      metric_(options.metric) {
+                       const ChunkOptions &options)
+    : fd_(-1), chunkId_(options.id), size_(options.chunkSize),
+      pageSize_(options.pageSize), baseDir_(options.baseDir), lfs_(lfs),
+      chunkFilePool_(chunkFilePool), metric_(options.metric) {
     CHECK(!baseDir_.empty()) << "Create snapshot failed";
     CHECK(lfs_ != nullptr) << "Create snapshot failed";
     uint32_t bits = size_ / pageSize_;
@@ -143,23 +182,21 @@ CSErrorCode CSSnapshot::Open(bool createFile) {
     // The existence of snapshot files may be caused by the following conditions
     // getchunk succeeded, but failed later in stat or loadmetapage,
     // when the download is opened again;
-    if (createFile
-        && !lfs_->FileExists(snapshotPath)
-        && metaPage_.sn > 0) {
+    if (createFile && !lfs_->FileExists(snapshotPath) && metaPage_.sn > 0) {
         std::unique_ptr<char[]> buf(new char[pageSize_]);
         memset(buf.get(), 0, pageSize_);
         metaPage_.encode(buf.get());
         int ret = chunkFilePool_->GetFile(snapshotPath, buf.get());
         if (ret != 0) {
             LOG(ERROR) << "Error occured when create snapshot."
-                   << " filepath = " << snapshotPath;
+                       << " filepath = " << snapshotPath;
             return CSErrorCode::InternalError;
         }
     }
-    int rc = lfs_->Open(snapshotPath, O_RDWR|O_NOATIME|O_DSYNC);
+    int rc = lfs_->Open(snapshotPath, O_RDWR | O_NOATIME | O_DSYNC);
     if (rc < 0) {
         LOG(ERROR) << "Error occured when opening file."
-                   << " filepath = "<< snapshotPath;
+                   << " filepath = " << snapshotPath;
         return CSErrorCode::InternalError;
     }
     fd_ = rc;
@@ -179,12 +216,12 @@ CSErrorCode CSSnapshot::Open(bool createFile) {
     return loadMetaPage();
 }
 
-CSErrorCode CSSnapshot::Read(char * buf, off_t offset, size_t length) {
+CSErrorCode CSSnapshot::Read(char *buf, off_t offset, size_t length) {
     // TODO(yyk) Do you need to compare the bit state of the offset?
     int rc = readData(buf, offset, length);
     if (rc < 0) {
         LOG(ERROR) << "Error occured when reading snapshot."
-                   << " filepath = "<< path();
+                   << " filepath = " << path();
         return CSErrorCode::InternalError;
     }
     return CSErrorCode::Success;
@@ -201,15 +238,13 @@ CSErrorCode CSSnapshot::Delete() {
     return CSErrorCode::Success;
 }
 
-SequenceNum CSSnapshot::GetSn() const {
-    return metaPage_.sn;
-}
+SequenceNum CSSnapshot::GetSn() const { return metaPage_.sn; }
 
 std::shared_ptr<const Bitmap> CSSnapshot::GetPageStatus() const {
     return metaPage_.bitmap;
 }
 
-CSErrorCode CSSnapshot::Write(const char * buf, off_t offset, size_t length) {
+CSErrorCode CSSnapshot::Write(const char *buf, off_t offset, size_t length) {
     int rc = writeData(buf, offset, length);
     if (rc < 0) {
         LOG(ERROR) << "Write snapshot failed."
@@ -237,7 +272,7 @@ CSErrorCode CSSnapshot::Flush() {
     return errorCode;
 }
 
-CSErrorCode CSSnapshot::updateMetaPage(SnapshotMetaPage* metaPage) {
+CSErrorCode CSSnapshot::updateMetaPage(SnapshotMetaPage *metaPage) {
     std::unique_ptr<char[]> buf(new char[pageSize_]);
     memset(buf.get(), 0, pageSize_);
     metaPage->encode(buf.get());

--- a/src/chunkserver/datastore/chunkserver_snapshot.h
+++ b/src/chunkserver/datastore/chunkserver_snapshot.h
@@ -151,22 +151,24 @@ class CSSnapshot {
                FileNameOperator::GenerateSnapshotName(chunkId_, metaPage_.sn);
     }
 
-    inline uint32_t fileSize() { return pageSize_ + size_; }
-
-    inline int readMetaPage(char *buf) {
-        return lfs_->Read(fd_, buf, 0, pageSize_);
+    uint32_t fileSize() const {
+        return metaPageSize_ + size_;
     }
 
-    inline int writeMetaPage(const char *buf) {
-        return lfs_->Write(fd_, buf, 0, pageSize_);
+    inline int readMetaPage(char* buf) {
+        return lfs_->Read(fd_, buf, 0, metaPageSize_);
     }
 
-    inline int readData(char *buf, off_t offset, size_t length) {
-        return lfs_->Read(fd_, buf, offset + pageSize_, length);
+    inline int writeMetaPage(const char* buf) {
+        return lfs_->Write(fd_, buf, 0, metaPageSize_);
     }
 
-    inline int writeData(const char *buf, off_t offset, size_t length) {
-        return lfs_->Write(fd_, buf, offset + pageSize_, length);
+    inline int readData(char* buf, off_t offset, size_t length) {
+        return lfs_->Read(fd_, buf, offset + metaPageSize_, length);
+    }
+
+    inline int writeData(const char* buf, off_t offset, size_t length) {
+        return lfs_->Write(fd_, buf, offset + metaPageSize_, length);
     }
 
  private:

--- a/src/chunkserver/datastore/chunkserver_snapshot.h
+++ b/src/chunkserver/datastore/chunkserver_snapshot.h
@@ -66,21 +66,20 @@ struct SnapshotMetaPage {
     // bitmap  representing the current snapshot page status
     std::shared_ptr<Bitmap> bitmap;
 
-    SnapshotMetaPage()  : version(FORMAT_VERSION)
-                        , damaged(false)
-                        , bitmap(nullptr) {}
+    SnapshotMetaPage()  
+        : version(FORMAT_VERSION), damaged(false), bitmap(nullptr) {}
     SnapshotMetaPage(const SnapshotMetaPage &metaPage);
     SnapshotMetaPage &operator=(const SnapshotMetaPage &metaPage);
 
-    void encode(char *buf);
-    CSErrorCode decode(const char *buf);
+    void encode(char* buf);
+    CSErrorCode decode(const char* buf);
 };
 
 class CSSnapshot {
  public:
     CSSnapshot(std::shared_ptr<LocalFileSystem> lfs,
                std::shared_ptr<FilePool> chunkFilePool,
-               const ChunkOptions &options);
+               const ChunkOptions& options);
     virtual ~CSSnapshot();
     /**
      * open snapshot file, called when starting to load snapshot file or create
@@ -99,7 +98,7 @@ class CSSnapshot {
      * @param length: The length of the data requested to be written
      * @return: return error code
      */
-    CSErrorCode Write(const char *buf, off_t offset, size_t length);
+    CSErrorCode Write(const char* buf, off_t offset, size_t length);
     /**
      * Read the snapshot data, according to the bitmap to determine whether to
      * read the data from the chunk file
@@ -108,7 +107,7 @@ class CSSnapshot {
      * @param length: The length of the data requested to be read
      * @return: return error code
      */
-    CSErrorCode Read(char *buf, off_t offset, size_t length);
+    CSErrorCode Read(char* buf, off_t offset, size_t length);
     /**
      * Delete snapshot files
      * @return: return error code
@@ -140,7 +139,7 @@ class CSSnapshot {
      * will be changed
      * If it fails, it will not be changed
      */
-    CSErrorCode updateMetaPage(SnapshotMetaPage *metaPage);
+    CSErrorCode updateMetaPage(SnapshotMetaPage* metaPage);
     /**
      * Load metapage into memory
      */
@@ -151,9 +150,7 @@ class CSSnapshot {
                FileNameOperator::GenerateSnapshotName(chunkId_, metaPage_.sn);
     }
 
-    uint32_t fileSize() const {
-        return metaPageSize_ + size_;
-    }
+    uint32_t fileSize() const {return metaPageSize_ + size_;}
 
     inline int readMetaPage(char* buf) {
         return lfs_->Read(fd_, buf, 0, metaPageSize_);

--- a/src/chunkserver/datastore/chunkserver_snapshot.h
+++ b/src/chunkserver/datastore/chunkserver_snapshot.h
@@ -66,8 +66,9 @@ struct SnapshotMetaPage {
     // bitmap  representing the current snapshot page status
     std::shared_ptr<Bitmap> bitmap;
 
-    SnapshotMetaPage()
-        : version(FORMAT_VERSION), damaged(false), bitmap(nullptr) {}
+    SnapshotMetaPage()  : version(FORMAT_VERSION)
+                        , damaged(false)
+                        , bitmap(nullptr) {}
     SnapshotMetaPage(const SnapshotMetaPage &metaPage);
     SnapshotMetaPage &operator=(const SnapshotMetaPage &metaPage);
 

--- a/src/chunkserver/datastore/chunkserver_snapshot.h
+++ b/src/chunkserver/datastore/chunkserver_snapshot.h
@@ -66,21 +66,22 @@ struct SnapshotMetaPage {
     // bitmap  representing the current snapshot page status
     std::shared_ptr<Bitmap> bitmap;
 
-    SnapshotMetaPage() : version(FORMAT_VERSION)
-                       , damaged(false)
-                       , bitmap(nullptr) {}
-    SnapshotMetaPage(const SnapshotMetaPage& metaPage);
-    SnapshotMetaPage& operator = (const SnapshotMetaPage& metaPage);
+    SnapshotMetaPage()
+        : version(FORMAT_VERSION), damaged(false), bitmap(nullptr) {}
+    SnapshotMetaPage(const SnapshotMetaPage &metaPage);
+    SnapshotMetaPage &operator=(const SnapshotMetaPage &metaPage);
 
-    void encode(char* buf);
-    CSErrorCode decode(const char* buf);
+    uint64_t htonll(uint64_t val);
+    uint64_t ntohll(uint64_t val);
+    void encode(char *buf);
+    CSErrorCode decode(const char *buf);
 };
 
 class CSSnapshot {
  public:
     CSSnapshot(std::shared_ptr<LocalFileSystem> lfs,
                std::shared_ptr<FilePool> chunkFilePool,
-               const ChunkOptions& options);
+               const ChunkOptions &options);
     virtual ~CSSnapshot();
     /**
      * open snapshot file, called when starting to load snapshot file or create
@@ -99,15 +100,16 @@ class CSSnapshot {
      * @param length: The length of the data requested to be written
      * @return: return error code
      */
-    CSErrorCode Write(const char * buf, off_t offset, size_t length);
+    CSErrorCode Write(const char *buf, off_t offset, size_t length);
     /**
-     * Read the snapshot data, according to the bitmap to determine whether to read the data from the chunk file
+     * Read the snapshot data, according to the bitmap to determine whether to
+     * read the data from the chunk file
      * @param buf: Snapshot data read
      * @param offset: the starting offset of the request to read
      * @param length: The length of the data requested to be read
      * @return: return error code
      */
-    CSErrorCode Read(char * buf, off_t offset, size_t length);
+    CSErrorCode Read(char *buf, off_t offset, size_t length);
     /**
      * Delete snapshot files
      * @return: return error code
@@ -139,7 +141,7 @@ class CSSnapshot {
      * will be changed
      * If it fails, it will not be changed
      */
-    CSErrorCode updateMetaPage(SnapshotMetaPage* metaPage);
+    CSErrorCode updateMetaPage(SnapshotMetaPage *metaPage);
     /**
      * Load metapage into memory
      */
@@ -150,23 +152,21 @@ class CSSnapshot {
                FileNameOperator::GenerateSnapshotName(chunkId_, metaPage_.sn);
     }
 
-    inline uint32_t fileSize() {
-        return pageSize_ + size_;
-    }
+    inline uint32_t fileSize() { return pageSize_ + size_; }
 
-    inline int readMetaPage(char* buf) {
+    inline int readMetaPage(char *buf) {
         return lfs_->Read(fd_, buf, 0, pageSize_);
     }
 
-    inline int writeMetaPage(const char* buf) {
+    inline int writeMetaPage(const char *buf) {
         return lfs_->Write(fd_, buf, 0, pageSize_);
     }
 
-    inline int readData(char* buf, off_t offset, size_t length) {
+    inline int readData(char *buf, off_t offset, size_t length) {
         return lfs_->Read(fd_, buf, offset + pageSize_, length);
     }
 
-    inline int writeData(const char* buf, off_t offset, size_t length) {
+    inline int writeData(const char *buf, off_t offset, size_t length) {
         return lfs_->Write(fd_, buf, offset + pageSize_, length);
     }
 

--- a/src/chunkserver/datastore/chunkserver_snapshot.h
+++ b/src/chunkserver/datastore/chunkserver_snapshot.h
@@ -72,8 +72,6 @@ struct SnapshotMetaPage {
     SnapshotMetaPage(const SnapshotMetaPage &metaPage);
     SnapshotMetaPage &operator=(const SnapshotMetaPage &metaPage);
 
-    uint64_t htonll(uint64_t val);
-    uint64_t ntohll(uint64_t val);
     void encode(char *buf);
     CSErrorCode decode(const char *buf);
 };

--- a/src/chunkserver/datastore/define.h
+++ b/src/chunkserver/datastore/define.h
@@ -34,10 +34,14 @@ namespace chunkserver {
 
 using curve::common::Bitmap;
 
+// In zeroed chunk file, taking endianness into consideration, the version is 8,
+// Taking endianness into consideration, the version is 4,
 // In zeroed chunk file, the version is 2,
 // otherwise, the version is 1
 const uint8_t FORMAT_VERSION = 1;
 const uint8_t FORMAT_VERSION_V2 = 2;
+const uint8_t FORMAT_VERSION_V3 = 4;
+const uint8_t FORMAT_VERSION_V4 = 8;
 const SequenceNum kInvalidSeq = 0;
 
 DECLARE_uint32(minIoAlignment);


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #2260 

Problem Summary: 

ChunkFileMetaPage and SnapshotMetaPage does not take endianness into consideration

What's Changed:

Take endianness into consideration
Add verison 

Side effects(Breaking backward compatibility? Performance regression?):
The metapage's attributes will convert to network endianess after encode. 
Change metapage the version if the metapage is new or have been decoded.

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
