### PR TITLE
[fix]: toos-v2: bs create file

### DIFF
--- a/tools-v2/pkg/cli/command/curvebs/create/file/file.go
+++ b/tools-v2/pkg/cli/command/curvebs/create/file/file.go
@@ -42,7 +42,6 @@ type fileCommand struct {
 
 var _ basecmd.FinalCurveCmdFunc = (*fileCommand)(nil)
 
-
 func (fCmd *fileCommand) Init(cmd *cobra.Command, args []string) error {
 	config.AddBsFileTypeRequiredFlag(fCmd.Cmd)
 	fCmd.Cmd.ParseFlags([]string{
@@ -77,7 +76,7 @@ func (fCmd *fileCommand) AddFlags() {
 	config.AddBsPathRequiredFlag(fCmd.Cmd)
 	config.AddBsUserOptionFlag(fCmd.Cmd)
 	config.AddBsPasswordOptionFlag(fCmd.Cmd)
-	config.AddBsSizeRequiredFlag(fCmd.Cmd)
+	config.AddBsSizeOptionFlag(fCmd.Cmd)
 	config.AddBsStripeUnitOptionFlag(fCmd.Cmd)
 	config.AddBsStripeCountOptionFlag(fCmd.Cmd)
 }

--- a/tools-v2/pkg/config/bs.go
+++ b/tools-v2/pkg/config/bs.go
@@ -231,7 +231,7 @@ func AddBsEtcdAddrFlag(cmd *cobra.Command) {
 }
 
 func AddBsSizeOptionFlag(cmd *cobra.Command) {
-	AddBsStringOptionFlag(cmd, CURVEBS_SIZE, "size, just like: 10GiB")
+	AddBsUint64OptionFlag(cmd, CURVEBS_SIZE, "size, unit is GiB")
 }
 
 func AddBsStripeUnitOptionFlag(cmd *cobra.Command) {


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

some bugs in `size` flag in `bs create file`

Problem Summary:

### What is changed and how it works?

What's Changed: /tools-v2/pkg/cli/command/curvebs/create/file/file.go and /tools-v2/pkg/config/bs.go

How it Works: use uint64 instead of string and change this flag to optional

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [x] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license
