### PR TITLE
[fix] tools-v2: fix return error format

### DIFF
--- a/tools-v2/internal/error/error.go
+++ b/tools-v2/internal/error/error.go
@@ -420,6 +420,21 @@ var (
 	ErrBsOpNameNotSupport = func() *CmdError {
 		return NewInternalCmdError(53, "not support op[%s], only support: operator, change_peer, add_peer, remove_peer, transfer_leader")
 	}
+	ErrBsGetClientList = func() *CmdError {
+		return NewInternalCmdError(54, "get client list fail, err: %s")
+	}
+	ErrBsGetClientStatus = func() *CmdError {
+		return NewInternalCmdError(55, "get client status fail, err: %s")
+	}
+	ErrBsGetEtcdStatus = func() *CmdError {
+		return NewInternalCmdError(56, "get etcd status fail, err: %s")
+	}
+	ErrBsGetMdsStatus = func() *CmdError {
+		return NewInternalCmdError(57, "get mds status fail, err: %s")
+	}
+	ErrBsGetSnapshotServerStatus = func() *CmdError {
+		return NewInternalCmdError(58, "get snapshotserver status fail, err: %s")
+	}
 
 	// http error
 	ErrHttpUnreadableResult = func() *CmdError {

--- a/tools-v2/pkg/cli/command/curvebs/list/client/client.go
+++ b/tools-v2/pkg/cli/command/curvebs/list/client/client.go
@@ -167,7 +167,9 @@ func GetClientList(caller *cobra.Command) (*interface{}, *cmderror.CmdError) {
 	listClientCmd.Cmd.SilenceErrors = true
 	err := listClientCmd.Cmd.Execute()
 	if err != nil {
-		return nil, listClientCmd.Error
+		retErr := cmderror.ErrBsGetClientList()
+		retErr.Format(err.Error())
+		return nil, retErr
 	}
-	return &listClientCmd.Result, listClientCmd.Error
+	return &listClientCmd.Result, cmderror.Success()
 }

--- a/tools-v2/pkg/cli/command/curvebs/status/client/client.go
+++ b/tools-v2/pkg/cli/command/curvebs/status/client/client.go
@@ -23,7 +23,6 @@
 package client
 
 import (
-	"errors"
 	"strconv"
 	"strings"
 
@@ -89,11 +88,13 @@ func (cCmd *ClientCommand) Init(cmd *cobra.Command, args []string) error {
 	// get client list
 	results, err := client.GetClientList(cmd)
 	if err.Code != cmderror.CODE_SUCCESS {
-		return errors.New("Get Client List fail!")
+		return err.ToError()
 	}
 
 	if len((*results).([]map[string]string)) == 0 {
-		return errors.New("Client List is null!")
+		retErr := cmderror.ErrBsGetClientStatus()
+		retErr.Format("Client List is null!")
+		return retErr.ToError()
 	}
 
 	clientAddr := make([]string, 0)

--- a/tools-v2/pkg/cli/command/curvebs/status/etcd/etcd.go
+++ b/tools-v2/pkg/cli/command/curvebs/status/etcd/etcd.go
@@ -25,7 +25,6 @@ package etcd
 import (
 	"fmt"
 
-	"github.com/olekukonko/tablewriter"
 	cmderror "github.com/opencurve/curve/tools-v2/internal/error"
 	cobrautil "github.com/opencurve/curve/tools-v2/internal/utils"
 	basecmd "github.com/opencurve/curve/tools-v2/pkg/cli/command"
@@ -205,7 +204,7 @@ func NewStatusEtcdCommand() *EtcdCommand {
 	return etcdCmd
 }
 
-func GetEtcdStatus(caller *cobra.Command) (*interface{}, *tablewriter.Table, *cmderror.CmdError, cobrautil.ClUSTER_HEALTH_STATUS) {
+func GetEtcdStatus(caller *cobra.Command) (*interface{}, *cmderror.CmdError, cobrautil.ClUSTER_HEALTH_STATUS) {
 	etcdCmd := NewStatusEtcdCommand()
 	etcdCmd.Cmd.SetArgs([]string{
 		fmt.Sprintf("--%s", config.FORMAT), config.FORMAT_NOOUT,
@@ -214,6 +213,11 @@ func GetEtcdStatus(caller *cobra.Command) (*interface{}, *tablewriter.Table, *cm
 		config.RPCRETRYTIMES, config.RPCTIMEOUT, config.CURVEFS_ETCDADDR,
 	})
 	etcdCmd.Cmd.SilenceErrors = true
-	etcdCmd.Cmd.Execute()
-	return &etcdCmd.Result, etcdCmd.TableNew, etcdCmd.Error, etcdCmd.health
+	err := etcdCmd.Cmd.Execute()
+	if err != nil {
+		retErr := cmderror.ErrBsGetEtcdStatus()
+		retErr.Format(err.Error())
+		return nil, retErr, cobrautil.HEALTH_ERROR
+	}
+	return &etcdCmd.Result, cmderror.Success(), etcdCmd.health
 }

--- a/tools-v2/pkg/cli/command/curvebs/status/mds/mds.go
+++ b/tools-v2/pkg/cli/command/curvebs/status/mds/mds.go
@@ -25,7 +25,6 @@ package mds
 import (
 	"fmt"
 
-	"github.com/olekukonko/tablewriter"
 	cmderror "github.com/opencurve/curve/tools-v2/internal/error"
 	cobrautil "github.com/opencurve/curve/tools-v2/internal/utils"
 	basecmd "github.com/opencurve/curve/tools-v2/pkg/cli/command"
@@ -196,13 +195,18 @@ func NewStatusMdsCommand() *MdsCommand {
 	return mdsCmd
 }
 
-func GetMdsStatus(caller *cobra.Command) (*interface{}, *tablewriter.Table, *cmderror.CmdError, cobrautil.ClUSTER_HEALTH_STATUS) {
+func GetMdsStatus(caller *cobra.Command) (*interface{}, *cmderror.CmdError, cobrautil.ClUSTER_HEALTH_STATUS) {
 	mdsCmd := NewStatusMdsCommand()
 	mdsCmd.Cmd.SetArgs([]string{
 		fmt.Sprintf("--%s", config.FORMAT), config.FORMAT_NOOUT,
 	})
 	config.AlignFlagsValue(caller, mdsCmd.Cmd, []string{config.RPCRETRYTIMES, config.RPCTIMEOUT, config.CURVEBS_MDSADDR})
 	mdsCmd.Cmd.SilenceErrors = true
-	mdsCmd.Cmd.Execute()
-	return &mdsCmd.Result, mdsCmd.TableNew, mdsCmd.Error, mdsCmd.health
+	err := mdsCmd.Cmd.Execute()
+	if err != nil {
+		retErr := cmderror.ErrBsGetMdsStatus()
+		retErr.Format(err.Error())
+		return nil, retErr, cobrautil.HEALTH_ERROR
+	}
+	return &mdsCmd.Result, cmderror.Success(), mdsCmd.health
 }

--- a/tools-v2/pkg/cli/command/curvebs/status/snapshot/snapshot.go
+++ b/tools-v2/pkg/cli/command/curvebs/status/snapshot/snapshot.go
@@ -25,7 +25,6 @@ package snapshot
 import (
 	"fmt"
 
-	"github.com/olekukonko/tablewriter"
 	cmderror "github.com/opencurve/curve/tools-v2/internal/error"
 	cobrautil "github.com/opencurve/curve/tools-v2/internal/utils"
 	basecmd "github.com/opencurve/curve/tools-v2/pkg/cli/command"
@@ -206,7 +205,7 @@ func NewStatusSnapshotCommand() *SnapshotCommand {
 	return snapshotCmd
 }
 
-func GetSnapshotStatus(caller *cobra.Command) (*interface{}, *tablewriter.Table, *cmderror.CmdError, cobrautil.ClUSTER_HEALTH_STATUS) {
+func GetSnapshotStatus(caller *cobra.Command) (*interface{}, *cmderror.CmdError, cobrautil.ClUSTER_HEALTH_STATUS) {
 	snapshotCmd := NewStatusSnapshotCommand()
 	snapshotCmd.Cmd.SetArgs([]string{
 		fmt.Sprintf("--%s", config.FORMAT), config.FORMAT_NOOUT,
@@ -215,6 +214,11 @@ func GetSnapshotStatus(caller *cobra.Command) (*interface{}, *tablewriter.Table,
 		config.RPCRETRYTIMES, config.RPCTIMEOUT, config.CURVEBS_SNAPSHOTADDR,
 	})
 	snapshotCmd.Cmd.SilenceErrors = true
-	snapshotCmd.Cmd.Execute()
-	return &snapshotCmd.Result, snapshotCmd.TableNew, snapshotCmd.Error, snapshotCmd.health
+	err := snapshotCmd.Cmd.Execute()
+	if err != nil {
+		retErr := cmderror.ErrBsGetSnapshotServerStatus()
+		retErr.Format(err.Error())
+		return nil, retErr, cobrautil.HEALTH_ERROR
+	}
+	return &snapshotCmd.Result, cmderror.Success(), snapshotCmd.health
 }


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #xxx <!-- replace xxx with issue number -->

Problem Summary: fix return error format (special case: when we run a command, and it init fail, err is nil...)

### What is changed and how it works?

What's Changed:
1. modified:   internal/error/error.go
2. modified:   pkg/cli/command/curvebs/list/client/client.go
3. modified:   pkg/cli/command/curvebs/status/client/client.go
4. modified:   pkg/cli/command/curvebs/status/etcd/etcd.go
5. modified:   pkg/cli/command/curvebs/status/mds/mds.go
6. modified:   pkg/cli/command/curvebs/status/snapshot/snapshot.go

How it Works:
return a non-nil err to client, client can judge by `err.Code`.

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [x] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license
