### PR TITLE
curvefs/client: fuse client exit when cache size less than 8MB

### DIFF
--- a/curvefs/conf/client.conf
+++ b/curvefs/conf/client.conf
@@ -149,6 +149,7 @@ s3.baseSleepUs=500
 s3.threadScheduleInterval=3
 # data cache flush wait time
 s3.cacheFlushIntervalSec=5
+# write cache < 8,388,608 (8MB) is not allowed
 s3.writeCacheMaxByte=838860800
 s3.readCacheMaxByte=209715200
 # file cache read thread num

--- a/curvefs/src/client/error_code.h
+++ b/curvefs/src/client/error_code.h
@@ -49,6 +49,7 @@ enum class CURVEFS_ERROR {
     OUT_OF_RANGE = -15,
     NODATA = -16,
     IO_ERROR = -17,
+    CACHETOOSMALL = -18,
 };
 
 

--- a/curvefs/src/client/fuse_s3_client.h
+++ b/curvefs/src/client/fuse_s3_client.h
@@ -33,6 +33,7 @@
 #include "curvefs/src/client/fuse_client.h"
 #include "curvefs/src/client/s3/client_s3_cache_manager.h"
 #include "curvefs/src/client/warmup/warmup_manager.h"
+#include "curvefs/src/volume/common.h"
 #include "src/common/s3_adapter.h"
 
 namespace curvefs {
@@ -40,6 +41,7 @@ namespace client {
 
 using curve::common::GetObjectAsyncContext;
 using curve::common::GetObjectAsyncCallBack;
+using curvefs::volume::kMiB;
 namespace warmup {
 class WarmupManager;
 class WarmupManagerS3Impl;
@@ -119,6 +121,8 @@ class FuseS3Client : public FuseClient {
     // s3 adaptor
     std::shared_ptr<S3ClientAdaptor> s3Adaptor_;
     std::shared_ptr<KVClientManager> kvClientManager_;
+
+    static constexpr auto MIN_WRITE_CACHE_SIZE = 8 * kMiB;
 };
 
 

--- a/curvefs/test/client/test_fuse_s3_client.cpp
+++ b/curvefs/test/client/test_fuse_s3_client.cpp
@@ -147,6 +147,7 @@ class TestFuseS3Client : public ::testing::Test {
 
     void InitOptionBasic(FuseClientOption *opt) {
         opt->s3Opt.s3ClientAdaptorOpt.readCacheThreads = 2;
+        opt->s3Opt.s3ClientAdaptorOpt.writeCacheMaxByte = 838860800;
         opt->s3Opt.s3AdaptrOpt.asyncThreadNum = 1;
         opt->dummyServerStartPort = 5000;
         opt->maxNameLength = 20u;
@@ -205,6 +206,21 @@ TEST_F(TestFuseS3Client, test_Init_with_KVCache) {
         testclient->UnInit();
     }
     curvefs::client::common::FLAGS_supportKVcache = false;
+}
+
+TEST_F(TestFuseS3Client, test_Init_with_cache_size_0) {
+    curvefs::client::common::FLAGS_supportKVcache = false;
+    auto testClient = std::make_shared<FuseS3Client>(
+        mdsClient_, metaClient_, inodeManager_, dentryManager_,
+        s3ClientAdaptor_, nullptr);
+    FuseClientOption opt;
+    InitOptionBasic(&opt);
+    InitFSInfo(testClient);
+
+    // test init when write cache is 0
+    opt.s3Opt.s3ClientAdaptorOpt.writeCacheMaxByte = 0;
+    ASSERT_EQ(CURVEFS_ERROR::CACHETOOSMALL, testClient->Init(opt));
+    testClient->UnInit();
 }
 
 // GetInode failed; bad fd


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: https://github.com/opencurve/curve/issues/2427

Problem Summary:

### What is changed and how it works?

What's Changed:

- `FuseS3client` exit when `writeCacheMaxByte <= 8MB`

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [x] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license
