### PR TITLE
[feat] tools-v2: add transfer-leader

### DIFF
--- a/tools-v2/README.md
+++ b/tools-v2/README.md
@@ -64,6 +64,9 @@ A tool for CurveFS & CurveBs.
       - [update peer](#update-peer)
       - [update file](#update-file)
       - [update throttle](#update-throttle)
+      - [update leader](#update-leader)
+    - [create](#create-1)
+      - [create file](#create-file)
       - [create dir](#create-dir)
     - [check](#check-1)
       - [check copyset](#check-copyset-1)
@@ -1152,6 +1155,24 @@ Output:
 +----------------------+---------+---------+--------+
 ```
 
+#### update leader
+
+transfer leader
+
+Usage:
+```bash
+curve bs update leader 127.0.0.1:8202:0 --logicalpoolid=1 --copysetid=1 --peers=127.0.0.1:8200:0,127.0.0.1:8201:0,127.0.0.1:8202:0
+```
+
+Output:
+```
++-----------------------+-----------------------+---------+---------+
+|        LEADER         |       OLDLEADER       | COPYSET | RESULT  |
++-----------------------+-----------------------+---------+---------+
+| ***.***.**.***:****:* | ***.***.**.***:****:* | (1:1)   | success |
++-----------------------+-----------------------+---------+---------+
+```
+
 #### update file
 
 expand pagefile
@@ -1177,6 +1198,7 @@ update file throttle params
 Usage:
 ```bash
 curve bs update throttle --path /test1 --type=bps_total --limit 20000
+```
 
 Output:
 ```
@@ -1277,6 +1299,7 @@ Output:
 
 ### curve bs
 
+<<<<<<< HEAD
 | old                                  | new                            |
 | ------------------------------------ | ------------------------------ |
 | curve_ops_tool logical-pool-list     | curve bs list logical-pool     |
@@ -1298,13 +1321,13 @@ Output:
 | curve_ops_tool client-status         | curve bs status client         |
 | curve_ops_tool check-operator        | curve bs check operator        |
 | curve_ops_tool snapshot-clone-status | curve bs status snapshotserver |
+| transfer-leader                      | curve bs update leader         |
 | curve_ops_tool status                |                                |
 | curve_ops_tool chunkserver-status    |                                |
 | curve_ops_tool copysets-status       |                                |
 | curve_ops_tool chunkserver-list      |                                |
 | curve_ops_tool clean-recycle         |                                |
 | curve_ops_tool check-consistency     |                                |
-| curve_ops_tool transfer-leader       |                                |
 | curve_ops_tool do-snapshot           |                                |
 | curve_ops_tool do-snapshot-all       |                                |
 | curve_ops_tool check-chunkserver     |                                |

--- a/tools-v2/internal/utils/row.go
+++ b/tools-v2/internal/utils/row.go
@@ -57,6 +57,7 @@ const (
 	ROW_IP              = "ip"
 	ROW_KEY             = "key"
 	ROW_LEADER          = "leader"
+	ROW_OLDLEADER       = "oldLeader"
 	ROW_LEADER_PEER     = "leaderPeer"
 	ROW_LEFT            = "left"
 	ROW_LENGTH          = "length"

--- a/tools-v2/pkg/cli/command/curvebs/update/leader/leader.go
+++ b/tools-v2/pkg/cli/command/curvebs/update/leader/leader.go
@@ -1,0 +1,184 @@
+/*
+ *  Copyright (c) 2023 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * Project: CurveCli
+ * Created Date: 2023-04-28
+ * Author: Xinlong-Chen
+ */
+
+package leader
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+
+	cmderror "github.com/opencurve/curve/tools-v2/internal/error"
+	cobrautil "github.com/opencurve/curve/tools-v2/internal/utils"
+	basecmd "github.com/opencurve/curve/tools-v2/pkg/cli/command"
+	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/delete/peer"
+	"github.com/opencurve/curve/tools-v2/pkg/config"
+	"github.com/opencurve/curve/tools-v2/pkg/output"
+	"github.com/opencurve/curve/tools-v2/proto/proto/cli2"
+)
+
+const (
+	leaderExample = `$ curve bs update leader 127.0.0.1:8200:0 --logicalpoolid=1 --copysetid=10001
+	--peers=127.0.0.1:8200:0,127.0.0.1:8201:0,127.0.0.1:8202:0`
+)
+
+type LeaderRpc struct {
+	Info    *basecmd.Rpc
+	Request *cli2.TransferLeaderRequest2
+	Client  cli2.CliService2Client
+}
+
+func (lRpc *LeaderRpc) NewRpcClient(cc grpc.ClientConnInterface) {
+	lRpc.Client = cli2.NewCliService2Client(cc)
+}
+
+func (lRpc *LeaderRpc) Stub_Func(ctx context.Context) (interface{}, error) {
+	return lRpc.Client.TransferLeader(ctx, lRpc.Request)
+}
+
+type leaderCommand struct {
+	basecmd.FinalCurveCmd
+
+	Rpc      *LeaderRpc
+	Response *cli2.TransferLeaderResponse2
+	row      map[string]string
+}
+
+var _ basecmd.FinalCurveCmdFunc = (*leaderCommand)(nil) // check interface
+
+// NewCommand ...
+func NewleaderCommand() *cobra.Command {
+	peerCmd := &leaderCommand{
+		FinalCurveCmd: basecmd.FinalCurveCmd{
+			Use:     "leader",
+			Short:   "update(reset) the leader from the copyset",
+			Example: leaderExample,
+		},
+	}
+	basecmd.NewFinalCurveCli(&peerCmd.FinalCurveCmd, peerCmd)
+	return peerCmd.Cmd
+}
+
+func (lCmd *leaderCommand) AddFlags() {
+	config.AddRpcRetryTimesFlag(lCmd.Cmd)
+	config.AddRpcTimeoutFlag(lCmd.Cmd)
+
+	config.AddBSLogicalPoolIdRequiredFlag(lCmd.Cmd)
+	config.AddBSCopysetIdRequiredFlag(lCmd.Cmd)
+
+	config.AddBSPeersConfFlag(lCmd.Cmd)
+}
+
+func (lCmd *leaderCommand) Init(cmd *cobra.Command, args []string) error {
+	lCmd.SetHeader([]string{cobrautil.ROW_LEADER, cobrautil.ROW_OLDLEADER, cobrautil.ROW_COPYSET, cobrautil.ROW_RESULT})
+	lCmd.TableNew.SetAutoMergeCellsByColumnIndex(cobrautil.GetIndexSlice(
+		lCmd.Header, []string{},
+	))
+
+	opts := peer.Options{}
+	opts.Timeout = config.GetFlagDuration(lCmd.Cmd, config.RPCTIMEOUT)
+	opts.RetryTimes = config.GetFlagInt32(lCmd.Cmd, config.RPCRETRYTIMES)
+
+	copysetID := config.GetBsFlagUint32(lCmd.Cmd, config.CURVEBS_COPYSET_ID)
+	logicalPoolID := config.GetBsFlagUint32(lCmd.Cmd, config.CURVEBS_LOGIC_POOL_ID)
+
+	// parse peers config
+	peers := config.GetBsFlagStringSlice(lCmd.Cmd, config.CURVEBS_PEERS_ADDRESS)
+	c, err := peer.ParseConfiguration(peers)
+	if err != nil {
+		return err.ToError()
+	}
+	conf := *c
+
+	// parse peer conf
+	if len(args) < 1 {
+		pErr := cmderror.ErrGetPeer()
+		pErr.Format("should specified the peer address")
+		return pErr.ToError()
+	}
+	peerPara := args[0]
+	leaderPeer, err := peer.ParsePeer(peerPara)
+	if err != nil {
+		return err.ToError()
+	}
+
+	// 1. acquire leader peer info.
+	oldLeader, err := peer.GetLeader(logicalPoolID, copysetID, conf, opts)
+	if err != nil {
+		return err.ToError()
+	}
+
+	// 2. judge is same?
+	oldLeaderPeer, err := peer.ParsePeer(oldLeader.GetAddress())
+	if err != nil {
+		return err.ToError()
+	}
+
+	if oldLeaderPeer.GetAddress() == leaderPeer.GetAddress() {
+		return errors.New("don't need transfer!")
+	}
+
+	out := make(map[string]string)
+	out[cobrautil.ROW_OLDLEADER] = oldLeader.GetAddress()
+	out[cobrautil.ROW_LEADER] = fmt.Sprintf("%s:%d", leaderPeer.GetAddress(), leaderPeer.GetId())
+	out[cobrautil.ROW_COPYSET] = fmt.Sprintf("(%d:%d)", logicalPoolID, copysetID)
+	lCmd.row = out
+
+	lCmd.Rpc = &LeaderRpc{
+		Info: basecmd.NewRpc([]string{oldLeaderPeer.GetAddress()}, opts.Timeout, opts.RetryTimes, "TransferLeader"),
+		Request: &cli2.TransferLeaderRequest2{
+			LogicPoolId: &logicalPoolID,
+			CopysetId:   &copysetID,
+			Leader:      oldLeaderPeer,
+			Transferee:  leaderPeer,
+		},
+	}
+
+	return nil
+}
+
+func (lCmd *leaderCommand) Print(cmd *cobra.Command, args []string) error {
+	return output.FinalCmdOutput(&lCmd.FinalCurveCmd, lCmd)
+}
+
+func (lCmd *leaderCommand) RunCommand(cmd *cobra.Command, args []string) error {
+	// 3. transfer leader
+	response, err := basecmd.GetRpcResponse(lCmd.Rpc.Info, lCmd.Rpc)
+	lCmd.Error = err
+	if err.TypeCode() != cmderror.CODE_SUCCESS {
+		return err.ToError()
+	}
+
+	lCmd.row[cobrautil.ROW_RESULT] = "success"
+	lCmd.Response = response.(*cli2.TransferLeaderResponse2)
+
+	list := cobrautil.Map2List(lCmd.row, lCmd.Header)
+	lCmd.TableNew.Append(list)
+	return nil
+}
+
+func (lCmd *leaderCommand) ResultPlainOutput() error {
+	return output.FinalCmdOutputPlain(&lCmd.FinalCurveCmd)
+}

--- a/tools-v2/pkg/cli/command/curvebs/update/peer/peer.go
+++ b/tools-v2/pkg/cli/command/curvebs/update/peer/peer.go
@@ -42,7 +42,7 @@ import (
 )
 
 const (
-	updateExample = `$ curve bs update peer 127.0.0.0:8200:0 --logicalpoolid=1 --copysetid=1`
+	peerExample = `$ curve bs update peer 127.0.0.0:8200:0 --logicalpoolid=1 --copysetid=1`
 )
 
 type ResetRpc struct {
@@ -84,7 +84,7 @@ func NewPeerCommand() *cobra.Command {
 		FinalCurveCmd: basecmd.FinalCurveCmd{
 			Use:     "peer",
 			Short:   "update(reset) the peer from the copyset",
-			Example: updateExample,
+			Example: peerExample,
 		},
 	}
 	basecmd.NewFinalCurveCli(&peerCmd.FinalCurveCmd, peerCmd)
@@ -128,7 +128,7 @@ func (pCmd *PeerCommand) Init(cmd *cobra.Command, args []string) error {
 	pCmd.TableNew.SetAutoMergeCellsByColumnIndex(cobrautil.GetIndexSlice(
 		pCmd.Header, []string{},
 	))
-	
+
 	var e *cmderror.CmdError
 
 	pCmd.opts.Timeout = config.GetFlagDuration(pCmd.Cmd, config.RPCTIMEOUT)

--- a/tools-v2/pkg/cli/command/curvebs/update/update.go
+++ b/tools-v2/pkg/cli/command/curvebs/update/update.go
@@ -27,6 +27,7 @@ import (
 
 	basecmd "github.com/opencurve/curve/tools-v2/pkg/cli/command"
 	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/update/file"
+	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/update/leader"
 	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/update/peer"
 	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/update/throttle"
 )
@@ -42,6 +43,7 @@ func (updateCmd *UpdateCommand) AddSubCommands() {
 		peer.NewPeerCommand(),
 		file.NewFileCommand(),
 		throttle.NewThrottleCommand(),
+		leader.NewleaderCommand(),
 	)
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #2022<!-- replace xxx with issue number -->

Problem Summary: add command `curve bs update leader`

### What is changed and how it works?

What's Changed:
1. modified:   internal/utils/row.go
2. new file:   pkg/cli/command/curvebs/update/leader/leader.go
3. modified:   pkg/cli/command/curvebs/update/peer/peer.go
4. modified:   pkg/cli/command/curvebs/update/update.go

How it Works:
implement by using `TransferLeaderRequest2` rpc.
step 1: transfer leader from 192.168.20.149:8202:0 to 192.168.20.149:8201:0
```shell
$ curve bs update leader 192.168.20.149:8201:0 --logicalpoolid=1 --copysetid=1 --peers=192.168.20.149:8200:0,192.168.20.149:8201:1,192.168.20.149:8202:2
+-----------------------+-----------------------+---------+---------+--------+
|        LEADER         |       OLDLEADER       | COPYSET | RESULT  | REASON |
+-----------------------+-----------------------+---------+---------+--------+
| 192.168.20.149:8201:0 | 192.168.20.149:8202:0 | (1:1)   | success | null   |
+-----------------------+-----------------------+---------+---------+--------+

```
step 2: check-copyset, proving that the leader has changed
```shell
$ curve_ops_tool check-copyset -logicalPoolId=1 -copysetId=1 --detail
Copyset is healthy!

[4294967297]
peer_id: 192.168.20.149:8202:0
state: FOLLOWER
readonly: 0
term: 14
conf_index: 7
peers: 192.168.20.149:8200:0 192.168.20.149:8201:0 192.168.20.149:8202:0
leader: 192.168.20.149:8201:0
last_msg_to_now: 70
election_timer: timeout(1000ms) SCHEDULING(in 665ms)
vote_timer: timeout(1000ms) STOPPED
stepdown_timer: timeout(1000ms) STOPPED
snapshot_timer: timeout(1800000ms) SCHEDULING(in 507552ms)
storage: [1, 7]
disk_index: 7
known_applied_index: 7
last_log_id: (index=7,term=14)
state_machine: Idle
last_committed_index: 7
last_snapshot_index: 6
last_snapshot_term: 13
snapshot_status: IDLE

[4294967297]
peer_id: 192.168.20.149:8200:0
state: FOLLOWER
readonly: 0
term: 14
conf_index: 7
peers: 192.168.20.149:8200:0 192.168.20.149:8201:0 192.168.20.149:8202:0
leader: 192.168.20.149:8201:0
last_msg_to_now: 24
election_timer: timeout(1000ms) SCHEDULING(in 1277ms)
vote_timer: timeout(1000ms) STOPPED
stepdown_timer: timeout(1000ms) STOPPED
snapshot_timer: timeout(1800000ms) SCHEDULING(in 1318788ms)
storage: [1, 7]
disk_index: 7
known_applied_index: 7
last_log_id: (index=7,term=14)
state_machine: Idle
last_committed_index: 7
last_snapshot_index: 6
last_snapshot_term: 13
snapshot_status: IDLE

[4294967297]
peer_id: 192.168.20.149:8201:0
state: LEADER
readonly: 0
term: 14
conf_index: 7
peers: 192.168.20.149:8200:0 192.168.20.149:8201:0 192.168.20.149:8202:0
changing_conf: NO    stage: STAGE_NONE
election_timer: timeout(1000ms) STOPPED
vote_timer: timeout(1000ms) STOPPED
stepdown_timer: timeout(1000ms) SCHEDULING(in 667ms)
snapshot_timer: timeout(1800000ms) SCHEDULING(in 1402999ms)
storage: [1, 7]
disk_index: 7
known_applied_index: 7
last_log_id: (index=7,term=14)
state_machine: Idle
last_committed_index: 7
last_snapshot_index: 6
last_snapshot_term: 13
snapshot_status: IDLE
replicator_9526237464223@192.168.20.149:8200:0: next_index=8  flying_append_entries_size=0 idle hc=1252 ac=2 ic=0
replicator_16531329124485@192.168.20.149:8202:0: next_index=8  flying_append_entries_size=0 idle hc=1252 ac=2 ic=0
```
step 3: transfer leader again:
```shell
$ curve bs update leader 192.168.20.149:8202:0 --logicalpoolid=1 --copysetid=1 --peers=192.168.20.149:8200:0,192.168.20.149:8201:1,192.168.20.149:8202:2
+-----------------------+-----------------------+---------+---------+--------+
|        LEADER         |       OLDLEADER       | COPYSET | RESULT  | REASON |
+-----------------------+-----------------------+---------+---------+--------+
| 192.168.20.149:8202:0 | 192.168.20.149:8201:0 | (1:1)   | success | null   |
+-----------------------+-----------------------+---------+---------+--------+
```
step 4: check-copyset again:
```shell
$ curve_ops_tool check-copyset -logicalPoolId=1 -copysetId=1 --detail
Copyset is healthy!

[4294967297]
peer_id: 192.168.20.149:8202:0
state: LEADER
readonly: 0
term: 15
conf_index: 8
peers: 192.168.20.149:8200:0 192.168.20.149:8201:0 192.168.20.149:8202:0
changing_conf: NO    stage: STAGE_NONE
election_timer: timeout(1000ms) STOPPED
vote_timer: timeout(1000ms) STOPPED
stepdown_timer: timeout(1000ms) SCHEDULING(in 766ms)
snapshot_timer: timeout(1800000ms) SCHEDULING(in 387262ms)
storage: [1, 8]
disk_index: 8
known_applied_index: 8
last_log_id: (index=8,term=15)
state_machine: Idle
last_committed_index: 8
last_snapshot_index: 6
last_snapshot_term: 13
snapshot_status: IDLE
replicator_26491358283205@192.168.20.149:8200:0: next_index=9  flying_append_entries_size=0 idle hc=349 ac=2 ic=0
replicator_9972914062800@192.168.20.149:8201:0: next_index=9  flying_append_entries_size=0 idle hc=349 ac=2 ic=0

[4294967297]
peer_id: 192.168.20.149:8200:0
state: FOLLOWER
readonly: 0
term: 15
conf_index: 8
peers: 192.168.20.149:8200:0 192.168.20.149:8201:0 192.168.20.149:8202:0
leader: 192.168.20.149:8202:0
last_msg_to_now: 62
election_timer: timeout(1000ms) SCHEDULING(in 170ms)
vote_timer: timeout(1000ms) STOPPED
stepdown_timer: timeout(1000ms) STOPPED
snapshot_timer: timeout(1800000ms) SCHEDULING(in 1198495ms)
storage: [1, 8]
disk_index: 8
known_applied_index: 8
last_log_id: (index=8,term=15)
state_machine: Idle
last_committed_index: 8
last_snapshot_index: 6
last_snapshot_term: 13
snapshot_status: IDLE

[4294967297]
peer_id: 192.168.20.149:8201:0
state: FOLLOWER
readonly: 0
term: 15
conf_index: 8
peers: 192.168.20.149:8200:0 192.168.20.149:8201:0 192.168.20.149:8202:0
leader: 192.168.20.149:8202:0
last_msg_to_now: 63
election_timer: timeout(1000ms) SCHEDULING(in 689ms)
vote_timer: timeout(1000ms) STOPPED
stepdown_timer: timeout(1000ms) STOPPED
snapshot_timer: timeout(1800000ms) SCHEDULING(in 1282707ms)
storage: [1, 8]
disk_index: 8
known_applied_index: 8
last_log_id: (index=8,term=15)
state_machine: Idle
last_committed_index: 8
last_snapshot_index: 6
last_snapshot_term: 13
snapshot_status: IDLE
```
step 5: test if leader is same:
```shell
$ curve bs update leader 192.168.20.149:8202:0 --logicalpoolid=1 --copysetid=1 --peers=192.168.20.149:8200:0,192.168.20.149:8201:1,192.168.20.149:8202:2
+-----------------------+-----------------------+---------+---------+------------------------+
|        LEADER         |       OLDLEADER       | COPYSET | RESULT  |         REASON         |
+-----------------------+-----------------------+---------+---------+------------------------+
| 192.168.20.149:8202:0 | 192.168.20.149:8202:0 | (1:1)   | success | don't need to transfer |
+-----------------------+-----------------------+---------+---------+------------------------+
```
Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [x] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license
