### PR TITLE
[fix] tools-v2: fix robust string process

### DIFF
--- a/tools-v2/pkg/config/bs.go
+++ b/tools-v2/pkg/config/bs.go
@@ -514,7 +514,12 @@ func GetBsAddrSlice(cmd *cobra.Command, addrType string) ([]string, *cmderror.Cm
 	} else {
 		addrsStr = viper.GetString(BSFLAG2VIPER[addrType])
 	}
+
 	addrslice := strings.Split(addrsStr, ",")
+	for i, addr := range addrslice {
+		addrslice[i] = strings.TrimSpace(addr)
+	}
+
 	for _, addr := range addrslice {
 		if !IsValidAddr(addr) {
 			err := cmderror.ErrGetAddr()


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #2431<!-- replace xxx with issue number -->

Problem Summary: 
solve panic
```
root@f8df310173eb:/# ./curve bs status mds
+----------------+----------------+------------------------------+----------+
|      ADDR      |   DUMMYADDR    |           VERSION            |  STATUS  |
+----------------+----------------+------------------------------+----------+
| 127.0.0.1:6701 | 127.0.0.1:7701 | v2.1.0-beta+09566f57+release | follower |
+----------------+----------------+                              +          +
| 127.0.0.1:6702 | 127.0.0.1:7702 |                              |          |
+----------------+----------------+                              +----------+
| 127.0.0.1:6700 | 127.0.0.1:7700 |                              | leader   |
+----------------+----------------+------------------------------+----------+
root@f8df310173eb:/# ./curve bs status etcd
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x38 pc=0xa40d7b]

goroutine 15 [running]:
github.com/opencurve/curve/tools-v2/pkg/cli/command.httpGet({0xc000241920, 0x1f}, 0x1dcd6500, 0xa7dd6a?, 0xc000102240?)
	/home/xinlong/curve/tools-v2/pkg/cli/command/base.go:235 +0x19b
created by github.com/opencurve/curve/tools-v2/pkg/cli/command.QueryMetric
	/home/xinlong/curve/tools-v2/pkg/cli/command/base.go:182 +0xcf
```

### What is changed and how it works?

What's Changed:
modified:   pkg/config/bs.go

How it Works:
add `strings.TrimSpace(addr)`

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [x] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license
