### PR TITLE
[feat]tools-v2: add bs list may-broken-vol

### DIFF
--- a/tools-v2/README.md
+++ b/tools-v2/README.md
@@ -50,6 +50,7 @@ A tool for CurveFS & CurveBs.
         - [list space](#list-space)
         - [list chunkserver](#list-chunkserver)
         - [list scan-status](#list-scan-status)
+        - [list may-broken-vol](#list-may-broken-vol)
     - [clean-recycle](#clean-recycle)
     - [query](#query-1)
         - [query file](#query-file)
@@ -1171,6 +1172,26 @@ Output:
 +-------------+-----------+
 ```
 
+##### list may-broken-vol
+
+list may broken volumes
+
+Usage:
+
+```bash
+curve bs list may-broken-vol
+```
+
+Output:
+
+```bash
++----------+
+| FILENAME | 
++----------+
+|   test   |        
++----------+
+```
+
 ### clean-recycle
 
 clean the recycle bin 
@@ -1698,10 +1719,10 @@ Output:
 | curve_ops_tool scan-status           | curve bs list/query scan-status   |
 | curve_ops_tool clean-recycle         | curve bs clean-recycle            |
 | curve_ops_tool copysets-status       | curve bs status copyset           |
+| curve_ops_tool list-may-broken-vol   | curve bs list may-broken-vol      |
 | curve_ops_tool status                |                                   |
 | curve_ops_tool check-consistency     |                                   |
 | curve_ops_tool do-snapshot-all       |                                   |
 | curve_ops_tool check-chunkserver     |                                   |
 | curve_ops_tool check-server          |                                   |
-| curve_ops_tool list-may-broken-vol   |                                   |
 | curve_ops_tool rapid-leader-schedule |                                   |

--- a/tools-v2/internal/error/error.go
+++ b/tools-v2/internal/error/error.go
@@ -459,6 +459,9 @@ var (
 	ErrBsListScanStatus = func() *CmdError {
 		return NewInternalCmdError(66, "list scan-status fail, err: %s")
 	}
+	ErrBsListOfflineChunkServer = func() *CmdError {
+		return NewInternalCmdError(67, "list offline chunkserver fail, err: %s")
+	}
 
 	// http error
 	ErrHttpUnreadableResult = func() *CmdError {

--- a/tools-v2/pkg/cli/command/curvebs/list/chunkserver/offline_chunkserver.go
+++ b/tools-v2/pkg/cli/command/curvebs/list/chunkserver/offline_chunkserver.go
@@ -1,0 +1,120 @@
+/*
+ *  Copyright (c) 2023 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * Project: CurveCli
+ * Created Date: 2023-06-07
+ * Author: baytan0720
+ */
+
+package chunkserver
+
+import (
+	"fmt"
+
+	cmderror "github.com/opencurve/curve/tools-v2/internal/error"
+	basecmd "github.com/opencurve/curve/tools-v2/pkg/cli/command"
+	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/query/chunk"
+	"github.com/opencurve/curve/tools-v2/pkg/config"
+	"github.com/opencurve/curve/tools-v2/pkg/output"
+	"github.com/opencurve/curve/tools-v2/proto/proto/topology"
+	"github.com/spf13/cobra"
+)
+
+type OfflineChunkServerCommand struct {
+	basecmd.FinalCurveCmd
+	csInfos []*topology.ChunkServerInfo
+}
+
+var _ basecmd.FinalCurveCmdFunc = (*OfflineChunkServerCommand)(nil) // check interface
+
+func NewOfflineChunkServerCommand() *cobra.Command {
+	return NewListOfflineChunkServerCommand().Cmd
+}
+
+func NewListOfflineChunkServerCommand() *OfflineChunkServerCommand {
+	oCmd := &OfflineChunkServerCommand{
+		FinalCurveCmd: basecmd.FinalCurveCmd{},
+	}
+	basecmd.NewFinalCurveCli(&oCmd.FinalCurveCmd, oCmd)
+	return oCmd
+}
+
+func (oCmd *OfflineChunkServerCommand) AddFlags() {
+	config.AddBsMdsFlagOption(oCmd.Cmd)
+	config.AddRpcRetryTimesFlag(oCmd.Cmd)
+	config.AddRpcTimeoutFlag(oCmd.Cmd)
+}
+
+func (oCmd *OfflineChunkServerCommand) Init(cmd *cobra.Command, args []string) error {
+	// list chunkserver
+	chunkserverInfos, errCmd := GetChunkServerInCluster(oCmd.Cmd)
+	if errCmd.TypeCode() != cmderror.CODE_SUCCESS {
+		return errCmd.ToError()
+	}
+	addr2CsInfo := make(map[string]*topology.ChunkServerInfo)
+
+	config.AddBsCopysetIdSliceRequiredFlag(oCmd.Cmd)
+	config.AddBsLogicalPoolIdSliceRequiredFlag(oCmd.Cmd)
+	config.AddBsChunkIdSliceRequiredFlag(oCmd.Cmd)
+	config.AddBsChunkServerAddressSliceRequiredFlag(oCmd.Cmd)
+	for i, info := range chunkserverInfos {
+		address := fmt.Sprintf("%s:%d", *info.HostIp, *info.Port)
+		addr2CsInfo[fmt.Sprintf("%s:%d", *info.HostIp, *info.Port)] = chunkserverInfos[i]
+		oCmd.Cmd.ParseFlags([]string{
+			fmt.Sprintf("--%s", config.CURVEBS_LOGIC_POOL_ID), "1",
+			fmt.Sprintf("--%s", config.CURVEBS_COPYSET_ID), "1",
+			fmt.Sprintf("--%s", config.CURVEBS_CHUNK_ID), "1",
+			fmt.Sprintf("--%s", config.CURVEBS_CHUNKSERVER_ADDRESS), address,
+		})
+	}
+	addr2Chunk, errCmd := chunk.GetChunkInfo(oCmd.Cmd)
+	for addr, info := range *addr2Chunk {
+		if info == nil {
+			oCmd.csInfos = append(oCmd.csInfos, addr2CsInfo[addr])
+		}
+	}
+	return nil
+}
+
+func (oCmd *OfflineChunkServerCommand) RunCommand(cmd *cobra.Command, args []string) error {
+	return nil
+}
+
+func (oCmd *OfflineChunkServerCommand) Print(cmd *cobra.Command, args []string) error {
+	return output.FinalCmdOutput(&oCmd.FinalCurveCmd, oCmd)
+}
+
+func (oCmd *OfflineChunkServerCommand) ResultPlainOutput() error {
+	return output.FinalCmdOutputPlain(&oCmd.FinalCurveCmd)
+}
+
+func ListOfflineChunkServer(caller *cobra.Command) ([]*topology.ChunkServerInfo, *cmderror.CmdError) {
+	cCmd := NewListOfflineChunkServerCommand()
+	cCmd.Cmd.SetArgs([]string{"--format", config.FORMAT_NOOUT})
+	config.AlignFlagsValue(caller, cCmd.Cmd, []string{
+		config.RPCRETRYTIMES, config.RPCTIMEOUT, config.CURVEBS_MDSADDR,
+	})
+	cCmd.Cmd.SilenceErrors = true
+	cCmd.Cmd.SilenceUsage = true
+	err := cCmd.Cmd.Execute()
+	if err != nil {
+		retErr := cmderror.ErrBsListOfflineChunkServer()
+		retErr.Format(err.Error())
+		return cCmd.csInfos, retErr
+	}
+	return cCmd.csInfos, cmderror.Success()
+}

--- a/tools-v2/pkg/cli/command/curvebs/list/list.go
+++ b/tools-v2/pkg/cli/command/curvebs/list/list.go
@@ -28,6 +28,7 @@ import (
 	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/list/client"
 	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/list/dir"
 	logicalpool "github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/list/logicalPool"
+	may_broken_vol "github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/list/may-broken-vol"
 	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/list/scanstatus"
 	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/list/server"
 	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/list/space"
@@ -49,6 +50,7 @@ func (listCmd *ListCommand) AddSubCommands() {
 		space.NewSpaceCommand(),
 		chunkserver.NewChunkServerCommand(),
 		scanstatus.NewScanStatusCommand(),
+		may_broken_vol.NewMayBrokenVolCommand(),
 	)
 }
 

--- a/tools-v2/pkg/cli/command/curvebs/list/may-broken-vol/may-broken-vol.go
+++ b/tools-v2/pkg/cli/command/curvebs/list/may-broken-vol/may-broken-vol.go
@@ -1,0 +1,176 @@
+/*
+ *  Copyright (c) 2023 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * Project: CurveCli
+ * Created Date: 2023-06-07
+ * Author: baytan0720
+ */
+
+package may_broken_vol
+
+import (
+	"context"
+	"fmt"
+
+	cmderror "github.com/opencurve/curve/tools-v2/internal/error"
+	cobrautil "github.com/opencurve/curve/tools-v2/internal/utils"
+	basecmd "github.com/opencurve/curve/tools-v2/pkg/cli/command"
+	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/list/chunkserver"
+	"github.com/opencurve/curve/tools-v2/pkg/config"
+	"github.com/opencurve/curve/tools-v2/pkg/output"
+	"github.com/opencurve/curve/tools-v2/proto/proto/nameserver2"
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+)
+
+const (
+	mayBrokenVolExample = `$ curve bs list may-broken-vol`
+)
+
+type ListVolumeOnCopysetsRpc struct {
+	Info             *basecmd.Rpc
+	Request          *nameserver2.ListVolumesOnCopysetsRequest
+	nameserverClient nameserver2.CurveFSServiceClient
+}
+
+var _ basecmd.RpcFunc = (*ListVolumeOnCopysetsRpc)(nil) // check interface
+
+func (lRpc *ListVolumeOnCopysetsRpc) NewRpcClient(cc grpc.ClientConnInterface) {
+	lRpc.nameserverClient = nameserver2.NewCurveFSServiceClient(cc)
+}
+
+func (lRpc *ListVolumeOnCopysetsRpc) Stub_Func(ctx context.Context) (interface{}, error) {
+	return lRpc.nameserverClient.ListVolumesOnCopysets(ctx, lRpc.Request)
+}
+
+type MayBrokenVolCommand struct {
+	basecmd.FinalCurveCmd
+	Rpc []*ListVolumeOnCopysetsRpc
+}
+
+var _ basecmd.FinalCurveCmdFunc = (*MayBrokenVolCommand)(nil) // check interface
+
+func NewMayBrokenVolCommand() *cobra.Command {
+	return NewListMayBrokenVolCommand().Cmd
+}
+
+func NewListMayBrokenVolCommand() *MayBrokenVolCommand {
+	mCmd := &MayBrokenVolCommand{
+		FinalCurveCmd: basecmd.FinalCurveCmd{
+			Use:     "may-broken-vol",
+			Short:   "list all volumes on majority offline copysets",
+			Example: mayBrokenVolExample,
+		},
+	}
+	basecmd.NewFinalCurveCli(&mCmd.FinalCurveCmd, mCmd)
+	return mCmd
+}
+
+func (mCmd *MayBrokenVolCommand) AddFlags() {
+	config.AddBsMdsFlagOption(mCmd.Cmd)
+	config.AddRpcRetryTimesFlag(mCmd.Cmd)
+	config.AddRpcTimeoutFlag(mCmd.Cmd)
+}
+
+func (mCmd *MayBrokenVolCommand) Init(cmd *cobra.Command, args []string) error {
+	mdsAddrs, err := config.GetBsMdsAddrSlice(mCmd.Cmd)
+	if err.TypeCode() != cmderror.CODE_SUCCESS {
+		return err.ToError()
+	}
+	timeout := config.GetFlagDuration(mCmd.Cmd, config.RPCTIMEOUT)
+	retrytimes := config.GetFlagInt32(mCmd.Cmd, config.RPCRETRYTIMES)
+
+	offlineChunkServers, err := chunkserver.ListOfflineChunkServer(mCmd.Cmd)
+	if err.TypeCode() != cmderror.CODE_SUCCESS {
+		return err.ToError()
+	}
+
+	config.AddBsChunkServerIdFlag(mCmd.Cmd)
+	for i, info := range offlineChunkServers {
+		if i > 0 {
+			mCmd.Cmd.Flag(config.CURVEBS_CHUNKSERVER_ID).Value.Set(fmt.Sprintf("%d", *info.ChunkServerID))
+		} else {
+			mCmd.Cmd.ParseFlags([]string{
+				fmt.Sprintf("--%s", config.CURVEBS_CHUNKSERVER_ID), fmt.Sprintf("%d", *info.ChunkServerID),
+			})
+		}
+		copysets, err := chunkserver.GetCopySetsInChunkServer(mCmd.Cmd)
+		if err.TypeCode() != cmderror.CODE_SUCCESS {
+			return err.ToError()
+		}
+		rpc := &ListVolumeOnCopysetsRpc{
+			Request: &nameserver2.ListVolumesOnCopysetsRequest{
+				Copysets: copysets,
+			},
+			Info: basecmd.NewRpc(mdsAddrs, timeout, retrytimes, "ListVolumesOnCopysets"),
+		}
+		mCmd.Rpc = append(mCmd.Rpc, rpc)
+	}
+
+	header := []string{cobrautil.ROW_FILE_NAME}
+	mCmd.SetHeader(header)
+	return nil
+}
+
+func (mCmd *MayBrokenVolCommand) RunCommand(cmd *cobra.Command, args []string) error {
+	if len(mCmd.Rpc) == 0 {
+		mCmd.Cmd.Println("no offline chunk server")
+		return nil
+	}
+	var infos []*basecmd.Rpc
+	var funcs []basecmd.RpcFunc
+	for _, rpc := range mCmd.Rpc {
+		infos = append(infos, rpc.Info)
+		funcs = append(funcs, rpc)
+	}
+	results, errs := basecmd.GetRpcListResponse(infos, funcs)
+	if len(errs) == len(infos) {
+		mergeErr := cmderror.MergeCmdErrorExceptSuccess(errs)
+		return mergeErr.ToError()
+	}
+
+	rows := make([]map[string]string, 0)
+	count := 0
+	for _, result := range results {
+		if result == nil {
+			continue
+		}
+		resp := result.(*nameserver2.ListVolumesOnCopysetsResponse)
+		for _, name := range resp.FileNames {
+			row := make(map[string]string)
+			row[cobrautil.ROW_FILE_NAME] = name
+			rows = append(rows, row)
+			count++
+		}
+	}
+
+	if count == 0 {
+		mCmd.Cmd.Println("no may broken volume")
+	}
+
+	mCmd.Result = rows
+
+	return nil
+}
+
+func (mCmd *MayBrokenVolCommand) Print(cmd *cobra.Command, args []string) error {
+	return output.FinalCmdOutput(&mCmd.FinalCurveCmd, mCmd)
+}
+
+func (mCmd *MayBrokenVolCommand) ResultPlainOutput() error {
+	return output.FinalCmdOutputPlain(&mCmd.FinalCurveCmd)
+}


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #2356 <!-- replace xxx with issue number -->

Problem Summary:

### What is changed and how it works?

What's Changed:
add tools-v2/pkg/cli/command/curvebs/list/chunkserver/offline_chunkserver.go
add tools-v2/pkg/cli/command/curvebs/list/may-broken-vol/may-broken-vol.go
modify tools-v2/pkg/cli/command/curvebs/list/list.go

How it Works:

Usage: 
```bash
$curve bs list may-broken-vol --help
Usage:  curve bs list may-broken-vol [flags]

list all volumes on majority offline copysets

Flags:
  -f, --format string         output format (json|plain) (default "plain")
      --mdsaddr string        mds address, should be like 127.0.0.1:6700,127.0.0.1:6701,127.0.0.1:6702
      --rpcretrytimes int32   rpc retry times (default 1)
      --rpctimeout duration   rpc timeout (default 10s)

Global Flags:
  -c, --conf string   config file (default is $HOME/.curve/curve.yaml or /etc/curve/curve.yaml)
  -h, --help          print help
      --showerror     display all errors in command
      --verbose       show some log

Examples:
$ curve bs list may-broken-vol
```


Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [x] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license
