### PR TITLE
[feat] tools-v2: add snapshot-clone-status

### DIFF
--- a/tools-v2/README.md
+++ b/tools-v2/README.md
@@ -54,9 +54,10 @@ A tool for CurveFS & CurveBs.
         - [query chunk](#query-chunk)
         - [query segment](#query-segment)
     - [status](#status-1)
-      - [staus etcd](#staus-etcd)
-      - [staus mds](#staus-mds)
+      - [status etcd](#status-etcd-1)
+      - [status mds](#status-mds-1)
       - [status client](#status-client)
+      - [status snapshotserver](#status-snapshotserver)
     - [delete](#delete-1)
       - [delete peer](#delete-peer)
     - [update](#update)
@@ -1011,7 +1012,7 @@ Output:
 
 ### status
 
-#### staus etcd
+#### status etcd
 
 get the etcd status of curvebs
 
@@ -1035,7 +1036,7 @@ Output:
 +---------------------+---------+----------+
 ```
 
-#### staus mds
+#### status mds
 
 get the mds status of curvebs
 
@@ -1059,6 +1060,7 @@ Output:
 +-------------------+-------------------+-------------------+----------+
 ```
 
+
 #### status client
 
 get the client status of curvebs
@@ -1080,6 +1082,31 @@ Output:
 |             |                | ***.***.**.***:**** |     |
 +-------------+----------------+---------------------+-----+
 ```
+
+#### status snapshotserver
+
+get the mds status of curvebs
+
+Usage:
+
+```bash
+curve bs status snapshotserver
+```
+
+Output:
+
+```bash
++---------------------+---------------------+-------------------+----------+
+|        ADDR         |      DUMMYADDR      |    VERSION        |  STATUS  |
++---------------------+---------------------+-------------------+----------+
+| ***.***.**.***:**** | ***.***.**.***:**** | ci+562296c7+debug | follower |
++---------------------+---------------------+                   +          +
+| ***.***.**.***:**** | ***.***.**.***:**** |                   |          |
++---------------------+---------------------+                   +----------+
+| ***.***.**.***:**** | ***.***.**.***:**** |                   | leader   |
++---------------------+---------------------+-------------------+----------+
+```
+
 
 ### delete
 
@@ -1273,6 +1300,8 @@ Output:
 | status                           |                            |
 | chunkserver-status               |                            |
 | snapshot-clone-status            |                            |
+| client-status                    | curve bs status client     |
+| snapshot-clone-status            | curve bs status snapshotserver |
 | copysets-status                  |                            |
 | chunkserver-list                 |                            |
 | cluster-status                   |                            |

--- a/tools-v2/docs/zh/develop.md
+++ b/tools-v2/docs/zh/develop.md
@@ -386,7 +386,7 @@ docker cp ./sbin/curve de7603f17cf9:/
 4. 准备配置文件，将之拷贝进 playground 容器内：
 
 ```shell
-docker cp ./pkg/config/template.yaml de7603f17cf9:/etc/curve/curve.yaml
+docker cp ./pkg/config/curve.yaml de7603f17cf9:/etc/curve/curve.yaml
 ```
 
 5. 进入对应的容器：
@@ -558,10 +558,10 @@ curveadm status
 make
 ```
 
-3. 准备配置文件，将项目目录下的 `tools-v2/pkg/config/template.yaml` 复制到 `$(HOME)/.curve/curve.yaml`：
+3. 准备配置文件，将项目目录下的 `tools-v2/pkg/config/curve.yaml` 复制到 `$(HOME)/.curve/curve.yaml`：
 
 ```shell
-cp ./pkg/config/template.yaml ~/.curve/curve.yaml
+cp ./pkg/config/curve.yaml ~/.curve/curve.yaml
 ```
 
 4. 在项目目录（`curve/tools-v2`） 下执行命令/调试：

--- a/tools-v2/pkg/cli/command/curvebs/status/status.go
+++ b/tools-v2/pkg/cli/command/curvebs/status/status.go
@@ -27,6 +27,7 @@ import (
 	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/status/client"
 	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/status/etcd"
 	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/status/mds"
+	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/status/snapshot"
 	"github.com/spf13/cobra"
 )
 
@@ -41,6 +42,7 @@ func (statusCmd *StatusCommand) AddSubCommands() {
 		etcd.NewEtcdCommand(),
 		mds.NewMdsCommand(),
 		client.NewClientCommand(),
+		snapshot.NewSnapshotCommand(),
 	)
 }
 

--- a/tools-v2/pkg/config/bs.go
+++ b/tools-v2/pkg/config/bs.go
@@ -36,66 +36,70 @@ import (
 
 const (
 	// curvebs
-	CURVEBS_MDSADDR              = "mdsaddr"
-	VIPER_CURVEBS_MDSADDR        = "curvebs.mdsAddr"
-	CURVEBS_MDSDUMMYADDR         = "mdsdummyaddr"
-	VIPER_CURVEBS_MDSDUMMYADDR   = "curvebs.mdsDummyAddr"
-	CURVEBS_ETCDADDR             = "etcdaddr"
-	VIPER_CURVEBS_ETCDADDR       = "curvebs.etcdAddr"
-	CURVEBS_PATH                 = "path"
-	VIPER_CURVEBS_PATH           = "curvebs.path"
-	CURVEBS_DEFAULT_PATH         = "/test"
-	CURVEBS_USER                 = "user"
-	VIPER_CURVEBS_USER           = "curvebs.root.user"
-	CURVEBS_DEFAULT_USER         = "root"
-	CURVEBS_PASSWORD             = "password"
-	VIPER_CURVEBS_PASSWORD       = "curvebs.root.password"
-	CURVEBS_DEFAULT_PASSWORD     = "root_password"
-	CURVEBS_CLUSTERMAP           = "clustermap"
-	VIPER_CURVEBS_CLUSTERMAP     = "curvebs.clustermap"
-	CURVEBS_FORCE                = "force"
-	VIPER_CURVEBS_FORCE          = "curvebs.force"
-	CURVEBS_DEFAULT_FORCE        = false
-	CURVEBS_LOGIC_POOL_ID        = "logicalpoolid"
-	VIPER_CURVEBS_LOGIC_POOL_ID  = "curvebs.logicalpoolid"
-	CURVEBS_COPYSET_ID           = "copysetid"
-	VIPER_CURVEBS_COPYSET_ID     = "curvebs.copysetid"
-	CURVEBS_PEERS_ADDRESS        = "peers"
-	VIPER_CURVEBS_PEERS_ADDRESS  = "curvebs.peers"
-	CURVEBS_OFFSET               = "offset"
-	VIPER_CURVEBS_OFFSET         = "curvebs.offset"
-	CURVEBS_SIZE                 = "size"
-	VIPER_CURVEBS_SIZE           = "curvebs.size"
-	CURVEBS_DEFAULT_SIZE         = uint64(10)
-	CURVEBS_TYPE                 = "type"
-	VIPER_CURVEBS_TYPE           = "curvebs.type"
-	CURVEBS_STRIPE_UNIT          = "stripeunit"
-	VIPER_CURVEBS_STRIPE_UNIT    = "curvebs.stripeunit"
-	CURVEBS_DEFAULT_STRIPE_UNIT  = "32 KiB"
-	CURVEBS_STRIPE_COUNT         = "stripecount"
-	VIPER_CURVEBS_STRIPE_COUNT   = "curvebs.stripecount"
-	CURVEBS_DEFAULT_STRIPE_COUNT = uint64(32)
-	CURVEBS_RECYCLE_PREFIX       = "recycleprefix"
-	VIPER_RECYCLE_PREFIX         = "curvebs.recycleprefix"
-	CURVEBS_EXPIRED_TIME         = "expiredtime"
-	VIPER_CURVEBS_EXPIRED_TIME   = "curvebs.expiredtime"
-	CURVEBS_LIMIT                = "limit"
-	VIPER_CURVEBS_LIMIT          = "curvebs.limit"
-	CURVEBS_BURST                = "burst"
-	VIPER_CURVEBS_BURST          = "curvebs.burst"
-	CURVEBS_DEFAULT_BURST        = uint64(30000)
-	CURVEBS_BURST_LENGTH         = "burstlength"
-	VIPER_CURVEBS_BURST_LENGTH   = "curvebs.burstlength"
-	CURVEBS_DEFAULT_BURST_LENGTH = uint64(10)
-	CURVEBS_OP                   = "op"
-	VIPER_CURVEBS_OP             = "curvebs.op"
-	CURVEBS_DEFAULT_OP           = "operator"
-	CURVEBS_CHECK_TIME           = "checktime"
-	VIPER_CURVEBS_CHECK_TIME     = "curvebs.checktime"
-	CURVEBS_DEFAULT_CHECK_TIME   = 30 * time.Second
-	CURVEBS_MARGIN               = "margin"
-	VIPER_CURVEBS_MARGIN         = "curvebs.margin"
-	CURVEBS_DEFAULT_MARGIN       = uint64(1000)
+	CURVEBS_MDSADDR                 = "mdsaddr"
+	VIPER_CURVEBS_MDSADDR           = "curvebs.mdsAddr"
+	CURVEBS_MDSDUMMYADDR            = "mdsdummyaddr"
+	VIPER_CURVEBS_MDSDUMMYADDR      = "curvebs.mdsDummyAddr"
+	CURVEBS_ETCDADDR                = "etcdaddr"
+	VIPER_CURVEBS_ETCDADDR          = "curvebs.etcdAddr"
+	CURVEBS_PATH                    = "path"
+	VIPER_CURVEBS_PATH              = "curvebs.path"
+	CURVEBS_DEFAULT_PATH            = "/test"
+	CURVEBS_USER                    = "user"
+	VIPER_CURVEBS_USER              = "curvebs.root.user"
+	CURVEBS_DEFAULT_USER            = "root"
+	CURVEBS_PASSWORD                = "password"
+	VIPER_CURVEBS_PASSWORD          = "curvebs.root.password"
+	CURVEBS_DEFAULT_PASSWORD        = "root_password"
+	CURVEBS_CLUSTERMAP              = "clustermap"
+	VIPER_CURVEBS_CLUSTERMAP        = "curvebs.clustermap"
+	CURVEBS_FORCE                   = "force"
+	VIPER_CURVEBS_FORCE             = "curvebs.force"
+	CURVEBS_DEFAULT_FORCE           = false
+	CURVEBS_LOGIC_POOL_ID           = "logicalpoolid"
+	VIPER_CURVEBS_LOGIC_POOL_ID     = "curvebs.logicalpoolid"
+	CURVEBS_COPYSET_ID              = "copysetid"
+	VIPER_CURVEBS_COPYSET_ID        = "curvebs.copysetid"
+	CURVEBS_PEERS_ADDRESS           = "peers"
+	VIPER_CURVEBS_PEERS_ADDRESS     = "curvebs.peers"
+	CURVEBS_OFFSET                  = "offset"
+	VIPER_CURVEBS_OFFSET            = "curvebs.offset"
+	CURVEBS_SIZE                    = "size"
+	VIPER_CURVEBS_SIZE              = "curvebs.size"
+	CURVEBS_DEFAULT_SIZE            = uint64(10)
+	CURVEBS_TYPE                    = "type"
+	VIPER_CURVEBS_TYPE              = "curvebs.type"
+	CURVEBS_STRIPE_UNIT             = "stripeunit"
+	VIPER_CURVEBS_STRIPE_UNIT       = "curvebs.stripeunit"
+	CURVEBS_DEFAULT_STRIPE_UNIT     = "32 KiB"
+	CURVEBS_STRIPE_COUNT            = "stripecount"
+	VIPER_CURVEBS_STRIPE_COUNT      = "curvebs.stripecount"
+	CURVEBS_DEFAULT_STRIPE_COUNT    = uint64(32)
+	CURVEBS_RECYCLE_PREFIX          = "recycleprefix"
+	VIPER_RECYCLE_PREFIX            = "curvebs.recycleprefix"
+	CURVEBS_EXPIRED_TIME            = "expiredtime"
+	VIPER_CURVEBS_EXPIRED_TIME      = "curvebs.expiredtime"
+	CURVEBS_LIMIT                   = "limit"
+	VIPER_CURVEBS_LIMIT             = "curvebs.limit"
+	CURVEBS_BURST                   = "burst"
+	VIPER_CURVEBS_BURST             = "curvebs.burst"
+	CURVEBS_DEFAULT_BURST           = uint64(30000)
+	CURVEBS_BURST_LENGTH            = "burstlength"
+	VIPER_CURVEBS_BURST_LENGTH      = "curvebs.burstlength"
+	CURVEBS_DEFAULT_BURST_LENGTH    = uint64(10)
+	CURVEBS_OP                      = "op"
+	VIPER_CURVEBS_OP                = "curvebs.op"
+	CURVEBS_DEFAULT_OP              = "operator"
+	CURVEBS_CHECK_TIME              = "checktime"
+	VIPER_CURVEBS_CHECK_TIME        = "curvebs.checktime"
+	CURVEBS_DEFAULT_CHECK_TIME      = 30 * time.Second
+	CURVEBS_MARGIN                  = "margin"
+	VIPER_CURVEBS_MARGIN            = "curvebs.margin"
+	CURVEBS_DEFAULT_MARGIN          = uint64(1000)
+	CURVEBS_SNAPSHOTADDR            = "snapshotaddr"
+	VIPER_CURVEBS_SNAPSHOTADDR      = "curvebs.snapshotAddr"
+	CURVEBS_SNAPSHOTDUMMYADDR       = "snapshotdummyaddr"
+	VIPER_CURVEBS_SNAPSHOTDUMMYADDR = "curvebs.snapshotDummyAddr"
 )
 
 var (
@@ -105,30 +109,32 @@ var (
 		RPCRETRYTIMES: VIPER_GLOBALE_RPCRETRYTIMES,
 
 		// bs
-		CURVEBS_MDSADDR:        VIPER_CURVEBS_MDSADDR,
-		CURVEBS_MDSDUMMYADDR:   VIPER_CURVEBS_MDSDUMMYADDR,
-		CURVEBS_PATH:           VIPER_CURVEBS_PATH,
-		CURVEBS_USER:           VIPER_CURVEBS_USER,
-		CURVEBS_PASSWORD:       VIPER_CURVEBS_PASSWORD,
-		CURVEBS_ETCDADDR:       VIPER_CURVEBS_ETCDADDR,
-		CURVEBS_LOGIC_POOL_ID:  VIPER_CURVEBS_LOGIC_POOL_ID,
-		CURVEBS_COPYSET_ID:     VIPER_CURVEBS_COPYSET_ID,
-		CURVEBS_PEERS_ADDRESS:  VIPER_CURVEBS_PEERS_ADDRESS,
-		CURVEBS_CLUSTERMAP:     VIPER_CURVEBS_CLUSTERMAP,
-		CURVEBS_OFFSET:         VIPER_CURVEBS_OFFSET,
-		CURVEBS_SIZE:           VIPER_CURVEBS_SIZE,
-		CURVEBS_STRIPE_UNIT:    VIPER_CURVEBS_STRIPE_UNIT,
-		CURVEBS_STRIPE_COUNT:   VIPER_CURVEBS_STRIPE_COUNT,
-		CURVEBS_LIMIT:          VIPER_CURVEBS_LIMIT,
-		CURVEBS_BURST:          VIPER_CURVEBS_BURST,
-		CURVEBS_BURST_LENGTH:   VIPER_CURVEBS_BURST_LENGTH,
-		CURVEBS_FORCE:          VIPER_CURVEBS_FORCE,
-		CURVEBS_TYPE:           VIPER_CURVEBS_TYPE,
-		CURVEBS_EXPIRED_TIME:   VIPER_CURVEBS_EXPIRED_TIME,
-		CURVEBS_RECYCLE_PREFIX: VIPER_RECYCLE_PREFIX,
-		CURVEBS_MARGIN:         VIPER_CURVEBS_MARGIN,
-		CURVEBS_OP:             VIPER_CURVEBS_OP,
-		CURVEBS_CHECK_TIME:     VIPER_CURVEBS_CHECK_TIME,
+		CURVEBS_MDSADDR:           VIPER_CURVEBS_MDSADDR,
+		CURVEBS_MDSDUMMYADDR:      VIPER_CURVEBS_MDSDUMMYADDR,
+		CURVEBS_PATH:              VIPER_CURVEBS_PATH,
+		CURVEBS_USER:              VIPER_CURVEBS_USER,
+		CURVEBS_PASSWORD:          VIPER_CURVEBS_PASSWORD,
+		CURVEBS_ETCDADDR:          VIPER_CURVEBS_ETCDADDR,
+		CURVEBS_LOGIC_POOL_ID:     VIPER_CURVEBS_LOGIC_POOL_ID,
+		CURVEBS_COPYSET_ID:        VIPER_CURVEBS_COPYSET_ID,
+		CURVEBS_PEERS_ADDRESS:     VIPER_CURVEBS_PEERS_ADDRESS,
+		CURVEBS_CLUSTERMAP:        VIPER_CURVEBS_CLUSTERMAP,
+		CURVEBS_OFFSET:            VIPER_CURVEBS_OFFSET,
+		CURVEBS_SIZE:              VIPER_CURVEBS_SIZE,
+		CURVEBS_STRIPE_UNIT:       VIPER_CURVEBS_STRIPE_UNIT,
+		CURVEBS_STRIPE_COUNT:      VIPER_CURVEBS_STRIPE_COUNT,
+		CURVEBS_LIMIT:             VIPER_CURVEBS_LIMIT,
+		CURVEBS_BURST:             VIPER_CURVEBS_BURST,
+		CURVEBS_BURST_LENGTH:      VIPER_CURVEBS_BURST_LENGTH,
+		CURVEBS_FORCE:             VIPER_CURVEBS_FORCE,
+		CURVEBS_TYPE:              VIPER_CURVEBS_TYPE,
+		CURVEBS_EXPIRED_TIME:      VIPER_CURVEBS_EXPIRED_TIME,
+		CURVEBS_RECYCLE_PREFIX:    VIPER_RECYCLE_PREFIX,
+		CURVEBS_MARGIN:            VIPER_CURVEBS_MARGIN,
+		CURVEBS_OP:                VIPER_CURVEBS_OP,
+		CURVEBS_CHECK_TIME:        VIPER_CURVEBS_CHECK_TIME,
+		CURVEBS_SNAPSHOTADDR:      VIPER_CURVEBS_SNAPSHOTADDR,
+		CURVEBS_SNAPSHOTDUMMYADDR: VIPER_CURVEBS_SNAPSHOTDUMMYADDR,
 	}
 
 	BSFLAG2DEFAULT = map[string]interface{}{
@@ -311,8 +317,18 @@ func AddBsDurationRequiredFlag(cmd *cobra.Command, name string, usage string) {
 func AddBsMdsFlagOption(cmd *cobra.Command) {
 	AddBsStringOptionFlag(cmd, CURVEBS_MDSADDR, "mds address, should be like 127.0.0.1:6700,127.0.0.1:6701,127.0.0.1:6702")
 }
+
 func AddBsMdsDummyFlagOption(cmd *cobra.Command) {
 	AddBsStringOptionFlag(cmd, CURVEBS_MDSDUMMYADDR, "mds dummy address, should be like 127.0.0.1:6700,127.0.0.1:6701,127.0.0.1:6702")
+}
+
+// snapshot clone
+func AddBsSnapshotCloneFlagOption(cmd *cobra.Command) {
+	AddBsStringOptionFlag(cmd, CURVEBS_SNAPSHOTADDR, "snapshot clone address, should be like 127.0.0.1:5550,127.0.0.1:5551,127.0.0.1:5552")
+}
+
+func AddBsSnapshotCloneDummyFlagOption(cmd *cobra.Command) {
+	AddBsStringOptionFlag(cmd, CURVEBS_SNAPSHOTDUMMYADDR, "snapshot clone dummy address, should be like 127.0.0.1:8100,127.0.0.1:8101,127.0.0.1:8102")
 }
 
 // user
@@ -502,12 +518,21 @@ func GetBsAddrSlice(cmd *cobra.Command, addrType string) ([]string, *cmderror.Cm
 func GetBsEtcdAddrSlice(cmd *cobra.Command) ([]string, *cmderror.CmdError) {
 	return GetBsAddrSlice(cmd, CURVEBS_ETCDADDR)
 }
+
 func GetBsMdsAddrSlice(cmd *cobra.Command) ([]string, *cmderror.CmdError) {
 	return GetBsAddrSlice(cmd, CURVEBS_MDSADDR)
 }
 
 func GetBsMdsDummyAddrSlice(cmd *cobra.Command) ([]string, *cmderror.CmdError) {
 	return GetBsAddrSlice(cmd, CURVEBS_MDSDUMMYADDR)
+}
+
+func GetBsSnapshotAddrSlice(cmd *cobra.Command) ([]string, *cmderror.CmdError) {
+	return GetBsAddrSlice(cmd, CURVEBS_SNAPSHOTADDR)
+}
+
+func GetBsSnapshotDummyAddrSlice(cmd *cobra.Command) ([]string, *cmderror.CmdError) {
+	return GetBsAddrSlice(cmd, CURVEBS_SNAPSHOTDUMMYADDR)
 }
 
 func GetBsFlagBool(cmd *cobra.Command, flagName string) bool {

--- a/tools-v2/pkg/config/curve.yaml
+++ b/tools-v2/pkg/config/curve.yaml
@@ -20,6 +20,8 @@ curvebs:
   mdsAddr: 127.0.0.1:6700,127.0.0.1:6701,127.0.0.1:6702   # __CURVEADM_TEMPLATE__ ${cluster_mds_addr} __CURVEADM_TEMPLATE__
   mdsDummyAddr: 127.0.0.1:7700,127.0.0.1:7701,127.0.0.1:7702  # __CURVEADM_TEMPLATE__ ${cluster_mds_dummy_addr} __CURVEADM_TEMPLATE__
   etcdAddr: 127.0.0.1:23790,127.0.0.1:23791,127.0.0.1:23792  # __CURVEADM_TEMPLATE__ ${cluster_etcd_addr} __CURVEADM_TEMPLATE__
+  snapshotAddr: 127.0.0.1:5550,127.0.0.1:5551,127.0.0.1:5552  # __CURVEADM_TEMPLATE__ ${cluster_snapshot_addr} __CURVEADM_TEMPLATE__
+  snapshotDummyAddr: 127.0.0.1:8100,127.0.0.1:8101,127.0.0.1:8102  # __CURVEADM_TEMPLATE__ ${cluster_snapshot_dummy_addr} __CURVEADM_TEMPLATE__
   root:
     user: root
     password: root_password


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #2346<!-- replace xxx with issue number -->

Problem Summary:  support `bs status snapshot` command in [curve tool](https://github.com/opencurve/curve/tree/master/tools-v2)

### What is changed and how it works?

What's Changed:  
1. add snapshot command(`snapshot.go`) in `curve/tools-v2/pkg/cli/command/curvebs/status` (also modify some code style in `etcd.go` and `mds.go`).
2. add new command reference in `tools-v2/pkg/cli/command/curvebs/status/status.go`.
3. add snapshot clone config in config file(`tools-v2/pkg/config`) and modify the user config file.

How it Works: using command `curve bs status snapshot`

Side effects(Breaking backward compatibility? Performance regression?): just client
the result in tools-v1:
```
SnapshotCloneServer status:
version: 9.9.9+2c4861ca
current snapshot-clone-server: 192.168.20.149:5550
online snapshot-clone-server list: 192.168.20.149:5550, 192.168.20.149:5551, 192.168.20.149:5552
offline snapshot-clone-server list:
```
the result in tools-v2:
```
+---------------------+---------------------+----------------+----------+
|        ADDR         |      DUMMYADDR      |    VERSION     |  STATUS  |
+---------------------+---------------------+----------------+----------+
| 192.168.20.149:5551 | 192.168.20.149:8101 | 9.9.9+2c4861ca | follower |
+---------------------+---------------------+                +          +
| 192.168.20.149:5552 | 192.168.20.149:8102 |                |          |
+---------------------+---------------------+                +----------+
| 192.168.20.149:5550 | 192.168.20.149:8100 |                | leader   |
+---------------------+---------------------+----------------+----------+
```

### Check List

- [x] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license
