### PR TITLE
[feat]tools-v2: add update copyset availflag

### DIFF
--- a/tools-v2/README.md
+++ b/tools-v2/README.md
@@ -68,6 +68,7 @@ A tool for CurveFS & CurveBs.
       - [update file](#update-file)
       - [update throttle](#update-throttle)
       - [update scan-state](#update-scan-state)
+      - [update copyset availflag](#update-copyset-availflag)
     - [create](#create-1)
       - [create file](#create-file)
       - [create dir](#create-dir)
@@ -1275,6 +1276,24 @@ Output:
 +----+------+---------+--------+
 ```
 
+#### update copyset availflag
+
+update copyset availflag
+
+Usage:
+```bash
+curve bs update copyset availflag --availflag=true [--dryrun=true/false]
+```
+
+Output:
+```
++--------+-----------+---------------+--------+
+| POOLID | COPYSETID |   AVAILFLAG   | DRYRUN |
++--------+-----------+---------------+--------+
+| 1      | 1         | false => true | true   |
++--------+-----------+---------------+--------+
+```
+
 ### create
 
 #### create file
@@ -1385,40 +1404,40 @@ Output:
 
 ### curve bs
 
-| old                                  | new                            |
-| ------------------------------------ | ------------------------------ |
-| curve_ops_tool logical-pool-list     | curve bs list logical-pool     |
-| curve_ops_tool get -fileName=        | curve bs query file -path      |
-| curve_ops_tool etcd-status           | curve bs status etcd           |
-| curve_ops_tool mds-status            | curve bs status mds            |
-| curve_ops_tool server-list           | curve bs list server           |
-| curve_ops_tool client-list           | curve bs list client           |
-| curve_ops_tool delete                | curve bs delete file           |
-| curve_ops_tool list                  | curve bs list dir              |
-| curve_ops_tool create                | curve bs create file/dir       |
-| curve_ops_tool seginfo               | curve bs query seginfo         |
-| curve_ops_tool chunk-location        | curve bs query chunk           |
-| curve_ops_tool remove-peer           | curve bs delete peer           |
-| curve_ops_tool reset-peer            | curve bs update peer           |
-| curve_ops_tool space                 | curve bs list space            |
-| curve_ops_tool update-throttle       | curve bs update throttle       |
-| curve_ops_tool check-copyset         | curve bs check copyset         |
-| curve_ops_tool client-status         | curve bs status client         |
-| curve_ops_tool check-operator        | curve bs check operator        |
-| curve_ops_tool snapshot-clone-status | curve bs status snapshotserver |
-| curve_ops_tool transfer-leader       | curve bs update leader         |
-| curve_ops_tool do-snapshot           | curve bs snapshot copyset      |
-| curve_ops_tool set-scan-state        | curve bs update scan-state     |
-| curve_ops_tool chunkserver-status    | curve bs status chunkserver    |
-| curve_ops_tool status                |                                |
-| curve_ops_tool copysets-status       |                                |
-| curve_ops_tool chunkserver-list      | curve bs list chunkserver      |
-| curve_ops_tool clean-recycle         |                                |
-| curve_ops_tool check-consistency     |                                |
-| curve_ops_tool do-snapshot-all       |                                |
-| curve_ops_tool check-chunkserver     |                                |
-| curve_ops_tool check-server          |                                |
-| curve_ops_tool list-may-broken-vol   |                                |
-| curve_ops_tool set-copyset-availflag |                                |
-| curve_ops_tool rapid-leader-schedule |                                |
-| curve_ops_tool scan-status           |                                |
+| old                                  | new                               |
+|--------------------------------------|-----------------------------------|
+| curve_ops_tool logical-pool-list     | curve bs list logical-pool        |
+| curve_ops_tool get -fileName=        | curve bs query file -path         |
+| curve_ops_tool etcd-status           | curve bs status etcd              |
+| curve_ops_tool mds-status            | curve bs status mds               |
+| curve_ops_tool server-list           | curve bs list server              |
+| curve_ops_tool client-list           | curve bs list client              |
+| curve_ops_tool delete                | curve bs delete file              |
+| curve_ops_tool list                  | curve bs list dir                 |
+| curve_ops_tool create                | curve bs create file/dir          |
+| curve_ops_tool seginfo               | curve bs query seginfo            |
+| curve_ops_tool chunk-location        | curve bs query chunk              |
+| curve_ops_tool remove-peer           | curve bs delete peer              |
+| curve_ops_tool reset-peer            | curve bs update peer              |
+| curve_ops_tool space                 | curve bs list space               |
+| curve_ops_tool update-throttle       | curve bs update throttle          |
+| curve_ops_tool check-copyset         | curve bs check copyset            |
+| curve_ops_tool client-status         | curve bs status client            |
+| curve_ops_tool check-operator        | curve bs check operator           |
+| curve_ops_tool snapshot-clone-status | curve bs status snapshotserver    |
+| curve_ops_tool transfer-leader       | curve bs update leader            |
+| curve_ops_tool do-snapshot           | curve bs snapshot copyset         |
+| curve_ops_tool set-scan-state        | curve bs update scan-state        |
+| curve_ops_tool chunkserver-status    | curve bs status chunkserver       |
+| curve_ops_tool chunkserver-list      | curve bs list chunkserver         |
+| curve_ops_tool set-copyset-availflag | curve bs update copyset availflag |
+| curve_ops_tool status                |                                   |
+| curve_ops_tool copysets-status       |                                   |
+| curve_ops_tool clean-recycle         |                                   |
+| curve_ops_tool check-consistency     |                                   |
+| curve_ops_tool do-snapshot-all       |                                   |
+| curve_ops_tool check-chunkserver     |                                   |
+| curve_ops_tool check-server          |                                   |
+| curve_ops_tool list-may-broken-vol   |                                   |
+| curve_ops_tool rapid-leader-schedule |                                   |
+| curve_ops_tool scan-status           |                                   |

--- a/tools-v2/internal/error/error.go
+++ b/tools-v2/internal/error/error.go
@@ -442,9 +442,17 @@ var (
 		return NewInternalCmdError(60, "query chunkserver recover status fail, err: %s")
 	}
 	ErrBsListChunkServer = func() *CmdError {
-		return NewInternalCmdError(54, "list chunkserver fail, err: %s")
+		return NewInternalCmdError(61, "list chunkserver fail, err: %s")
 	}
-
+	ErrBsGetCopysetInChunkServer = func() *CmdError {
+		return NewInternalCmdError(62, "get copyset in chunkserver fail, err: %s")
+	}
+	ErrBsGetChunkInfo = func() *CmdError {
+		return NewInternalCmdError(63, "get chunk info fail, err: %s")
+	}
+	ErrBsGetUnavailCopysets = func() *CmdError {
+		return NewInternalCmdError(64, "get unavail copysets fail, err: %s")
+	}
 	// http error
 	ErrHttpUnreadableResult = func() *CmdError {
 		return NewHttpResultCmdError(1, "http response is unreadable, the uri is: %s, the error is: %s")
@@ -655,6 +663,18 @@ var (
 	}
 	ErrBsListPoolZoneRpc = func(statuscode bs_topo_statuscode.TopoStatusCode) *CmdError {
 		message := fmt.Sprintf("Rpc[ListPoolZone] faild status code: %s", statuscode.String())
+		return NewInternalCmdError(int(statuscode), message)
+	}
+	ErrBsGetChunkserverInClusterRpc = func(statuscode bs_topo_statuscode.TopoStatusCode) *CmdError {
+		message := fmt.Sprintf("Rpc[GetChunkserverInCluster] faild status code: %s", statuscode.String())
+		return NewInternalCmdError(int(statuscode), message)
+	}
+	ErrBsSetCopysetAvailFlagRpc = func(statuscode bs_topo_statuscode.TopoStatusCode) *CmdError {
+		message := fmt.Sprintf("Rpc[SetCopysetAvailFlag] faild status code: %s", statuscode.String())
+		return NewInternalCmdError(int(statuscode), message)
+	}
+	ErrBsGetCopysetInChunkServerRpc = func(statuscode bs_topo_statuscode.TopoStatusCode) *CmdError {
+		message := fmt.Sprintf("Rpc[GetCopySetsInChunkServer] faild status code: %s", statuscode.String())
 		return NewInternalCmdError(int(statuscode), message)
 	}
 

--- a/tools-v2/internal/utils/row.go
+++ b/tools-v2/internal/utils/row.go
@@ -111,6 +111,8 @@ const (
 	ROW_USED            = "used"
 	ROW_VERSION         = "version"
 	ROW_ZONE            = "zone"
+	ROW_AVAILFLAG       = "availFlag"
+	ROW_DRYRUN          = "dryrun"
 
 	ROW_RW_STATUS         = "rwStatus"
 	ROW_DISK_STATE        = "diskState"
@@ -141,6 +143,8 @@ const (
 	ROW_VALUE_RECOVERING_OUT = "recovering from out"
 	ROW_VALUE_SUCCESS        = "success"
 	ROW_VALUE_UNKNOWN        = "unknown"
+	ROW_VALUE_TRUE           = "true"
+	ROW_VALUE_FALSE          = "false"
 )
 
 // topology type

--- a/tools-v2/pkg/cli/command/base.go
+++ b/tools-v2/pkg/cli/command/base.go
@@ -113,6 +113,9 @@ func NewFinalCurveCli(cli *FinalCurveCmd, funcs FinalCurveCmdFunc) *cobra.Comman
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
 			err := funcs.Init(cmd, args)
+			if cli.Cmd.Flag(config.VERBOSE) == nil {
+				cli.Cmd.PersistentFlags().BoolP(config.VERBOSE, "v", false, "verbose output")
+			}
 			show := config.GetFlagBool(cli.Cmd, config.VERBOSE)
 			process.SetShow(show)
 			if err != nil {

--- a/tools-v2/pkg/cli/command/curvebs/check/copyset/copyset.go
+++ b/tools-v2/pkg/cli/command/curvebs/check/copyset/copyset.go
@@ -33,7 +33,7 @@ import (
 	cmderror "github.com/opencurve/curve/tools-v2/internal/error"
 	cobrautil "github.com/opencurve/curve/tools-v2/internal/utils"
 	basecmd "github.com/opencurve/curve/tools-v2/pkg/cli/command"
-	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/query/chunk"
+	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/query/chunkserver"
 	status "github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/status/copyset"
 	fscopyset "github.com/opencurve/curve/tools-v2/pkg/cli/command/curvefs/check/copyset"
 	"github.com/opencurve/curve/tools-v2/pkg/config"
@@ -103,7 +103,7 @@ func (cCmd *CopysetCommand) Init(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("parse copysetid%v fail", copysetidList)
 	}
 
-	key2Location, err := chunk.GetChunkServerListInCopySets(cCmd.Cmd)
+	key2Location, err := chunkserver.GetChunkServerListInCopySets(cCmd.Cmd)
 	if err.TypeCode() != cmderror.CODE_SUCCESS {
 		return err.ToError()
 	}
@@ -235,7 +235,6 @@ func (cCmd *CopysetCommand) RunCommand(cmd *cobra.Command, args []string) error 
 					} else {
 						explain += e.Message
 					}
-					errs = append(errs, e)
 				}
 			}
 			margin := config.GetMarginOptionFlag(cCmd.Cmd)
@@ -360,11 +359,12 @@ func CheckCopysets(caller *cobra.Command) (*map[uint64]cobrautil.ClUSTER_HEALTH_
 		config.CURVEBS_COPYSET_ID, config.CURVEBS_LOGIC_POOL_ID, config.CURVEBS_MARGIN,
 	})
 	cCmd.Cmd.SilenceErrors = true
+	cCmd.Cmd.SilenceUsage = true
 	err := cCmd.Cmd.Execute()
 	if err != nil {
 		retErr := cmderror.ErrCheckCopyset()
 		retErr.Format(err.Error())
 		return cCmd.Key2Health, retErr
 	}
-	return cCmd.Key2Health, cCmd.Error
+	return cCmd.Key2Health, cmderror.Success()
 }

--- a/tools-v2/pkg/cli/command/curvebs/list/chunkserver/copyset.go
+++ b/tools-v2/pkg/cli/command/curvebs/list/chunkserver/copyset.go
@@ -61,7 +61,7 @@ func (lRpc *GetCopySetsInChunkServerRpc) Stub_Func(ctx context.Context) (interfa
 	return lRpc.topologyServiceClient.GetCopySetsInChunkServer(ctx, lRpc.Request)
 }
 
-func NewCopySetsInChenkServerCommand() *cobra.Command {
+func NewCopySetsInChunkServerCommand() *cobra.Command {
 	return NewGetCopySetsInCopySetCommand().Cmd
 }
 

--- a/tools-v2/pkg/cli/command/curvebs/list/chunkserver/copyset_by_host.go
+++ b/tools-v2/pkg/cli/command/curvebs/list/chunkserver/copyset_by_host.go
@@ -1,0 +1,163 @@
+/*
+ *  Copyright (c) 2023 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * Project: tools-v2
+ * Created Date: 2023-04-28
+ * Author: baytan0720
+ */
+
+package chunkserver
+
+import (
+	"context"
+	"fmt"
+
+	cmderror "github.com/opencurve/curve/tools-v2/internal/error"
+	cobrautil "github.com/opencurve/curve/tools-v2/internal/utils"
+	basecmd "github.com/opencurve/curve/tools-v2/pkg/cli/command"
+	"github.com/opencurve/curve/tools-v2/pkg/config"
+	"github.com/opencurve/curve/tools-v2/pkg/output"
+	"github.com/opencurve/curve/tools-v2/proto/proto/common"
+	"github.com/opencurve/curve/tools-v2/proto/proto/topology"
+	"github.com/opencurve/curve/tools-v2/proto/proto/topology/statuscode"
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+)
+
+type GetCopySetsInChunkServerByHostRpc struct {
+	Info      *basecmd.Rpc
+	Request   *topology.GetCopySetsInChunkServerRequest
+	mdsClient topology.TopologyServiceClient
+}
+
+var _ basecmd.RpcFunc = (*GetCopySetsInChunkServerByHostRpc)(nil) // check interface
+
+func (gRpc *GetCopySetsInChunkServerByHostRpc) NewRpcClient(cc grpc.ClientConnInterface) {
+	gRpc.mdsClient = topology.NewTopologyServiceClient(cc)
+}
+
+func (gRpc *GetCopySetsInChunkServerByHostRpc) Stub_Func(ctx context.Context) (interface{}, error) {
+	return gRpc.mdsClient.GetCopySetsInChunkServer(ctx, gRpc.Request)
+}
+
+type CopySetsInChunkServerCommand struct {
+	basecmd.FinalCurveCmd
+	Rpc           []*GetCopySetsInChunkServerByHostRpc
+	addr2Copysets *map[string][]*common.CopysetInfo
+}
+
+var _ basecmd.FinalCurveCmdFunc = (*CopySetsInChunkServerCommand)(nil) // check interface
+
+func NewCopySetsInChunkServerByHostCommand() *cobra.Command {
+	return NewGetCopySetsInChunkServerCommand().Cmd
+}
+
+func NewGetCopySetsInChunkServerCommand() *CopySetsInChunkServerCommand {
+	copysetCmd := &CopySetsInChunkServerCommand{
+		FinalCurveCmd: basecmd.FinalCurveCmd{},
+	}
+	basecmd.NewFinalCurveCli(&copysetCmd.FinalCurveCmd, copysetCmd)
+	return copysetCmd
+}
+
+func (cCmd *CopySetsInChunkServerCommand) Init(cmd *cobra.Command, args []string) error {
+	mdsAddrs, err := config.GetBsMdsAddrSlice(cCmd.Cmd)
+	if err.TypeCode() != cmderror.CODE_SUCCESS {
+		return err.ToError()
+	}
+	timeout := config.GetFlagDuration(cCmd.Cmd, config.RPCTIMEOUT)
+	retrytimes := config.GetFlagInt32(cCmd.Cmd, config.RPCRETRYTIMES)
+	chunkserverAddrs := config.GetBsFlagStringSlice(cCmd.Cmd, config.CURVEBS_CHUNKSERVER_ADDRESS)
+	for i := 0; i < len(chunkserverAddrs); i++ {
+		hostIp, port, addrErr := cobrautil.Addr2IpPort(chunkserverAddrs[i])
+		if addrErr.TypeCode() != cmderror.CODE_SUCCESS {
+			return addrErr.ToError()
+		}
+		rpc := &GetCopySetsInChunkServerByHostRpc{
+			Request: &topology.GetCopySetsInChunkServerRequest{
+				HostIp: &hostIp,
+				Port:   &port,
+			},
+			Info: basecmd.NewRpc(mdsAddrs, timeout, retrytimes, "GetCopySetsInChunkServer"),
+		}
+		cCmd.Rpc = append(cCmd.Rpc, rpc)
+	}
+	return nil
+}
+
+func (cCmd *CopySetsInChunkServerCommand) RunCommand(cmd *cobra.Command, args []string) error {
+	var infos []*basecmd.Rpc
+	var funcs []basecmd.RpcFunc
+	for _, rpc := range cCmd.Rpc {
+		infos = append(infos, rpc.Info)
+		funcs = append(funcs, rpc)
+	}
+	results, errs := basecmd.GetRpcListResponse(infos, funcs)
+	if len(errs) == len(infos) {
+		mergeErr := cmderror.MergeCmdErrorExceptSuccess(errs)
+		return mergeErr.ToError()
+	}
+	cCmd.addr2Copysets = &map[string][]*common.CopysetInfo{}
+	for i, result := range results {
+		resp := result.(*topology.GetCopySetsInChunkServerResponse)
+		if resp.GetStatusCode() != int32(statuscode.TopoStatusCode_Success) {
+			err := cmderror.ErrBsGetCopysetInChunkServerRpc(
+				statuscode.TopoStatusCode(resp.GetStatusCode()),
+			)
+			errs = append(errs, err)
+			continue
+		}
+		addr := fmt.Sprintf("%s:%d", *cCmd.Rpc[i].Request.HostIp, *cCmd.Rpc[i].Request.Port)
+		(*cCmd.addr2Copysets)[addr] = resp.CopysetInfos
+	}
+	errRet := cmderror.MergeCmdError(errs)
+	cCmd.Error = errRet
+	return nil
+}
+
+func (cCmd *CopySetsInChunkServerCommand) Print(cmd *cobra.Command, args []string) error {
+	return output.FinalCmdOutput(&cCmd.FinalCurveCmd, cCmd)
+}
+
+func (cCmd *CopySetsInChunkServerCommand) ResultPlainOutput() error {
+	return output.FinalCmdOutputPlain(&cCmd.FinalCurveCmd)
+}
+
+func (cCmd *CopySetsInChunkServerCommand) AddFlags() {
+	config.AddBsMdsFlagOption(cCmd.Cmd)
+	config.AddRpcRetryTimesFlag(cCmd.Cmd)
+	config.AddRpcTimeoutFlag(cCmd.Cmd)
+
+	config.AddBsChunkServerAddressSliceRequiredFlag(cCmd.Cmd)
+}
+
+func GetCopySetsInChunkServerByHost(caller *cobra.Command) (*map[string][]*common.CopysetInfo, *cmderror.CmdError) {
+	gCmd := NewGetCopySetsInChunkServerCommand()
+	config.AlignFlagsValue(caller, gCmd.Cmd, []string{
+		config.RPCRETRYTIMES, config.RPCTIMEOUT, config.CURVEBS_MDSADDR,
+	})
+	gCmd.Cmd.SilenceErrors = true
+	gCmd.Cmd.SilenceUsage = true
+	gCmd.Cmd.SetArgs([]string{"--format", config.FORMAT_NOOUT})
+	err := gCmd.Cmd.Execute()
+	if err != nil {
+		retErr := cmderror.ErrBsGetCopysetInChunkServer()
+		retErr.Format(err.Error())
+		return nil, retErr
+	}
+	return gCmd.addr2Copysets, cmderror.Success()
+}

--- a/tools-v2/pkg/cli/command/curvebs/list/unavailcopysets/unavailcopysets.go
+++ b/tools-v2/pkg/cli/command/curvebs/list/unavailcopysets/unavailcopysets.go
@@ -1,0 +1,133 @@
+/*
+ *  Copyright (c) 2023 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * Project: CurveCli
+ * Created Date: 2023-04-24
+ * Author: baytan
+ */
+
+package unavailcopysets
+
+import (
+	"context"
+
+	cmderror "github.com/opencurve/curve/tools-v2/internal/error"
+	basecmd "github.com/opencurve/curve/tools-v2/pkg/cli/command"
+	"github.com/opencurve/curve/tools-v2/pkg/config"
+	"github.com/opencurve/curve/tools-v2/pkg/output"
+	common "github.com/opencurve/curve/tools-v2/proto/proto/common"
+	"github.com/opencurve/curve/tools-v2/proto/proto/topology"
+	"github.com/opencurve/curve/tools-v2/proto/proto/topology/statuscode"
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+)
+
+type ListUnAvailCopySets struct {
+	Info           *basecmd.Rpc
+	Request        *topology.ListUnAvailCopySetsRequest
+	topologyClient topology.TopologyServiceClient
+}
+
+var _ basecmd.RpcFunc = (*ListUnAvailCopySets)(nil) // check interface
+
+func (lRpc *ListUnAvailCopySets) NewRpcClient(cc grpc.ClientConnInterface) {
+	lRpc.topologyClient = topology.NewTopologyServiceClient(cc)
+}
+
+func (lRpc *ListUnAvailCopySets) Stub_Func(ctx context.Context) (interface{}, error) {
+	return lRpc.topologyClient.ListUnAvailCopySets(ctx, lRpc.Request)
+}
+
+type UnAvailCopySetsCommand struct {
+	basecmd.FinalCurveCmd
+	Rpc      *ListUnAvailCopySets
+	response []*common.CopysetInfo
+}
+
+var _ basecmd.FinalCurveCmdFunc = (*UnAvailCopySetsCommand)(nil) // check interface
+
+func NewUnAvailCopySetsCommand() *cobra.Command {
+	return NewListUnAvailCopySetsCommand().Cmd
+}
+
+func NewListUnAvailCopySetsCommand() *UnAvailCopySetsCommand {
+	uCmd := &UnAvailCopySetsCommand{
+		FinalCurveCmd: basecmd.FinalCurveCmd{},
+	}
+
+	basecmd.NewFinalCurveCli(&uCmd.FinalCurveCmd, uCmd)
+	return uCmd
+}
+
+func (uCmd *UnAvailCopySetsCommand) AddFlags() {
+	config.AddBsMdsFlagOption(uCmd.Cmd)
+	config.AddRpcRetryTimesFlag(uCmd.Cmd)
+	config.AddRpcTimeoutFlag(uCmd.Cmd)
+}
+
+func (uCmd *UnAvailCopySetsCommand) Init(cmd *cobra.Command, args []string) error {
+	mdsAddrs, err := config.GetBsMdsAddrSlice(uCmd.Cmd)
+	if err.TypeCode() != cmderror.CODE_SUCCESS {
+		return err.ToError()
+	}
+	timeout := config.GetFlagDuration(uCmd.Cmd, config.RPCTIMEOUT)
+	retrytimes := config.GetFlagInt32(uCmd.Cmd, config.RPCRETRYTIMES)
+	uCmd.Rpc = &ListUnAvailCopySets{
+		Request: &topology.ListUnAvailCopySetsRequest{},
+		Info:    basecmd.NewRpc(mdsAddrs, timeout, retrytimes, "ListUnAvailCopySets"),
+	}
+	return nil
+}
+
+func (uCmd *UnAvailCopySetsCommand) Print(cmd *cobra.Command, args []string) error {
+	return output.FinalCmdOutput(&uCmd.FinalCurveCmd, uCmd)
+}
+
+func (uCmd *UnAvailCopySetsCommand) RunCommand(cmd *cobra.Command, args []string) error {
+	result, errCmd := basecmd.GetRpcResponse(uCmd.Rpc.Info, uCmd.Rpc)
+	if errCmd.TypeCode() != cmderror.CODE_SUCCESS {
+		return errCmd.ToError()
+	}
+	response := result.(*topology.ListUnAvailCopySetsResponse)
+	if response.StatusCode == nil ||
+		response.GetStatusCode() != int32(statuscode.TopoStatusCode_Success) {
+		code := statuscode.TopoStatusCode(response.GetStatusCode())
+		return cmderror.ErrBsListPhysicalPoolRpc(code).ToError()
+	}
+	uCmd.response = response.Copysets
+	return nil
+}
+
+func (uCmd *UnAvailCopySetsCommand) ResultPlainOutput() error {
+	return output.FinalCmdOutputPlain(&uCmd.FinalCurveCmd)
+}
+
+func GetUnAvailCopySets(caller *cobra.Command) ([]*common.CopysetInfo, *cmderror.CmdError) {
+	listUnAvailCopySets := NewListUnAvailCopySetsCommand()
+	listUnAvailCopySets.Cmd.SetArgs([]string{"--format", config.FORMAT_NOOUT})
+	listUnAvailCopySets.Cmd.SilenceErrors = true
+	config.AlignFlagsValue(caller, listUnAvailCopySets.Cmd, []string{
+		config.RPCRETRYTIMES, config.RPCTIMEOUT, config.CURVEBS_MDSADDR,
+	})
+	err := listUnAvailCopySets.Cmd.Execute()
+	if err != nil {
+		retErr := cmderror.ErrBsGetUnavailCopysets()
+		retErr.Format(err.Error())
+		return nil, retErr
+	}
+	return listUnAvailCopySets.response, cmderror.ErrSuccess()
+}

--- a/tools-v2/pkg/cli/command/curvebs/query/chunk/chunk.go
+++ b/tools-v2/pkg/cli/command/curvebs/query/chunk/chunk.go
@@ -28,6 +28,7 @@ import (
 	cmderror "github.com/opencurve/curve/tools-v2/internal/error"
 	cobrautil "github.com/opencurve/curve/tools-v2/internal/utils"
 	basecmd "github.com/opencurve/curve/tools-v2/pkg/cli/command"
+	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/query/chunkserver"
 	"github.com/opencurve/curve/tools-v2/pkg/config"
 	"github.com/opencurve/curve/tools-v2/pkg/output"
 	"github.com/opencurve/curve/tools-v2/proto/proto/common"
@@ -92,7 +93,7 @@ func (cCmd *ChunkCommand) Init(cmd *cobra.Command, args []string) error {
 		fmt.Sprintf("--%s", config.CURVEBS_COPYSET_ID),
 		fmt.Sprintf("%d", cCmd.CopysetId),
 	})
-	key2Location, err := GetChunkServerListInCopySets(cCmd.Cmd)
+	key2Location, err := chunkserver.GetChunkServerListInCopySets(cCmd.Cmd)
 	if err.TypeCode() != cmderror.CODE_SUCCESS {
 		return err.ToError()
 	}

--- a/tools-v2/pkg/cli/command/curvebs/query/chunk/chunkinfo.go
+++ b/tools-v2/pkg/cli/command/curvebs/query/chunk/chunkinfo.go
@@ -1,0 +1,171 @@
+/*
+ *  Copyright (c) 2023 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * Project: tools-v2
+ * Created Date: 2023-04-24
+ * Author: baytan0720
+ */
+
+package chunk
+
+import (
+	"context"
+	"fmt"
+
+	cmderror "github.com/opencurve/curve/tools-v2/internal/error"
+	cobrautil "github.com/opencurve/curve/tools-v2/internal/utils"
+	basecmd "github.com/opencurve/curve/tools-v2/pkg/cli/command"
+	"github.com/opencurve/curve/tools-v2/pkg/config"
+	"github.com/opencurve/curve/tools-v2/pkg/output"
+	"github.com/opencurve/curve/tools-v2/proto/proto/chunk"
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+)
+
+type GetChunkInfoRpc struct {
+	Info      *basecmd.Rpc
+	Request   *chunk.GetChunkInfoRequest
+	mdsClient chunk.ChunkServiceClient
+}
+
+var _ basecmd.RpcFunc = (*GetChunkInfoRpc)(nil) // check interface
+
+func (gRpc *GetChunkInfoRpc) NewRpcClient(cc grpc.ClientConnInterface) {
+	gRpc.mdsClient = chunk.NewChunkServiceClient(cc)
+}
+
+func (gRpc *GetChunkInfoRpc) Stub_Func(ctx context.Context) (interface{}, error) {
+	return gRpc.mdsClient.GetChunkInfo(ctx, gRpc.Request)
+}
+
+type GetChunkInfoCommand struct {
+	basecmd.FinalCurveCmd
+	Rpc        []*GetChunkInfoRpc
+	addr2Chunk *map[string]*chunk.GetChunkInfoResponse
+}
+
+var _ basecmd.FinalCurveCmdFunc = (*GetChunkInfoCommand)(nil) // check interface
+
+func NewChunkInfoCommand() *cobra.Command {
+	return NewGetChunkInfoCommand().Cmd
+}
+
+func NewGetChunkInfoCommand() *GetChunkInfoCommand {
+	chunkCmd := &GetChunkInfoCommand{
+		FinalCurveCmd: basecmd.FinalCurveCmd{},
+	}
+	basecmd.NewFinalCurveCli(&chunkCmd.FinalCurveCmd, chunkCmd)
+	return chunkCmd
+}
+
+func (cCmd *GetChunkInfoCommand) Init(cmd *cobra.Command, args []string) error {
+	timeout := config.GetFlagDuration(cCmd.Cmd, config.RPCTIMEOUT)
+	retrytimes := config.GetFlagInt32(cCmd.Cmd, config.RPCRETRYTIMES)
+
+	logicalpoolidList := config.GetBsFlagStringSlice(cCmd.Cmd, config.CURVEBS_LOGIC_POOL_ID)
+	copysetidList := config.GetBsFlagStringSlice(cCmd.Cmd, config.CURVEBS_COPYSET_ID)
+	chunkidList := config.GetBsFlagStringSlice(cCmd.Cmd, config.CURVEBS_CHUNK_ID)
+	addressList := config.GetBsFlagStringSlice(cCmd.Cmd, config.CURVEBS_CHUNKSERVER_ADDRESS)
+	if len(copysetidList) != len(logicalpoolidList) || len(copysetidList) != len(chunkidList) || len(copysetidList) != len(addressList) {
+		return fmt.Errorf("copysetid, logicalpoolid, chunkid, address length not equal")
+	}
+	logicalpoolIds, errParse := cobrautil.StringList2Uint32List(logicalpoolidList)
+	if errParse != nil {
+		return fmt.Errorf("parse logicalpoolid %v fail", logicalpoolidList)
+	}
+	copysetIds, errParse := cobrautil.StringList2Uint32List(copysetidList)
+	if errParse != nil {
+		return fmt.Errorf("parse copysetid %v fail", copysetidList)
+	}
+	chunkIds, errParse := cobrautil.StringList2Uint64List(chunkidList)
+	if errParse != nil {
+		return fmt.Errorf("parse chunkid %v fail", chunkidList)
+	}
+	for i := 0; i < len(copysetIds); i++ {
+		rpc := &GetChunkInfoRpc{
+			Request: &chunk.GetChunkInfoRequest{
+				LogicPoolId: &logicalpoolIds[i],
+				CopysetId:   &copysetIds[i],
+				ChunkId:     &chunkIds[i],
+			},
+			Info: basecmd.NewRpc([]string{addressList[i]}, timeout, retrytimes, "GetChunkInfo"),
+		}
+		cCmd.Rpc = append(cCmd.Rpc, rpc)
+	}
+	return nil
+}
+
+func (cCmd *GetChunkInfoCommand) RunCommand(cmd *cobra.Command, args []string) error {
+	var infos []*basecmd.Rpc
+	var funcs []basecmd.RpcFunc
+	for _, rpc := range cCmd.Rpc {
+		infos = append(infos, rpc.Info)
+		funcs = append(funcs, rpc)
+	}
+	results, errs := basecmd.GetRpcListResponse(infos, funcs)
+	if len(errs) == len(infos) {
+		mergeErr := cmderror.MergeCmdErrorExceptSuccess(errs)
+		return mergeErr.ToError()
+	}
+	addr2Chunk := make(map[string]*chunk.GetChunkInfoResponse)
+	cCmd.addr2Chunk = &addr2Chunk
+	for i, result := range results {
+		if resp, ok := result.(*chunk.GetChunkInfoResponse); ok {
+			(*cCmd.addr2Chunk)[cCmd.Rpc[i].Info.Addrs[0]] = resp
+		} else {
+			(*cCmd.addr2Chunk)[cCmd.Rpc[i].Info.Addrs[0]] = nil
+		}
+	}
+	return nil
+}
+
+func (cCmd *GetChunkInfoCommand) Print(cmd *cobra.Command, args []string) error {
+	return output.FinalCmdOutput(&cCmd.FinalCurveCmd, cCmd)
+}
+
+func (cCmd *GetChunkInfoCommand) ResultPlainOutput() error {
+	return output.FinalCmdOutputPlain(&cCmd.FinalCurveCmd)
+}
+
+func (cCmd *GetChunkInfoCommand) AddFlags() {
+	config.AddBsMdsFlagOption(cCmd.Cmd)
+	config.AddRpcRetryTimesFlag(cCmd.Cmd)
+	config.AddRpcTimeoutFlag(cCmd.Cmd)
+
+	config.AddBsCopysetIdSliceRequiredFlag(cCmd.Cmd)
+	config.AddBsLogicalPoolIdSliceRequiredFlag(cCmd.Cmd)
+	config.AddBsChunkIdSliceRequiredFlag(cCmd.Cmd)
+	config.AddBsChunkServerAddressSliceRequiredFlag(cCmd.Cmd)
+}
+
+func GetChunkInfo(caller *cobra.Command) (*map[string]*chunk.GetChunkInfoResponse, *cmderror.CmdError) {
+	sCmd := NewGetChunkInfoCommand()
+	config.AlignFlagsValue(caller, sCmd.Cmd, []string{
+		config.RPCRETRYTIMES, config.RPCTIMEOUT, config.CURVEBS_MDSADDR,
+		config.CURVEBS_LOGIC_POOL_ID, config.CURVEBS_COPYSET_ID, config.CURVEBS_CHUNK_ID, config.CURVEBS_CHUNKSERVER_ADDRESS,
+	})
+	sCmd.Cmd.SilenceErrors = true
+	sCmd.Cmd.SilenceUsage = true
+	sCmd.Cmd.SetArgs([]string{"--format", config.FORMAT_NOOUT})
+	err := sCmd.Cmd.Execute()
+	if err != nil {
+		retErr := cmderror.ErrBsGetChunkInfo()
+		retErr.Format(err.Error())
+		return nil, retErr
+	}
+	return sCmd.addr2Chunk, cmderror.Success()
+}

--- a/tools-v2/pkg/cli/command/curvebs/query/chunkserver/chunkserver.go
+++ b/tools-v2/pkg/cli/command/curvebs/query/chunkserver/chunkserver.go
@@ -19,7 +19,7 @@
 * Author: chengyi01
  */
 
-package chunk
+package chunkserver
 
 import (
 	"context"

--- a/tools-v2/pkg/cli/command/curvebs/update/copyset/availflag/availflag.go
+++ b/tools-v2/pkg/cli/command/curvebs/update/copyset/availflag/availflag.go
@@ -1,0 +1,264 @@
+/*
+ *  Copyright (c) 2023 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * Project: CurveCli
+ * Created Date: 2023-04-24
+ * Author: baytan
+ */
+
+package availflag
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	cmderror "github.com/opencurve/curve/tools-v2/internal/error"
+	cobrautil "github.com/opencurve/curve/tools-v2/internal/utils"
+	basecmd "github.com/opencurve/curve/tools-v2/pkg/cli/command"
+	copyset2 "github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/check/copyset"
+	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/list/chunkserver"
+	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/list/unavailcopysets"
+	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/query/chunk"
+	"github.com/opencurve/curve/tools-v2/pkg/config"
+	"github.com/opencurve/curve/tools-v2/pkg/output"
+	"github.com/opencurve/curve/tools-v2/proto/proto/common"
+	"github.com/opencurve/curve/tools-v2/proto/proto/topology"
+	"github.com/opencurve/curve/tools-v2/proto/proto/topology/statuscode"
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+)
+
+const (
+	copysetAvailflagExample = `$ curve bs update copyset availflag --availflag=true --dryrun=false`
+)
+
+type UpdateCopysetAvailflagRpc struct {
+	Info           *basecmd.Rpc
+	Request        *topology.SetCopysetsAvailFlagRequest
+	topologyClient topology.TopologyServiceClient
+}
+
+var _ basecmd.RpcFunc = (*UpdateCopysetAvailflagRpc)(nil) // check interface
+
+func (cRpc *UpdateCopysetAvailflagRpc) NewRpcClient(cc grpc.ClientConnInterface) {
+	cRpc.topologyClient = topology.NewTopologyServiceClient(cc)
+}
+
+func (cRpc *UpdateCopysetAvailflagRpc) Stub_Func(ctx context.Context) (interface{}, error) {
+	return cRpc.topologyClient.SetCopysetsAvailFlag(ctx, cRpc.Request)
+}
+
+type CopysetAvailflagCommand struct {
+	basecmd.FinalCurveCmd
+	Rpc *UpdateCopysetAvailflagRpc
+}
+
+var _ basecmd.FinalCurveCmdFunc = (*CopysetAvailflagCommand)(nil) // check interface
+
+func NewCommand() *cobra.Command {
+	return NewCopysetAvailflagCommand().Cmd
+}
+
+func NewCopysetAvailflagCommand() *CopysetAvailflagCommand {
+	fsCmd := &CopysetAvailflagCommand{
+		FinalCurveCmd: basecmd.FinalCurveCmd{
+			Use:     "availflag",
+			Short:   "update copyset availflag",
+			Example: copysetAvailflagExample,
+		},
+	}
+
+	basecmd.NewFinalCurveCli(&fsCmd.FinalCurveCmd, fsCmd)
+	return fsCmd
+}
+
+func (cCmd *CopysetAvailflagCommand) AddFlags() {
+	config.AddBsMdsFlagOption(cCmd.Cmd)
+	config.AddRpcRetryTimesFlag(cCmd.Cmd)
+	config.AddRpcTimeoutFlag(cCmd.Cmd)
+
+	config.AddBsDryrunOptionFlag(cCmd.Cmd)
+	config.AddBsAvailFlagRequireFlag(cCmd.Cmd)
+}
+
+func (cCmd *CopysetAvailflagCommand) Init(cmd *cobra.Command, args []string) error {
+	mdsAddrs, err := config.GetBsMdsAddrSlice(cCmd.Cmd)
+	if err.TypeCode() != cmderror.CODE_SUCCESS {
+		return err.ToError()
+	}
+	timeout := config.GetFlagDuration(cCmd.Cmd, config.RPCTIMEOUT)
+	retrytimes := config.GetFlagInt32(cCmd.Cmd, config.RPCRETRYTIMES)
+	availFlag := config.GetBsFlagBool(cCmd.Cmd, config.CURVEBS_AVAILFLAG)
+	var copysets []*common.CopysetInfo
+	if availFlag {
+		var err *cmderror.CmdError
+		copysets, err = unavailcopysets.GetUnAvailCopySets(cCmd.Cmd)
+		if err.TypeCode() != cmderror.CODE_SUCCESS {
+			return err.ToError()
+		}
+	} else {
+		// list chunkserver
+		chunkserverInfos, errCmd := chunkserver.GetChunkServerInCluster(cCmd.Cmd)
+		if errCmd.TypeCode() != cmderror.CODE_SUCCESS {
+			return errCmd.ToError()
+		}
+
+		// check chunkserver offline
+		config.AddBsCopysetIdSliceRequiredFlag(cCmd.Cmd)
+		config.AddBsLogicalPoolIdSliceRequiredFlag(cCmd.Cmd)
+		config.AddBsChunkIdSliceRequiredFlag(cCmd.Cmd)
+		config.AddBsChunkServerAddressSliceRequiredFlag(cCmd.Cmd)
+		for _, info := range chunkserverInfos {
+			address := fmt.Sprintf("%s:%d", *info.HostIp, *info.Port)
+			cCmd.Cmd.ParseFlags([]string{
+				fmt.Sprintf("--%s", config.CURVEBS_LOGIC_POOL_ID), "1",
+				fmt.Sprintf("--%s", config.CURVEBS_COPYSET_ID), "1",
+				fmt.Sprintf("--%s", config.CURVEBS_CHUNK_ID), "1",
+				fmt.Sprintf("--%s", config.CURVEBS_CHUNKSERVER_ADDRESS), address,
+			})
+		}
+		addr2Chunk, errCmd := chunk.GetChunkInfo(cCmd.Cmd)
+		if errCmd.TypeCode() != cmderror.CODE_SUCCESS {
+			return errCmd.ToError()
+		}
+		var offlineChunkServer []string
+		for addr, info := range *addr2Chunk {
+			if info == nil {
+				offlineChunkServer = append(offlineChunkServer, addr)
+			}
+		}
+		if len(offlineChunkServer) > 0 {
+			cCmd.Cmd.ResetFlags()
+			cCmd.AddFlags()
+			config.AddBsChunkServerAddressSliceRequiredFlag(cCmd.Cmd)
+			config.AddFormatFlag(cCmd.Cmd)
+			cCmd.Cmd.SetArgs([]string{
+				fmt.Sprintf("--%s", config.CURVEBS_CHUNKSERVER_ADDRESS), strings.Join(offlineChunkServer, ","),
+			})
+			addr2Copysets, errCmd := chunkserver.GetCopySetsInChunkServerByHost(cCmd.Cmd)
+			if errCmd.TypeCode() != cmderror.CODE_SUCCESS {
+				return errCmd.ToError()
+			}
+			copysetIds := make([]string, 0)
+			logicalpoolids := make([]string, 0)
+			for _, infos := range *addr2Copysets {
+				for _, info := range infos {
+					copysetid := info.GetCopysetId()
+					logicalpoolid := info.GetLogicalPoolId()
+					copysetIds = append(copysetIds, strconv.FormatUint(uint64(copysetid), 10))
+					logicalpoolids = append(logicalpoolids, strconv.FormatUint(uint64(logicalpoolid), 10))
+				}
+			}
+
+			config.AddBsCopysetIdSliceRequiredFlag(cCmd.Cmd)
+			config.AddBsLogicalPoolIdSliceRequiredFlag(cCmd.Cmd)
+			cCmd.Cmd.SetArgs([]string{
+				fmt.Sprintf("--%s", config.CURVEBS_LOGIC_POOL_ID), strings.Join(logicalpoolids, ","),
+				fmt.Sprintf("--%s", config.CURVEBS_COPYSET_ID), strings.Join(copysetIds, ","),
+			})
+			key2Health, errCmd := copyset2.CheckCopysets(cCmd.Cmd)
+			if errCmd.TypeCode() != cmderror.CODE_SUCCESS {
+				return errCmd.ToError()
+			}
+
+			for _, infos := range *addr2Copysets {
+				for _, info := range infos {
+					key := cobrautil.GetCopysetKey(uint64(info.GetLogicalPoolId()), uint64(info.GetCopysetId()))
+					if health, ok := (*key2Health)[key]; !ok || health == cobrautil.HEALTH_ERROR {
+						copysets = append(copysets, info)
+					}
+				}
+			}
+		}
+	}
+
+	cCmd.Rpc = &UpdateCopysetAvailflagRpc{
+		Request: &topology.SetCopysetsAvailFlagRequest{
+			AvailFlag: &availFlag,
+			Copysets:  copysets,
+		},
+		Info: basecmd.NewRpc(mdsAddrs, timeout, retrytimes, "SetCopysetsAvailFlag"),
+	}
+
+	header := []string{cobrautil.ROW_COPYSET_ID,
+		cobrautil.ROW_POOL_ID, cobrautil.ROW_AVAILFLAG, cobrautil.ROW_DRYRUN,
+	}
+	cCmd.SetHeader(header)
+	cCmd.TableNew.SetAutoMergeCellsByColumnIndex(cobrautil.GetIndexSlice(
+		cCmd.Header, []string{cobrautil.ROW_AVAILFLAG, cobrautil.ROW_DRYRUN},
+	))
+	return nil
+}
+
+func (cCmd *CopysetAvailflagCommand) Print(cmd *cobra.Command, args []string) error {
+	return output.FinalCmdOutput(&cCmd.FinalCurveCmd, cCmd)
+}
+
+func (cCmd *CopysetAvailflagCommand) RunCommand(cmd *cobra.Command, args []string) error {
+	if len(cCmd.Rpc.Request.Copysets) == 0 {
+		return nil
+	}
+	rows := make([]map[string]string, 0)
+	dryrun := config.GetFlagBool(cmd, config.CURVEBS_DRYRUN)
+	if dryrun {
+		for _, info := range cCmd.Rpc.Request.Copysets {
+			row := make(map[string]string)
+			row[cobrautil.ROW_POOL_ID] = strconv.FormatUint(uint64(info.GetLogicalPoolId()), 10)
+			row[cobrautil.ROW_COPYSET_ID] = strconv.FormatUint(uint64(info.GetCopysetId()), 10)
+			row[cobrautil.ROW_AVAILFLAG] = fmt.Sprintf("%v => %v", !*cCmd.Rpc.Request.AvailFlag, *cCmd.Rpc.Request.AvailFlag)
+			row[cobrautil.ROW_DRYRUN] = cobrautil.ROW_VALUE_TRUE
+			rows = append(rows, row)
+		}
+	} else {
+		result, err := basecmd.GetRpcResponse(cCmd.Rpc.Info, cCmd.Rpc)
+		if err.TypeCode() != cmderror.CODE_SUCCESS {
+			return err.ToError()
+		}
+		response := result.(*topology.SetCopysetsAvailFlagResponse)
+		if response.GetStatusCode() != int32(statuscode.TopoStatusCode_Success) {
+			err := cmderror.ErrBsSetCopysetAvailFlagRpc(
+				statuscode.TopoStatusCode(response.GetStatusCode()),
+			)
+			return err.ToError()
+		}
+		for _, info := range cCmd.Rpc.Request.Copysets {
+			row := make(map[string]string)
+			row[cobrautil.ROW_POOL_ID] = strconv.FormatUint(uint64(info.GetLogicalPoolId()), 10)
+			row[cobrautil.ROW_COPYSET_ID] = strconv.FormatUint(uint64(info.GetCopysetId()), 10)
+			row[cobrautil.ROW_AVAILFLAG] = fmt.Sprintf("%v => %v", !*cCmd.Rpc.Request.AvailFlag, *cCmd.Rpc.Request.AvailFlag)
+			row[cobrautil.ROW_DRYRUN] = cobrautil.ROW_VALUE_FALSE
+			rows = append(rows, row)
+		}
+	}
+
+	sort.Slice(rows, func(i, j int) bool {
+		return rows[i][cobrautil.ROW_COPYSET_KEY] < rows[j][cobrautil.ROW_COPYSET_KEY]
+	})
+	list := cobrautil.ListMap2ListSortByKeys(rows, cCmd.Header, []string{
+		cobrautil.ROW_POOL_ID, cobrautil.ROW_STATUS, cobrautil.ROW_COPYSET_ID,
+	})
+	cCmd.TableNew.AppendBulk(list)
+	cCmd.Result = rows
+	return nil
+}
+
+func (cCmd *CopysetAvailflagCommand) ResultPlainOutput() error {
+	return output.FinalCmdOutputPlain(&cCmd.FinalCurveCmd)
+}

--- a/tools-v2/pkg/cli/command/curvebs/update/copyset/copyset.go
+++ b/tools-v2/pkg/cli/command/curvebs/update/copyset/copyset.go
@@ -1,0 +1,51 @@
+/*
+ *  Copyright (c) 2023 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * Project: tools-v2
+ * Created Date: 2023-04-24
+ * Author: baytan
+ */
+
+package copyset
+
+import (
+	basecmd "github.com/opencurve/curve/tools-v2/pkg/cli/command"
+	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/update/copyset/availflag"
+	"github.com/spf13/cobra"
+)
+
+type CopysetCommand struct {
+	basecmd.MidCurveCmd
+}
+
+var _ basecmd.MidCurveCmdFunc = (*CopysetCommand)(nil) // check interface
+
+func (sCmd *CopysetCommand) AddSubCommands() {
+	sCmd.Cmd.AddCommand(
+		availflag.NewCommand(),
+	)
+}
+
+func NewCopysetCommand() *cobra.Command {
+	sCmd := &CopysetCommand{
+		basecmd.MidCurveCmd{
+			Use:   "copyset",
+			Short: "update copyset resources in the curvebs",
+		},
+	}
+	return basecmd.NewMidCurveCli(&sCmd.MidCurveCmd, sCmd)
+}

--- a/tools-v2/pkg/cli/command/curvebs/update/update.go
+++ b/tools-v2/pkg/cli/command/curvebs/update/update.go
@@ -23,6 +23,7 @@
 package update
 
 import (
+	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/update/copyset"
 	"github.com/spf13/cobra"
 
 	basecmd "github.com/opencurve/curve/tools-v2/pkg/cli/command"
@@ -46,6 +47,7 @@ func (updateCmd *UpdateCommand) AddSubCommands() {
 		throttle.NewThrottleCommand(),
 		leader.NewleaderCommand(),
 		scan_state.NewScanStateCommand(),
+		copyset.NewCopysetCommand(),
 	)
 }
 

--- a/tools-v2/pkg/config/bs.go
+++ b/tools-v2/pkg/config/bs.go
@@ -23,10 +23,9 @@ package config
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
-
-	"strconv"
 
 	"github.com/gookit/color"
 	cmderror "github.com/opencurve/curve/tools-v2/internal/error"
@@ -36,84 +35,93 @@ import (
 
 const (
 	// curvebs
-	CURVEBS_MDSADDR                 = "mdsaddr"
-	VIPER_CURVEBS_MDSADDR           = "curvebs.mdsAddr"
-	CURVEBS_MDSDUMMYADDR            = "mdsdummyaddr"
-	VIPER_CURVEBS_MDSDUMMYADDR      = "curvebs.mdsDummyAddr"
-	CURVEBS_ETCDADDR                = "etcdaddr"
-	VIPER_CURVEBS_ETCDADDR          = "curvebs.etcdAddr"
-	CURVEBS_PATH                    = "path"
-	VIPER_CURVEBS_PATH              = "curvebs.path"
-	CURVEBS_DEFAULT_PATH            = "/test"
-	CURVEBS_USER                    = "user"
-	VIPER_CURVEBS_USER              = "curvebs.root.user"
-	CURVEBS_DEFAULT_USER            = "root"
-	CURVEBS_PASSWORD                = "password"
-	VIPER_CURVEBS_PASSWORD          = "curvebs.root.password"
-	CURVEBS_DEFAULT_PASSWORD        = "root_password"
-	CURVEBS_CLUSTERMAP              = "clustermap"
-	VIPER_CURVEBS_CLUSTERMAP        = "curvebs.clustermap"
-	CURVEBS_FORCE                   = "force"
-	VIPER_CURVEBS_FORCE             = "curvebs.force"
-	CURVEBS_DEFAULT_FORCE           = false
-	CURVEBS_LOGIC_POOL_ID           = "logicalpoolid"
-	VIPER_CURVEBS_LOGIC_POOL_ID     = "curvebs.logicalpoolid"
-	CURVEBS_COPYSET_ID              = "copysetid"
-	VIPER_CURVEBS_COPYSET_ID        = "curvebs.copysetid"
-	CURVEBS_PEERS_ADDRESS           = "peers"
-	VIPER_CURVEBS_PEERS_ADDRESS     = "curvebs.peers"
-	CURVEBS_OFFSET                  = "offset"
-	VIPER_CURVEBS_OFFSET            = "curvebs.offset"
-	CURVEBS_SIZE                    = "size"
-	VIPER_CURVEBS_SIZE              = "curvebs.size"
-	CURVEBS_DEFAULT_SIZE            = uint64(10)
-	CURVEBS_TYPE                    = "type"
-	VIPER_CURVEBS_TYPE              = "curvebs.type"
-	CURVEBS_STRIPE_UNIT             = "stripeunit"
-	VIPER_CURVEBS_STRIPE_UNIT       = "curvebs.stripeunit"
-	CURVEBS_DEFAULT_STRIPE_UNIT     = "32 KiB"
-	CURVEBS_STRIPE_COUNT            = "stripecount"
-	VIPER_CURVEBS_STRIPE_COUNT      = "curvebs.stripecount"
-	CURVEBS_DEFAULT_STRIPE_COUNT    = uint64(32)
-	CURVEBS_RECYCLE_PREFIX          = "recycleprefix"
-	VIPER_RECYCLE_PREFIX            = "curvebs.recycleprefix"
-	CURVEBS_EXPIRED_TIME            = "expiredtime"
-	VIPER_CURVEBS_EXPIRED_TIME      = "curvebs.expiredtime"
-	CURVEBS_LIMIT                   = "limit"
-	VIPER_CURVEBS_LIMIT             = "curvebs.limit"
-	CURVEBS_BURST                   = "burst"
-	VIPER_CURVEBS_BURST             = "curvebs.burst"
-	CURVEBS_DEFAULT_BURST           = uint64(30000)
-	CURVEBS_BURST_LENGTH            = "burstlength"
-	VIPER_CURVEBS_BURST_LENGTH      = "curvebs.burstlength"
-	CURVEBS_DEFAULT_BURST_LENGTH    = uint64(10)
-	CURVEBS_OP                      = "op"
-	VIPER_CURVEBS_OP                = "curvebs.op"
-	CURVEBS_DEFAULT_OP              = "operator"
-	CURVEBS_CHECK_TIME              = "checktime"
-	VIPER_CURVEBS_CHECK_TIME        = "curvebs.checktime"
-	CURVEBS_DEFAULT_CHECK_TIME      = 30 * time.Second
-	CURVEBS_MARGIN                  = "margin"
-	VIPER_CURVEBS_MARGIN            = "curvebs.margin"
-	CURVEBS_DEFAULT_MARGIN          = uint64(1000)
-	CURVEBS_SNAPSHOTADDR            = "snapshotaddr"
-	VIPER_CURVEBS_SNAPSHOTADDR      = "curvebs.snapshotAddr"
-	CURVEBS_SNAPSHOTDUMMYADDR       = "snapshotdummyaddr"
-	VIPER_CURVEBS_SNAPSHOTDUMMYADDR = "curvebs.snapshotDummyAddr"
-	CURVEBS_SCAN                    = "scan"
-	VIPER_CURVEBS_SCAN              = "curvebs.scan"
-	CURVEBS_DEFAULT_SCAN            = true
-	CURVEBS_CHUNKSERVER_ID          = "chunkserverid"
-	VIPER_CHUNKSERVER_ID            = "curvebs.chunkserverid"
-	CURVEBS_DEFAULT_CHUNKSERVER_ID  = "*"
-	CURVEBS_CHECK_CSALIVE           = "checkalive"
-	VIPER_CURVEBS_CHECK_CSALIVE     = "curvebs.checkalive"
-	CURVEBS_CHECK_HEALTH            = "checkhealth"
-	VIPER_CURVEBS_CHECK_HEALTH      = "curvebs.checkHealth"
-	CURVEBS_CS_OFFLINE              = "offline"
-	VIPER_CURVEBS_CS_OFFLINE        = "curvebs.offline"
-	CURVEBS_CS_UNHEALTHY            = "unhealthy"
-	VIPER_CURVEBS_CS_UNHEALTHY      = "curvebs.unhealthy"
+	CURVEBS_MDSADDR                   = "mdsaddr"
+	VIPER_CURVEBS_MDSADDR             = "curvebs.mdsAddr"
+	CURVEBS_MDSDUMMYADDR              = "mdsdummyaddr"
+	VIPER_CURVEBS_MDSDUMMYADDR        = "curvebs.mdsDummyAddr"
+	CURVEBS_ETCDADDR                  = "etcdaddr"
+	VIPER_CURVEBS_ETCDADDR            = "curvebs.etcdAddr"
+	CURVEBS_PATH                      = "path"
+	VIPER_CURVEBS_PATH                = "curvebs.path"
+	CURVEBS_DEFAULT_PATH              = "/test"
+	CURVEBS_USER                      = "user"
+	VIPER_CURVEBS_USER                = "curvebs.root.user"
+	CURVEBS_DEFAULT_USER              = "root"
+	CURVEBS_PASSWORD                  = "password"
+	VIPER_CURVEBS_PASSWORD            = "curvebs.root.password"
+	CURVEBS_DEFAULT_PASSWORD          = "root_password"
+	CURVEBS_CLUSTERMAP                = "clustermap"
+	VIPER_CURVEBS_CLUSTERMAP          = "curvebs.clustermap"
+	CURVEBS_FORCE                     = "force"
+	VIPER_CURVEBS_FORCE               = "curvebs.force"
+	CURVEBS_DEFAULT_FORCE             = false
+	CURVEBS_LOGIC_POOL_ID             = "logicalpoolid"
+	VIPER_CURVEBS_LOGIC_POOL_ID       = "curvebs.logicalpoolid"
+	CURVEBS_COPYSET_ID                = "copysetid"
+	VIPER_CURVEBS_COPYSET_ID          = "curvebs.copysetid"
+	CURVEBS_PEERS_ADDRESS             = "peers"
+	VIPER_CURVEBS_PEERS_ADDRESS       = "curvebs.peers"
+	CURVEBS_OFFSET                    = "offset"
+	VIPER_CURVEBS_OFFSET              = "curvebs.offset"
+	CURVEBS_SIZE                      = "size"
+	VIPER_CURVEBS_SIZE                = "curvebs.size"
+	CURVEBS_DEFAULT_SIZE              = uint64(10)
+	CURVEBS_TYPE                      = "type"
+	VIPER_CURVEBS_TYPE                = "curvebs.type"
+	CURVEBS_STRIPE_UNIT               = "stripeunit"
+	VIPER_CURVEBS_STRIPE_UNIT         = "curvebs.stripeunit"
+	CURVEBS_DEFAULT_STRIPE_UNIT       = "32 KiB"
+	CURVEBS_STRIPE_COUNT              = "stripecount"
+	VIPER_CURVEBS_STRIPE_COUNT        = "curvebs.stripecount"
+	CURVEBS_DEFAULT_STRIPE_COUNT      = uint64(32)
+	CURVEBS_RECYCLE_PREFIX            = "recycleprefix"
+	VIPER_RECYCLE_PREFIX              = "curvebs.recycleprefix"
+	CURVEBS_EXPIRED_TIME              = "expiredtime"
+	VIPER_CURVEBS_EXPIRED_TIME        = "curvebs.expiredtime"
+	CURVEBS_LIMIT                     = "limit"
+	VIPER_CURVEBS_LIMIT               = "curvebs.limit"
+	CURVEBS_BURST                     = "burst"
+	VIPER_CURVEBS_BURST               = "curvebs.burst"
+	CURVEBS_DEFAULT_BURST             = uint64(30000)
+	CURVEBS_BURST_LENGTH              = "burstlength"
+	VIPER_CURVEBS_BURST_LENGTH        = "curvebs.burstlength"
+	CURVEBS_DEFAULT_BURST_LENGTH      = uint64(10)
+	CURVEBS_OP                        = "op"
+	VIPER_CURVEBS_OP                  = "curvebs.op"
+	CURVEBS_DEFAULT_OP                = "operator"
+	CURVEBS_CHECK_TIME                = "checktime"
+	VIPER_CURVEBS_CHECK_TIME          = "curvebs.checktime"
+	CURVEBS_DEFAULT_CHECK_TIME        = 30 * time.Second
+	CURVEBS_MARGIN                    = "margin"
+	VIPER_CURVEBS_MARGIN              = "curvebs.margin"
+	CURVEBS_DEFAULT_MARGIN            = uint64(1000)
+	CURVEBS_SNAPSHOTADDR              = "snapshotaddr"
+	VIPER_CURVEBS_SNAPSHOTADDR        = "curvebs.snapshotAddr"
+	CURVEBS_SNAPSHOTDUMMYADDR         = "snapshotdummyaddr"
+	VIPER_CURVEBS_SNAPSHOTDUMMYADDR   = "curvebs.snapshotDummyAddr"
+	CURVEBS_SCAN                      = "scan"
+	VIPER_CURVEBS_SCAN                = "curvebs.scan"
+	CURVEBS_DEFAULT_SCAN              = true
+	CURVEBS_CHUNKSERVER_ID            = "chunkserverid"
+	VIPER_CHUNKSERVER_ID              = "curvebs.chunkserverid"
+	CURVEBS_DEFAULT_CHUNKSERVER_ID    = "*"
+	CURVEBS_CHECK_CSALIVE             = "checkalive"
+	VIPER_CURVEBS_CHECK_CSALIVE       = "curvebs.checkalive"
+	CURVEBS_CHECK_HEALTH              = "checkhealth"
+	VIPER_CURVEBS_CHECK_HEALTH        = "curvebs.checkHealth"
+	CURVEBS_CS_OFFLINE                = "offline"
+	VIPER_CURVEBS_CS_OFFLINE          = "curvebs.offline"
+	CURVEBS_CS_UNHEALTHY              = "unhealthy"
+	VIPER_CURVEBS_CS_UNHEALTHY        = "curvebs.unhealthy"
+	CURVEBS_DRYRUN                    = "dryrun"
+	VIPER_CURVEBS_DRYRUN              = "curvebs.dryrun"
+	CURVEBS_DEFAULT_DRYRUN            = true
+	CURVEBS_AVAILFLAG                 = "availflag"
+	VIPER_CURVEBS_AVAILFLAG           = "curvebs.availflag"
+	CURVEBS_CHUNK_ID                  = "chunkid"
+	VIPER_CURVEBS_CHUNK_ID            = "curvebs.chunkid"
+	CURVEBS_CHUNKSERVER_ADDRESS       = "chunkserveraddr"
+	VIPER_CURVEBS_CHUNKSERVER_ADDRESS = "curvebs.chunkserverAddr"
 )
 
 var (
@@ -123,38 +131,42 @@ var (
 		RPCRETRYTIMES: VIPER_GLOBALE_RPCRETRYTIMES,
 
 		// bs
-		CURVEBS_MDSADDR:           VIPER_CURVEBS_MDSADDR,
-		CURVEBS_MDSDUMMYADDR:      VIPER_CURVEBS_MDSDUMMYADDR,
-		CURVEBS_PATH:              VIPER_CURVEBS_PATH,
-		CURVEBS_USER:              VIPER_CURVEBS_USER,
-		CURVEBS_PASSWORD:          VIPER_CURVEBS_PASSWORD,
-		CURVEBS_ETCDADDR:          VIPER_CURVEBS_ETCDADDR,
-		CURVEBS_LOGIC_POOL_ID:     VIPER_CURVEBS_LOGIC_POOL_ID,
-		CURVEBS_COPYSET_ID:        VIPER_CURVEBS_COPYSET_ID,
-		CURVEBS_PEERS_ADDRESS:     VIPER_CURVEBS_PEERS_ADDRESS,
-		CURVEBS_CLUSTERMAP:        VIPER_CURVEBS_CLUSTERMAP,
-		CURVEBS_OFFSET:            VIPER_CURVEBS_OFFSET,
-		CURVEBS_SIZE:              VIPER_CURVEBS_SIZE,
-		CURVEBS_STRIPE_UNIT:       VIPER_CURVEBS_STRIPE_UNIT,
-		CURVEBS_STRIPE_COUNT:      VIPER_CURVEBS_STRIPE_COUNT,
-		CURVEBS_LIMIT:             VIPER_CURVEBS_LIMIT,
-		CURVEBS_BURST:             VIPER_CURVEBS_BURST,
-		CURVEBS_BURST_LENGTH:      VIPER_CURVEBS_BURST_LENGTH,
-		CURVEBS_FORCE:             VIPER_CURVEBS_FORCE,
-		CURVEBS_TYPE:              VIPER_CURVEBS_TYPE,
-		CURVEBS_EXPIRED_TIME:      VIPER_CURVEBS_EXPIRED_TIME,
-		CURVEBS_RECYCLE_PREFIX:    VIPER_RECYCLE_PREFIX,
-		CURVEBS_MARGIN:            VIPER_CURVEBS_MARGIN,
-		CURVEBS_OP:                VIPER_CURVEBS_OP,
-		CURVEBS_CHECK_TIME:        VIPER_CURVEBS_CHECK_TIME,
-		CURVEBS_SNAPSHOTADDR:      VIPER_CURVEBS_SNAPSHOTADDR,
-		CURVEBS_SNAPSHOTDUMMYADDR: VIPER_CURVEBS_SNAPSHOTDUMMYADDR,
-		CURVEBS_SCAN:              VIPER_CURVEBS_SCAN,
-		CURVEBS_CHUNKSERVER_ID:    VIPER_CHUNKSERVER_ID,
-		CURVEBS_CHECK_CSALIVE:     VIPER_CURVEBS_CHECK_CSALIVE,
-		CURVEBS_CHECK_HEALTH:      VIPER_CURVEBS_CHECK_HEALTH,
-		CURVEBS_CS_OFFLINE:        VIPER_CURVEBS_CS_OFFLINE,
-		CURVEBS_CS_UNHEALTHY:      VIPER_CURVEBS_CS_UNHEALTHY,
+		CURVEBS_MDSADDR:             VIPER_CURVEBS_MDSADDR,
+		CURVEBS_MDSDUMMYADDR:        VIPER_CURVEBS_MDSDUMMYADDR,
+		CURVEBS_PATH:                VIPER_CURVEBS_PATH,
+		CURVEBS_USER:                VIPER_CURVEBS_USER,
+		CURVEBS_PASSWORD:            VIPER_CURVEBS_PASSWORD,
+		CURVEBS_ETCDADDR:            VIPER_CURVEBS_ETCDADDR,
+		CURVEBS_LOGIC_POOL_ID:       VIPER_CURVEBS_LOGIC_POOL_ID,
+		CURVEBS_COPYSET_ID:          VIPER_CURVEBS_COPYSET_ID,
+		CURVEBS_PEERS_ADDRESS:       VIPER_CURVEBS_PEERS_ADDRESS,
+		CURVEBS_CLUSTERMAP:          VIPER_CURVEBS_CLUSTERMAP,
+		CURVEBS_OFFSET:              VIPER_CURVEBS_OFFSET,
+		CURVEBS_SIZE:                VIPER_CURVEBS_SIZE,
+		CURVEBS_STRIPE_UNIT:         VIPER_CURVEBS_STRIPE_UNIT,
+		CURVEBS_STRIPE_COUNT:        VIPER_CURVEBS_STRIPE_COUNT,
+		CURVEBS_LIMIT:               VIPER_CURVEBS_LIMIT,
+		CURVEBS_BURST:               VIPER_CURVEBS_BURST,
+		CURVEBS_BURST_LENGTH:        VIPER_CURVEBS_BURST_LENGTH,
+		CURVEBS_FORCE:               VIPER_CURVEBS_FORCE,
+		CURVEBS_TYPE:                VIPER_CURVEBS_TYPE,
+		CURVEBS_EXPIRED_TIME:        VIPER_CURVEBS_EXPIRED_TIME,
+		CURVEBS_RECYCLE_PREFIX:      VIPER_RECYCLE_PREFIX,
+		CURVEBS_MARGIN:              VIPER_CURVEBS_MARGIN,
+		CURVEBS_OP:                  VIPER_CURVEBS_OP,
+		CURVEBS_CHECK_TIME:          VIPER_CURVEBS_CHECK_TIME,
+		CURVEBS_SNAPSHOTADDR:        VIPER_CURVEBS_SNAPSHOTADDR,
+		CURVEBS_SNAPSHOTDUMMYADDR:   VIPER_CURVEBS_SNAPSHOTDUMMYADDR,
+		CURVEBS_SCAN:                VIPER_CURVEBS_SCAN,
+		CURVEBS_CHUNKSERVER_ID:      VIPER_CHUNKSERVER_ID,
+		CURVEBS_CHECK_CSALIVE:       VIPER_CURVEBS_CHECK_CSALIVE,
+		CURVEBS_CHECK_HEALTH:        VIPER_CURVEBS_CHECK_HEALTH,
+		CURVEBS_CS_OFFLINE:          VIPER_CURVEBS_CS_OFFLINE,
+		CURVEBS_CS_UNHEALTHY:        VIPER_CURVEBS_CS_UNHEALTHY,
+		CURVEBS_DRYRUN:              VIPER_CURVEBS_DRYRUN,
+		CURVEBS_AVAILFLAG:           VIPER_CURVEBS_AVAILFLAG,
+		CURVEBS_CHUNK_ID:            VIPER_CURVEBS_CHUNK_ID,
+		CURVEBS_CHUNKSERVER_ADDRESS: VIPER_CURVEBS_CHUNKSERVER_ADDRESS,
 	}
 
 	BSFLAG2DEFAULT = map[string]interface{}{
@@ -173,6 +185,7 @@ var (
 		CURVEBS_CHECK_TIME:     CURVEBS_DEFAULT_CHECK_TIME,
 		CURVEBS_SCAN:           CURVEBS_DEFAULT_SCAN,
 		CURVEBS_CHUNKSERVER_ID: CURVEBS_DEFAULT_CHUNKSERVER_ID,
+		CURVEBS_DRYRUN:         CURVEBS_DEFAULT_DRYRUN,
 	}
 )
 
@@ -296,6 +309,19 @@ func AddBsUint32SliceOptionFlag(cmd *cobra.Command, name string, usage string) {
 	if err != nil {
 		cobra.CheckErr(err)
 	}
+}
+
+func AddBsBoolRequireFlag(cmd *cobra.Command, name string, usage string) {
+	cmd.Flags().Bool(name, false, usage+color.Red.Sprint("[required]"))
+	cmd.MarkFlagRequired(name)
+	err := viper.BindPFlag(BSFLAG2VIPER[name], cmd.Flags().Lookup(name))
+	if err != nil {
+		cobra.CheckErr(err)
+	}
+}
+
+func AddBsDryrunOptionFlag(cmd *cobra.Command) {
+	AddBsBoolOptionFlag(cmd, CURVEBS_DRYRUN, "when dry run set true, no changes will be made")
 }
 
 // add bs required flag
@@ -499,6 +525,18 @@ func AddBSCSOfflineOptionFlag(cmd *cobra.Command) {
 
 func AddBSCSUnhealthyOptionFlag(cmd *cobra.Command) {
 	AddBsBoolOptionFlag(cmd, CURVEBS_CS_UNHEALTHY, "unhealthy")
+}
+
+func AddBsAvailFlagRequireFlag(cmd *cobra.Command) {
+	AddBsBoolRequireFlag(cmd, CURVEBS_AVAILFLAG, "copysets available flag")
+}
+
+func AddBsChunkIdSliceRequiredFlag(cmd *cobra.Command) {
+	AddBsStringSliceRequiredFlag(cmd, CURVEBS_CHUNK_ID, "chunk ids")
+}
+
+func AddBsChunkServerAddressSliceRequiredFlag(cmd *cobra.Command) {
+	AddBsStringSliceRequiredFlag(cmd, CURVEBS_CHUNKSERVER_ADDRESS, "chunk server address")
 }
 
 // get stingslice flag


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #2357  <!-- replace xxx with issue number -->

Problem Summary: support update availflag command in [curve tool](https://github.com/opencurve/curve/tree/master/tools-v2)

### What is changed and how it works?

What's Changed:
add tools-v2/pkg/cli/command/curvebs/list/unavailcopysets/unavailcopysets.go
add tools-v2/pkg/cli/command/curvebs/query/chunk/chunkinfo.go
add tools-v2/pkg/cli/command/curvebs/list/chunkserver/copyset_by_host.go
add tools-v2/pkg/cli/command/curvebs/set/set.go
add tools-v2/pkg/cli/command/curvebs/update/copyset/copyset.go
add tools-v2/pkg/cli/command/curvebs/update/copyset/availflag/availflag.go
modify tools-v2/internal/error/error.go
modify tools-v2/internal/utils/row.go
modify tools-v2/pkg/cli/command/curvebs/bs.go
modify tools-v2/pkg/config/bs.go
modify tools-v2/pkg/cli/command/curvebs/update/update.go
modify tools-v2/pkg/cli/command/curvebs/check/copyset/copyset.go

How it Works:
```
root@0ad49a8af612:/# curve bs update copyset-availflag -h               
Usage:  curve bs update copyset-availflag [flags]

set copyset availflag

Flags:
      --availflag             copysets available flag[required]
  -c, --conf string           config file (default is
                              $HOME/.curve/curve.yaml or
                              /etc/curve/curve.yaml)
      --dryrun                when dry run set true, no changes will be
                              made (default true)
  -f, --format string         output format (json|plain) (default "plain")
  -h, --help                  print help
      --mdsaddr string        mds address, should be like
                              127.0.0.1:6700,127.0.0.1:6701,127.0.0.1:6702
      --rpcretrytimes int32   rpc retry times (default 1)
      --rpctimeout duration   rpc timeout (default 10s)
      --showerror             display all errors in command
      --verbose               show some log

Examples:
$ curve bs update copyset-availflag --availflag=true --dryrun=false
```

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [x] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license
