### PR TITLE
curvefs/client: remove unused setting fuseMaxSize 

### DIFF
--- a/curvefs/conf/client.conf
+++ b/curvefs/conf/client.conf
@@ -135,8 +135,6 @@ volume.blockGroup.allocateOnce=4
 #### s3
 # this is for test. if s3.fakeS3=true, all data will be discarded
 s3.fakeS3=false
-# the max size that fuse send
-s3.fuseMaxSize=131072
 s3.pageSize=65536
 # prefetch blocks that disk cache use
 s3.prefetchBlocks=1

--- a/curvefs/src/client/common/config.cpp
+++ b/curvefs/src/client/common/config.cpp
@@ -157,8 +157,6 @@ void InitDiskCacheOption(Configuration *conf,
 
 void InitS3Option(Configuration *conf, S3Option *s3Opt) {
     conf->GetValueFatalIfFail("s3.fakeS3", &FLAGS_useFakeS3);
-    conf->GetValueFatalIfFail("s3.fuseMaxSize",
-                              &s3Opt->s3ClientAdaptorOpt.fuseMaxSize);
     conf->GetValueFatalIfFail("s3.pageSize",
                               &s3Opt->s3ClientAdaptorOpt.pageSize);
     conf->GetValueFatalIfFail("s3.prefetchBlocks",

--- a/curvefs/src/client/common/config.h
+++ b/curvefs/src/client/common/config.h
@@ -122,7 +122,6 @@ struct DiskCacheOption {
 struct S3ClientAdaptorOption {
     uint64_t blockSize;
     uint64_t chunkSize;
-    uint32_t fuseMaxSize;
     uint64_t pageSize;
     uint32_t prefetchBlocks;
     uint32_t prefetchExecQueueNum;

--- a/curvefs/src/client/s3/client_s3_adaptor.cpp
+++ b/curvefs/src/client/s3/client_s3_adaptor.cpp
@@ -42,7 +42,6 @@ S3ClientAdaptorImpl::Init(
     std::shared_ptr<DiskCacheManagerImpl> diskCacheManagerImpl,
     std::shared_ptr<KVClientManager> kvClientManager,
     bool startBackGround) {
-    pendingReq_ = 0;
     blockSize_ = option.blockSize;
     chunkSize_ = option.chunkSize;
     pageSize_ = option.pageSize;
@@ -52,7 +51,6 @@ S3ClientAdaptorImpl::Init(
                    << blockSize_;
         return CURVEFS_ERROR::INVALIDPARAM;
     }
-    fuseMaxSize_ = option.fuseMaxSize;
     prefetchBlocks_ = option.prefetchBlocks;
     prefetchExecQueueNum_ = option.prefetchExecQueueNum;
     diskCacheType_ = option.diskCacheOpt.diskCacheType;
@@ -117,13 +115,10 @@ int S3ClientAdaptorImpl::Write(uint64_t inodeId, uint64_t offset,
         fsCacheManager_->FindOrCreateFileCacheManager(fsId_, inodeId);
     {
         std::lock_guard<std::mutex> lockguard(ioMtx_);
-        pendingReq_.fetch_add(1, std::memory_order_seq_cst);
-        VLOG(6) << "pendingReq_ is: " << pendingReq_;
-        uint64_t pendingReq = pendingReq_.load(std::memory_order_seq_cst);
         fsCacheManager_->DataCacheByteInc(length);
         uint64_t size = fsCacheManager_->GetDataCacheSize();
         uint64_t maxSize = fsCacheManager_->GetDataCacheMaxSize();
-        if ((size + pendingReq * fuseMaxSize_) >= maxSize) {
+        if (size >= maxSize) {
             VLOG(6) << "write cache is full, wait flush. size: " << size
                     << ", maxSize:" << maxSize;
             // offer to do flush
@@ -148,14 +143,12 @@ int S3ClientAdaptorImpl::Write(uint64_t inodeId, uint64_t offset,
         }
     }
     int ret = fileCacheManager->Write(offset, length, buf);
-    pendingReq_.fetch_sub(1, std::memory_order_seq_cst);
     fsCacheManager_->DataCacheByteDec(length);
     if (s3Metric_.get() != nullptr) {
         CollectMetrics(&s3Metric_->adaptorWrite, ret, start);
         s3Metric_->writeSize.set_value(length);
     }
-    VLOG(6) << "write end inodeId:" << inodeId << ",ret:" << ret
-            << ", pendingReq_ is: " << pendingReq_;
+    VLOG(6) << "write end inodeId: " << inodeId << ", ret: " << ret;
     return ret;
 }
 

--- a/curvefs/src/client/s3/client_s3_adaptor.h
+++ b/curvefs/src/client/s3/client_s3_adaptor.h
@@ -249,7 +249,6 @@ class S3ClientAdaptorImpl : public S3ClientAdaptor {
     std::shared_ptr<S3Client> client_;
     uint64_t blockSize_;
     uint64_t chunkSize_;
-    uint32_t fuseMaxSize_;
     uint32_t prefetchBlocks_;
     uint32_t prefetchExecQueueNum_;
     std::string allocateServerEps_;
@@ -270,7 +269,6 @@ class S3ClientAdaptorImpl : public S3ClientAdaptor {
     std::shared_ptr<InodeCacheManager> inodeManager_;
     std::shared_ptr<DiskCacheManagerImpl> diskCacheManagerImpl_;
     DiskCacheType diskCacheType_;
-    std::atomic<uint64_t> pendingReq_;
     std::shared_ptr<MdsClient> mdsClient_;
     uint32_t fsId_;
     std::string fsName_;

--- a/curvefs/test/client/chunk_cache_manager_test.cpp
+++ b/curvefs/test/client/chunk_cache_manager_test.cpp
@@ -47,6 +47,7 @@ class ChunkCacheManagerTest : public testing::Test {
         S3ClientAdaptorOption option;
         option.blockSize = 1 * 1024 * 1024;
         option.chunkSize = 4 * 1024 * 1024;
+        option.baseSleepUs = 500;
         option.objectPrefix = 0;
         option.pageSize = 64 * 1024;
         option.intervalSec = 5000;

--- a/curvefs/test/client/client_s3_adaptor_Integration.cpp
+++ b/curvefs/test/client/client_s3_adaptor_Integration.cpp
@@ -131,6 +131,7 @@ class ClientS3IntegrationTest : public testing::Test {
         S3ClientAdaptorOption option;
         option.blockSize = 1 * 1024 * 1024;
         option.chunkSize = 4 * 1024 * 1024;
+        option.baseSleepUs = 500;
         option.pageSize = 64 * 1024;
         option.intervalSec = 5000;
         option.flushIntervalSec = 5000;

--- a/curvefs/test/client/client_s3_adaptor_test.cpp
+++ b/curvefs/test/client/client_s3_adaptor_test.cpp
@@ -64,13 +64,13 @@ class ClientS3AdaptorTest : public testing::Test {
         S3ClientAdaptorOption option;
         option.blockSize = 1 * 1024 * 1024;
         option.chunkSize = 4 * 1024 * 1024;
+        option.baseSleepUs = 500;
         option.pageSize = 64 * 1024;
         option.intervalSec = 5000;
         option.flushIntervalSec = 5000;
         option.readCacheMaxByte = 104857600;
         option.writeCacheMaxByte = 10485760000;
         option.readCacheThreads = 5;
-        option.fuseMaxSize = 131072;
         option.chunkFlushThreads = 5;
         option.objectPrefix = 0;
         option.diskCacheOpt.diskCacheType = (DiskCacheType)0;

--- a/curvefs/test/client/data_cache_test.cpp
+++ b/curvefs/test/client/data_cache_test.cpp
@@ -45,6 +45,7 @@ class DataCacheTest : public testing::Test {
         S3ClientAdaptorOption option;
         option.blockSize = 1 * 1024 * 1024;
         option.chunkSize = 4 * 1024 * 1024;
+        option.baseSleepUs = 500;
         option.objectPrefix = 0;
         option.pageSize = 64 * 1024;
         option.intervalSec = 5000;

--- a/curvefs/test/client/file_cache_manager_test.cpp
+++ b/curvefs/test/client/file_cache_manager_test.cpp
@@ -62,6 +62,7 @@ class FileCacheManagerTest : public testing::Test {
         S3ClientAdaptorOption option;
         option.blockSize = 1 * 1024 * 1024;
         option.chunkSize = 4 * 1024 * 1024;
+        option.baseSleepUs = 500;
         option.objectPrefix = 0;
         option.pageSize = 64 * 1024;
         option.intervalSec = 5000;

--- a/curvefs/test/client/fs_cache_manager_test.cpp
+++ b/curvefs/test/client/fs_cache_manager_test.cpp
@@ -48,6 +48,7 @@ class FsCacheManagerTest : public testing::Test {
         S3ClientAdaptorOption option;
         option.blockSize = 1 * 1024 * 1024;
         option.chunkSize = 4 * 1024 * 1024;
+        option.baseSleepUs = 500;
         option.objectPrefix = 0;
         option.pageSize = 64 * 1024;
         option.intervalSec = 5000;


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Depends on: https://github.com/opencurve/curve/pull/2492

Problem Summary: after that, fuseMaxSize is not needed anymore

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
