### PR TITLE
[fix]fs list copysetinfo err

### DIFF
--- a/tools-v2/pkg/cli/command/base.go
+++ b/tools-v2/pkg/cli/command/base.go
@@ -27,6 +27,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"log"
+	"math"
 	"net/http"
 	"os"
 	"strings"
@@ -300,7 +301,13 @@ func GetRpcResponse(rpc *Rpc, rpcFunc RpcFunc) (interface{}, *cmderror.CmdError)
 			log.Printf("%s: start to dial [%s]", address, rpc.RpcFuncName)
 			ctx, cancel := context.WithTimeout(context.Background(), rpc.RpcTimeout)
 			defer cancel()
-			conn, err := grpc.DialContext(ctx, address, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
+			conn, err := grpc.DialContext(
+				ctx,
+				address,
+				grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock(),
+				grpc.WithInitialConnWindowSize(math.MaxInt32),
+				grpc.WithInitialWindowSize(math.MaxInt32),
+			)
 			if err != nil {
 				errDial := cmderror.ErrRpcDial()
 				errDial.Format(address, err.Error())

--- a/tools-v2/pkg/cli/command/curvefs/list/copyset/copyset.go
+++ b/tools-v2/pkg/cli/command/curvefs/list/copyset/copyset.go
@@ -25,6 +25,7 @@ package copyset
 import (
 	"context"
 	"fmt"
+	"math"
 
 	cmderror "github.com/opencurve/curve/tools-v2/internal/error"
 	cobrautil "github.com/opencurve/curve/tools-v2/internal/utils"
@@ -65,7 +66,10 @@ func (cRpc *ListCopysetRpc) NewRpcClient(cc grpc.ClientConnInterface) {
 }
 
 func (cRpc *ListCopysetRpc) Stub_Func(ctx context.Context) (interface{}, error) {
-	return cRpc.topologyClient.ListCopysetInfo(ctx, cRpc.Request)
+	return cRpc.topologyClient.ListCopysetInfo(ctx, 
+		cRpc.Request, 
+		grpc.MaxCallRecvMsgSize(math.MaxInt32),
+	)
 }
 
 func NewCopysetCommand() *cobra.Command {


### PR DESCRIPTION
when run `curve fs status copyset`, while get error:
```bahs
rpc error: code = ResourceExhausted desc = stream terminated by
RST_STREAM with error code: FLOW_CONTROL_ERROR
```

Refer to [issue](https://github.com/apache/brpc/issues/1087).

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #2524 2524 <!-- replace xxx with issue number -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
