### PR TITLE
curvefs/client: make user agent configurable

### DIFF
--- a/conf/s3.conf
+++ b/conf/s3.conf
@@ -13,7 +13,7 @@ s3.region=us-east-1
 # http = 0, https = 1
 s3.http_scheme=0
 s3.verify_SSL=false
-s3.user_agent_conf=S3 Browser
+s3.user_agent=S3 Browser
 s3.maxConnections=32
 s3.connectTimeout=60000
 s3.requestTimeout=10000

--- a/curvefs/conf/client.conf
+++ b/curvefs/conf/client.conf
@@ -207,6 +207,7 @@ s3.readCacheThreads=5
 # http = 0, https = 1
 s3.http_scheme=0
 s3.verify_SSL=False
+s3.user_agent=S3 Browser
 s3.region=us-east-1
 s3.maxConnections=500
 s3.connectTimeout=60000

--- a/curvefs/conf/mds.conf
+++ b/curvefs/conf/mds.conf
@@ -119,6 +119,7 @@ mds.fsmanager.client.timeoutSec=20
 # http = 0, https = 1
 s3.http_scheme=0
 s3.verify_SSL=False
+s3.user_agent=S3 Browser
 s3.region=us-east-1
 s3.maxConnections=32
 s3.connectTimeout=60000

--- a/curvefs/conf/metaserver.conf
+++ b/curvefs/conf/metaserver.conf
@@ -12,6 +12,7 @@ s3.enableDeleteObjects=False
 # http = 0, https = 1
 s3.http_scheme=0
 s3.verify_SSL=False
+s3.user_agent=S3 Browser
 s3.region=us-east-1
 s3.maxConnections=32
 s3.connectTimeout=60000

--- a/curvefs/test/client/client_s3_test.cpp
+++ b/curvefs/test/client/client_s3_test.cpp
@@ -57,6 +57,16 @@ class ClientS3Test : public testing::Test {
     Aws::SDKOptions awsOptions_;
 };
 
+TEST_F(ClientS3Test, init_s3Adapter_userAgent) {
+    std::string userAgent = "S3 Browser";
+    curve::common::S3AdapterOption option;
+    option.userAgent = userAgent;
+
+    curve::common::S3Adapter s3Adapter;
+    s3Adapter.Init(option);
+    ASSERT_STREQ(userAgent.c_str(), s3Adapter.GetConfig()->userAgent.c_str());
+}
+
 TEST_F(ClientS3Test, upload) {
     const std::string obj("test");
     uint64_t len = 1024;
@@ -69,7 +79,7 @@ TEST_F(ClientS3Test, upload) {
         .WillOnce(Return(-1));
     ASSERT_EQ(0, client_->Upload(obj, buf, len));
     ASSERT_EQ(-1, client_->Upload(obj, buf, len));
-    delete buf;
+    delete[] buf;
 }
 
 TEST_F(ClientS3Test, download) {
@@ -90,7 +100,7 @@ TEST_F(ClientS3Test, download) {
     ASSERT_EQ(0, client_->Download(obj, buf, offset, len));
     ASSERT_EQ(-1, client_->Download(obj, buf, offset, len));
     ASSERT_EQ(-2, client_->Download(obj, buf, offset, len));
-    delete buf;
+    delete[] buf;
 }
 
 TEST_F(ClientS3Test, uploadync) {
@@ -106,7 +116,7 @@ TEST_F(ClientS3Test, uploadync) {
     EXPECT_CALL(*s3Client_, PutObjectAsync(_))
         .WillOnce(Return());
     client_->UploadAsync(context);
-    delete buf;
+    delete[] buf;
 }
 
 TEST_F(ClientS3Test, downloadAsync) {
@@ -124,7 +134,7 @@ TEST_F(ClientS3Test, downloadAsync) {
     EXPECT_CALL(*s3Client_, GetObjectAsync(_))
         .WillOnce(Return());
     client_->DownloadAsync(context);
-    delete buf;
+    delete[] buf;
 }
 
 

--- a/curvefs/test/client/test_fuse_s3_client.cpp
+++ b/curvefs/test/client/test_fuse_s3_client.cpp
@@ -128,6 +128,7 @@ class TestFuseS3Client : public ::testing::Test {
         InitOptionBasic(&fuseClientOption_);
         InitFSInfo(client_);
         fuseClientOption_.s3Opt.s3AdaptrOpt.asyncThreadNum = 1;
+        fuseClientOption_.s3Opt.s3AdaptrOpt.userAgent = "S3 Browser";
         fuseClientOption_.dummyServerStartPort = 5000;
         fuseClientOption_.fileSystemOption.maxNameLength = 20u;
         fuseClientOption_.listDentryThreads = 2;
@@ -170,6 +171,7 @@ class TestFuseS3Client : public ::testing::Test {
         opt->s3Opt.s3ClientAdaptorOpt.readCacheThreads = 2;
         opt->s3Opt.s3ClientAdaptorOpt.writeCacheMaxByte = 838860800;
         opt->s3Opt.s3AdaptrOpt.asyncThreadNum = 1;
+        opt->s3Opt.s3AdaptrOpt.userAgent = "S3 Browser";
         opt->dummyServerStartPort = 5000;
         opt->fileSystemOption.maxNameLength = 20u;
         opt->listDentryThreads = 2;

--- a/curvefs/test/metaserver/s3compact/s3compact_test.cpp
+++ b/curvefs/test/metaserver/s3compact/s3compact_test.cpp
@@ -184,6 +184,7 @@ TEST_F(S3CompactTest, test_S3AdapterManager) {
     opt.bucketName = "";
     opt.scheme = 0;
     opt.verifySsl = false;
+    opt.userAgent = "S3 Browser";
     opt.maxConnections = 32;
     opt.connectTimeout = 60000;
     opt.requestTimeout = 10000;

--- a/src/common/s3_adapter.cpp
+++ b/src/common/s3_adapter.cpp
@@ -82,6 +82,7 @@ void InitS3AdaptorOptionExceptS3InfoOption(Configuration* conf,
     LOG_IF(FATAL, !conf->GetStringValue("s3.logPrefix", &s3Opt->logPrefix));
     LOG_IF(FATAL, !conf->GetIntValue("s3.http_scheme", &s3Opt->scheme));
     LOG_IF(FATAL, !conf->GetBoolValue("s3.verify_SSL", &s3Opt->verifySsl));
+    LOG_IF(FATAL, !conf->GetStringValue("s3.user_agent", &s3Opt->userAgent));
     LOG_IF(FATAL, !conf->GetIntValue("s3.maxConnections",
         &s3Opt->maxConnections));
     LOG_IF(FATAL, !conf->GetIntValue("s3.connectTimeout",
@@ -149,8 +150,7 @@ void S3Adapter::Init(const S3AdapterOption &option) {
     clientCfg_ = Aws::New<Aws::Client::ClientConfiguration>(AWS_ALLOCATE_TAG);
     clientCfg_->scheme = Aws::Http::Scheme(option.scheme);
     clientCfg_->verifySSL = option.verifySsl;
-    //clientCfg_->userAgent = conf_.GetStringValue("s3.user_agent_conf").c_str();  //NOLINT
-    clientCfg_->userAgent = "S3 Browser";
+    clientCfg_->userAgent = option.userAgent.c_str();
     clientCfg_->region = option.region.c_str();
     clientCfg_->maxConnections = option.maxConnections;
     clientCfg_->connectTimeoutMs = option.connectTimeout;

--- a/src/common/s3_adapter.h
+++ b/src/common/s3_adapter.h
@@ -76,6 +76,7 @@ struct S3AdapterOption {
     std::string logPrefix;
     int scheme;
     bool verifySsl;
+    std::string userAgent;
     int maxConnections;
     int connectTimeout;
     int requestTimeout;
@@ -313,6 +314,8 @@ class S3Adapter {
                                  const Aws::String &uploadId);
     void SetBucketName(const Aws::String &name) { bucketName_ = name; }
     Aws::String GetBucketName() { return bucketName_; }
+
+    Aws::Client::ClientConfiguration *GetConfig() { return clientCfg_; }
 
  private:
     class AsyncRequestInflightBytesThrottle {


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: https://github.com/opencurve/curve/issues/2499

Problem Summary: 

Let user agent item configurable for users having security reasons

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [x] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license
