### PR TITLE
[fix]tools-v2: supplementary status collection

### DIFF
--- a/tools-v2/pkg/cli/command/curvefs/check/copyset/copyset.go
+++ b/tools-v2/pkg/cli/command/curvefs/check/copyset/copyset.go
@@ -158,10 +158,12 @@ func (cCmd *CopysetCommand) RunCommand(cmd *cobra.Command, args []string) error 
 		row[cobrautil.ROW_COPYSET_ID] = fmt.Sprintf("%d", copysetid)
 		if v == nil {
 			row[cobrautil.ROW_STATUS] = cobrautil.CopysetHealthStatus_Str[int32(cobrautil.COPYSET_NOTEXIST)]
+			(*cCmd.copysetKey2Status)[k] = cobrautil.COPYSET_NOTEXIST
 		} else {
 			status, errsCheck := cobrautil.CheckCopySetHealth(v)
 			copysetHealthCount[status]++
 			row[cobrautil.ROW_STATUS] = cobrautil.CopysetHealthStatus_Str[int32(status)]
+			(*cCmd.copysetKey2Status)[k] = status
 			explain := ""
 			if status != cobrautil.COPYSET_OK {
 				for i, e := range errsCheck {
@@ -177,6 +179,10 @@ func (cCmd *CopysetCommand) RunCommand(cmd *cobra.Command, args []string) error 
 			leaderInfo := (*cCmd.copysetKey2LeaderInfo)[k]
 			if leaderInfo == nil {
 				explain = "no leader peer"
+				if row[cobrautil.ROW_STATUS] == cobrautil.COPYSET_OK_STR {
+					row[cobrautil.ROW_STATUS] = cobrautil.COPYSET_ERROR_STR
+					copysetHealthCount[cobrautil.COPYSET_ERROR]++
+				}
 			} else if leaderInfo.Snapshot {
 				installSnapshot := "installing snapshot"
 				if len(explain) > 0 {


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #xxx <!-- replace xxx with issue number -->

Problem Summary:
1. the error "no leader peer" status is still ok
2. copysetKey2Status is unused

### What is changed and how it works?

What's Changed: modify /tools-v2/pkg/cli/command/curvefs/check/copyset/copyset.go

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
