### PR TITLE
[fix]get copyset in clusetr

### DIFF
--- a/src/mds/topology/topology_service_manager.cpp
+++ b/src/mds/topology/topology_service_manager.cpp
@@ -1680,7 +1680,7 @@ void TopologyServiceManager::GetCopySetsInCluster(
     const GetCopySetsInClusterRequest* request,
     GetCopySetsInClusterResponse* response) {
     auto filter = [&](const CopySetInfo& copysetInfo) {
-        if (request->has_filterscaning() && !copysetInfo.GetScaning()) {
+        if (request->filterscaning() && !copysetInfo.GetScaning()) {
             return false;
         }
 


### PR DESCRIPTION
The judgment condition is wrong. If it is the old way, as long as filterScanning is set, the filter will be started regardless of the value, which is inconsistent with expectations.

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #xxx <!-- replace xxx with issue number -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
