### PR TITLE
[fix] rm apt cmd in bs

### DIFF
--- a/docker/debian9/Dockerfile
+++ b/docker/debian9/Dockerfile
@@ -1,9 +1,7 @@
 FROM opencurvedocker/curve-base:debian9
 COPY --from=opencurvedocker/curve-base:curve-tgt-debian9 /curve-tgt/  /curve-tgt/
 COPY --from=opencurvedocker/curve-base:curve-tgt-debian9 /curve/curve-sdk /curve-tgt/curve-sdk
-RUN apt update \
-    && apt install -y kmod \
-    && cd /curve-tgt/curve-sdk \
+RUN cd /curve-tgt/curve-sdk \
     && cp -f lib/* /usr/lib \
     && cp -f bin/* /usr/bin \
     && mkdir -p /usr/curvefs \


### PR DESCRIPTION
debian9 eol. rm apt cmd
It will cause the execution of modprobe nbd to fail when the bs client container restarts.

<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #xxx <!-- replace xxx with issue number -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
