### PR TITLE
[fix]tools-v2: bs delete file

### DIFF
--- a/tools-v2/pkg/cli/command/curvebs/delete/file/file.go
+++ b/tools-v2/pkg/cli/command/curvebs/delete/file/file.go
@@ -113,6 +113,10 @@ func (deleteCommand *DeleteCommand) ResultPlainOutput() error {
 }
 
 func (deleteCommand *DeleteCommand) AddFlags() {
+	config.AddFsMdsAddrFlag(deleteCommand.Cmd)
+	config.AddRpcTimeoutFlag(deleteCommand.Cmd)
+	config.AddRpcRetryTimesFlag(deleteCommand.Cmd)
+
 	config.AddBsFilenameRequiredFlag(deleteCommand.Cmd)
 	config.AddBsUsernameRequiredFlag(deleteCommand.Cmd)
 	config.AddBsPasswordOptionFlag(deleteCommand.Cmd)


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #2402 

Problem Summary: curve bs delete file raises panic

### What is changed and how it works?

What's Changed: /tools-v2/pkg/cli/command/delete/file.go

How it Works: registering the flags for RPC communication in the Init function

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [x] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license
