### PR TITLE
[refactor]tools-v2: refactor all *map to map

### DIFF
--- a/tools-v2/pkg/cli/command/curvebs/list/chunkserver/offline_chunkserver.go
+++ b/tools-v2/pkg/cli/command/curvebs/list/chunkserver/offline_chunkserver.go
@@ -82,7 +82,7 @@ func (oCmd *OfflineChunkServerCommand) Init(cmd *cobra.Command, args []string) e
 		})
 	}
 	addr2Chunk, errCmd := chunk.GetChunkInfo(oCmd.Cmd)
-	for addr, info := range *addr2Chunk {
+	for addr, info := range addr2Chunk {
 		if info == nil {
 			oCmd.csInfos = append(oCmd.csInfos, addr2CsInfo[addr])
 		}

--- a/tools-v2/pkg/cli/command/curvebs/query/chunk/chunk.go
+++ b/tools-v2/pkg/cli/command/curvebs/query/chunk/chunk.go
@@ -98,7 +98,7 @@ func (cCmd *ChunkCommand) Init(cmd *cobra.Command, args []string) error {
 		return err.ToError()
 	}
 	key := cobrautil.GetCopysetKey(uint64(cCmd.LogicalpoolId), uint64(cCmd.CopysetId))
-	cCmd.ChunkServerList = (*key2Location)[key]
+	cCmd.ChunkServerList = key2Location[key]
 	header := []string{cobrautil.ROW_CHUNK, cobrautil.ROW_LOGICALPOOL,
 		cobrautil.ROW_COPYSET, cobrautil.ROW_GROUP, cobrautil.ROW_LOCATION,
 	}

--- a/tools-v2/pkg/cli/command/curvebs/query/chunk/chunkinfo.go
+++ b/tools-v2/pkg/cli/command/curvebs/query/chunk/chunkinfo.go
@@ -55,7 +55,7 @@ func (gRpc *GetChunkInfoRpc) Stub_Func(ctx context.Context) (interface{}, error)
 type GetChunkInfoCommand struct {
 	basecmd.FinalCurveCmd
 	Rpc        []*GetChunkInfoRpc
-	addr2Chunk *map[string]*chunk.GetChunkInfoResponse
+	addr2Chunk map[string]*chunk.GetChunkInfoResponse
 }
 
 var _ basecmd.FinalCurveCmdFunc = (*GetChunkInfoCommand)(nil) // check interface
@@ -122,12 +122,12 @@ func (cCmd *GetChunkInfoCommand) RunCommand(cmd *cobra.Command, args []string) e
 		return mergeErr.ToError()
 	}
 	addr2Chunk := make(map[string]*chunk.GetChunkInfoResponse)
-	cCmd.addr2Chunk = &addr2Chunk
+	cCmd.addr2Chunk = addr2Chunk
 	for i, result := range results {
 		if resp, ok := result.(*chunk.GetChunkInfoResponse); ok {
-			(*cCmd.addr2Chunk)[cCmd.Rpc[i].Info.Addrs[0]] = resp
+			cCmd.addr2Chunk[cCmd.Rpc[i].Info.Addrs[0]] = resp
 		} else {
-			(*cCmd.addr2Chunk)[cCmd.Rpc[i].Info.Addrs[0]] = nil
+			cCmd.addr2Chunk[cCmd.Rpc[i].Info.Addrs[0]] = nil
 		}
 	}
 	return nil
@@ -152,7 +152,7 @@ func (cCmd *GetChunkInfoCommand) AddFlags() {
 	config.AddBsChunkServerAddressSliceRequiredFlag(cCmd.Cmd)
 }
 
-func GetChunkInfo(caller *cobra.Command) (*map[string]*chunk.GetChunkInfoResponse, *cmderror.CmdError) {
+func GetChunkInfo(caller *cobra.Command) (map[string]*chunk.GetChunkInfoResponse, *cmderror.CmdError) {
 	sCmd := NewGetChunkInfoCommand()
 	config.AlignFlagsValue(caller, sCmd.Cmd, []string{
 		config.RPCRETRYTIMES, config.RPCTIMEOUT, config.CURVEBS_MDSADDR,

--- a/tools-v2/pkg/cli/command/curvebs/query/chunkserver/chunkserver.go
+++ b/tools-v2/pkg/cli/command/curvebs/query/chunkserver/chunkserver.go
@@ -56,7 +56,7 @@ func (gRpc *GetChunkServerListRpc) Stub_Func(ctx context.Context) (interface{}, 
 type ChunkServerListInCoysetCommand struct {
 	basecmd.FinalCurveCmd
 	Rpc          []*GetChunkServerListRpc
-	key2Location *map[uint64][]*common.ChunkServerLocation
+	key2Location map[uint64][]*common.ChunkServerLocation
 }
 
 var _ basecmd.FinalCurveCmdFunc = (*ChunkServerListInCoysetCommand)(nil) // check interface
@@ -141,7 +141,7 @@ func (cCmd *ChunkServerListInCoysetCommand) RunCommand(cmd *cobra.Command, args 
 	}
 
 	key2Location := make(map[uint64][]*common.ChunkServerLocation)
-	cCmd.key2Location = &key2Location
+	cCmd.key2Location = key2Location
 	for i, result := range results {
 		logicalpoolid := cCmd.Rpc[i].Request.GetLogicalPoolId()
 		copysetids := cCmd.Rpc[i].Request.GetCopysetId()
@@ -154,7 +154,7 @@ func (cCmd *ChunkServerListInCoysetCommand) RunCommand(cmd *cobra.Command, args 
 		}
 		for _, info := range response.CsInfo {
 			key := cobrautil.GetCopysetKey(uint64(logicalpoolid), uint64(*info.CopysetId))
-			(*cCmd.key2Location)[key] = info.CsLocs
+			cCmd.key2Location[key] = info.CsLocs
 		}
 	}
 	errRet := cmderror.MergeCmdErrorExceptSuccess(errs)
@@ -169,7 +169,7 @@ func (cCmd *ChunkServerListInCoysetCommand) ResultPlainOutput() error {
 	return output.FinalCmdOutputPlain(&cCmd.FinalCurveCmd)
 }
 
-func GetChunkServerListInCopySets(caller *cobra.Command) (*map[uint64][]*common.ChunkServerLocation, *cmderror.CmdError) {
+func GetChunkServerListInCopySets(caller *cobra.Command) (map[uint64][]*common.ChunkServerLocation, *cmderror.CmdError) {
 	getCmd := NewQueryChunkServerListCommand()
 	config.AlignFlagsValue(caller, getCmd.Cmd, []string{
 		config.RPCRETRYTIMES, config.RPCTIMEOUT, config.CURVEBS_MDSADDR,

--- a/tools-v2/pkg/cli/command/curvebs/query/copyset/get_copyset_status.go
+++ b/tools-v2/pkg/cli/command/curvebs/query/copyset/get_copyset_status.go
@@ -54,7 +54,7 @@ func (gRpc *GetCopysetStatusRpc) Stub_Func(ctx context.Context) (interface{}, er
 type GetCopysetStatusCommand struct {
 	basecmd.FinalCurveCmd
 	Rpc         []*GetCopysetStatusRpc
-	peer2Status *map[string]*copyset.CopysetStatusResponse
+	peer2Status map[string]*copyset.CopysetStatusResponse
 }
 
 var _ basecmd.FinalCurveCmdFunc = (*GetCopysetStatusCommand)(nil) // check interface
@@ -107,12 +107,12 @@ func (cCmd *GetCopysetStatusCommand) RunCommand(cmd *cobra.Command, args []strin
 		return mergeErr.ToError()
 	}
 	addr2Status := make(map[string]*copyset.CopysetStatusResponse)
-	cCmd.peer2Status = &addr2Status
+	cCmd.peer2Status = addr2Status
 	for i, result := range results {
 		if respone, ok := result.(*copyset.CopysetStatusResponse); ok {
-			(*cCmd.peer2Status)[infos[i].Addrs[0]] = respone
+			cCmd.peer2Status[infos[i].Addrs[0]] = respone
 		} else {
-			(*cCmd.peer2Status)[infos[i].Addrs[0]] = nil
+			cCmd.peer2Status[infos[i].Addrs[0]] = nil
 		}
 	}
 	return nil
@@ -136,7 +136,7 @@ func (cCmd *GetCopysetStatusCommand) AddFlags() {
 	config.AddBsPeersConfFlag(cCmd.Cmd)
 }
 
-func GetCopysetStatus(caller *cobra.Command) (*map[string]*copyset.CopysetStatusResponse, *cmderror.CmdError) {
+func GetCopysetStatus(caller *cobra.Command) (map[string]*copyset.CopysetStatusResponse, *cmderror.CmdError) {
 	sCmd := NewGetCopysetStatusCommand()
 	config.AlignFlagsValue(caller, sCmd.Cmd, []string{
 		config.RPCRETRYTIMES, config.RPCTIMEOUT, config.CURVEBS_MDSADDR,

--- a/tools-v2/pkg/cli/command/curvebs/query/file/file.go
+++ b/tools-v2/pkg/cli/command/curvebs/query/file/file.go
@@ -107,10 +107,10 @@ func (fCmd *FileCommand) Print(cmd *cobra.Command, args []string) error {
 	return output.FinalCmdOutput(&fCmd.FinalCurveCmd, fCmd)
 }
 
-func updateByFileInfo(data *map[string]string, header *[]string, fileInfo *nameserver2.FileInfo) {
+func updateByFileInfo(data map[string]string, header *[]string, fileInfo *nameserver2.FileInfo) {
 	pref := fileInfo.ProtoReflect()
 	setHeaderData := func(name, value string) {
-		(*data)[name] = value
+		data[name] = value
 		(*header) = append((*header), name)
 	}
 	pref.Range(func(fd protoreflect.FieldDescriptor, v protoreflect.Value) bool {
@@ -164,7 +164,7 @@ func updateByFileInfo(data *map[string]string, header *[]string, fileInfo *names
 	}
 }
 
-func updateByAllocSize(data *map[string]string, header *[]string, allocSize *nameserver2.GetAllocatedSizeResponse) {
+func updateByAllocSize(data map[string]string, header *[]string, allocSize *nameserver2.GetAllocatedSizeResponse) {
 	name := cobrautil.ROW_ALLOC
 	message := ""
 	if allocSize.AllocatedSize != nil {
@@ -174,15 +174,15 @@ func updateByAllocSize(data *map[string]string, header *[]string, allocSize *nam
 	for k, v := range allocMap {
 		message += fmt.Sprintf("\nlogical pool:%d, size:%s", k, humanize.IBytes(v))
 	}
-	(*data)[name] = message
+	data[name] = message
 	(*header) = append((*header), name)
 }
 
-func updateByFileSize(data *map[string]string, header *[]string, size *nameserver2.GetFileSizeResponse) {
-	if 	size != nil && size.FileSize != nil {
+func updateByFileSize(data map[string]string, header *[]string, size *nameserver2.GetFileSizeResponse) {
+	if size != nil && size.FileSize != nil {
 		name := cobrautil.ROW_SIZE
 		message := fmt.Sprintf("size:%s", humanize.IBytes(size.GetFileSize()))
-		(*data)[name] = message
+		data[name] = message
 		(*header) = append((*header), name)
 	}
 }
@@ -190,20 +190,20 @@ func updateByFileSize(data *map[string]string, header *[]string, size *nameserve
 func (fCmd *FileCommand) RunCommand(cmd *cobra.Command, args []string) error {
 	data := make(map[string]string, 0)
 	header := make([]string, 0)
-	updateByFileInfo(&data, &header, fCmd.fileInfo.GetFileInfo())
-	updateByAllocSize(&data, &header, fCmd.allocSize)
-	updateByFileSize(&data, &header, fCmd.fileSize)
+	updateByFileInfo(data, &header, fCmd.fileInfo.GetFileInfo())
+	updateByAllocSize(data, &header, fCmd.allocSize)
+	updateByFileSize(data, &header, fCmd.fileSize)
 	fCmd.SetHeader(header)
 	list := cobrautil.Map2List(data, header)
 	fCmd.TableNew.Append(list)
 	fCmd.Result = map[string]interface{}{
-		"info": fCmd.fileInfo,
+		"info":  fCmd.fileInfo,
 		"alloc": fCmd.allocSize,
 	}
 	if fCmd.fileSize != nil {
 		fCmd.Result.(map[string]interface{})["size"] = fCmd.fileSize
 	}
-	
+
 	return nil
 }
 

--- a/tools-v2/pkg/cli/command/curvebs/update/copyset/availflag/availflag.go
+++ b/tools-v2/pkg/cli/command/curvebs/update/copyset/availflag/availflag.go
@@ -158,7 +158,7 @@ func (cCmd *CopysetAvailflagCommand) Init(cmd *cobra.Command, args []string) err
 
 			for _, info := range addr2Copysets {
 				key := cobrautil.GetCopysetKey(uint64(info.GetLogicalPoolId()), uint64(info.GetCopysetId()))
-				if health, ok := (*key2Health)[key]; !ok || health == cobrautil.HEALTH_ERROR {
+				if health, ok := key2Health[key]; !ok || health == cobrautil.HEALTH_ERROR {
 					copysets = append(copysets, info)
 				}
 			}

--- a/tools-v2/pkg/cli/command/curvefs/list/partition/partition.go
+++ b/tools-v2/pkg/cli/command/curvefs/list/partition/partition.go
@@ -184,22 +184,22 @@ func (pCmd *PartitionCommand) RunCommand(cmd *cobra.Command, args []string) erro
 		for _, partition := range partitionList {
 			fsId := partition.GetFsId()
 			pCmd.fsId2PartitionList[fsId] = append(pCmd.fsId2PartitionList[fsId], partition)
-			var row *map[string]string
+			var row map[string]string
 			if len(pCmd.fsId2Rows[fsId]) == 1 && pCmd.fsId2Rows[fsId][0][cobrautil.ROW_POOL_ID] == cobrautil.ROW_VALUE_DNE {
-				row = &pCmd.fsId2Rows[fsId][0]
+				row = pCmd.fsId2Rows[fsId][0]
 				pCmd.fsId2Rows[fsId] = make([]map[string]string, 0)
 			} else {
 				temp := make(map[string]string)
-				row = &temp
-				(*row)[cobrautil.ROW_FS_ID] = strconv.FormatUint(uint64(fsId), 10)
+				row = temp
+				row[cobrautil.ROW_FS_ID] = strconv.FormatUint(uint64(fsId), 10)
 			}
-			(*row)[cobrautil.ROW_POOL_ID] = strconv.FormatUint(uint64(partition.GetPoolId()), 10)
-			(*row)[cobrautil.ROW_COPYSET_ID] = strconv.FormatUint(uint64(partition.GetCopysetId()), 10)
-			(*row)[cobrautil.ROW_PARTITION_ID] = strconv.FormatUint(uint64(partition.GetPartitionId()), 10)
-			(*row)[cobrautil.ROW_START] = strconv.FormatUint(uint64(partition.GetStart()), 10)
-			(*row)[cobrautil.ROW_END] = strconv.FormatUint(uint64(partition.GetEnd()), 10)
-			(*row)[cobrautil.ROW_STATUS] = partition.GetStatus().String()
-			pCmd.fsId2Rows[fsId] = append(pCmd.fsId2Rows[fsId], (*row))
+			row[cobrautil.ROW_POOL_ID] = strconv.FormatUint(uint64(partition.GetPoolId()), 10)
+			row[cobrautil.ROW_COPYSET_ID] = strconv.FormatUint(uint64(partition.GetCopysetId()), 10)
+			row[cobrautil.ROW_PARTITION_ID] = strconv.FormatUint(uint64(partition.GetPartitionId()), 10)
+			row[cobrautil.ROW_START] = strconv.FormatUint(uint64(partition.GetStart()), 10)
+			row[cobrautil.ROW_END] = strconv.FormatUint(uint64(partition.GetEnd()), 10)
+			row[cobrautil.ROW_STATUS] = partition.GetStatus().String()
+			pCmd.fsId2Rows[fsId] = append(pCmd.fsId2Rows[fsId], row)
 		}
 	}
 
@@ -211,7 +211,7 @@ func (pCmd *PartitionCommand) RunCommand(cmd *cobra.Command, args []string) erro
 }
 
 func (pCmd *PartitionCommand) ResultPlainOutput() error {
-	if pCmd.TableNew.NumLines() ==0 {
+	if pCmd.TableNew.NumLines() == 0 {
 		fmt.Println("no partition in cluster")
 		return nil
 	}
@@ -241,7 +241,7 @@ func NewListPartitionCommand() *PartitionCommand {
 	return pCmd
 }
 
-func GetFsPartition(caller *cobra.Command) (*map[uint32][]*common.PartitionInfo, *cmderror.CmdError) {
+func GetFsPartition(caller *cobra.Command) (map[uint32][]*common.PartitionInfo, *cmderror.CmdError) {
 	listPartionCmd := NewListPartitionCommand()
 	listPartionCmd.Cmd.SetArgs([]string{
 		fmt.Sprintf("--%s", config.FORMAT), config.FORMAT_NOOUT,
@@ -257,5 +257,5 @@ func GetFsPartition(caller *cobra.Command) (*map[uint32][]*common.PartitionInfo,
 		retErr.Format(err.Error())
 		return nil, retErr
 	}
-	return &listPartionCmd.fsId2PartitionList, cmderror.ErrSuccess()
+	return listPartionCmd.fsId2PartitionList, cmderror.ErrSuccess()
 }

--- a/tools-v2/pkg/cli/command/curvefs/list/topology/topology.go
+++ b/tools-v2/pkg/cli/command/curvefs/list/topology/topology.go
@@ -158,7 +158,7 @@ func (tCmd *TopologyCommand) RunCommand(cmd *cobra.Command, args []string) error
 	tCmd.updateMetaserverAddr(topologyResponse.GetMetaservers().MetaServerInfos)
 	topologyMap, topoErr := cobrautil.Topology2Map(topologyResponse)
 	tCmd.Error = topoErr
-	tCmd.updateTable(&topologyMap)
+	tCmd.updateTable(topologyMap)
 	tCmd.Result = topologyMap
 
 	return nil
@@ -168,9 +168,9 @@ func (tCmd *TopologyCommand) ResultPlainOutput() error {
 	return output.FinalCmdOutputPlain(&tCmd.FinalCurveCmd)
 }
 
-func (tCmd *TopologyCommand) updateTable(topoMap *map[string]interface{}) *cmderror.CmdError {
+func (tCmd *TopologyCommand) updateTable(topoMap map[string]interface{}) *cmderror.CmdError {
 	errs := make([]*cmderror.CmdError, 0)
-	poolList := (*topoMap)[cobrautil.POOL_LIST].([]*cobrautil.PoolInfo)
+	poolList := topoMap[cobrautil.POOL_LIST].([]*cobrautil.PoolInfo)
 	sort.SliceStable(poolList, func(i, j int) bool {
 		return *poolList[i].PoolID <
 			*poolList[j].PoolID

--- a/tools-v2/pkg/cli/command/curvefs/query/copyset/copyset.go
+++ b/tools-v2/pkg/cli/command/curvefs/query/copyset/copyset.go
@@ -295,7 +295,7 @@ func (cCmd *CopysetCommand) UpdateCopysetsStatus(values []*topology.CopysetValue
 	retrytimes := viper.GetInt32(config.VIPER_GLOBALE_RPCRETRYTIMES)
 	var results []*StatusResult
 	if len(addr2Request) != 0 {
-		results = GetCopysetsStatus(&addr2Request, timeout, retrytimes)
+		results = GetCopysetsStatus(addr2Request, timeout, retrytimes)
 		for _, result := range results {
 			ret = append(ret, result.Error)
 			copysets := result.Request.GetCopysets()
@@ -353,7 +353,7 @@ func (cCmd *CopysetCommand) ResultPlainOutput() error {
 }
 
 // copsetIds,poolId just like: 1,2,3
-func QueryCopysetInfoStatus(caller *cobra.Command) (*map[uint64]*cobrautil.CopysetInfoStatus, *cmderror.CmdError) {
+func QueryCopysetInfoStatus(caller *cobra.Command) (map[uint64]*cobrautil.CopysetInfoStatus, *cmderror.CmdError) {
 	queryCopyset := NewQueryCopysetCommand()
 	queryCopyset.Cmd.SetArgs([]string{
 		fmt.Sprintf("--%s", config.CURVEFS_DETAIL),
@@ -368,10 +368,10 @@ func QueryCopysetInfoStatus(caller *cobra.Command) (*map[uint64]*cobrautil.Copys
 		return nil, retErr
 	}
 
-	return &queryCopyset.key2Copyset, cmderror.ErrSuccess()
+	return queryCopyset.key2Copyset, cmderror.ErrSuccess()
 }
 
-func QueryCopysetInfo(caller *cobra.Command) (*map[uint64]*cobrautil.CopysetInfoStatus, *cmderror.CmdError) {
+func QueryCopysetInfo(caller *cobra.Command) (map[uint64]*cobrautil.CopysetInfoStatus, *cmderror.CmdError) {
 	queryCopyset := NewQueryCopysetCommand()
 	queryCopyset.Cmd.SetArgs([]string{
 		fmt.Sprintf("--%s", config.FORMAT), config.FORMAT_NOOUT,
@@ -385,5 +385,5 @@ func QueryCopysetInfo(caller *cobra.Command) (*map[uint64]*cobrautil.CopysetInfo
 		return nil, retErr
 	}
 
-	return &queryCopyset.key2Copyset, cmderror.ErrSuccess()
+	return queryCopyset.key2Copyset, cmderror.ErrSuccess()
 }

--- a/tools-v2/pkg/cli/command/curvefs/query/copyset/status.go
+++ b/tools-v2/pkg/cli/command/curvefs/query/copyset/status.go
@@ -56,14 +56,14 @@ func (scRpc *StatusCopysetRpc) Stub_Func(ctx context.Context) (interface{}, erro
 	return scRpc.copysetClient.GetCopysetsStatus(ctx, scRpc.Request)
 }
 
-func GetCopysetsStatus(addr2Request *map[string]*copyset.CopysetsStatusRequest, timeout time.Duration, retrytimes int32) []*StatusResult {
-	chanSize := len(*addr2Request)
+func GetCopysetsStatus(addr2Request map[string]*copyset.CopysetsStatusRequest, timeout time.Duration, retrytimes int32) []*StatusResult {
+	chanSize := len(addr2Request)
 	if chanSize > config.MaxChannelSize() {
 		chanSize = config.MaxChannelSize()
 	}
 	results := make(chan StatusResult, chanSize)
 	size := 0
-	for k, v := range *addr2Request {
+	for k, v := range addr2Request {
 		size++
 		rpc := &StatusCopysetRpc{
 			Request: v,

--- a/tools-v2/pkg/cli/command/curvefs/query/inode/inode.go
+++ b/tools-v2/pkg/cli/command/curvefs/query/inode/inode.go
@@ -109,7 +109,7 @@ func (iCmd *InodeCommand) Prepare() error {
 	if errGet.TypeCode() != cmderror.CODE_SUCCESS {
 		return errGet.ToError()
 	}
-	partitionInfoList := (*fsId2PartitionList)[fsId]
+	partitionInfoList := fsId2PartitionList[fsId]
 	if partitionInfoList == nil {
 		return fmt.Errorf("inode[%d] is not found in fs[%d]", inodeId, fsId)
 	}
@@ -147,11 +147,11 @@ func (iCmd *InodeCommand) Prepare() error {
 	if errQuery.TypeCode() != cmderror.CODE_SUCCESS {
 		return fmt.Errorf("query copyset info failed: %s", errQuery.Message)
 	}
-	if len(*key2Copyset) == 0 {
+	if len(key2Copyset) == 0 {
 		return fmt.Errorf("no copysetinfo found")
 	}
 	key := cobrautil.GetCopysetKey(uint64(poolId), uint64(copyetId))
-	leader := (*key2Copyset)[key].Info.GetLeaderPeer()
+	leader := key2Copyset[key].Info.GetLeaderPeer()
 	addr, peerErr := cobrautil.PeertoAddr(leader)
 	if peerErr.TypeCode() != cmderror.CODE_SUCCESS {
 		return fmt.Errorf("pares leader peer[%s] failed: %s", leader, peerErr.Message)


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #2535 <!-- replace xxx with issue number -->

Problem Summary: remove the pointer of map

### What is changed and how it works?

What's Changed: remove all *map from struct and function

How it Works:

The map in Golang itself is a reference type and does not need to be declared as a pointer type

### Check List

- [x] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license
