### PR TITLE
Curvefs: enable async read for `FileCacheManager::ReadKVRequest`

### DIFF
--- a/curvefs/conf/client.conf
+++ b/curvefs/conf/client.conf
@@ -153,6 +153,8 @@ s3.threadScheduleInterval=3
 s3.cacheFlushIntervalSec=5
 s3.writeCacheMaxByte=838860800
 s3.readCacheMaxByte=209715200
+# file cache read thread num
+s3.readCacheThreads=5
 # http = 0, https = 1
 s3.http_scheme=0
 s3.verify_SSL=False

--- a/curvefs/src/client/BUILD
+++ b/curvefs/src/client/BUILD
@@ -73,6 +73,7 @@ cc_library(
         "//curvefs/src/common:dynamic_vlog",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/synchronization",
         "@com_google_absl//absl/meta:type_traits",
         "@com_google_absl//absl/types:optional",
         "@com_google_googletest//:gtest_prod",

--- a/curvefs/src/client/common/config.cpp
+++ b/curvefs/src/client/common/config.cpp
@@ -175,6 +175,8 @@ void InitS3Option(Configuration *conf, S3Option *s3Opt) {
                               &s3Opt->s3ClientAdaptorOpt.writeCacheMaxByte);
     conf->GetValueFatalIfFail("s3.readCacheMaxByte",
                               &s3Opt->s3ClientAdaptorOpt.readCacheMaxByte);
+    conf->GetValueFatalIfFail("s3.readCacheThreads",
+                              &s3Opt->s3ClientAdaptorOpt.readCacheThreads);
     conf->GetValueFatalIfFail("s3.nearfullRatio",
                               &s3Opt->s3ClientAdaptorOpt.nearfullRatio);
     conf->GetValueFatalIfFail("s3.baseSleepUs",

--- a/curvefs/src/client/common/config.h
+++ b/curvefs/src/client/common/config.h
@@ -131,6 +131,7 @@ struct S3ClientAdaptorOption {
     uint32_t flushIntervalSec;
     uint64_t writeCacheMaxByte;
     uint64_t readCacheMaxByte;
+    uint32_t readCacheThreads;
     uint32_t nearfullRatio;
     uint32_t baseSleepUs;
     uint32_t maxReadRetryIntervalMs;

--- a/curvefs/src/client/fuse_s3_client.cpp
+++ b/curvefs/src/client/fuse_s3_client.cpp
@@ -70,7 +70,9 @@ CURVEFS_ERROR FuseS3Client::Init(const FuseClientOption &option) {
     auto fsCacheManager = std::make_shared<FsCacheManager>(
         dynamic_cast<S3ClientAdaptorImpl *>(s3Adaptor_.get()),
         opt.s3Opt.s3ClientAdaptorOpt.readCacheMaxByte,
-        opt.s3Opt.s3ClientAdaptorOpt.writeCacheMaxByte, kvClientManager_);
+        opt.s3Opt.s3ClientAdaptorOpt.writeCacheMaxByte,
+        opt.s3Opt.s3ClientAdaptorOpt.readCacheThreads,
+        kvClientManager_);
     if (opt.s3Opt.s3ClientAdaptorOpt.diskCacheOpt.diskCacheType !=
         DiskCacheType::Disable) {
         auto s3DiskCacheClient = std::make_shared<S3ClientImpl>();

--- a/curvefs/src/client/s3/client_s3_adaptor.cpp
+++ b/curvefs/src/client/s3/client_s3_adaptor.cpp
@@ -100,6 +100,7 @@ S3ClientAdaptorImpl::Init(
               << ", flushIntervalSec: " << option.flushIntervalSec
               << ", writeCacheMaxByte: " << option.writeCacheMaxByte
               << ", readCacheMaxByte: " << option.readCacheMaxByte
+              << ", readCacheThreads: " << option.readCacheThreads
               << ", nearfullRatio: " << option.nearfullRatio
               << ", baseSleepUs: " << option.baseSleepUs;
     // start chunk flush threads

--- a/curvefs/test/client/chunk_cache_manager_test.cpp
+++ b/curvefs/test/client/chunk_cache_manager_test.cpp
@@ -53,12 +53,13 @@ class ChunkCacheManagerTest : public testing::Test {
         option.flushIntervalSec = 5000;
         option.readCacheMaxByte = 104857600;
         option.writeCacheMaxByte = 10485760000;
+        option.readCacheThreads = 5;
         option.chunkFlushThreads = 5;
         option.diskCacheOpt.diskCacheType = (DiskCacheType)0;
         s3ClientAdaptor_ = new S3ClientAdaptorImpl();
         auto fsCacheManager_ = std::make_shared<FsCacheManager>(
             s3ClientAdaptor_, option.readCacheMaxByte, option.writeCacheMaxByte,
-            nullptr);
+            option.readCacheThreads, nullptr);
         s3ClientAdaptor_->Init(option, nullptr, nullptr, nullptr,
                                fsCacheManager_, nullptr, nullptr);
         chunkCacheManager_ = std::make_shared<ChunkCacheManager>(

--- a/curvefs/test/client/client_s3_adaptor_Integration.cpp
+++ b/curvefs/test/client/client_s3_adaptor_Integration.cpp
@@ -136,6 +136,7 @@ class ClientS3IntegrationTest : public testing::Test {
         option.flushIntervalSec = 5000;
         option.readCacheMaxByte = 104857600;
         option.writeCacheMaxByte = 10485760000;
+        option.readCacheThreads = 5;
         option.diskCacheOpt.diskCacheType = (DiskCacheType)0;
         option.chunkFlushThreads = 5;
         option.objectPrefix = 0;
@@ -145,8 +146,8 @@ class ClientS3IntegrationTest : public testing::Test {
         std::shared_ptr<MockS3Client> mockS3Client(&mockS3Client_);
         s3ClientAdaptor_ = new S3ClientAdaptorImpl();
         auto fsCacheManager = std::make_shared<FsCacheManager>(
-            s3ClientAdaptor_, option.readCacheMaxByte,
-            option.writeCacheMaxByte, kvClientManager_);
+            s3ClientAdaptor_, option.readCacheMaxByte, option.writeCacheMaxByte,
+            option.readCacheThreads, kvClientManager_);
         s3ClientAdaptor_->Init(option, mockS3Client, mockInodeManager,
                                mockMdsClient, fsCacheManager, nullptr,
                                kvClientManager_);

--- a/curvefs/test/client/client_s3_adaptor_test.cpp
+++ b/curvefs/test/client/client_s3_adaptor_test.cpp
@@ -69,6 +69,7 @@ class ClientS3AdaptorTest : public testing::Test {
         option.flushIntervalSec = 5000;
         option.readCacheMaxByte = 104857600;
         option.writeCacheMaxByte = 10485760000;
+        option.readCacheThreads = 5;
         option.fuseMaxSize = 131072;
         option.chunkFlushThreads = 5;
         option.objectPrefix = 0;

--- a/curvefs/test/client/data_cache_test.cpp
+++ b/curvefs/test/client/data_cache_test.cpp
@@ -50,12 +50,13 @@ class DataCacheTest : public testing::Test {
         option.intervalSec = 5000;
         option.flushIntervalSec = 5000;
         option.readCacheMaxByte = 104857600;
+        option.readCacheThreads = 5;
         option.diskCacheOpt.diskCacheType = (DiskCacheType)0;
         option.chunkFlushThreads = 5;
         s3ClientAdaptor_ = new S3ClientAdaptorImpl();
         auto fsCacheManager = std::make_shared<FsCacheManager>(
-            s3ClientAdaptor_, option.readCacheMaxByte,
-            option.writeCacheMaxByte, nullptr);
+            s3ClientAdaptor_, option.readCacheMaxByte, option.writeCacheMaxByte,
+            option.readCacheThreads, nullptr);
         s3ClientAdaptor_->Init(option, nullptr, nullptr, nullptr,
                                fsCacheManager, nullptr, nullptr);
         mockChunkCacheManager_ = std::make_shared<MockChunkCacheManager>();

--- a/curvefs/test/client/file_cache_manager_test.cpp
+++ b/curvefs/test/client/file_cache_manager_test.cpp
@@ -28,6 +28,7 @@
 #include "curvefs/test/client/mock_client_s3_cache_manager.h"
 #include "curvefs/test/client/mock_inode_cache_manager.h"
 #include "curvefs/test/client/mock_client_s3.h"
+#include "src/common/concurrent/task_thread_pool.h"
 
 namespace curvefs {
 namespace client {
@@ -47,6 +48,7 @@ using ::testing::Return;
 using ::testing::SetArgPointee;
 using ::testing::SetArgReferee;
 using ::testing::WithArg;
+using curve::common::TaskThreadPool;
 
 // extern KVClientManager *g_kvClientManager;
 
@@ -66,19 +68,22 @@ class FileCacheManagerTest : public testing::Test {
         option.flushIntervalSec = 5000;
         option.readCacheMaxByte = 104857600;
         option.writeCacheMaxByte = 10485760000;
+        option.readCacheThreads = 5;
         option.diskCacheOpt.diskCacheType = (DiskCacheType)0;
         option.chunkFlushThreads = 5;
         s3ClientAdaptor_ = new S3ClientAdaptorImpl();
-        auto fsCacheManager_ = std::make_shared<FsCacheManager>(
+        auto fsCacheManager = std::make_shared<FsCacheManager>(
             s3ClientAdaptor_, option.readCacheMaxByte, option.writeCacheMaxByte,
-            nullptr);
+            option.readCacheThreads, nullptr);
         mockInodeManager_ = std::make_shared<MockInodeCacheManager>();
         mockS3Client_ = std::make_shared<MockS3Client>();
         s3ClientAdaptor_->Init(option, mockS3Client_, mockInodeManager_,
-                               nullptr, fsCacheManager_, nullptr, nullptr);
+                               nullptr, fsCacheManager, nullptr, nullptr);
         s3ClientAdaptor_->SetFsId(fsId);
+
+        threadPool_->Start(option.readCacheThreads);
         fileCacheManager_ = std::make_shared<FileCacheManager>(
-            fsId, inodeId, s3ClientAdaptor_, nullptr);
+            fsId, inodeId, s3ClientAdaptor_, nullptr, threadPool_);
         mockChunkCacheManager_ = std::make_shared<MockChunkCacheManager>();
         curvefs::client::common::FLAGS_enableCto = false;
         kvClientManager_ = nullptr;
@@ -97,6 +102,8 @@ class FileCacheManagerTest : public testing::Test {
     std::shared_ptr<MockInodeCacheManager> mockInodeManager_;
     std::shared_ptr<MockS3Client> mockS3Client_;
     std::shared_ptr<KVClientManager> kvClientManager_;
+    std::shared_ptr<TaskThreadPool<>> threadPool_ =
+        std::make_shared<TaskThreadPool<>>();
 };
 
 TEST_F(FileCacheManagerTest, test_FindOrCreateChunkCacheManager) {
@@ -141,8 +148,8 @@ TEST_F(FileCacheManagerTest, test_flush_fail) {
 
 TEST_F(FileCacheManagerTest, test_new_write) {
     uint64_t offset = 0;
-    uint64_t len = 5 * 1024 * 1024;
-    char *buf = new char[len];
+    const uint64_t len = 5 * 1024 * 1024;
+    char buf[len] = {0};
 
     memset(buf, 'a', len);
     EXPECT_CALL(*mockChunkCacheManager_, FindWriteableDataCache(_, _, _, _))
@@ -154,13 +161,12 @@ TEST_F(FileCacheManagerTest, test_new_write) {
     fileCacheManager_->SetChunkCacheManagerForTest(0, mockChunkCacheManager_);
     fileCacheManager_->SetChunkCacheManagerForTest(1, mockChunkCacheManager_);
     ASSERT_EQ(len, fileCacheManager_->Write(offset, len, buf));
-    delete[] buf;
 }
 
 TEST_F(FileCacheManagerTest, test_old_write) {
     uint64_t offset = 0;
-    uint64_t len = 1024;
-    char *buf = new char[len];
+    const uint64_t len = 1024;
+    char buf[len] = {0};
 
     memset(buf, 0, len);
     auto dataCache = std::make_shared<MockDataCache>(
@@ -172,14 +178,13 @@ TEST_F(FileCacheManagerTest, test_old_write) {
     fileCacheManager_->SetChunkCacheManagerForTest(0, mockChunkCacheManager_);
     ASSERT_EQ(len, fileCacheManager_->Write(offset, len, buf));
     fileCacheManager_->ReleaseCache();
-    delete[] buf;
 }
 
 TEST_F(FileCacheManagerTest, test_read_cache) {
     uint64_t inodeId = 1;
     uint64_t offset = 0;
-    uint64_t len = 5 * 1024 * 1024;
-    char *buf = new char[len];
+    const uint64_t len = 5 * 1024 * 1024;
+    char buf[len] = {0};
     ReadRequest request;
         memset(buf, 0, len);
     std::vector<ReadRequest> requests;
@@ -195,14 +200,13 @@ TEST_F(FileCacheManagerTest, test_read_cache) {
     fileCacheManager_->SetChunkCacheManagerForTest(1, mockChunkCacheManager_);
 
     ASSERT_EQ(len, fileCacheManager_->Read(inodeId, offset, len, buf));
-    delete[] buf;
 }
 
 TEST_F(FileCacheManagerTest, test_read_getinode_fail) {
     uint64_t inodeId = 1;
     uint64_t offset = 0;
-    uint64_t len = 1024;
-    char *buf = new char[len];
+    const uint64_t len = 1024;
+    char buf[len] = {0};
 
     memset(buf, 0, len);
     ReadRequest request;
@@ -220,24 +224,18 @@ TEST_F(FileCacheManagerTest, test_read_getinode_fail) {
     EXPECT_CALL(*mockInodeManager_, GetInode(_, _))
         .WillOnce(Return(CURVEFS_ERROR::NOTEXIST));
     ASSERT_EQ(-1, fileCacheManager_->Read(inodeId, offset, len, buf));
-    delete[] buf;
 }
 
 TEST_F(FileCacheManagerTest, test_read_s3) {
-    uint64_t inodeId = 1;
-    uint64_t offset = 0;
-    uint64_t len = 1024;
-    char *buf = new char[len];
-    char *tmpbuf = new char[len];
+    const uint64_t inodeId = 1;
+    const uint64_t offset = 0;
+    const uint64_t len = 1024;
 
-    memset(tmpbuf, 'a', len);
-    ReadRequest request;
-    std::vector<ReadRequest> requests;
-    request.index = 0;
-    request.chunkPos = offset;
-    request.len = len;
-    request.bufOffset = 0;
-    requests.emplace_back(request);
+    std::vector<char> buf(len);
+    std::vector<char> tmpBuf(len, 'a');
+
+    ReadRequest req{.index = 0, .chunkPos = offset, .len = len, .bufOffset = 0};
+    std::vector<ReadRequest> requests{req};
     EXPECT_CALL(*mockChunkCacheManager_, ReadByWriteCache(_, _, _, _, _))
         .WillOnce(DoAll(SetArgPointee<4>(requests), Return()))
         .WillOnce(DoAll(SetArgPointee<4>(requests), Return()));
@@ -249,9 +247,9 @@ TEST_F(FileCacheManagerTest, test_read_s3) {
     fileCacheManager_->SetChunkCacheManagerForTest(0, mockChunkCacheManager_);
     Inode inode;
     inode.set_length(len);
-    auto s3ChunkInfoMap = inode.mutable_s3chunkinfomap();
-    S3ChunkInfoList *s3ChunkInfoList = new S3ChunkInfoList();
-    S3ChunkInfo *s3ChunkInfo = s3ChunkInfoList->add_s3chunks();
+    auto *s3ChunkInfoMap = inode.mutable_s3chunkinfomap();
+    auto *s3ChunkInfoList = new S3ChunkInfoList();
+    auto *s3ChunkInfo = s3ChunkInfoList->add_s3chunks();
     s3ChunkInfo->set_chunkid(25);
     s3ChunkInfo->set_compaction(0);
     s3ChunkInfo->set_offset(offset);
@@ -266,14 +264,11 @@ TEST_F(FileCacheManagerTest, test_read_s3) {
         .WillOnce(
             DoAll(SetArgReferee<1>(inodeWrapper), Return(CURVEFS_ERROR::OK)));
     EXPECT_CALL(*mockS3Client_, Download(_, _, _, _))
-        .WillOnce(DoAll(SetArgPointee<1>(*tmpbuf), Return(len)))
+        .WillOnce(DoAll(SetArgPointee<1>(*tmpBuf.data()), Return(len)))
         .WillOnce(Return(-1));
 
-    ASSERT_EQ(len, fileCacheManager_->Read(inodeId, offset, len, buf));
-    ASSERT_EQ(-1, fileCacheManager_->Read(inodeId, offset, len, buf));
-
-    delete buf;
-    delete tmpbuf;
+    ASSERT_EQ(len, fileCacheManager_->Read(inodeId, offset, len, buf.data()));
+    ASSERT_EQ(-1, fileCacheManager_->Read(inodeId, offset, len, buf.data()));
 }
 
 }  // namespace client

--- a/curvefs/test/client/fs_cache_manager_test.cpp
+++ b/curvefs/test/client/fs_cache_manager_test.cpp
@@ -53,11 +53,13 @@ class FsCacheManagerTest : public testing::Test {
         option.intervalSec = 5000;
         option.flushIntervalSec = 5000;
         option.readCacheMaxByte = 104857600;
+        option.readCacheThreads = 5;
         option.diskCacheOpt.diskCacheType = (DiskCacheType)0;
         option.chunkFlushThreads = 5;
         s3ClientAdaptor_ = new S3ClientAdaptorImpl();
         fsCacheManager_ = std::make_shared<FsCacheManager>(
-            s3ClientAdaptor_, maxReadCacheByte_, maxWriteCacheByte, nullptr);
+            s3ClientAdaptor_, maxReadCacheByte_, maxWriteCacheByte,
+            option.readCacheThreads, nullptr);
         s3ClientAdaptor_->Init(option, nullptr, nullptr, nullptr,
                                fsCacheManager_, nullptr, nullptr);
         s3ClientAdaptor_->SetFsId(2);

--- a/curvefs/test/client/test_fuse_s3_client.cpp
+++ b/curvefs/test/client/test_fuse_s3_client.cpp
@@ -146,6 +146,7 @@ class TestFuseS3Client : public ::testing::Test {
     }
 
     void InitOptionBasic(FuseClientOption *opt) {
+        opt->s3Opt.s3ClientAdaptorOpt.readCacheThreads = 2;
         opt->s3Opt.s3AdaptrOpt.asyncThreadNum = 1;
         opt->dummyServerStartPort = 5000;
         opt->maxNameLength = 20u;


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: https://github.com/opencurve/curve/issues/2070

Problem Summary:

`FileCacheManager::ProcessKVRequest` processes kvRequests one by one, maybe we can increase the concurrency

### What is changed and how it works?

What's Changed: 

- Handle kvRequests through TaskThreadPool
- Cancel all threads and return when any kvRequests fail

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [x] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license
