### PR TITLE
build: refactor and fix build issues in mk-deb.sh and mk-tar.sh

### DIFF
--- a/mk-deb.sh
+++ b/mk-deb.sh
@@ -16,37 +16,39 @@
 #  limitations under the License.
 #
 
-dir=`pwd`
-#step1 清除生成的目录和文件
+set -o errexit
+
+dir=$(pwd)
+
+# step1 清除生成的目录和文件
 bazel clean
-rm -rf curvefs_python/BUILD
-rm -rf curvefs_python/tmplib/
-rm -rf curvesnapshot_python/BUILD
-rm -rf curvesnapshot_python/tmplib/
-rm -rf *.deb
-rm -rf *.whl
-rm -rf build
+
+cleandir=(
+    curvefs_python/BUILD
+    curvefs_python/tmplib/
+    curvesnapshot_python/BUILD
+    curvesnapshot_python/tmplib/
+    *.deb
+    *.whl
+    *.tar.gz
+    build
+)
+
+rm -rf "${cleandir[@]}"
 
 git submodule update --init
-if [ $? -ne 0 ]
-then
-    echo "submodule init failed"
-    exit
-fi
 
-#step2 获取tag版本和git提交版本信息
-#获取tag版本
-tag_version=`git status | grep -w "HEAD detached at" | awk '{print $NF}' | awk -F"v" '{print $2}'`
-if [ -z ${tag_version} ]
-then
+# step2 获取tag版本和git提交版本信息
+# 获取tag版本
+tag_version=$(git status | grep -Ew "HEAD detached at|On branch" | awk '{print $NF}' | awk -F"v" '{print $2}')
+if [ -z ${tag_version} ]; then
     echo "not found version info, set version to 9.9.9"
     tag_version=9.9.9
 fi
 
-#获取git提交版本信息
-commit_id=`git show --abbrev-commit HEAD|head -n 1|awk '{print $2}'`
-if [ "$1" = "debug" ]
-then
+# 获取git提交版本信息
+commit_id=$(git rev-parse --short HEAD)
+if [ "$1" = "debug" ]; then
     debug="+debug"
 else
     debug=""
@@ -55,9 +57,9 @@ fi
 curve_version=${tag_version}+${commit_id}${debug}
 
 function create_python_wheel() {
-    PYTHON_VER=$(basename $1)
-    curdir=$(pwd)
-    basedir="build/curvefs_${PYTHON_VER}/"
+    local PYTHON_VER=$(basename $1)
+    local curdir=$(pwd)
+    local basedir="build/curvefs_${PYTHON_VER}/"
 
     mkdir -p ${basedir}/tmplib
     mkdir -p ${basedir}/curvefs
@@ -93,9 +95,7 @@ function build_curvefs_python() {
             continue
         fi
 
-        bash ./curvefs_python/configure.sh $(basename ${bin})
-
-        if [ $? -ne 0 ]; then
+        if ! bash ./curvefs_python/configure.sh $(basename ${bin}); then
             echo "configure for ${bin} failed"
             continue
         fi
@@ -125,373 +125,161 @@ function build_curvefs_python() {
     done
 }
 
-#step3 执行编译
-bazel_version=`bazel version | grep "Build label" | awk '{print $3}'`
-if [ -z ${bazel_version} ]
-then
+# step3 执行编译
+bazel_version=$(bazel version | grep "Build label" | awk '{print $3}')
+if [ -z ${bazel_version} ]; then
     echo "please install bazel 4.2.2 first"
-    exit
+    exit 1
 fi
-if [ ${bazel_version} != "4.2.2" ]
-then
-    echo "bazel version must 4.2.2"
-    echo "now version is ${bazel_version}"
-    exit
+if [ ${bazel_version} != "4.2.2" ]; then
+    echo "bazel version must be 4.2.2"
+    echo "current version is ${bazel_version}"
+    exit 1
 fi
 echo "bazel version : ${bazel_version}"
 
-
 # check gcc version, gcc version must >= 4.8.5
-gcc_version_major=`gcc -dumpversion | awk -F'.' '{print $1}'`
-gcc_version_minor=`gcc -dumpversion | awk -F'.' '{print $2}'`
-gcc_version_pathlevel=`gcc -dumpversion | awk -F'.' '{print $3}'`
-if [ ${gcc_version_major} -lt 4 ]
-then
-    echo "gcc version must >= 4.8.5, current version is "`gcc -dumpversion`
-    exit
+gcc_version_major=$(gcc -dumpversion | awk -F'.' '{print $1}')
+gcc_version_minor=$(gcc -dumpversion | awk -F'.' '{print $2}')
+gcc_version_pathlevel=$(gcc -dumpversion | awk -F'.' '{print $3}')
+if [ ${gcc_version_major} -lt 4 ]; then
+    echo "gcc version must >= 4.8.5, current version is "$(gcc -dumpversion)
+    exit 1
 fi
 
-if [[ ${gcc_version_major} -eq 4 ]] && [[ ${gcc_version_minor} -lt 8 ]]
-then
-    echo "gcc version must >= 4.8.5, current version is "`gcc -dumpversion`
-    exit
+if [[ ${gcc_version_major} -eq 4 ]] && [[ ${gcc_version_minor} -lt 8 ]]; then
+    echo "gcc version must >= 4.8.5, current version is "$(gcc -dumpversion)
+    exit 1
 fi
 
-if  [[ ${gcc_version_major} -eq 4 ]] && [[ ${gcc_version_minor} -eq 8 ]] && [[ ${gcc_version_pathlevel} -lt 5 ]]
-then
-    echo "gcc version must >= 4.8.5, current version is "`gcc -dumpversion`
-    exit
+if [[ ${gcc_version_major} -eq 4 ]] && [[ ${gcc_version_minor} -eq 8 ]] && [[ ${gcc_version_pathlevel} -lt 5 ]]; then
+    echo "gcc version must >= 4.8.5, current version is "$(gcc -dumpversion)
+    exit 1
 fi
-echo "gcc version : "`gcc -dumpversion`
-echo "start compile"
+echo "gcc version : "$(gcc -dumpversion)
 
-cd ${dir}/thirdparties/etcdclient
-make clean
-make all
-if [ $? -ne 0 ]
-then
-    echo "make etcd client failed"
-    exit
-fi
-cd ${dir}
+echo "start compiling"
+
+cd ${dir}/thirdparties/etcdclient &&
+    make clean &&
+    make all &&
+    cd $OLDPWD
 
 cp ${dir}/thirdparties/etcdclient/libetcdclient.h ${dir}/include/etcdclient/etcdclient.h
-if [ `gcc -dumpversion | awk -F'.' '{print $1}'` -le 6 ]
-then
+
+if [ $(gcc -dumpversion | awk -F'.' '{print $1}') -le 6 ]; then
     bazelflags=''
 else
     bazelflags='--copt -faligned-new'
 fi
 
-if [ "$1" = "debug" ]
-then
-bazel build ... --copt -DHAVE_ZLIB=1 --compilation_mode=dbg -s --define=with_glog=true \
---define=libunwind=true --copt -DGFLAGS_NS=google --copt \
--Wno-error=format-security --copt -DUSE_BTHREAD_MUTEX --copt -DCURVEVERSION=${curve_version} \
---linkopt -L/usr/local/lib ${bazelflags}
-if [ $? -ne 0 ]
-then
-    echo "build phase1 failed"
-    exit
-fi
-bash ./curvefs_python/configure.sh python2
-if [ $? -ne 0 ]
-then
-    echo "configure failed"
-    exit
-fi
-bazel build curvefs_python:curvefs  --copt -DHAVE_ZLIB=1 --compilation_mode=dbg -s \
---define=with_glog=true --define=libunwind=true --copt -DGFLAGS_NS=google \
---copt \
--Wno-error=format-security --copt -DUSE_BTHREAD_MUTEX --linkopt \
--L${dir}/curvefs_python/tmplib/ --copt -DCURVEVERSION=${curve_version} \
---linkopt -L/usr/local/lib ${bazelflags}
-if [ $? -ne 0 ]
-then
-    echo "build phase2 failed"
-    exit
-fi
+if [ "$1" = "debug" ]; then
+    make build stor=bs release=0 dep=1 only=src/*
+
+    fail_count=0
+    for python in "python2" "python3"; do
+        if ! bash ./curvefs_python/configure.sh ${python}; then
+            echo "configure ${python} failed"
+            let fail_count++
+        fi
+    done
+
+    if [[ $fail_count -ge 2 ]]; then
+        echo "configure python2/3 failed"
+        exit
+    fi
+
+    bazel build curvefs_python:curvefs --copt -DHAVE_ZLIB=1 --compilation_mode=dbg -s \
+        --define=with_glog=true --define=libunwind=true --copt -DGFLAGS_NS=google \
+        --copt \
+        -Wno-error=format-security --copt -DUSE_BTHREAD_MUTEX --linkopt \
+        -L${dir}/curvefs_python/tmplib/ --copt -DCURVEVERSION=${curve_version} \
+        --linkopt -L/usr/local/lib ${bazelflags}
 else
-bazel build ... --copt -DHAVE_ZLIB=1 --copt -O2 -s --define=with_glog=true \
---define=libunwind=true --copt -DGFLAGS_NS=google --copt \
--Wno-error=format-security --copt -DUSE_BTHREAD_MUTEX --copt -DCURVEVERSION=${curve_version} \
---linkopt -L/usr/local/lib ${bazelflags}
-if [ $? -ne 0 ]
-then
-    echo "build phase1 failed"
-    exit
-fi
-bash ./curvefs_python/configure.sh python2
-if [ $? -ne 0 ]
-then
-    echo "configure failed"
-    exit
-fi
-bazel build curvefs_python:curvefs  --copt -DHAVE_ZLIB=1 --copt -O2 -s \
---define=with_glog=true --define=libunwind=true --copt -DGFLAGS_NS=google \
---copt \
--Wno-error=format-security --copt -DUSE_BTHREAD_MUTEX --linkopt \
--L${dir}/curvefs_python/tmplib/ --copt -DCURVEVERSION=${curve_version} \
---linkopt -L/usr/local/lib ${bazelflags}
-if [ $? -ne 0 ]
-then
-    echo "build phase2 failed"
-    exit
-fi
+    make build stor=bs release=1 dep=1 only=src/*
+
+    fail_count=0
+    for python in "python2" "python3"; do
+        if ! bash ./curvefs_python/configure.sh ${python}; then
+            echo "configure ${python} failed"
+            let fail_count++
+        fi
+    done
+
+    if [[ $fail_count -ge 2 ]]; then
+        echo "configure python2/3 failed"
+        exit
+    fi
+
+    bazel build curvefs_python:curvefs --copt -DHAVE_ZLIB=1 --copt -O2 -s \
+        --define=with_glog=true --define=libunwind=true --copt -DGFLAGS_NS=google \
+        --copt \
+        -Wno-error=format-security --copt -DUSE_BTHREAD_MUTEX --linkopt \
+        -L${dir}/curvefs_python/tmplib/ --copt -DCURVEVERSION=${curve_version} \
+        --linkopt -L/usr/local/lib ${bazelflags}
 fi
 echo "end compile"
 
 #step4 创建临时目录，拷贝二进制、lib库和配置模板
 mkdir build
-if [ $? -ne 0 ]
-then
-    exit
-fi
 cp -r curve-mds build/
-if [ $? -ne 0 ]
-then
-    exit
-fi
 cp -r curve-chunkserver build/
-if [ $? -ne 0 ]
-then
-    exit
-fi
 
 cp -r curve-sdk build/
-if [ $? -ne 0 ]
-then
-    exit
-fi
 cp -r curve-tools build/
-if [ $? -ne 0 ]
-then
-    exit
-fi
 cp -r curve-monitor build/
-if [ $? -ne 0 ]
-then
-    exit
-fi
 cp -r curve-snapshotcloneserver build/
-if [ $? -ne 0 ]
-then
-    exit
-fi
 cp -r curve-nginx build/
-if [ $? -ne 0 ]
-then
-    exit
-fi
 
 mkdir -p build/curve-mds/usr/bin
-if [ $? -ne 0 ]
-then
-    exit
-fi
+
 mkdir -p build/curve-mds/etc/curve
-if [ $? -ne 0 ]
-then
-    exit
-fi
 mkdir -p build/curve-mds/usr/lib
-if [ $? -ne 0 ]
-then
-    exit
-fi
 mkdir -p build/curve-tools/usr/bin
-if [ $? -ne 0 ]
-then
-    exit
-fi
 cp ./bazel-bin/src/mds/main/curvemds build/curve-mds/usr/bin/curve-mds
-if [ $? -ne 0 ]
-then
-    exit
-fi
-#cp ./bazel-bin/src/tools/curve_status_tool \
-#build/curve-mds/usr/bin/curve_status_tool
-#if [ $? -ne 0 ]
-#then
-#	exit
-#fi
 cp thirdparties/etcdclient/libetcdclient.so \
-build/curve-mds/usr/lib/libetcdclient.so
-if [ $? -ne 0 ]
-then
-    exit
-fi
-#cp ./conf/mds.conf build/curve-mds/etc/curve/mds.conf
-#if [ $? -ne 0 ]
-#then
-#	exit
-#fi
+    build/curve-mds/usr/lib/libetcdclient.so
 cp ./bazel-bin/tools/curvefsTool build/curve-mds/usr/bin/curve-tool
-if [ $? -ne 0 ]
-then
-    exit
-fi
 cp -r tools/snaptool build/curve-tools/usr/bin/snaptool-lib
 cp tools/snaptool/snaptool build/curve-tools/usr/bin/snaptool
 chmod a+x build/curve-tools/usr/bin/snaptool
-if [ $? -ne 0 ]
-then
-      exit
-fi
 cp ./bazel-bin/src/tools/curve_tool \
-build/curve-tools/usr/bin/curve_ops_tool
-if [ $? -ne 0 ]
-then
-    exit
-fi
+    build/curve-tools/usr/bin/curve_ops_tool
 mkdir -p build/curve-chunkserver/usr/bin
-if [ $? -ne 0 ]
-then
-    exit
-fi
 mkdir -p build/curve-chunkserver/etc/curve
-if [ $? -ne 0 ]
-then
-    exit
-fi
 cp ./bazel-bin/src/chunkserver/chunkserver \
-build/curve-chunkserver/usr/bin/curve-chunkserver
-if [ $? -ne 0 ]
-then
-    exit
-fi
+    build/curve-chunkserver/usr/bin/curve-chunkserver
 cp ./bazel-bin/src/tools/curve_chunkserver_tool \
-build/curve-chunkserver/usr/bin/curve_chunkserver_tool
-if [ $? -ne 0 ]
-then
-    exit
-fi
-#cp ./conf/chunkserver.conf.example \
-#build/curve-chunkserver/etc/curve/chunkserver.conf
-#if [ $? -ne 0 ]
-#then
-#	exit
-#fi
-#cp ./conf/s3.conf build/curve-chunkserver/etc/curve/s3.conf
-#if [ $? -ne 0 ]
-#then
-#	exit
-#fi
+    build/curve-chunkserver/usr/bin/curve_chunkserver_tool
 
 cp ./bazel-bin/src/tools/curve_format \
-build/curve-chunkserver/usr/bin/curve-format
-if [ $? -ne 0 ]
-then
-    exit
-fi
+    build/curve-chunkserver/usr/bin/curve-format
 
 mkdir -p build/curve-sdk/usr/curvefs
-if [ $? -ne 0 ]
-then
-    exit
-fi
 mkdir -p build/curve-sdk/usr/bin
-if [ $? -ne 0 ]
-then
-    exit
-fi
 mkdir -p build/curve-sdk/etc/curve
-if [ $? -ne 0 ]
-then
-    exit
-fi
 mkdir -p build/curve-sdk/usr/lib
-if [ $? -ne 0 ]
-then
-    exit
-fi
 mkdir -p build/curve-sdk/usr/include
-if [ $? -ne 0 ]
-then
-    exit
-fi
 cp ./bazel-bin/curvefs_python/libcurvefs.so \
-build/curve-sdk/usr/curvefs/_curvefs.so
-if [ $? -ne 0 ]
-then
-    exit
-fi
+    build/curve-sdk/usr/curvefs/_curvefs.so
 cp curvefs_python/curvefs.py build/curve-sdk/usr/curvefs/curvefs.py
-if [ $? -ne 0 ]
-then
-    exit
-fi
 cp curvefs_python/__init__.py build/curve-sdk/usr/curvefs/__init__.py
-if [ $? -ne 0 ]
-then
-    exit
-fi
 cp curvefs_python/curvefs_tool.py build/curve-sdk/usr/curvefs/curvefs_tool.py
-if [ $? -ne 0 ]
-then
-    exit
-fi
 cp curvefs_python/parser.py build/curve-sdk/usr/curvefs/parser.py
-if [ $? -ne 0 ]
-then
-    exit
-fi
 cp curvefs_python/curve build/curve-sdk/usr/bin/curve
-if [ $? -ne 0 ]
-then
-    exit
-fi
 chmod a+x build/curve-sdk/usr/bin/curve
 cp curvefs_python/tmplib/* build/curve-sdk/usr/lib/
-if [ $? -ne 0 ]
-then
-    exit
-fi
-cp ./bazel-bin/src/client/libcurve.so build/curve-sdk/usr/lib
 cp include/client/libcurve.h build/curve-sdk/usr/include
 cp include/client/libcbd.h build/curve-sdk/usr/include
 cp include/client/libcurve_define.h build/curve-sdk/usr/include
-if [ $? -ne 0 ]
-then
-    exit
-fi
-#cp ./conf/client.conf build/curve-sdk/etc/curve/client.conf
-#if [ $? -ne 0 ]
-#then
-#	exit
-#fi
 mkdir -p build/curve-monitor/etc/curve/monitor
-if [ $? -ne 0 ]
-then
-    exit
-fi
 cp -r monitor/* build/curve-monitor/etc/curve/monitor
-if [ $? -ne 0 ]
-then
-    exit
-fi
 mkdir -p build/curve-snapshotcloneserver/usr/bin
-if [ $? -ne 0 ]
-then
-    exit
-fi
 cp ./bazel-bin/src/snapshotcloneserver/snapshotcloneserver \
-build/curve-snapshotcloneserver/usr/bin/curve-snapshotcloneserver
-if [ $? -ne 0 ]
-then
-    exit
-fi
+    build/curve-snapshotcloneserver/usr/bin/curve-snapshotcloneserver
 
 mkdir -p build/curve-nginx/etc/curve/nginx/app/etc
-if [ $? -ne 0 ]
-then
-    exit
-fi
 mkdir -p build/curve-nginx/etc/curve/nginx/conf
-if [ $? -ne 0 ]
-then
-    exit
-fi
 # step 4.1 prepare for nebd-package
 cp -r nebd/nebd-package build/
 mkdir -p build/nebd-package/usr/include/nebd
@@ -505,8 +293,7 @@ cp -r k8s/nebd/nebd-package build/k8s-nebd-package
 mkdir -p build/k8s-nebd-package/usr/bin
 mkdir -p build/k8s-nebd-package/usr/lib/nebd
 
-for i in `find bazel-bin/|grep -w so|grep -v solib|grep -v params|grep -v test|grep -v fake`
-do
+for i in $(find bazel-bin/ | grep -w so | grep -v solib | grep -v params | grep -v test | grep -v fake); do
     cp -f $i build/nebd-package/usr/lib/nebd
     cp -f $i build/k8s-nebd-package/usr/lib/nebd
 done
@@ -524,19 +311,19 @@ cp -r k8s/nbd/nbd-package build/k8s-nbd-package
 mkdir -p build/k8s-nbd-package/usr/bin
 cp bazel-bin/nbd/src/curve-nbd build/k8s-nbd-package/usr/bin
 
-#step5 记录到debian包的配置文件，打包debian包
+# step5 记录到debian包的配置文件，打包debian包
 version="Version: ${curve_version}"
-echo ${version} >> build/curve-mds/DEBIAN/control
-echo ${version} >> build/curve-sdk/DEBIAN/control
-echo ${version} >> build/curve-chunkserver/DEBIAN/control
-echo ${version} >> build/curve-tools/DEBIAN/control
-echo ${version} >> build/curve-monitor/DEBIAN/control
-echo ${version} >> build/curve-snapshotcloneserver/DEBIAN/control
-echo ${version} >> build/curve-nginx/DEBIAN/control
-echo ${version} >> build/nebd-package/DEBIAN/control
-echo ${version} >> build/k8s-nebd-package/DEBIAN/control
-echo ${version} >> build/nbd-package/DEBIAN/control
-echo ${version} >> build/k8s-nbd-package/DEBIAN/control
+echo ${version} >>build/curve-mds/DEBIAN/control
+echo ${version} >>build/curve-sdk/DEBIAN/control
+echo ${version} >>build/curve-chunkserver/DEBIAN/control
+echo ${version} >>build/curve-tools/DEBIAN/control
+echo ${version} >>build/curve-monitor/DEBIAN/control
+echo ${version} >>build/curve-snapshotcloneserver/DEBIAN/control
+echo ${version} >>build/curve-nginx/DEBIAN/control
+echo ${version} >>build/nebd-package/DEBIAN/control
+echo ${version} >>build/k8s-nebd-package/DEBIAN/control
+echo ${version} >>build/nbd-package/DEBIAN/control
+echo ${version} >>build/k8s-nbd-package/DEBIAN/control
 
 dpkg-deb -b build/curve-mds .
 dpkg-deb -b build/curve-sdk .
@@ -550,7 +337,7 @@ dpkg-deb -b build/k8s-nebd-package .
 dpkg-deb -b build/nbd-package .
 dpkg-deb -b build/k8s-nbd-package .
 
-#step6 清理libetcdclient.so编译出现的临时文件
+# step6 清理libetcdclient.so编译出现的临时文件
 cd ${dir}/thirdparties/etcdclient
 make clean
 cd ${dir}

--- a/mk-tar.sh
+++ b/mk-tar.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 #
 #  Copyright (c) 2020 NetEase Inc.
@@ -16,37 +16,39 @@
 #  limitations under the License.
 #
 
-dir=`pwd`
-#step1 清除生成的目录和文件
+set -o errexit
+
+dir=$(pwd)
+
+# step1 清除生成的目录和文件
 bazel clean
-rm -rf curvefs_python/BUILD
-rm -rf curvefs_python/tmplib/
-rm -rf curvesnapshot_python/BUILD
-rm -rf curvesnapshot_python/tmplib/
-rm -rf *.whl
-rm -rf *.tar.gz
-rm -rf build
+
+cleandir=(
+    curvefs_python/BUILD
+    curvefs_python/tmplib/
+    curvesnapshot_python/BUILD
+    curvesnapshot_python/tmplib/
+    *.deb
+    *.whl
+    *.tar.gz
+    build
+)
+
+rm -rf "${cleandir[@]}"
 
 git submodule update --init
-if [ $? -ne 0 ]
-then
-    echo "submodule init failed"
-    exit
-fi
 
-#step2 获取tag版本和git提交版本信息
-#获取tag版本
-tag_version=`git status | grep -Ew "HEAD detached at|On branch" | awk '{print $NF}' | awk -F"v" '{print $2}'`
-if [ -z ${tag_version} ]
-then
+# step2 获取tag版本和git提交版本信息
+# 获取tag版本
+tag_version=$(git status | grep -Ew "HEAD detached at|On branch" | awk '{print $NF}' | awk -F"v" '{print $2}')
+if [ -z ${tag_version} ]; then
     echo "not found version info, set version to 9.9.9"
     tag_version=9.9.9
 fi
 
-#获取git提交版本信息
-commit_id=`git show --abbrev-commit HEAD|head -n 1|awk '{print $2}'`
-if [ "$1" = "debug" ]
-then
+# 获取git提交版本信息
+commit_id=$(git rev-parse --short HEAD)
+if [ "$1" = "debug" ]; then
     debug="+debug"
 else
     debug=""
@@ -55,9 +57,9 @@ fi
 curve_version=${tag_version}+${commit_id}${debug}
 
 function create_python_wheel() {
-    PYTHON_VER=$(basename $1)
-    curdir=$(pwd)
-    basedir="build/curvefs_${PYTHON_VER}/"
+    local PYTHON_VER=$(basename $1)
+    local curdir=$(pwd)
+    local basedir="build/curvefs_${PYTHON_VER}/"
 
     mkdir -p ${basedir}/tmplib
     mkdir -p ${basedir}/curvefs
@@ -93,9 +95,7 @@ function build_curvefs_python() {
             continue
         fi
 
-        bash ./curvefs_python/configure.sh $(basename ${bin})
-
-        if [ $? -ne 0 ]; then
+        if ! bash ./curvefs_python/configure.sh $(basename ${bin}); then
             echo "configure for ${bin} failed"
             continue
         fi
@@ -125,320 +125,160 @@ function build_curvefs_python() {
     done
 }
 
-#step3 执行编译
-bazel_version=`bazel version | grep "Build label" | awk '{print $3}'`
-if [ -z ${bazel_version} ]
-then
+# step3 执行编译
+bazel_version=$(bazel version | grep "Build label" | awk '{print $3}')
+if [ -z ${bazel_version} ]; then
     echo "please install bazel 4.2.2 first"
-    exit
+    exit 1
 fi
-if [ ${bazel_version} != "4.2.2" ]
-then
-    echo "bazel version must 4.2.2"
-    echo "now version is ${bazel_version}"
-    exit
+if [ ${bazel_version} != "4.2.2" ]; then
+    echo "bazel version must be 4.2.2"
+    echo "current version is ${bazel_version}"
+    exit 1
 fi
 echo "bazel version : ${bazel_version}"
 
 # check gcc version, gcc version must >= 4.8.5
-gcc_version_major=`gcc -dumpversion | awk -F'.' '{print $1}'`
-gcc_version_minor=`gcc -dumpversion | awk -F'.' '{print $2}'`
-gcc_version_pathlevel=`gcc -dumpversion | awk -F'.' '{print $3}'`
-if [ ${gcc_version_major} -lt 4 ]
-then
-    echo "gcc version must >= 4.8.5, current version is "`gcc -dumpversion`
-    exit
+gcc_version_major=$(gcc -dumpversion | awk -F'.' '{print $1}')
+gcc_version_minor=$(gcc -dumpversion | awk -F'.' '{print $2}')
+gcc_version_pathlevel=$(gcc -dumpversion | awk -F'.' '{print $3}')
+if [ ${gcc_version_major} -lt 4 ]; then
+    echo "gcc version must >= 4.8.5, current version is "$(gcc -dumpversion)
+    exit 1
 fi
 
-if [[ ${gcc_version_major} -eq 4 ]] && [[ ${gcc_version_minor} -lt 8 ]]
-then
-    echo "gcc version must >= 4.8.5, current version is "`gcc -dumpversion`
-    exit
+if [[ ${gcc_version_major} -eq 4 ]] && [[ ${gcc_version_minor} -lt 8 ]]; then
+    echo "gcc version must >= 4.8.5, current version is "$(gcc -dumpversion)
+    exit 1
 fi
 
-if  [[ ${gcc_version_major} -eq 4 ]] && [[ ${gcc_version_minor} -eq 8 ]] && [[ ${gcc_version_pathlevel} -lt 5 ]]
-then
-    echo "gcc version must >= 4.8.5, current version is "`gcc -dumpversion`
-    exit
+if [[ ${gcc_version_major} -eq 4 ]] && [[ ${gcc_version_minor} -eq 8 ]] && [[ ${gcc_version_pathlevel} -lt 5 ]]; then
+    echo "gcc version must >= 4.8.5, current version is "$(gcc -dumpversion)
+    exit 1
 fi
-echo "gcc version : "`gcc -dumpversion`
+echo "gcc version : "$(gcc -dumpversion)
 
-echo "start compile"
-cd ${dir}/thirdparties/etcdclient
-make clean
-make all
-if [ $? -ne 0 ]
-then
-    echo "make etcd client failed"
-    exit
-fi
-cd ${dir}
+echo "start compiling"
+
+cd ${dir}/thirdparties/etcdclient &&
+    make clean &&
+    make all &&
+    cd $OLDPWD
 
 cp ${dir}/thirdparties/etcdclient/libetcdclient.h ${dir}/include/etcdclient/etcdclient.h
 
-if [ `gcc -dumpversion | awk -F'.' '{print $1}'` -le 6 ]
-then
+if [ $(gcc -dumpversion | awk -F'.' '{print $1}') -le 6 ]; then
     bazelflags=''
 else
     bazelflags='--copt -faligned-new'
 fi
 
-if [ "$1" = "debug" ]
-then
-bazel build ... --copt -DHAVE_ZLIB=1 --compilation_mode=dbg -s --define=with_glog=true \
---define=libunwind=true --copt -DGFLAGS_NS=google --copt \
--Wno-error=format-security --copt -DUSE_BTHREAD_MUTEX --copt -DCURVEVERSION=${curve_version} \
---linkopt -L/usr/local/lib ${bazelflags}
-if [ $? -ne 0 ]
-then
-    echo "build phase1 failed"
-    exit
-fi
-bash ./curvefs_python/configure.sh python2
-if [ $? -ne 0 ]
-then
-    echo "configure failed"
-    exit
-fi
-bazel build curvefs_python:curvefs  --copt -DHAVE_ZLIB=1 --compilation_mode=dbg -s \
---define=with_glog=true --define=libunwind=true --copt -DGFLAGS_NS=google \
---copt \
--Wno-error=format-security --copt -DUSE_BTHREAD_MUTEX --linkopt \
--L${dir}/curvefs_python/tmplib/ --copt -DCURVEVERSION=${curve_version} \
---linkopt -L/usr/local/lib ${bazelflags}
-if [ $? -ne 0 ]
-then
-    echo "build phase2 failed"
-    exit
-fi
-else
-bazel build ... --copt -DHAVE_ZLIB=1 --copt -O2 -s --define=with_glog=true \
---define=libunwind=true --copt -DGFLAGS_NS=google --copt \
--Wno-error=format-security --copt -DUSE_BTHREAD_MUTEX --copt -DCURVEVERSION=${curve_version} \
---linkopt -L/usr/local/lib ${bazelflags}
-if [ $? -ne 0 ]
-then
-    echo "build phase1 failed"
-    exit
-fi
-fail_count=0
-for python in "python2" "python3"; do 
-    bash ./curvefs_python/configure.sh ${python}
-    if [ $? -ne 0 ]
-    then
-        echo "configure ${python} failed"
-        let fail_count++
+if [ "$1" = "debug" ]; then
+    make build stor=bs release=0 dep=1 only=src/*
+
+    fail_count=0
+    for python in "python2" "python3"; do
+        if ! bash ./curvefs_python/configure.sh ${python}; then
+            echo "configure ${python} failed"
+            let fail_count++
+        fi
+    done
+
+    if [[ $fail_count -ge 2 ]]; then
+        echo "configure python2/3 failed"
+        exit
     fi
-done
 
-if [ $fail_count -ge 2] 
-then
-    echo "configure python2/3 failed"
-    exit
-fi
+    bazel build curvefs_python:curvefs --copt -DHAVE_ZLIB=1 --compilation_mode=dbg -s \
+        --define=with_glog=true --define=libunwind=true --copt -DGFLAGS_NS=google \
+        --copt \
+        -Wno-error=format-security --copt -DUSE_BTHREAD_MUTEX --linkopt \
+        -L${dir}/curvefs_python/tmplib/ --copt -DCURVEVERSION=${curve_version} \
+        --linkopt -L/usr/local/lib ${bazelflags}
+else
+    make build stor=bs release=1 dep=1 only=src/*
 
-bazel build curvefs_python:curvefs  --copt -DHAVE_ZLIB=1 --copt -O2 -s \
---define=with_glog=true --define=libunwind=true --copt -DGFLAGS_NS=google \
---copt \
--Wno-error=format-security --copt -DUSE_BTHREAD_MUTEX --linkopt \
--L${dir}/curvefs_python/tmplib/ --copt -DCURVEVERSION=${curve_version} \
---linkopt -L/usr/local/lib ${bazelflags}
-if [ $? -ne 0 ]
-then
-    echo "build phase2 failed"
-    exit
-fi
+    fail_count=0
+    for python in "python2" "python3"; do
+        if ! bash ./curvefs_python/configure.sh ${python}; then
+            echo "configure ${python} failed"
+            let fail_count++
+        fi
+    done
+
+    if [[ $fail_count -ge 2 ]]; then
+        echo "configure python2/3 failed"
+        exit
+    fi
+
+    bazel build curvefs_python:curvefs --copt -DHAVE_ZLIB=1 --copt -O2 -s \
+        --define=with_glog=true --define=libunwind=true --copt -DGFLAGS_NS=google \
+        --copt \
+        -Wno-error=format-security --copt -DUSE_BTHREAD_MUTEX --linkopt \
+        -L${dir}/curvefs_python/tmplib/ --copt -DCURVEVERSION=${curve_version} \
+        --linkopt -L/usr/local/lib ${bazelflags}
 fi
 echo "end compile"
 
 #step4 创建临时目录，拷贝二进制、lib库和配置模板
 echo "start copy"
 mkdir -p build/curve/
-if [ $? -ne 0 ]
-then
-    exit
-fi
 # curve-mds
 mkdir -p build/curve/curve-mds/bin
-if [ $? -ne 0 ]
-then
-    exit
-fi
 mkdir -p build/curve/curve-mds/lib
-if [ $? -ne 0 ]
-then
-    exit
-fi
 cp ./bazel-bin/src/mds/main/curvemds build/curve/curve-mds/bin/curve-mds
-if [ $? -ne 0 ]
-then
-    exit
-fi
 cp thirdparties/etcdclient/libetcdclient.so \
-build/curve/curve-mds/lib/libetcdclient.so
-if [ $? -ne 0 ]
-then
-    exit
-fi
+    build/curve/curve-mds/lib/libetcdclient.so
 cp ./bazel-bin/tools/curvefsTool build/curve/curve-mds/bin/curve-tool
-if [ $? -ne 0 ]
-then
-    exit
-fi
 # curve-tools
 mkdir -p build/curve/curve-tools/bin
-if [ $? -ne 0 ]
-then
-    exit
-fi
 cp ./bazel-bin/src/tools/curve_tool \
-build/curve/curve-tools/bin/curve_ops_tool
-if [ $? -ne 0 ]
-then
-    exit
-fi
+    build/curve/curve-tools/bin/curve_ops_tool
 cp -r tools/snaptool build/curve/curve-tools/bin/snaptool-lib
 cp tools/snaptool/snaptool build/curve/curve-tools/bin/snaptool
 chmod a+x build/curve/curve-tools/bin/snaptool
-if [ $? -ne 0 ]
-then
-      exit
-fi
 # curve-chunkserver
 mkdir -p build/curve/curve-chunkserver/bin
-if [ $? -ne 0 ]
-then
-    exit
-fi
 cp ./bazel-bin/src/chunkserver/chunkserver \
-build/curve/curve-chunkserver/bin/curve-chunkserver
-if [ $? -ne 0 ]
-then
-    exit
-fi
+    build/curve/curve-chunkserver/bin/curve-chunkserver
 cp ./bazel-bin/src/tools/curve_chunkserver_tool \
-build/curve/curve-chunkserver/bin/curve_chunkserver_tool
-if [ $? -ne 0 ]
-then
-    exit
-fi
+    build/curve/curve-chunkserver/bin/curve_chunkserver_tool
 cp ./bazel-bin/src/tools/curve_format \
-build/curve/curve-chunkserver/bin/curve-format
-if [ $? -ne 0 ]
-then
-    exit
-fi
+    build/curve/curve-chunkserver/bin/curve-format
 # curve-sdk
 mkdir -p build/curve/curve-sdk/curvefs
-if [ $? -ne 0 ]
-then
-    exit
-fi
 mkdir -p build/curve/curve-sdk/bin
-if [ $? -ne 0 ]
-then
-    exit
-fi
 mkdir -p build/curve/curve-sdk/lib
-if [ $? -ne 0 ]
-then
-    exit
-fi
 mkdir -p build/curve/curve-sdk/include
-if [ $? -ne 0 ]
-then
-    exit
-fi
 cp ./bazel-bin/curvefs_python/libcurvefs.so \
-build/curve/curve-sdk/curvefs/_curvefs.so
-if [ $? -ne 0 ]
-then
-    exit
-fi
+    build/curve/curve-sdk/curvefs/_curvefs.so
 cp curvefs_python/curvefs.py build/curve/curve-sdk/curvefs/curvefs.py
-if [ $? -ne 0 ]
-then
-    exit
-fi
 cp curvefs_python/__init__.py build/curve/curve-sdk/curvefs/__init__.py
-if [ $? -ne 0 ]
-then
-    exit
-fi
 cp curvefs_python/curvefs_tool.py build/curve/curve-sdk/curvefs/curvefs_tool.py
-if [ $? -ne 0 ]
-then
-    exit
-fi
 cp curvefs_python/parser.py build/curve/curve-sdk/curvefs/parser.py
-if [ $? -ne 0 ]
-then
-    exit
-fi
 cp curvefs_python/curve build/curve/curve-sdk/bin/curve
-if [ $? -ne 0 ]
-then
-    exit
-fi
 chmod a+x build/curve/curve-sdk/bin/curve
 cp curvefs_python/tmplib/* build/curve/curve-sdk/lib/
-if [ $? -ne 0 ]
-then
-    exit
-fi
-cp ./bazel-bin/src/client/libcurve.so build/curve/curve-sdk/lib/
 cp include/client/libcurve.h build/curve/curve-sdk/include
 cp include/client/libcbd.h build/curve/curve-sdk/include
 cp include/client/libcurve_define.h build/curve/curve-sdk/include
-if [ $? -ne 0 ]
-then
-    exit
-fi
 # curve-snapshotcloneserver
 mkdir -p build/curve/curve-snapshotcloneserver/bin
-if [ $? -ne 0 ]
-then
-    exit
-fi
 cp ./bazel-bin/src/snapshotcloneserver/snapshotcloneserver \
-build/curve/curve-snapshotcloneserver/bin/curve-snapshotcloneserver
-if [ $? -ne 0 ]
-then
-    exit
-fi
+    build/curve/curve-snapshotcloneserver/bin/curve-snapshotcloneserver
 mkdir -p build/curve/curve-snapshotcloneserver/lib
 cp thirdparties/etcdclient/libetcdclient.so \
-build/curve/curve-snapshotcloneserver/lib/libetcdclient.so
-if [ $? -ne 0 ]
-then
-    exit
-fi
+    build/curve/curve-snapshotcloneserver/lib/libetcdclient.so
 # curve-nginx
 mkdir -p build/curve/curve-nginx/app/etc
-if [ $? -ne 0 ]
-then
-    exit
-fi
 mkdir -p build/curve/curve-nginx/conf
-if [ $? -ne 0 ]
-then
-    exit
-fi
 # ansible
 cp -r curve-ansible build/curve/
-if [ $? -ne 0 ]
-then
-    exit
-fi
 # README
 
 # curve-monitor
 mkdir -p build/curve-monitor
 cp -r monitor/* build/curve-monitor/
-if [ $? -ne 0 ]
-then
-    exit
-fi
 echo "end copy"
 
 # step 4.1 prepare for nebd-package
@@ -446,8 +286,7 @@ mkdir -p build/nebd-package/include/nebd
 mkdir -p build/nebd-package/bin
 mkdir -p build/nebd-package/lib/nebd
 
-for i in `find bazel-bin/|grep -w so|grep -v solib|grep -v params|grep -v test|grep -v fake`
-do
+for i in $(find bazel-bin/ | grep -w so | grep -v solib | grep -v params | grep -v test | grep -v fake); do
     cp -f $i build/nebd-package/lib/nebd
 done
 
@@ -462,35 +301,35 @@ cp nbd/nbd-package/usr/bin/map_curve_disk.sh build/nbd-package/bin
 cp nbd/nbd-package/etc/curve/curvetab build/nbd-package/etc
 cp nbd/nbd-package/etc/systemd/system/map_curve_disk.service build/nbd-package/etc
 
-#step5 打包tar包
+# step5 打包tar包
 echo "start make tarball"
 cd ${dir}/build
 curve_name="curve_${curve_version}.tar.gz"
 echo "curve_name: ${curve_name}"
-tar zcvf ${curve_name} curve
+tar zcf ${curve_name} curve
 cp ${curve_name} $dir
 monitor_name="curve-monitor_${curve_version}.tar.gz"
-echo "curve_name: ${curve_name}"
-tar zcvf ${monitor_name} curve-monitor
+echo "monitor_name: ${monitor_name}"
+tar zcf ${monitor_name} curve-monitor
 cp ${monitor_name} $dir
 nebd_name="nebd_${curve_version}.tar.gz"
 echo "nebd_name: ${nebd_name}"
-tar zcvf ${nebd_name} nebd-package
+tar zcf ${nebd_name} nebd-package
 cp ${nebd_name} $dir
 nbd_name="nbd_${curve_version}.tar.gz"
 echo "nbd_name: ${nbd_name}"
-tar zcvf ${nbd_name} nbd-package
+tar zcf ${nbd_name} nbd-package
 cp ${nbd_name} $dir
 echo "end make tarball"
 
-#step6 清理libetcdclient.so编译出现的临时文件
+# step6 清理libetcdclient.so编译出现的临时文件
 echo "start clean etcd"
 cd ${dir}/thirdparties/etcdclient
 make clean
 cd ${dir}
 echo "end clean etcd"
 
-# step7 打包python whell
-echo "start make python whell"
+# step7 打包python wheel
+echo "start make python wheel"
 build_curvefs_python $1
-echo "end make python whell"
+echo "end make python wheel"

--- a/thirdparties/memcache/Makefile
+++ b/thirdparties/memcache/Makefile
@@ -2,7 +2,7 @@
 .PHONY: download build clean
 
 build: clean download
-	@cd libmemcached-1.1.2 && mkdir build-libmemcached && cd build-libmemcached && cmake .. && make libmemcached
+	@cd libmemcached-1.1.2 && mkdir build-libmemcached && cd build-libmemcached && cmake .. && make libmemcached -j$$(nproc)
 	@cp libmemcached-1.1.2/build-libmemcached/include/libmemcached-1.0/configure.h libmemcached-1.1.2/include/libmemcached-1.0
 
 download: clean


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Part of #2024 .

Since #2024 will be reserved for OSPP2023, so only necessary build fixes and cleanups are included in this PR. It will NOT solve that issue.

### What is changed and how it works?

**What's Changed:**

- fix missing dependency (`memcache` and `rocksdb`) issues when using on a clean build machine
- clean up code by removing unnecessary error checking (replaced with `errexit`)
- format shell script to make it human-readable

Note that the first part of the `mk-deb.sh` and `mk-tar.sh` is intentionally made the same, so we can merge them easily later.

**Side effects(Breaking backward compatibility? Performance regression?):**

No. The build logic is not touched. Only additional dependency (`memcache` and `rocksdb`) is installed.

### Check List

- [x] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license
