### PR TITLE
[fix] optimize some metric style in curvefs

### DIFF
--- a/curvefs/src/client/metric/client_metric.cpp
+++ b/curvefs/src/client/metric/client_metric.cpp
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2023 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * Project: curve
+ * Created Date: Fri Apr 21 2023
+ * Author: Xinlong-Chen
+ */
+
+#include "curvefs/src/client/metric/client_metric.h"
+
+namespace curvefs {
+namespace client {
+namespace metric {
+
+const std::string MDSClientMetric::prefix = "curvefs_mds_client";  // NOLINT
+const std::string MetaServerClientMetric::prefix = "curvefs_metaserver_client";  // NOLINT
+const std::string ClientOpMetric::prefix = "curvefs_client";  // NOLINT
+const std::string S3MultiManagerMetric::prefix = "curvefs_client_manager";  // NOLINT
+const std::string FSMetric::prefix = "curvefs_client";  // NOLINT
+const std::string S3Metric::prefix = "curvefs_s3";  // NOLINT
+const std::string DiskCacheMetric::prefix = "curvefs_disk_cache";  // NOLINT
+const std::string KVClientMetric::prefix = "curvefs_kvclient";  // NOLINT
+const std::string S3ChunkInfoMetric::prefix = "inode_s3_chunk_info";  // NOLINT
+const std::string WarmupManagerS3Metric::prefix = "curvefs_warmup";  // NOLINT
+
+}  // namespace metric
+}  // namespace client
+}  // namespace curvefs
+

--- a/curvefs/src/client/metric/client_metric.h
+++ b/curvefs/src/client/metric/client_metric.h
@@ -36,8 +36,7 @@ namespace client {
 namespace metric {
 
 struct MDSClientMetric {
-    std::string prefix;
-    std::string mdsAddrs;
+    static const std::string prefix;
 
     InterfaceMetric mountFs;
     InterfaceMetric umountFs;
@@ -53,11 +52,8 @@ struct MDSClientMetric {
     InterfaceMetric commitTx;
     InterfaceMetric allocOrGetMemcacheCluster;
 
-    explicit MDSClientMetric(const std::string& prefix_ = "")
-        : prefix(!prefix_.empty() ? prefix_
-                                  : "curvefs_mds_client_" +
-                                        curve::common::ToHexString(this)),
-          mountFs(prefix, "mountFs"),
+    MDSClientMetric()
+        : mountFs(prefix, "mountFs"),
           umountFs(prefix, "umountFs"),
           getFsInfo(prefix, "getFsInfo"),
           getMetaServerInfo(prefix, "getMetaServerInfo"),
@@ -73,7 +69,7 @@ struct MDSClientMetric {
 };
 
 struct MetaServerClientMetric {
-    std::string prefix;
+    static const std::string prefix;
 
     // dentry
     InterfaceMetric getDentry;
@@ -97,11 +93,8 @@ struct MetaServerClientMetric {
     InterfaceMetric updateVolumeExtent;
     InterfaceMetric getVolumeExtent;
 
-    explicit MetaServerClientMetric(const std::string &prefix_ = "")
-        : prefix(!prefix_.empty() ? prefix_
-                                  : "curvefs_metaserver_client_" +
-                                        curve::common::ToHexString(this)),
-          getDentry(prefix, "getDentry"),
+    MetaServerClientMetric()
+        : getDentry(prefix, "getDentry"),
           listDentry(prefix, "listDentry"),
           createDentry(prefix, "createDentry"),
           deleteDentry(prefix, "deleteDentry"),
@@ -142,7 +135,7 @@ struct OpMetric {
 };
 
 struct ClientOpMetric {
-    std::string prefix;
+    static const std::string prefix;
 
     OpMetric opLookup;
     OpMetric opOpen;
@@ -169,10 +162,8 @@ struct ClientOpMetric {
     OpMetric opWrite;
 
 
-    explicit ClientOpMetric(const std::string &prefix_ = "")
-        : prefix(!prefix_.empty() ? prefix_
-                                  : "curvefs_client"),
-          opLookup(prefix, "opLookup"),
+    ClientOpMetric()
+        : opLookup(prefix, "opLookup"),
           opOpen(prefix, "opOpen"),
           opCreate(prefix, "opCreate"),
           opMkNod(prefix, "opMkNod"),
@@ -198,7 +189,8 @@ struct ClientOpMetric {
 };
 
 struct S3MultiManagerMetric {
-    const std::string prefix;
+    static const std::string prefix;
+
     bvar::Adder<int64_t> fileManagerNum;
     bvar::Adder<int64_t> chunkManagerNum;
     bvar::Adder<int64_t> writeDataCacheNum;
@@ -206,9 +198,7 @@ struct S3MultiManagerMetric {
     bvar::Adder<int64_t> readDataCacheNum;
     bvar::Adder<int64_t> readDataCacheByte;
 
-    explicit S3MultiManagerMetric(
-        const std::string &prefix_ = "curvefs_client_manager")
-        : prefix(prefix_) {
+    S3MultiManagerMetric() {
         fileManagerNum.expose_as(prefix, "file_manager_num");
         chunkManagerNum.expose_as(prefix, "chunk_manager_num");
         writeDataCacheNum.expose_as(prefix, "write_data_cache_num");
@@ -219,7 +209,7 @@ struct S3MultiManagerMetric {
 };
 
 struct FSMetric {
-    const std::string prefix = "curvefs_client";
+    static const std::string prefix;
 
     std::string fsName;
 
@@ -238,7 +228,7 @@ struct FSMetric {
 };
 
 struct S3Metric {
-    const std::string prefix = "curvefs_s3";
+    static const std::string prefix;
 
     std::string fsName;
     InterfaceMetric adaptorWrite;
@@ -264,7 +254,7 @@ struct S3Metric {
 };
 
 struct DiskCacheMetric {
-    const std::string prefix = "curvefs_disk_cache";
+    static const std::string prefix;
 
     std::string fsName;
     InterfaceMetric writeS3;
@@ -278,16 +268,17 @@ struct DiskCacheMetric {
 };
 
 struct KVClientMetric {
-    const std::string prefix = "curvefs_kvclient";
-    InterfaceMetric kvClientSet;
+    static const std::string prefix;
+
     InterfaceMetric kvClientGet;
+    InterfaceMetric kvClientSet;
 
     KVClientMetric()
         : kvClientGet(prefix, "get"), kvClientSet(prefix, "set") {}
 };
 
 struct S3ChunkInfoMetric {
-    const std::string prefix = "inode_s3_chunk_info";
+    static const std::string prefix;
 
     bvar::Adder<int64_t> s3ChunkInfoSize;
 
@@ -295,7 +286,8 @@ struct S3ChunkInfoMetric {
 };
 
 struct WarmupManagerS3Metric {
-    static constexpr const char* prefix = "curvefs_warmup";
+    static const std::string prefix;
+
     InterfaceMetric warmupS3Cached;
     bvar::Adder<uint64_t> warmupS3CacheSize;
 

--- a/curvefs/src/client/rpcclient/mds_client.h
+++ b/curvefs/src/client/rpcclient/mds_client.h
@@ -159,8 +159,7 @@ class MdsClient {
 
 class MdsClientImpl : public MdsClient {
  public:
-    explicit MdsClientImpl(const std::string &metricPrefix = "")
-        : mdsClientMetric_(metricPrefix) {}
+    MdsClientImpl() = default;
 
     FSStatusCode Init(const ::curve::client::MetaServerOption &mdsOpt,
                       MDSBaseClient *baseclient) override;

--- a/curvefs/src/client/rpcclient/metacache.h
+++ b/curvefs/src/client/rpcclient/metacache.h
@@ -25,12 +25,13 @@
 
 #include <brpc/channel.h>
 #include <brpc/controller.h>
-#include <unordered_map>
 
-#include <memory>
-#include <vector>
-#include <string>
 #include <map>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 #include "curvefs/proto/common.pb.h"
 #include "curvefs/src/client/common/common.h"

--- a/curvefs/src/client/rpcclient/metaserver_client.h
+++ b/curvefs/src/client/rpcclient/metaserver_client.h
@@ -172,8 +172,7 @@ class MetaServerClient {
 
 class MetaServerClientImpl : public MetaServerClient {
  public:
-    explicit MetaServerClientImpl(const std::string &metricPrefix = "")
-        : metric_(metricPrefix) {}
+    MetaServerClientImpl() = default;
 
     MetaStatusCode
     Init(const ExcutorOpt &excutorOpt, const ExcutorOpt &excutorInternalOpt,

--- a/curvefs/test/client/metric/BUILD
+++ b/curvefs/test/client/metric/BUILD
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2021 NetEase Inc.
+#  Copyright (c) 2023 NetEase Inc.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -14,17 +14,21 @@
 #  limitations under the License.
 #
 
-load("//:copts.bzl", "CURVE_DEFAULT_COPTS")
 
-cc_library(
-    name = "client_metric",
-    srcs = glob(["*.cpp"]),
-    hdrs = glob(["*.h"]),
-    copts = CURVE_DEFAULT_COPTS,
-    visibility = ["//visibility:public"],
-    deps = [
-        "//external:gflags",
-        "//external:bvar",
-        "//src/client:curve_client",
-    ],
+load("//:copts.bzl", "CURVE_TEST_COPTS")
+
+cc_test(
+   name = "client_metric_test",
+   srcs = glob([
+       "*.cpp",
+       "*.h"],
+   ),
+   copts = CURVE_TEST_COPTS,
+   deps = [
+        "//external:gtest",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+        "//curvefs/src/client/metric:client_metric",
+   ],
+   visibility = ["//visibility:public"],
 )

--- a/curvefs/test/client/metric/client_metric_test.cpp
+++ b/curvefs/test/client/metric/client_metric_test.cpp
@@ -1,0 +1,103 @@
+/*
+ *  Copyright (c) 2023 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * Project: curve
+ * Created Date: Fri Apr 21 2023
+ * Author: Xinlong-Chen
+ */
+
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+#include "curvefs/src/client/metric/client_metric.h"
+
+using ::curvefs::client::metric::MDSClientMetric;
+using ::curvefs::client::metric::MetaServerClientMetric;
+using ::curvefs::client::metric::ClientOpMetric;
+using ::curvefs::client::metric::S3MultiManagerMetric;
+using ::curvefs::client::metric::FSMetric;
+using ::curvefs::client::metric::S3Metric;
+using ::curvefs::client::metric::DiskCacheMetric;
+using ::curvefs::client::metric::KVClientMetric;
+using ::curvefs::client::metric::S3ChunkInfoMetric;
+using ::curvefs::client::metric::WarmupManagerS3Metric;
+
+
+namespace curvefs {
+namespace client {
+
+class ClientMetricTest : public ::testing::Test {
+ protected:
+    void SetUp() override {}
+    void TearDown() override {}
+};
+
+TEST_F(ClientMetricTest, test_prefix) {
+    {
+        const char* prefix = "curvefs_mds_client";
+        ASSERT_EQ(0, ::strcmp(MDSClientMetric::prefix.c_str(), prefix));
+    }
+
+    {
+        const char* prefix = "curvefs_metaserver_client";
+        ASSERT_EQ(0, ::strcmp(MetaServerClientMetric::prefix.c_str(), prefix));
+    }
+
+    {
+        const char* prefix = "curvefs_client";
+        ASSERT_EQ(0, ::strcmp(ClientOpMetric::prefix.c_str(), prefix));
+    }
+
+    {
+        const char* prefix = "curvefs_client_manager";
+        ASSERT_EQ(0, ::strcmp(S3MultiManagerMetric::prefix.c_str(), prefix));
+    }
+
+    {
+        const char* prefix = "curvefs_client";
+        ASSERT_EQ(0, ::strcmp(FSMetric::prefix.c_str(), prefix));
+    }
+
+    {
+        const char* prefix = "curvefs_s3";
+        ASSERT_EQ(0, ::strcmp(S3Metric::prefix.c_str(), prefix));
+    }
+
+    {
+        const char* prefix = "curvefs_disk_cache";
+        ASSERT_EQ(0, ::strcmp(DiskCacheMetric::prefix.c_str(), prefix));
+    }
+
+    {
+        const char* prefix = "curvefs_kvclient";
+        ASSERT_EQ(0, ::strcmp(KVClientMetric::prefix.c_str(), prefix));
+    }
+
+    {
+        const char* prefix = "inode_s3_chunk_info";
+        ASSERT_EQ(0, ::strcmp(S3ChunkInfoMetric::prefix.c_str(), prefix));
+    }
+
+    {
+        const char* prefix = "curvefs_warmup";
+        ASSERT_EQ(0, ::strcmp(WarmupManagerS3Metric::prefix.c_str(), prefix));
+    }
+}
+
+}  // namespace client
+}  // namespace curvefs


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #2319

Problem Summary: Use `static const std::string xxx` to replace `const std::string xxx`  in a struct type.

### What is changed and how it works?

What's Changed: some metric class in `curvefs/src/client/metric`, add a cpp file to initialize it;

How it Works: static variables only have one copy for all objects, so it occupy less memory in this way.

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
