### PR TITLE
[feat]tools-v2: GetChuckServerListInCopyset supports multiple request

### DIFF
--- a/tools-v2/pkg/cli/command/curvebs/query/chunk/chunk.go
+++ b/tools-v2/pkg/cli/command/curvebs/query/chunk/chunk.go
@@ -30,19 +30,19 @@ import (
 	basecmd "github.com/opencurve/curve/tools-v2/pkg/cli/command"
 	"github.com/opencurve/curve/tools-v2/pkg/config"
 	"github.com/opencurve/curve/tools-v2/pkg/output"
+	"github.com/opencurve/curve/tools-v2/proto/proto/common"
 	"github.com/opencurve/curve/tools-v2/proto/proto/nameserver2"
-	"github.com/opencurve/curve/tools-v2/proto/proto/topology"
 	"github.com/spf13/cobra"
 )
 
 type ChunkCommand struct {
 	basecmd.FinalCurveCmd
-	FileInfo          *nameserver2.FileInfo
-	ChunkId           uint64
-	LogicalpoolId     uint32
-	CopysetId         uint32
-	GroupId           uint64
-	CopysetServerList []*topology.CopySetServerInfo
+	FileInfo        *nameserver2.FileInfo
+	ChunkId         uint64
+	LogicalpoolId   uint32
+	CopysetId       uint32
+	GroupId         uint64
+	ChunkServerList []*common.ChunkServerLocation
 }
 
 var _ basecmd.FinalCurveCmdFunc = (*ChunkCommand)(nil) // check interface
@@ -92,11 +92,12 @@ func (cCmd *ChunkCommand) Init(cmd *cobra.Command, args []string) error {
 		fmt.Sprintf("--%s", config.CURVEBS_COPYSET_ID),
 		fmt.Sprintf("%d", cCmd.CopysetId),
 	})
-	chunkSeverListRes, err := GetChunkServerListInCopySets(cCmd.Cmd)
+	key2Location, err := GetChunkServerListInCopySets(cCmd.Cmd)
 	if err.TypeCode() != cmderror.CODE_SUCCESS {
 		return err.ToError()
 	}
-	cCmd.CopysetServerList = chunkSeverListRes.GetCsInfo()
+	key := cobrautil.GetCopysetKey(uint64(cCmd.LogicalpoolId), uint64(cCmd.CopysetId))
+	cCmd.ChunkServerList = (*key2Location)[key]
 	header := []string{cobrautil.ROW_CHUNK, cobrautil.ROW_LOGICALPOOL,
 		cobrautil.ROW_COPYSET, cobrautil.ROW_GROUP, cobrautil.ROW_LOCATION,
 	}
@@ -117,10 +118,8 @@ func (cCmd *ChunkCommand) Print(cmd *cobra.Command, args []string) error {
 func (cCmd *ChunkCommand) RunCommand(cmd *cobra.Command, args []string) error {
 	cCmd.GroupId = (uint64(cCmd.LogicalpoolId) << 32) | uint64(cCmd.CopysetId)
 	locations := []string{}
-	for _, copysetServer := range cCmd.CopysetServerList {
-		for _, chunkServer := range copysetServer.GetCsLocs() {
-			locations = append(locations, fmt.Sprintf("%s:%d", chunkServer.GetHostIp(), chunkServer.GetPort()))
-		}
+	for _, chunkServer := range cCmd.ChunkServerList {
+		locations = append(locations, fmt.Sprintf("%s:%d", chunkServer.GetHostIp(), chunkServer.GetPort()))
 	}
 	location := strings.Join(locations, "\n")
 	row := make(map[string]string)

--- a/tools-v2/pkg/cli/command/curvebs/query/query.go
+++ b/tools-v2/pkg/cli/command/curvebs/query/query.go
@@ -41,7 +41,6 @@ func (queryCmd *QueryCommand) AddSubCommands() {
 		file.NewFileCommand(),
 		seginfo.NewSeginfoCommand(),
 		chunk.NewChunkCommand(),
-		chunk.NewChunkServerListCommand(),
 	)
 }
 

--- a/tools-v2/pkg/config/bs.go
+++ b/tools-v2/pkg/config/bs.go
@@ -298,6 +298,10 @@ func AddBSCopysetIdSliceRequiredFlag(cmd *cobra.Command) {
 	AddBsStringSliceRequiredFlag(cmd, CURVEBS_COPYSET_ID, "copyset ids")
 }
 
+func AddBSLogicalPoolIdSliceRequiredFlag(cmd *cobra.Command) {
+	AddBsStringSliceRequiredFlag(cmd, CURVEBS_LOGIC_POOL_ID, "logical pool id")
+}
+
 func AddBSPeersConfFlag(cmd *cobra.Command) {
 	AddBsStringSliceRequiredFlag(cmd, CURVEBS_PEERS_ADDRESS, "peers info.")
 }


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #xxx <!-- replace xxx with issue number -->

Problem Summary:
1. make rpc GetChuckServerListInCopyset supports multiple request
2. GetChuckServerListInCopyset command should not be exported

### What is changed and how it works?

What's Changed:
modify tools-v2/pkg/cli/command/curvebs/query/chunk/chunk.go
modify tools-v2/pkg/cli/command/curvebs/query/chunk/chunkserver.go
modify tools-v2/pkg/cli/command/curvebs/query/query.go
modify tools-v2/pkg/config/bs.go

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
