### PR TITLE
[fix] clean up resources when partition persistence fails

### DIFF
--- a/curvefs/src/mds/heartbeat/heartbeat_manager.cpp
+++ b/curvefs/src/mds/heartbeat/heartbeat_manager.cpp
@@ -42,8 +42,9 @@ namespace mds {
 namespace heartbeat {
 HeartbeatManager::HeartbeatManager(
     const HeartbeatOption &option, const std::shared_ptr<Topology> &topology,
-    const std::shared_ptr<Coordinator> &coordinator)
-    : topology_(topology) {
+    const std::shared_ptr<Coordinator> &coordinator,
+    const std::shared_ptr<TopologyManager> &topologyManager)
+    : topology_(topology), topologyManager_(topologyManager){
     healthyChecker_ =
         std::make_shared<MetaserverHealthyChecker>(option, topology);
 
@@ -161,8 +162,9 @@ void HeartbeatManager::MetaServerHeartbeat(
         if (request.metaserverid() == reportCopySetInfo.GetLeader()) {
             topoUpdater_->UpdateCopysetTopo(reportCopySetInfo);
             if (!value.has_iscopysetloading() || !value.iscopysetloading()) {
-                topoUpdater_->UpdatePartitionTopo(reportCopySetInfo.GetId(),
-                                                  partitionList);
+                topoUpdater_ onTopo(reportCopySetInfo.GetId(),
+                                                  partitionList,
+                                                  topologyManager_);
             }
         }
     }

--- a/curvefs/src/mds/heartbeat/heartbeat_manager.h
+++ b/curvefs/src/mds/heartbeat/heartbeat_manager.h
@@ -65,7 +65,8 @@ class HeartbeatManager {
  public:
     HeartbeatManager(const HeartbeatOption &option,
                      const std::shared_ptr<Topology> &topology,
-                     const std::shared_ptr<Coordinator> &coordinator);
+                     const std::shared_ptr<Coordinator> &coordinator,
+                     const std::shared_ptr<TopologyManager> &topologyManager);
 
     ~HeartbeatManager() { Stop(); }
 
@@ -143,6 +144,7 @@ class HeartbeatManager {
  private:
     // Dependencies of heartbeat
     std::shared_ptr<Topology> topology_;
+    std::shared_ptr<TopologyManager> topologyManager_;
     std::shared_ptr<Coordinator> coordinator_;
 
     // healthyChecker_ health checker running in background thread

--- a/curvefs/src/mds/mds.cpp
+++ b/curvefs/src/mds/mds.cpp
@@ -417,7 +417,7 @@ void MDS::InitHeartbeatManager() {
 
     heartbeatOption.mdsStartTime = steady_clock::now();
     heartbeatManager_ = std::make_shared<HeartbeatManager>(
-        heartbeatOption, topology_, coordinator_);
+        heartbeatOption, topology_, coordinator_, topologyManager_);
     heartbeatManager_->Init();
 }
 

--- a/curvefs/src/mds/topology/topology_manager.cpp
+++ b/curvefs/src/mds/topology/topology_manager.cpp
@@ -1258,6 +1258,10 @@ void TopologyManager::GetTopology(ListTopologyResponse *response) {
     ListMetaserverOfCluster(response->mutable_metaservers());
 }
 
+std::shared_ptr<MetaserverClient> TopologyManager::GetMetaserverClient(){
+    return metaserverclient_;
+}
+
 void TopologyManager::ListZone(ListZoneResponse *response) {
     response->set_statuscode(TopoStatusCode::TOPO_OK);
     auto zoneIdVec = topology_->GetZoneInCluster();

--- a/curvefs/src/mds/topology/topology_manager.h
+++ b/curvefs/src/mds/topology/topology_manager.h
@@ -162,6 +162,8 @@ class TopologyManager {
 
     virtual void GetTopology(ListTopologyResponse* response);
 
+    virtual std::shared_ptr<MetaserverClient> GetMetaserverClient();
+
     virtual void ListZone(ListZoneResponse* response);
 
     virtual void ListServer(ListServerResponse* response);


### PR DESCRIPTION
What problem does this PR solve?
Issue Number: #2484

Problem Summary: When we find that the partition in metaserver but not in topology, we need to call deletepartition rpc in metaserver to delete the partitions;

What is changed and how it works?
What's Changed: Add a GetMetaserverClient api in topologymanager; pass topologymanager to heartbeatmanager; pass topologymanager to topoupdater->UpdatePartitionTopo(); call DeletePartition rpc in UpdatePartitionTopo().

How it Works: when detect partition in metaserver but not in topology during heartbeat, we call DeletePartition rpc to delete these partitions.

Side effects(Breaking backward compatibility? Performance regression?):

Check List
 Relevant documentation/comments is changed or added
 I acknowledge that all my contributions will be made under the project's license