### PR TITLE
[feat] tools-v2: add scan-state

### DIFF
--- a/tools-v2/README.md
+++ b/tools-v2/README.md
@@ -65,6 +65,7 @@ A tool for CurveFS & CurveBs.
       - [update file](#update-file)
       - [update throttle](#update-throttle)
       - [update leader](#update-leader)
+      - [update scan-state](#update-scan-state)
     - [create](#create-1)
       - [create file](#create-file)
       - [create dir](#create-dir)
@@ -1212,6 +1213,24 @@ Output:
 +---------+
 ```
 
+#### update scan-state
+
+enable/disable scan for logical pool
+
+Usage:
+```bash
+curve bs update scan-state --logicalpoolid 1 [--scan=true/false]
+```
+
+Output:
+```
++----+------+---------+--------+
+| ID | SCAN | RESULT  | REASON |
++----+------+---------+--------+
+| 1  | true | success | null   |
++----+------+---------+--------+
+```
+
 ### create
 
 #### create file
@@ -1345,6 +1364,7 @@ Output:
 | curve_ops_tool snapshot-clone-status | curve bs status snapshotserver |
 | curve_ops_tool transfer-leader       | curve bs update leader         |
 | curve_ops_tool do-snapshot           | curve bs snapshot copyset      |
+| curve_ops_tool set-scan-state        | curve bs update scan-state     |
 | curve_ops_tool status                |                                |
 | curve_ops_tool chunkserver-status    |                                |
 | curve_ops_tool copysets-status       |                                |
@@ -1357,5 +1377,4 @@ Output:
 | curve_ops_tool list-may-broken-vol   |                                |
 | curve_ops_tool set-copyset-availflag |                                |
 | curve_ops_tool rapid-leader-schedule |                                |
-| curve_ops_tool set-scan-state        |                                |
 | curve_ops_tool scan-status           |                                |

--- a/tools-v2/pkg/cli/command/curvebs/update/scan_state/scan_state.go
+++ b/tools-v2/pkg/cli/command/curvebs/update/scan_state/scan_state.go
@@ -1,0 +1,151 @@
+/*
+ *  Copyright (c) 2023 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+* Project: curvecli
+* Created Date: 2023-05-08
+* Author: montaguelhz
+ */
+
+package scan_state
+
+import (
+	"context"
+	"fmt"
+
+	cmderror "github.com/opencurve/curve/tools-v2/internal/error"
+	cobrautil "github.com/opencurve/curve/tools-v2/internal/utils"
+	basecmd "github.com/opencurve/curve/tools-v2/pkg/cli/command"
+	"github.com/opencurve/curve/tools-v2/pkg/config"
+	"github.com/opencurve/curve/tools-v2/pkg/output"
+	"github.com/opencurve/curve/tools-v2/proto/proto/topology"
+	"github.com/opencurve/curve/tools-v2/proto/proto/topology/statuscode"
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+)
+
+type UpdateScanStateRpc struct {
+	Info    *basecmd.Rpc
+	Request *topology.SetLogicalPoolScanStateRequest
+	Client  topology.TopologyServiceClient
+}
+
+var _ basecmd.RpcFunc = (*UpdateScanStateRpc)(nil) // check interface
+
+func (sRpc *UpdateScanStateRpc) NewRpcClient(cc grpc.ClientConnInterface) {
+	sRpc.Client = topology.NewTopologyServiceClient(cc)
+}
+
+func (sRpc *UpdateScanStateRpc) Stub_Func(ctx context.Context) (interface{}, error) {
+	return sRpc.Client.SetLogicalPoolScanState(ctx, sRpc.Request)
+}
+
+type ScanStateCommand struct {
+	basecmd.FinalCurveCmd
+
+	Rpc           *UpdateScanStateRpc
+	Response      *topology.SetLogicalPoolScanStateResponse
+	LogicalPoolID uint32
+	Scan          bool
+}
+
+var _ basecmd.FinalCurveCmdFunc = (*ScanStateCommand)(nil) // check interface
+
+const (
+	scanStateExample = `$ curve bs update scan-state --logicalpoolid 1 [--scan=true/false]`
+)
+
+func NewScanStateCommand() *cobra.Command {
+	return NewUpdateScanStateCommand().Cmd
+}
+
+func (sCmd *ScanStateCommand) AddFlags() {
+	config.AddBsMdsFlagOption(sCmd.Cmd)
+	config.AddRpcRetryTimesFlag(sCmd.Cmd)
+	config.AddRpcTimeoutFlag(sCmd.Cmd)
+
+	config.AddBSLogicalPoolIdRequiredFlag(sCmd.Cmd)
+	config.AddBsScanOptionFlag(sCmd.Cmd)
+}
+
+func NewUpdateScanStateCommand() *ScanStateCommand {
+	sCmd := &ScanStateCommand{
+		FinalCurveCmd: basecmd.FinalCurveCmd{
+			Use:     "scan-state",
+			Short:   "enable/disable scan for logical pool",
+			Example: scanStateExample,
+		},
+	}
+
+	basecmd.NewFinalCurveCli(&sCmd.FinalCurveCmd, sCmd)
+	return sCmd
+}
+
+func (sCmd *ScanStateCommand) Init(cmd *cobra.Command, args []string) error {
+	mdsAddrs, err := config.GetBsMdsAddrSlice(sCmd.Cmd)
+	if err.TypeCode() != cmderror.CODE_SUCCESS {
+		return err.ToError()
+	}
+
+	header := []string{cobrautil.ROW_ID, cobrautil.ROW_SCAN, cobrautil.ROW_RESULT, cobrautil.ROW_REASON}
+	sCmd.SetHeader(header)
+
+	Timeout := config.GetFlagDuration(sCmd.Cmd, config.RPCTIMEOUT)
+	RetryTimes := config.GetFlagInt32(sCmd.Cmd, config.RPCRETRYTIMES)
+	sCmd.LogicalPoolID = config.GetBsFlagUint32(sCmd.Cmd, config.CURVEBS_LOGIC_POOL_ID)
+	sCmd.Scan = config.GetBsFlagBool(sCmd.Cmd, config.CURVEBS_SCAN)
+	sCmd.Rpc = &UpdateScanStateRpc{
+		Info: basecmd.NewRpc(mdsAddrs, Timeout, RetryTimes, "UpdateScanState"),
+		Request: &topology.SetLogicalPoolScanStateRequest{
+			LogicalPoolID: &sCmd.LogicalPoolID,
+			ScanEnable:    &sCmd.Scan,
+		},
+	}
+	return nil
+}
+
+func (sCmd *ScanStateCommand) Print(cmd *cobra.Command, args []string) error {
+	return output.FinalCmdOutput(&sCmd.FinalCurveCmd, sCmd)
+}
+
+func (sCmd *ScanStateCommand) RunCommand(cmd *cobra.Command, args []string) error {
+	out := make(map[string]string)
+	out[cobrautil.ROW_ID] = fmt.Sprintf("%d", sCmd.LogicalPoolID)
+	out[cobrautil.ROW_SCAN] = fmt.Sprintf("%t", sCmd.Scan)
+	result, err := basecmd.GetRpcResponse(sCmd.Rpc.Info, sCmd.Rpc)
+	if err.TypeCode() != cmderror.CODE_SUCCESS {
+		return err.ToError()
+	}
+	sCmd.Response = result.(*topology.SetLogicalPoolScanStateResponse)
+	if *sCmd.Response.StatusCode != int32(statuscode.TopoStatusCode_Success) {
+		out[cobrautil.ROW_RESULT] = cobrautil.ROW_VALUE_FAILED
+		out[cobrautil.ROW_REASON] = statuscode.TopoStatusCode_name[*sCmd.Response.StatusCode]
+	} else {
+		out[cobrautil.ROW_RESULT] = cobrautil.ROW_VALUE_SUCCESS
+		out[cobrautil.ROW_REASON] = cobrautil.ROW_VALUE_NULL
+	}
+
+	res := cobrautil.Map2List(out, sCmd.Header)
+	sCmd.TableNew.Append(res)
+
+	sCmd.Result = out
+	sCmd.Error = cmderror.ErrSuccess()
+	return nil
+}
+
+func (sCmd *ScanStateCommand) ResultPlainOutput() error {
+	return output.FinalCmdOutputPlain(&sCmd.FinalCurveCmd)
+}

--- a/tools-v2/pkg/cli/command/curvebs/update/update.go
+++ b/tools-v2/pkg/cli/command/curvebs/update/update.go
@@ -29,6 +29,7 @@ import (
 	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/update/file"
 	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/update/leader"
 	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/update/peer"
+	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/update/scan_state"
 	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/update/throttle"
 )
 
@@ -44,6 +45,7 @@ func (updateCmd *UpdateCommand) AddSubCommands() {
 		file.NewFileCommand(),
 		throttle.NewThrottleCommand(),
 		leader.NewleaderCommand(),
+		scan_state.NewScanStateCommand(),
 	)
 }
 

--- a/tools-v2/pkg/config/bs.go
+++ b/tools-v2/pkg/config/bs.go
@@ -100,6 +100,9 @@ const (
 	VIPER_CURVEBS_SNAPSHOTADDR      = "curvebs.snapshotAddr"
 	CURVEBS_SNAPSHOTDUMMYADDR       = "snapshotdummyaddr"
 	VIPER_CURVEBS_SNAPSHOTDUMMYADDR = "curvebs.snapshotDummyAddr"
+	CURVEBS_SCAN                    = "scan"
+	VIPER_CURVEBS_SCAN              = "curvebs.scan"
+	CURVEBS_DEFAULT_SCAN            = true
 )
 
 var (
@@ -135,6 +138,7 @@ var (
 		CURVEBS_CHECK_TIME:        VIPER_CURVEBS_CHECK_TIME,
 		CURVEBS_SNAPSHOTADDR:      VIPER_CURVEBS_SNAPSHOTADDR,
 		CURVEBS_SNAPSHOTDUMMYADDR: VIPER_CURVEBS_SNAPSHOTDUMMYADDR,
+		CURVEBS_SCAN:              VIPER_CURVEBS_SCAN,
 	}
 
 	BSFLAG2DEFAULT = map[string]interface{}{
@@ -151,6 +155,7 @@ var (
 		CURVEBS_MARGIN:       CURVEBS_DEFAULT_MARGIN,
 		CURVEBS_OP:           CURVEBS_DEFAULT_OP,
 		CURVEBS_CHECK_TIME:   CURVEBS_DEFAULT_CHECK_TIME,
+		CURVEBS_SCAN:         CURVEBS_DEFAULT_SCAN,
 	}
 )
 
@@ -381,6 +386,11 @@ func AddBsMarginOptionFlag(cmd *cobra.Command) {
 
 func GetBsMargin(cmd *cobra.Command) uint64 {
 	return GetFlagUint64(cmd, CURVEBS_MARGIN)
+}
+
+// scan-state
+func AddBsScanOptionFlag(cmd *cobra.Command) {
+	AddBsBoolOptionFlag(cmd, CURVEBS_SCAN, "enable/disable scan for logical pool")
 }
 
 // add flag required


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #2360 

Problem Summary:

support bs set scan command in [curve tool]

### What is changed and how it works?

What's Changed:

1.  add tools-v2/pkg/cli/command/curvebs/update/scan_state.go
2. modify tools-v2/pkg/cli/command/curvebs/update.go
3. modify tools-v2/pkg/config/bs.go
4. modify tools-v2/README.md

How it Works:

```
Usage:  curve bs update scan-state [flags]

enable/disable scan for logical pool

Flags:
  -c, --conf string            config file (default is $HOME/.curve/curve.yaml or /etc/curve/curve.yaml)
  -f, --format string          output format (json|plain) (default "plain")
  -h, --help                   print help
      --logicalpoolid uint32   logical pool id[required]
      --mdsaddr string         mds address, should be like 127.0.0.1:6700,127.0.0.1:6701,127.0.0.1:6702
      --rpcretrytimes int32    rpc retry times (default 1)
      --rpctimeout duration    rpc timeout (default 10s)
      --scan                   enable/disable scan for logical pool (default true)
      --showerror              display all errors in command
      --verbose                show some log

Examples:
$ curve bs update scan-state --logicalpoolid 1 [--scan=true/false]
```
command result
```
curve bs update scan-state --logicalpoolid 1 --scan=true
+----+------+---------+--------+
| ID | SCAN | RESULT  | REASON |
+----+------+---------+--------+
| 1  | true | success | null   |
+----+------+---------+--------+
curve bs update scan-state --logicalpoolid 2 --scan=false
+----+-------+--------+---------------------+
| ID | SCAN  | RESULT |       REASON        |
+----+-------+--------+---------------------+
| 2  | false | fail   | LogicalPoolNotFound |
+----+-------+--------+---------------------+
```
Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
