### PR TITLE
[feat] tools-v2: add bs status cluster

### DIFF
--- a/tools-v2/internal/error/error.go
+++ b/tools-v2/internal/error/error.go
@@ -459,6 +459,15 @@ var (
 	ErrBsListOfflineChunkServer = func() *CmdError {
 		return NewInternalCmdError(66, "list offline chunkserver fail, err: %s")
 	}
+	ErrBsListSpaceStatus = func() *CmdError {
+		return NewInternalCmdError(68, "list space status fail, err: %s")
+	}
+	ErrConverResult = func() *CmdError {
+		return NewInternalCmdError(69, "conver results fail, err: %s")
+	}
+	ErrSnapShotAddrNotConfigured = func() *CmdError {
+		return NewInternalCmdError(70, "get snapshotAddr fail, err: %s")
+	}
 
 	// http error
 	ErrHttpUnreadableResult = func() *CmdError {
@@ -470,7 +479,6 @@ var (
 	ErrHttpStatus = func(statusCode int) *CmdError {
 		return NewHttpError(statusCode, "the url is: %s, http status code is: %d")
 	}
-
 	// rpc error
 	ErrRpcCall = func() *CmdError {
 		return NewRpcReultCmdError(1, "rpc[%s] is fail, the error is: %s")

--- a/tools-v2/internal/error/error_test.go
+++ b/tools-v2/internal/error/error_test.go
@@ -37,7 +37,7 @@ func TestCmdError(t *testing.T) {
 			Code:    0,
 			Message: "123%s",
 		}
-		tmp = tmp.Format("4")
+		tmp.Format("4")
 		tmp_json, err := json.Marshal(tmp)
 		So(err, ShouldBeNil)
 

--- a/tools-v2/internal/utils/health.go
+++ b/tools-v2/internal/utils/health.go
@@ -28,6 +28,8 @@ import (
 
 type ClUSTER_HEALTH_STATUS int32
 
+const HEALTH = "health"
+
 const (
 	HEALTH_OK    ClUSTER_HEALTH_STATUS = 1
 	HEALTH_WARN  ClUSTER_HEALTH_STATUS = 2

--- a/tools-v2/internal/utils/row.go
+++ b/tools-v2/internal/utils/row.go
@@ -23,6 +23,7 @@
 package cobrautil
 
 const (
+	ROW_ROLE                 = "role"
 	ROW_ADDR                 = "addr"
 	ROW_ALLOC                = "alloc"
 	ROW_ALLOC_SIZE           = "allocatedSize"
@@ -57,6 +58,7 @@ const (
 	ROW_IP                   = "ip"
 	ROW_KEY                  = "key"
 	ROW_LEADER               = "leader"
+	ROW_FOLLOWER             = "follower"
 	ROW_OLDLEADER            = "oldLeader"
 	ROW_LEADER_PEER          = "leaderPeer"
 	ROW_LEFT                 = "left"

--- a/tools-v2/pkg/cli/command/curvebs/check/copyset/copyset.go
+++ b/tools-v2/pkg/cli/command/curvebs/check/copyset/copyset.go
@@ -30,7 +30,6 @@ import (
 	"time"
 
 	mapset "github.com/deckarep/golang-set/v2"
-	"github.com/olekukonko/tablewriter"
 	cmderror "github.com/opencurve/curve/tools-v2/internal/error"
 	cobrautil "github.com/opencurve/curve/tools-v2/internal/utils"
 	basecmd "github.com/opencurve/curve/tools-v2/pkg/cli/command"
@@ -352,7 +351,7 @@ func CheckCopysets(caller *cobra.Command) (*map[uint64]cobrautil.ClUSTER_HEALTH_
 	return cCmd.Key2Health, cmderror.Success()
 }
 
-func GetCopysetsStatus(caller *cobra.Command) (*tablewriter.Table, *cmderror.CmdError) {
+func GetCopysetsStatus(caller *cobra.Command) (*interface{}, *cmderror.CmdError) {
 	cCmd := NewCheckCopysetCommand()
 	cCmd.Cmd.SetArgs([]string{fmt.Sprintf("--%s", config.FORMAT), config.FORMAT_NOOUT})
 	config.AlignFlagsValue(caller, cCmd.Cmd, []string{
@@ -367,5 +366,5 @@ func GetCopysetsStatus(caller *cobra.Command) (*tablewriter.Table, *cmderror.Cmd
 		retErr.Format(err.Error())
 		return nil, retErr
 	}
-	return cCmd.TableNew, cCmd.Error
+	return &cCmd.Result, cCmd.Error
 }

--- a/tools-v2/pkg/cli/command/curvebs/list/space/space.go
+++ b/tools-v2/pkg/cli/command/curvebs/list/space/space.go
@@ -187,3 +187,19 @@ func (sCmd *SpaceCommand) RunCommand(cmd *cobra.Command, args []string) error {
 func (sCmd *SpaceCommand) ResultPlainOutput() error {
 	return output.FinalCmdOutputPlain(&sCmd.FinalCurveCmd)
 }
+
+func GetSpaceStatus(caller *cobra.Command) (*interface{}, *cmderror.CmdError, cobrautil.ClUSTER_HEALTH_STATUS) {
+	sCmd := NewListSpaceCommand()
+	sCmd.Cmd.SetArgs([]string{
+		fmt.Sprintf("--%s", config.FORMAT), config.FORMAT_NOOUT,
+	})
+	config.AlignFlagsValue(caller, sCmd.Cmd, []string{config.HTTPTIMEOUT, config.RPCRETRYTIMES, config.RPCTIMEOUT, config.CURVEBS_MDSADDR})
+	sCmd.Cmd.SilenceErrors = true
+	err := sCmd.Cmd.Execute()
+	if err != nil {
+		retErr := cmderror.ErrBsListSpaceStatus()
+		retErr.Format(err.Error())
+		return nil, retErr, cobrautil.HEALTH_ERROR
+	}
+	return &sCmd.Result, cmderror.Success(), cobrautil.HEALTH_OK
+}

--- a/tools-v2/pkg/cli/command/curvebs/status/chunkserver/chunkserver.go
+++ b/tools-v2/pkg/cli/command/curvebs/status/chunkserver/chunkserver.go
@@ -56,7 +56,7 @@ func (csCmd *ChunkServerCommand) Init(cmd *cobra.Command, args []string) error {
 	}
 	csCmd.ChunkServerInfos = csInfos
 	header := []string{
-		cobrautil.ROW_EXTERNAL_ADDR, cobrautil.ROW_INTERNAL_ADDR, cobrautil.ROW_VERSION, 
+		cobrautil.ROW_EXTERNAL_ADDR, cobrautil.ROW_INTERNAL_ADDR, cobrautil.ROW_VERSION,
 		cobrautil.ROW_STATUS, cobrautil.ROW_RECOVERING,
 	}
 	csCmd.SetHeader(header)
@@ -79,7 +79,7 @@ func (csCmd *ChunkServerCommand) RunCommand(cmd *cobra.Command, args []string) e
 		} else {
 			row[cobrautil.ROW_STATUS] = cobrautil.ROW_VALUE_OFFLINE
 		}
-		row[cobrautil.ROW_RECOVERING] = fmt.Sprintf("%v",csCmd.RecoverStatusMap[csInfo.GetChunkServerID()])
+		row[cobrautil.ROW_RECOVERING] = fmt.Sprintf("%v", csCmd.RecoverStatusMap[csInfo.GetChunkServerID()])
 		rows = append(rows, row)
 	}
 	list := cobrautil.ListMap2ListSortByKeys(rows, csCmd.Header, []string{
@@ -119,4 +119,20 @@ func NewStatusChunkServerCommand() *ChunkServerCommand {
 
 func NewChunkServerCommand() *cobra.Command {
 	return NewStatusChunkServerCommand().Cmd
+}
+
+func GetChunkserverStatus(caller *cobra.Command) (*interface{}, *cmderror.CmdError, cobrautil.ClUSTER_HEALTH_STATUS) {
+	csCmd := NewStatusChunkServerCommand()
+	csCmd.Cmd.SetArgs([]string{
+		fmt.Sprintf("--%s", config.FORMAT), config.FORMAT_NOOUT,
+	})
+	config.AlignFlagsValue(caller, csCmd.Cmd, []string{config.RPCRETRYTIMES, config.RPCTIMEOUT, config.CURVEBS_MDSADDR})
+	csCmd.Cmd.SilenceErrors = true
+	err := csCmd.Cmd.Execute()
+	if err != nil {
+		retErr := cmderror.ErrBsGetChunkServerInCluster()
+		retErr.Format(err.Error())
+		return nil, retErr, cobrautil.HEALTH_ERROR
+	}
+	return &csCmd.Result, cmderror.Success(), cobrautil.HEALTH_OK
 }

--- a/tools-v2/pkg/cli/command/curvebs/status/cluster/cluster.go
+++ b/tools-v2/pkg/cli/command/curvebs/status/cluster/cluster.go
@@ -1,0 +1,282 @@
+/*
+ *  Copyright (c) 2022 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * Project: CurveCli
+ * Created Date: 2023-06-08
+ * Author: CXF
+ */
+
+package cluster
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/olekukonko/tablewriter"
+	cmderror "github.com/opencurve/curve/tools-v2/internal/error"
+	cobrautil "github.com/opencurve/curve/tools-v2/internal/utils"
+	basecmd "github.com/opencurve/curve/tools-v2/pkg/cli/command"
+	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/list/space"
+	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/status/chunkserver"
+	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/status/copyset"
+	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/status/etcd"
+	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/status/mds"
+	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/status/snapshot"
+	"github.com/opencurve/curve/tools-v2/pkg/config"
+	"github.com/opencurve/curve/tools-v2/pkg/output"
+	"github.com/spf13/cobra"
+)
+
+const (
+	TYPE_ETCD        = "etcd"
+	TYPE_MDS         = "mds"
+	TYPE_CHUNKSERVER = "chunkserver"
+	TYPE_SNAPSHOT    = "snapshot"
+	TYPE_COPYSET     = "copyset"
+	TYPE_SPACE       = "space"
+)
+
+type ClusterCommand struct {
+	basecmd.FinalCurveCmd
+	tableRoles   *tablewriter.Table
+	tableCopyset *tablewriter.Table
+	tableSpace   *tablewriter.Table
+	type2Func    map[string]func(caller *cobra.Command) (*interface{}, *cmderror.CmdError, cobrautil.ClUSTER_HEALTH_STATUS)
+	health       cobrautil.ClUSTER_HEALTH_STATUS
+}
+
+var _ basecmd.FinalCurveCmdFunc = (*ClusterCommand)(nil) // check interface
+
+const (
+	clusterExample = `$ curve bs status cluster`
+)
+
+func NewClusterCommand() *cobra.Command {
+	cCmd := &ClusterCommand{
+		FinalCurveCmd: basecmd.FinalCurveCmd{
+			Use:     "cluster",
+			Short:   "get status of the curvebs",
+			Example: clusterExample,
+		},
+	}
+	basecmd.NewFinalCurveCli(&cCmd.FinalCurveCmd, cCmd)
+	return cCmd.Cmd
+}
+
+func (cCmd *ClusterCommand) AddFlags() {
+	config.AddRpcRetryTimesFlag(cCmd.Cmd)
+	config.AddRpcTimeoutFlag(cCmd.Cmd)
+	config.AddBsMdsFlagOption(cCmd.Cmd)
+}
+
+func (cCmd *ClusterCommand) Init(cmd *cobra.Command, args []string) error {
+	cCmd.tableRoles = tablewriter.NewWriter(os.Stdout)
+	cCmd.tableCopyset = tablewriter.NewWriter(os.Stdout)
+	cCmd.tableSpace = tablewriter.NewWriter(os.Stdout)
+
+	rolesHeader := []string{cobrautil.ROW_ROLE, cobrautil.ROW_LEADER, cobrautil.ROW_VALUE_ONLINE, cobrautil.ROW_VALUE_OFFLINE}
+	copysetHeader := []string{cobrautil.ROW_POOL_ID, cobrautil.ROW_TOTAL, cobrautil.COPYSET_OK_STR, cobrautil.COPYSET_WARN_STR, cobrautil.COPYSET_ERROR_STR}
+	spaceHeader := []string{cobrautil.ROW_TYPE, cobrautil.ROW_USED, cobrautil.ROW_LEFT, cobrautil.ROW_RECYCLABLE, cobrautil.ROW_CREATED}
+	cCmd.tableRoles.SetHeader(rolesHeader)
+	cCmd.tableCopyset.SetHeader(copysetHeader)
+	cCmd.tableSpace.SetHeader(spaceHeader)
+
+	cCmd.tableRoles.SetRowLine(true)
+	cCmd.tableRoles.SetAlignment(tablewriter.ALIGN_CENTER)
+
+	cCmd.tableCopyset.SetRowLine(true)
+	cCmd.tableCopyset.SetAlignment(tablewriter.ALIGN_CENTER)
+
+	cCmd.tableSpace.SetRowLine(true)
+	cCmd.tableSpace.SetAlignment(tablewriter.ALIGN_CENTER)
+
+	cCmd.type2Func = map[string]func(caller *cobra.Command) (*interface{}, *cmderror.CmdError, cobrautil.ClUSTER_HEALTH_STATUS){
+		TYPE_ETCD:        etcd.GetEtcdStatus,
+		TYPE_MDS:         mds.GetMdsStatus,
+		TYPE_CHUNKSERVER: chunkserver.GetChunkserverStatus,
+		TYPE_SNAPSHOT:    snapshot.GetSnapshotStatus,
+		TYPE_COPYSET:     copyset.GetCopysetsStatus,
+		TYPE_SPACE:       space.GetSpaceStatus,
+	}
+	cCmd.health = cobrautil.HEALTH_OK
+	return nil
+}
+
+func (cCmd *ClusterCommand) Print(cmd *cobra.Command, args []string) error {
+	return output.FinalCmdOutput(&cCmd.FinalCurveCmd, cCmd)
+}
+
+func (cCmd *ClusterCommand) RunCommand(cmd *cobra.Command, args []string) error {
+	var errs []*cmderror.CmdError
+	results := make(map[string]interface{})
+	for key, function := range cCmd.type2Func {
+		result, err, health := function(cmd)
+
+		// snapshotserver addr is not configured
+		if err != nil && err.Code == cmderror.ErrSnapShotAddrNotConfigured().Code && key == TYPE_SNAPSHOT {
+			continue
+		}
+
+		errs = append(errs, err)
+		cCmd.health = cobrautil.CompareHealth(cCmd.health, health)
+		if result != nil && *result != nil {
+			results[key] = *result
+			// always true
+			rows, ok := (*result).([]map[string]string)
+			if !ok {
+				retErr := cmderror.ErrConverResult()
+				retErr.Format(key)
+				return retErr.ToError()
+			}
+			cCmd.parseResults(rows, key)
+		}
+	}
+
+	finalErr := cmderror.MergeCmdErrorExceptSuccess(errs)
+	cCmd.Error = finalErr
+	results[cobrautil.HEALTH] = cobrautil.ClusterHealthStatus_Str[int32(cCmd.health)]
+	cCmd.Result = results
+	return nil
+}
+
+func (cCmd *ClusterCommand) ResultPlainOutput() error {
+	fmt.Println("Services:")
+	if cCmd.tableRoles != nil && cCmd.tableRoles.NumLines() > 0 {
+		cCmd.tableRoles.Render()
+	} else {
+		fmt.Println("No found cluster services info")
+	}
+
+	fmt.Println("Copyset:")
+	if cCmd.tableCopyset != nil && cCmd.tableCopyset.NumLines() > 0 {
+		cCmd.tableCopyset.Render()
+	} else {
+		fmt.Println("No found copyset info")
+	}
+
+	fmt.Println("Space:")
+	if cCmd.tableSpace != nil && cCmd.tableSpace.NumLines() > 0 {
+		cCmd.tableSpace.Render()
+	} else {
+		fmt.Println("No found space info")
+	}
+	fmt.Println("Cluster health is:", cobrautil.ClusterHealthStatus_Str[int32(cCmd.health)])
+	return nil
+}
+
+func (cCmd *ClusterCommand) parseResults(results []map[string]string, role string) {
+	switch role {
+	case TYPE_COPYSET:
+		cCmd.buildTableCopyset(results)
+	case TYPE_SPACE:
+		cCmd.buildTableSpace(results)
+	default:
+		cCmd.buildTableRole(results, role)
+	}
+}
+
+func (cCmd *ClusterCommand) buildTableRole(results []map[string]string, role string) {
+	var leader string
+	var onlineSlice, offlineSlice []string
+	for _, row := range results {
+		switch row[cobrautil.ROW_STATUS] {
+		case cobrautil.ROW_LEADER:
+			leader = row[cobrautil.ROW_ADDR]
+		case cobrautil.ROW_VALUE_ONLINE, cobrautil.ROW_FOLLOWER:
+			if role == TYPE_CHUNKSERVER {
+				onlineSlice = append(onlineSlice, row[cobrautil.ROW_EXTERNAL_ADDR])
+			} else {
+				onlineSlice = append(onlineSlice, row[cobrautil.ROW_ADDR])
+			}
+		default:
+			offlineSlice = append(offlineSlice, row[cobrautil.ROW_ADDR])
+		}
+	}
+
+	if role == TYPE_CHUNKSERVER {
+		leader = "-"
+	}
+
+	online := strings.Join(onlineSlice, "\n")
+	offline := strings.Join(offlineSlice, "\n")
+	row := []string{role, leader, online, offline}
+	cCmd.tableRoles.Append(row)
+}
+
+func (cCmd *ClusterCommand) buildTableSpace(results []map[string]string) {
+	for _, row := range results {
+		if row[cobrautil.ROW_TYPE] == cobrautil.ROW_VALUE_PHYSICAL {
+			oneRow := []string{
+				row[cobrautil.ROW_TYPE],
+				row[cobrautil.ROW_USED],
+				row[cobrautil.ROW_LEFT],
+				row[cobrautil.ROW_RECYCLABLE],
+				row[cobrautil.ROW_CREATED],
+			}
+			cCmd.tableSpace.Append(oneRow)
+		}
+	}
+}
+
+func (cCmd *ClusterCommand) buildTableCopyset(results []map[string]string) {
+	var total, copysetOK, copysetWarn, copysetError int
+	var PrevPoolID string
+	var allRows [][]string = [][]string{}
+	for _, row := range results {
+		if PrevPoolID != row[cobrautil.ROW_POOL_ID] {
+			if PrevPoolID != "" {
+				allRows = append(
+					allRows,
+					[]string{
+						PrevPoolID,
+						strconv.Itoa(total),
+						strconv.Itoa(copysetOK),
+						strconv.Itoa(copysetWarn),
+						strconv.Itoa(copysetError),
+					})
+			}
+			PrevPoolID = row[cobrautil.ROW_POOL_ID]
+			total, copysetOK, copysetWarn, copysetError = 0, 0, 0, 0
+		}
+
+		switch row[cobrautil.ROW_STATUS] {
+		case cobrautil.COPYSET_OK_STR:
+			copysetOK++
+		case cobrautil.COPYSET_WARN_STR:
+			copysetWarn++
+		case cobrautil.COPYSET_ERROR_STR:
+			copysetError++
+		}
+
+		total++
+	}
+
+	if PrevPoolID != "" {
+		allRows = append(
+			allRows,
+			[]string{
+				PrevPoolID,
+				strconv.Itoa(total),
+				strconv.Itoa(copysetOK),
+				strconv.Itoa(copysetWarn),
+				strconv.Itoa(copysetError),
+			})
+	}
+	cCmd.tableCopyset.AppendBulk(allRows)
+}

--- a/tools-v2/pkg/cli/command/curvebs/status/status.go
+++ b/tools-v2/pkg/cli/command/curvebs/status/status.go
@@ -26,6 +26,7 @@ import (
 	basecmd "github.com/opencurve/curve/tools-v2/pkg/cli/command"
 	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/status/chunkserver"
 	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/status/client"
+	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/status/cluster"
 	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/status/copyset"
 	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/status/etcd"
 	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/status/mds"
@@ -47,6 +48,7 @@ func (statusCmd *StatusCommand) AddSubCommands() {
 		snapshot.NewSnapshotCommand(),
 		chunkserver.NewChunkServerCommand(),
 		copyset.NewCopysetCommand(),
+		cluster.NewClusterCommand(),
 	)
 }
 

--- a/tools-v2/pkg/config/bs.go
+++ b/tools-v2/pkg/config/bs.go
@@ -621,6 +621,12 @@ func GetBsAddrSlice(cmd *cobra.Command, addrType string) ([]string, *cmderror.Cm
 		addrslice[i] = strings.TrimSpace(addr)
 	}
 
+	if addrType == CURVEBS_SNAPSHOTADDR && len(strings.TrimSpace(addrsStr)) == 0 {
+		err := cmderror.ErrSnapShotAddrNotConfigured()
+		err.Format(fmt.Sprint(CURVEBS_SNAPSHOTADDR, " is not configured"))
+		return nil, err
+	}
+
 	for _, addr := range addrslice {
 		if !IsValidAddr(addr) {
 			err := cmderror.ErrGetAddr()

--- a/tools-v2/pkg/config/config.go
+++ b/tools-v2/pkg/config/config.go
@@ -169,7 +169,7 @@ func AlignFlagsValue(caller *cobra.Command, callee *cobra.Command, flagNames []s
 }
 
 type stringSlice struct {
-	value []string
+	value  []string
 	change bool
 }
 
@@ -190,7 +190,7 @@ func (s *stringSlice) Type() string {
 func ResetStringSliceFlag(flag *pflag.Flag, value string) {
 	flag.Changed = false
 	flag.Value = &stringSlice{
-		value: strings.Split(value, ","),
+		value:  strings.Split(value, ","),
 		change: true,
 	}
 	flag.Changed = true


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #xxx <!-- replace xxx with issue number -->

Problem Summary: 

### What is changed and how it works?

What's Changed:

How it Works:

`curve bs status cluster`

The output is as follows：

Services:
| ROLE | LEADER | ONLINE | OFFLINE |
| -------- | :--------: | -------- | -------- |
|    etcd     | 10.0.0.1:23790 | 10.0.0.2:23790 <br> 10.0.0.3:23790 |         |
|    mds     | 10.0.0.1:6700 | 10.0.0.2:6700 <br> 10.0.0.3:6700 |         |
|    chunkserver     | - | 10.0.0.1:8200 <br> 10.0.0.2:8200 <br> 10.0.0.3:8200 |         |
|    snapshot     | 10.0.0.1:5555 |  10.0.0.2:5555 <br> 10.0.0.3:5555 |         |

Copyset:
| POOLID | TOTAL | OK | WARN | ERROR |
| -------- | -------- | -------- | -------- |-------- |
|   1    |  100  | 94 |  3   |   3   |

Space:
|   TYPE   | USED |  LEFT  | RECYCLABLE | CREATED |
| -------- | -------- | -------- | :--------: | :--------: |
| physical | 0 B  | 98 GiB |     -      |    -    |

Cluster health is: ok

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
