### PR TITLE
[skipci] doc: modify build_and_run_en.md

### DIFF
--- a/docs/en/build_and_run_en.md
+++ b/docs/en/build_and_run_en.md
@@ -32,7 +32,7 @@ docker build -t opencurvedocker/curve-base:build-debian9
 docker run -it opencurvedocker/curve-base:build-debian9 /bin/bash
 cd <workspace>
 git clone https://github.com/opencurve/curve.git or git clone https://gitee.com/mirrors/curve.git
-# (Mainland China optional) Replace external dependencies with domestic download points or mirror warehouses, which can speed up compilation： bash replace-curve-repo.sh
+# (Optional for Chinese mainland) Replace external dependencies with domestic download points or mirror warehouses, which can speed up compilation： bash replace-curve-repo.sh
 # before curve v2.0
 bash mk-tar.sh （compile curvebs and make tar package）
 bash mk-deb.sh （compile curvebs and make debian package）


### PR DESCRIPTION
Document modify：
Modify `build_and_run_en.md`, change "Mainland China optional" to "Optional for Chinese mainland"，because both mainland and taiwan are one China. The adj should be China, not mainland.

reference:
[1] [为什么不要把「中国大陆」说成mainland China？](https://zhuanlan.zhihu.com/p/260814062)
[2] [embassy's translation](http://ae.china-embassy.gov.cn/eng/lsyw/1/1/)