### PR TITLE
[Build]: Support build on GCC 11+

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -133,7 +133,7 @@ git_repository(
     name = "com_github_brpc_brpc",
     remote = "https://github.com/apache/incubator-brpc",
     commit = "1b9e00641cbec1c8803da6a1f7f555398c954cb0",
-    patches = ["//:thirdparties/brpc/brpc.patch"],
+    patches = ["//:thirdparties/brpc/brpc.patch","//:thirdparties/brpc/fix-gcc11.patch"],
     patch_args = ["-p1"],
 )
 

--- a/curvefs/src/metaserver/copyset/copyset_node.h
+++ b/curvefs/src/metaserver/copyset/copyset_node.h
@@ -301,7 +301,7 @@ inline std::string CopysetNode::GetCopysetDataDir() const {
 }
 
 inline uint64_t CopysetNode::GetAppliedIndex() const {
-    return appliedIndex_.load(std::memory_order_acq_rel);
+    return appliedIndex_.load(std::memory_order::memory_order_acquire);
 }
 
 inline void CopysetNode::GetStatus(braft::NodeStatus* status) {

--- a/curvefs/test/client/chunk_cache_manager_test.cpp
+++ b/curvefs/test/client/chunk_cache_manager_test.cpp
@@ -84,7 +84,7 @@ TEST_F(ChunkCacheManagerTest, test_write_new_data) {
     chunkCacheManager_->WriteNewDataCache(s3ClientAdaptor_, offset, len, buf);
     ASSERT_EQ(65536, s3ClientAdaptor_->GetFsCacheManager()->GetDataCacheSize());
 
-    delete buf;
+    delete[] buf;
 }
 
 TEST_F(ChunkCacheManagerTest, test_add_read_data_cache) {
@@ -110,7 +110,7 @@ TEST_F(ChunkCacheManagerTest, test_add_read_data_cache) {
     chunkCacheManager_->AddReadDataCache(dataCache2);
     ASSERT_EQ(1.5 * 1024 * 1024,
               s3ClientAdaptor_->GetFsCacheManager()->GetLruByte());
-    delete buf;
+    delete[] buf;
 }
 
 TEST_F(ChunkCacheManagerTest, test_find_writeable_datacache) {
@@ -135,7 +135,7 @@ TEST_F(ChunkCacheManagerTest, test_find_writeable_datacache) {
                            offset, len, &mergeDataCacheVer, inodeId));
     ASSERT_EQ(1, mergeDataCacheVer.size());
 
-    delete buf;
+    delete[] buf;
 }
 
 TEST_F(ChunkCacheManagerTest, test_read_by_write_cache) {
@@ -172,8 +172,8 @@ TEST_F(ChunkCacheManagerTest, test_read_by_write_cache) {
     requests.clear();
 
     len = 2048;
-    delete buf;
-    delete expectBuf;
+    delete[] buf;
+    delete[] expectBuf;
     buf = new char[len + 1];
     expectBuf = new char[len + 1];
     memset(buf, 'a', len);
@@ -187,8 +187,8 @@ TEST_F(ChunkCacheManagerTest, test_read_by_write_cache) {
     requests.clear();
 
     len = 512;
-    delete buf;
-    delete expectBuf;
+    delete[] buf;
+    delete[] expectBuf;
     buf = new char[len + 1];
     expectBuf = new char[len + 1];
     memset(buf, 'a', len - 1);
@@ -202,8 +202,8 @@ TEST_F(ChunkCacheManagerTest, test_read_by_write_cache) {
     requests.clear();
 
     len = 1024;
-    delete buf;
-    delete expectBuf;
+    delete[] buf;
+    delete[] expectBuf;
     buf = new char[len + 1];
     expectBuf = new char[len + 1];
     memset(buf, 'a', len);
@@ -217,9 +217,9 @@ TEST_F(ChunkCacheManagerTest, test_read_by_write_cache) {
     ASSERT_EQ(1, requests.size());
     requests.clear();
 
-    delete buf;
-    delete expectBuf;
-    delete dataCacheBuf;
+    delete[] buf;
+    delete[] expectBuf;
+    delete[] dataCacheBuf;
 }
 
 TEST_F(ChunkCacheManagerTest, test_read_by_read_cache) {
@@ -257,8 +257,8 @@ TEST_F(ChunkCacheManagerTest, test_read_by_read_cache) {
     requests.clear();
 
     len = 2048;
-    delete buf;
-    delete expectBuf;
+    delete[] buf;
+    delete[] expectBuf;
     buf = new char[len + 1];
     expectBuf = new char[len + 1];
     memset(buf, 'a', len);
@@ -272,8 +272,8 @@ TEST_F(ChunkCacheManagerTest, test_read_by_read_cache) {
     requests.clear();
 
     len = 512;
-    delete buf;
-    delete expectBuf;
+    delete[] buf;
+    delete[] expectBuf;
     buf = new char[len + 1];
     expectBuf = new char[len + 1];
     memset(buf, 'a', len - 1);
@@ -287,8 +287,8 @@ TEST_F(ChunkCacheManagerTest, test_read_by_read_cache) {
     requests.clear();
 
     len = 1024;
-    delete buf;
-    delete expectBuf;
+    delete[] buf;
+    delete[] expectBuf;
     buf = new char[len + 1];
     expectBuf = new char[len + 1];
     memset(buf, 'a', len);
@@ -302,9 +302,9 @@ TEST_F(ChunkCacheManagerTest, test_read_by_read_cache) {
     ASSERT_EQ(1, requests.size());
     requests.clear();
 
-    delete buf;
-    delete expectBuf;
-    delete dataCacheBuf;
+    delete[] buf;
+    delete[] expectBuf;
+    delete[] dataCacheBuf;
 }
 
 TEST_F(ChunkCacheManagerTest, test_flush) {
@@ -335,7 +335,7 @@ TEST_F(ChunkCacheManagerTest, test_flush) {
               chunkCacheManager_->Flush(inodeId, true, true));
     chunkCacheManager_->ReleaseCacheForTest();
 
-    delete buf;
+    delete[] buf;
 }
 
 TEST_F(ChunkCacheManagerTest, test_release_read_dataCache) {
@@ -348,7 +348,7 @@ TEST_F(ChunkCacheManagerTest, test_release_read_dataCache) {
     chunkCacheManager_->ReleaseReadDataCache(offset);
     ASSERT_EQ(true, chunkCacheManager_->IsEmpty());
 
-    delete buf;
+    delete[] buf;
 }
 
 
@@ -377,7 +377,7 @@ TEST_F(ChunkCacheManagerTest, test_truncate_cache) {
     ASSERT_EQ(true, chunkCacheManager_->IsEmpty());
 
     chunkCacheManager_->ReleaseCacheForTest();
-    delete buf;
+    delete[] buf;
 }
 
 }  // namespace client

--- a/curvefs/test/client/client_s3_adaptor_Integration.cpp
+++ b/curvefs/test/client/client_s3_adaptor_Integration.cpp
@@ -199,7 +199,7 @@ TEST_F(ClientS3IntegrationTest, test_first_write) {
     ASSERT_EQ(1, fsCacheManager->GetDataCacheNum());
     ASSERT_EQ(len, ret);
 
-    delete buf;
+    delete[] buf;
     buf = NULL;
 }
 
@@ -225,7 +225,7 @@ TEST_F(ClientS3IntegrationTest, test_overlap_write) {
     s3ClientAdaptor_->Write(inode->GetInodeId(), offset, len, buf);
     ASSERT_EQ(1, fsCacheManager->GetDataCacheNum());
 
-    delete buf;
+    delete[] buf;
     buf = NULL;
 }
 
@@ -244,7 +244,7 @@ TEST_F(ClientS3IntegrationTest, test_hole_write) {
         s3ClientAdaptor_->GetFsCacheManager();
     ASSERT_EQ(2, fsCacheManager->GetDataCacheNum());
 
-    delete buf;
+    delete[] buf;
     buf = NULL;
 }
 
@@ -263,7 +263,7 @@ TEST_F(ClientS3IntegrationTest, test_append_write) {
         s3ClientAdaptor_->GetFsCacheManager();
     ASSERT_EQ(1, fsCacheManager->GetDataCacheNum());
 
-    delete buf;
+    delete[] buf;
     buf = NULL;
 }
 
@@ -280,7 +280,7 @@ TEST_F(ClientS3IntegrationTest, test_write_more_chunk) {
         s3ClientAdaptor_->GetFsCacheManager();
     ASSERT_EQ(2, fsCacheManager->GetDataCacheNum());
 
-    delete buf;
+    delete[] buf;
     buf = NULL;
 }
 
@@ -314,8 +314,8 @@ TEST_F(ClientS3IntegrationTest, test_write_merge_data1) {
     s3ClientAdaptor_->Write(inode->GetInodeId(), offset, len, buf1);
     ASSERT_EQ(1, fsCacheManager->GetDataCacheNum());
 
-    delete buf;
-    delete buf1;
+    delete[] buf;
+    delete[] buf1;
 }
 
 /*
@@ -348,8 +348,8 @@ TEST_F(ClientS3IntegrationTest, test_write_merge_data2) {
     s3ClientAdaptor_->Write(inode->GetInodeId(), offset, len, buf1);
     ASSERT_EQ(1, fsCacheManager->GetDataCacheNum());
 
-    delete buf;
-    delete buf1;
+    delete[] buf;
+    delete[] buf1;
 }
 
 TEST_F(ClientS3IntegrationTest, test_read_one_chunk) {
@@ -392,7 +392,7 @@ TEST_F(ClientS3IntegrationTest, test_read_one_chunk) {
     ret = s3ClientAdaptor_->Read(inode->GetInodeId(), offset, len, buf);
     ASSERT_EQ(-1, ret);
 
-    delete buf;
+    delete[] buf;
     buf = NULL;
 }
 
@@ -431,9 +431,9 @@ TEST_F(ClientS3IntegrationTest, test_read_overlap_block1) {
     s3ClientAdaptor_->Read(inode->GetInodeId(), offset, len, readBuf);
     EXPECT_STREQ(expectBuf, readBuf);
 
-    delete readBuf;
-    delete buf;
-    delete expectBuf;
+    delete[] readBuf;
+    delete[] buf;
+    delete[] expectBuf;
     std::map<std::string, S3Data>::iterator iter = gObjectDataMaps.begin();
     for (; iter != gObjectDataMaps.end(); iter++) {
         delete iter->second.buf;
@@ -477,9 +477,9 @@ TEST_F(ClientS3IntegrationTest, test_read_overlap_block2) {
     s3ClientAdaptor_->Read(inode->GetInodeId(), offset, len, readBuf);
     EXPECT_STREQ(expectBuf, readBuf);
 
-    delete readBuf;
-    delete buf;
-    delete expectBuf;
+    delete[] readBuf;
+    delete[] buf;
+    delete[] expectBuf;
     std::map<std::string, S3Data>::iterator iter = gObjectDataMaps.begin();
     for (; iter != gObjectDataMaps.end(); iter++) {
         delete iter->second.buf;
@@ -532,9 +532,9 @@ TEST_F(ClientS3IntegrationTest, test_read_overlap_block3) {
     s3ClientAdaptor_->Read(inode->GetInodeId(), offset, len, readBuf);
     EXPECT_STREQ(expectBuf, readBuf);
 
-    delete readBuf;
-    delete buf;
-    delete expectBuf;
+    delete[] readBuf;
+    delete[] buf;
+    delete[] expectBuf;
     std::map<std::string, S3Data>::iterator iter = gObjectDataMaps.begin();
     for (; iter != gObjectDataMaps.end(); iter++) {
         delete iter->second.buf;
@@ -590,9 +590,9 @@ TEST_F(ClientS3IntegrationTest, test_read_overlap_block4) {
     s3ClientAdaptor_->Read(inode->GetInodeId(), offset, len, readBuf);
     EXPECT_STREQ(expectBuf, readBuf);
 
-    delete readBuf;
-    delete buf;
-    delete expectBuf;
+    delete[] readBuf;
+    delete[] buf;
+    delete[] expectBuf;
     std::map<std::string, S3Data>::iterator iter = gObjectDataMaps.begin();
     for (; iter != gObjectDataMaps.end(); iter++) {
         delete iter->second.buf;
@@ -648,9 +648,9 @@ TEST_F(ClientS3IntegrationTest, test_read_overlap_block5) {
     s3ClientAdaptor_->Read(inode->GetInodeId(), offset, len, readBuf);
     EXPECT_STREQ(expectBuf, readBuf);
 
-    // delete readBuf;
-    delete buf;
-    delete expectBuf;
+    // delete[] readBuf;
+    delete[] buf;
+    delete[] expectBuf;
     std::map<std::string, S3Data>::iterator iter = gObjectDataMaps.begin();
     for (; iter != gObjectDataMaps.end(); iter++) {
         delete iter->second.buf;
@@ -697,9 +697,9 @@ TEST_F(ClientS3IntegrationTest, test_read_hole1) {
     EXPECT_STREQ(expectBuf, readBuf);
 
     // cleanup
-    delete buf;
-    delete readBuf;
-    delete expectBuf;
+    delete[] buf;
+    delete[] readBuf;
+    delete[] expectBuf;
     std::map<std::string, S3Data>::iterator iter = gObjectDataMaps.begin();
     for (; iter != gObjectDataMaps.end(); iter++) {
         delete iter->second.buf;
@@ -739,9 +739,9 @@ TEST_F(ClientS3IntegrationTest, test_read_hole2) {
     EXPECT_STREQ(expectBuf, readBuf);
 
     // cleanup
-    delete buf;
-    delete readBuf;
-    delete expectBuf;
+    delete[] buf;
+    delete[] readBuf;
+    delete[] expectBuf;
     std::map<std::string, S3Data>::iterator iter = gObjectDataMaps.begin();
     for (; iter != gObjectDataMaps.end(); iter++) {
         delete iter->second.buf;
@@ -780,9 +780,9 @@ TEST_F(ClientS3IntegrationTest, test_read_hole3) {
     EXPECT_STREQ(expectBuf, readBuf);
 
     // cleanup
-    delete buf;
-    delete readBuf;
-    delete expectBuf;
+    delete[] buf;
+    delete[] readBuf;
+    delete[] expectBuf;
     std::map<std::string, S3Data>::iterator iter = gObjectDataMaps.begin();
     for (; iter != gObjectDataMaps.end(); iter++) {
         delete iter->second.buf;
@@ -829,9 +829,9 @@ TEST_F(ClientS3IntegrationTest, test_read_hole4) {
     EXPECT_STREQ(expectBuf, readBuf);
 
     // cleanup
-    delete buf;
-    delete readBuf;
-    delete expectBuf;
+    delete[] buf;
+    delete[] readBuf;
+    delete[] expectBuf;
     std::map<std::string, S3Data>::iterator iter = gObjectDataMaps.begin();
     for (; iter != gObjectDataMaps.end(); iter++) {
         delete iter->second.buf;
@@ -880,9 +880,9 @@ TEST_F(ClientS3IntegrationTest, test_read_more_write) {
     EXPECT_STREQ(expectBuf, readBuf);
 
     // cleanup
-    delete buf;
-    delete readBuf;
-    delete expectBuf;
+    delete[] buf;
+    delete[] readBuf;
+    delete[] expectBuf;
     std::map<std::string, S3Data>::iterator iter = gObjectDataMaps.begin();
     for (; iter != gObjectDataMaps.end(); iter++) {
         delete iter->second.buf;
@@ -930,9 +930,9 @@ TEST_F(ClientS3IntegrationTest, test_read_more_write2) {
     EXPECT_STREQ(expectBuf, readBuf);
 
     // cleanup
-    delete buf;
-    delete readBuf;
-    delete expectBuf;
+    delete[] buf;
+    delete[] readBuf;
+    delete[] expectBuf;
     std::map<std::string, S3Data>::iterator iter = gObjectDataMaps.begin();
     for (; iter != gObjectDataMaps.end(); iter++) {
         delete iter->second.buf;
@@ -973,9 +973,9 @@ TEST_F(ClientS3IntegrationTest, test_read_more_chunks) {
     EXPECT_STREQ(expectBuf, readBuf);
 
     // cleanup
-    delete buf;
-    delete readBuf;
-    delete expectBuf;
+    delete[] buf;
+    delete[] readBuf;
+    delete[] expectBuf;
     std::map<std::string, S3Data>::iterator iter = gObjectDataMaps.begin();
     for (; iter != gObjectDataMaps.end(); iter++) {
         delete iter->second.buf;
@@ -1004,7 +1004,7 @@ TEST_F(ClientS3IntegrationTest, test_truncate_small1) {
     ASSERT_EQ(len, s3ClientAdaptor_->GetFsCacheManager()->GetDataCacheSize());
 
     // cleanup
-    delete buf;
+    delete[] buf;
     std::map<std::string, S3Data>::iterator iter = gObjectDataMaps.begin();
     for (; iter != gObjectDataMaps.end(); iter++) {
         delete iter->second.buf;
@@ -1046,7 +1046,7 @@ TEST_F(ClientS3IntegrationTest, test_truncate_small2) {
               s3ClientAdaptor_->GetFsCacheManager()->GetDataCacheSize());
 
     // cleanup
-    delete buf;
+    delete[] buf;
     std::map<std::string, S3Data>::iterator iter = gObjectDataMaps.begin();
     for (; iter != gObjectDataMaps.end(); iter++) {
         delete iter->second.buf;
@@ -1118,7 +1118,7 @@ TEST_F(ClientS3IntegrationTest, test_truncate_small3) {
     ASSERT_EQ(len, s3ClientAdaptor_->GetFsCacheManager()->GetLruByte());
 
     // cleanup
-    delete buf;
+    delete[] buf;
     std::map<std::string, S3Data>::iterator iter = gObjectDataMaps.begin();
     for (; iter != gObjectDataMaps.end(); iter++) {
         delete iter->second.buf;
@@ -1160,8 +1160,8 @@ TEST_F(ClientS3IntegrationTest, test_truncate_big1) {
     EXPECT_STREQ(expectBuf, readBuf);
 
     // cleanup
-    delete readBuf;
-    delete expectBuf;
+    delete[] readBuf;
+    delete[] expectBuf;
     std::map<std::string, S3Data>::iterator iter = gObjectDataMaps.begin();
     for (; iter != gObjectDataMaps.end(); iter++) {
         delete iter->second.buf;
@@ -1205,9 +1205,9 @@ TEST_F(ClientS3IntegrationTest, test_truncate_big2) {
     EXPECT_STREQ(expectBuf, readBuf);
 
     // cleanup
-    delete buf;
-    delete readBuf;
-    delete expectBuf;
+    delete[] buf;
+    delete[] readBuf;
+    delete[] expectBuf;
     std::map<std::string, S3Data>::iterator iter = gObjectDataMaps.begin();
     for (; iter != gObjectDataMaps.end(); iter++) {
         delete iter->second.buf;
@@ -1286,12 +1286,12 @@ TEST_F(ClientS3IntegrationTest, test_truncate_big3) {
     EXPECT_STREQ(expectBuf2, readBuf2);
 
     // cleanup
-    delete readBuf;
-    delete expectBuf;
-    delete readBuf1;
-    delete expectBuf1;
-    delete readBuf2;
-    delete expectBuf2;
+    delete[] readBuf;
+    delete[] expectBuf;
+    delete[] readBuf1;
+    delete[] expectBuf1;
+     delete[] readBuf2;
+    delete[] expectBuf2;
 
     std::map<std::string, S3Data>::iterator iter = gObjectDataMaps.begin();
     for (; iter != gObjectDataMaps.end(); iter++) {
@@ -1323,7 +1323,7 @@ TEST_F(ClientS3IntegrationTest, test_releaseCache) {
     ASSERT_EQ(0, fsCacheManager->GetDataCacheNum());
 
     //  cleanup
-    delete buf;
+    delete[] buf;
     std::map<std::string, S3Data>::iterator iter = gObjectDataMaps.begin();
     for (; iter != gObjectDataMaps.end(); iter++) {
         delete iter->second.buf;
@@ -1377,7 +1377,7 @@ TEST_F(ClientS3IntegrationTest, test_flush_first_write) {
     ASSERT_EQ(offset, tmp.offset());
 
     //  cleanup
-    delete buf;
+    delete[] buf;
     std::map<std::string, S3Data>::iterator iter = gObjectDataMaps.begin();
     for (; iter != gObjectDataMaps.end(); iter++) {
         delete iter->second.buf;
@@ -1437,7 +1437,7 @@ TEST_F(ClientS3IntegrationTest, test_flush_overlap_write) {
     ASSERT_EQ(0, tmp.offset());
 
     //  cleanup
-    delete buf;
+    delete[] buf;
     std::map<std::string, S3Data>::iterator iter = gObjectDataMaps.begin();
     for (; iter != gObjectDataMaps.end(); iter++) {
         delete iter->second.buf;
@@ -1495,7 +1495,7 @@ TEST_F(ClientS3IntegrationTest, test_flush_overlap_write2) {
     ASSERT_EQ(16748032, tmp.offset());
 
     //  cleanup
-    delete buf;
+    delete[] buf;
     std::map<std::string, S3Data>::iterator iter = gObjectDataMaps.begin();
     for (; iter != gObjectDataMaps.end(); iter++) {
         delete iter->second.buf;
@@ -1555,7 +1555,7 @@ TEST_F(ClientS3IntegrationTest, test_flush_hole_write) {
     ASSERT_EQ(2 * 1024 * 1024, tmp.offset());
 
     //  cleanup
-    delete buf;
+    delete[] buf;
     std::map<std::string, S3Data>::iterator iter = gObjectDataMaps.begin();
     for (; iter != gObjectDataMaps.end(); iter++) {
         delete iter->second.buf;
@@ -1615,7 +1615,7 @@ TEST_F(ClientS3IntegrationTest, test_flush_write_more_chunk) {
     ASSERT_EQ(4 * 1024 * 1024, tmp.offset());
 
     //  cleanup
-    delete buf;
+    delete[] buf;
     std::map<std::string, S3Data>::iterator iter = gObjectDataMaps.begin();
     for (; iter != gObjectDataMaps.end(); iter++) {
         delete iter->second.buf;
@@ -1695,7 +1695,7 @@ TEST_F(ClientS3IntegrationTest, test_flush_write_and_read1) {
     EXPECT_STREQ(expectBuf, readBuf);
 
     //  cleanup
-    delete buf;
+    delete[] buf;
     std::map<std::string, S3Data>::iterator iter = gObjectDataMaps.begin();
     for (; iter != gObjectDataMaps.end(); iter++) {
         delete iter->second.buf;
@@ -1777,7 +1777,7 @@ TEST_F(ClientS3IntegrationTest, test_flush_write_and_read2) {
     s3ClientAdaptor_->Read(inode->GetInodeId(), offset, len, readBuf);
     EXPECT_STREQ(expectBuf, readBuf);
     //  cleanup
-    delete buf;
+    delete[] buf;
     std::map<std::string, S3Data>::iterator iter = gObjectDataMaps.begin();
     for (; iter != gObjectDataMaps.end(); iter++) {
         delete iter->second.buf;
@@ -1876,11 +1876,11 @@ TEST_F(ClientS3IntegrationTest, test_flush_write_and_read3) {
     EXPECT_STREQ(expectBuf2, readBuf2);
 
     // cleanup
-    delete buf;
-    delete readBuf;
-    delete expectBuf;
-    delete readBuf1;
-    delete expectBuf1;
+    delete[] buf;
+    delete[] readBuf;
+    delete[] expectBuf;
+    delete[] readBuf1;
+    delete[] expectBuf1;
     std::map<std::string, S3Data>::iterator iter = gObjectDataMaps.begin();
     for (; iter != gObjectDataMaps.end(); iter++) {
         delete iter->second.buf;
@@ -1963,9 +1963,9 @@ TEST_F(ClientS3IntegrationTest, test_flush_write_and_read4) {
     EXPECT_STREQ(expectBuf, readBuf);
 
     // cleanup
-    delete buf;
-    delete readBuf;
-    delete expectBuf;
+    delete[] buf;
+    delete[] readBuf;
+    delete[] expectBuf;
     std::map<std::string, S3Data>::iterator iter = gObjectDataMaps.begin();
     for (; iter != gObjectDataMaps.end(); iter++) {
         delete iter->second.buf;
@@ -2051,9 +2051,9 @@ TEST_F(ClientS3IntegrationTest, test_flush_write_and_read5) {
     EXPECT_STREQ(expectBuf, readBuf);
 
     // cleanup
-    delete buf;
-    delete readBuf;
-    delete expectBuf;
+    delete[] buf;
+    delete[] readBuf;
+    delete[] expectBuf;
     std::map<std::string, S3Data>::iterator iter = gObjectDataMaps.begin();
     for (; iter != gObjectDataMaps.end(); iter++) {
         delete iter->second.buf;
@@ -2142,9 +2142,9 @@ TEST_F(ClientS3IntegrationTest, test_flush_write_and_read6) {
     EXPECT_STREQ(expectBuf, readBuf);
 
     // cleanup
-    delete buf;
-    delete readBuf;
-    delete expectBuf;
+    delete[] buf;
+    delete[] readBuf;
+    delete[] expectBuf;
     std::map<std::string, S3Data>::iterator iter = gObjectDataMaps.begin();
     for (; iter != gObjectDataMaps.end(); iter++) {
         delete iter->second.buf;
@@ -2241,9 +2241,9 @@ TEST_F(ClientS3IntegrationTest, test_flush_write_and_read7) {
     EXPECT_STREQ(expectBuf, readBuf);
 
     // cleanup
-    delete buf;
-    delete readBuf;
-    delete expectBuf;
+    delete[] buf;
+    delete[] readBuf;
+    delete[] expectBuf;
     std::map<std::string, S3Data>::iterator iter = gObjectDataMaps.begin();
     for (; iter != gObjectDataMaps.end(); iter++) {
         delete iter->second.buf;
@@ -2333,9 +2333,9 @@ TEST_F(ClientS3IntegrationTest, test_flush_write_and_read8) {
     EXPECT_STREQ(expectBuf, readBuf);
 
     // cleanup
-    delete buf;
-    delete readBuf;
-    delete expectBuf;
+    delete[] buf;
+    delete[] readBuf;
+    delete[] expectBuf;
     std::map<std::string, S3Data>::iterator iter = gObjectDataMaps.begin();
     for (; iter != gObjectDataMaps.end(); iter++) {
         delete iter->second.buf;
@@ -2428,9 +2428,9 @@ TEST_F(ClientS3IntegrationTest, test_flush_write_and_read9) {
     EXPECT_STREQ(expectBuf, readBuf);
 
     // cleanup
-    delete buf;
-    delete readBuf;
-    delete expectBuf;
+    delete[] buf;
+    delete[] readBuf;
+    delete[] expectBuf;
     std::map<std::string, S3Data>::iterator iter = gObjectDataMaps.begin();
     for (; iter != gObjectDataMaps.end(); iter++) {
         delete iter->second.buf;
@@ -2551,9 +2551,9 @@ TEST_F(ClientS3IntegrationTest, test_flush_write_and_read10) {
     EXPECT_STREQ(expectBuf, readBuf);
 
     // cleanup
-    delete buf;
-    delete readBuf;
-    delete expectBuf;
+    delete[] buf;
+    delete[] readBuf;
+    delete[] expectBuf;
     std::map<std::string, S3Data>::iterator iter = gObjectDataMaps.begin();
     for (; iter != gObjectDataMaps.end(); iter++) {
         delete iter->second.buf;
@@ -2635,9 +2635,9 @@ TEST_F(ClientS3IntegrationTest, test_flush_write_and_read11) {
     EXPECT_STREQ(expectBuf, readBuf);
 
     // cleanup
-    delete buf;
-    delete readBuf;
-    delete expectBuf;
+    delete[] buf;
+    delete[] readBuf;
+    delete[] expectBuf;
     std::map<std::string, S3Data>::iterator iter = gObjectDataMaps.begin();
     for (; iter != gObjectDataMaps.end(); iter++) {
         delete iter->second.buf;
@@ -2719,9 +2719,9 @@ TEST_F(ClientS3IntegrationTest, test_flush_write_and_read12) {
     EXPECT_STREQ(expectBuf, readBuf);
 
     // cleanup
-    delete buf;
-    delete readBuf;
-    delete expectBuf;
+    delete[] buf;
+    delete[] readBuf;
+    delete[] expectBuf;
     std::map<std::string, S3Data>::iterator iter = gObjectDataMaps.begin();
     for (; iter != gObjectDataMaps.end(); iter++) {
         delete iter->second.buf;
@@ -2783,7 +2783,7 @@ TEST_F(ClientS3IntegrationTest, test_fssync_success_and_fail) {
     ASSERT_EQ(CURVEFS_ERROR::OK, ret);
 
     //  cleanup
-    delete buf;
+    delete[] buf;
     std::map<std::string, S3Data>::iterator iter = gObjectDataMaps.begin();
     for (; iter != gObjectDataMaps.end(); iter++) {
         delete iter->second.buf;
@@ -2832,7 +2832,7 @@ TEST_F(ClientS3IntegrationTest, test_fssync_overlap_write) {
     ASSERT_EQ(0, fsCacheManager->GetDataCacheNum());
 
     //  cleanup
-    delete buf;
+    delete[] buf;
     std::map<std::string, S3Data>::iterator iter = gObjectDataMaps.begin();
     for (; iter != gObjectDataMaps.end(); iter++) {
         delete iter->second.buf;

--- a/curvefs/test/client/client_s3_test.cpp
+++ b/curvefs/test/client/client_s3_test.cpp
@@ -69,7 +69,7 @@ TEST_F(ClientS3Test, upload) {
         .WillOnce(Return(-1));
     ASSERT_EQ(0, client_->Upload(obj, buf, len));
     ASSERT_EQ(-1, client_->Upload(obj, buf, len));
-    delete buf;
+    delete[] buf;
 }
 
 TEST_F(ClientS3Test, download) {
@@ -90,7 +90,7 @@ TEST_F(ClientS3Test, download) {
     ASSERT_EQ(0, client_->Download(obj, buf, offset, len));
     ASSERT_EQ(-1, client_->Download(obj, buf, offset, len));
     ASSERT_EQ(-2, client_->Download(obj, buf, offset, len));
-    delete buf;
+    delete[] buf;
 }
 
 TEST_F(ClientS3Test, uploadync) {
@@ -106,7 +106,7 @@ TEST_F(ClientS3Test, uploadync) {
     EXPECT_CALL(*s3Client_, PutObjectAsync(_))
         .WillOnce(Return());
     client_->UploadAsync(context);
-    delete buf;
+    delete[] buf;
 }
 
 TEST_F(ClientS3Test, downloadAsync) {
@@ -124,7 +124,7 @@ TEST_F(ClientS3Test, downloadAsync) {
     EXPECT_CALL(*s3Client_, GetObjectAsync(_))
         .WillOnce(Return());
     client_->DownloadAsync(context);
-    delete buf;
+    delete[] buf;
 }
 
 

--- a/curvefs/test/client/data_cache_test.cpp
+++ b/curvefs/test/client/data_cache_test.cpp
@@ -67,7 +67,7 @@ class DataCacheTest : public testing::Test {
         dataCache_ = std::make_shared<DataCache>(s3ClientAdaptor_,
                                                  mockChunkCacheManager_, offset,
                                                  len, buf, nullptr);
-        delete buf;
+        delete[] buf;
     }
     void TearDown() override {}
 
@@ -85,7 +85,7 @@ TEST_F(DataCacheTest, test_write1) {
     dataCache_->Write(offset, len, buf, mergeDataCacheVer);
     ASSERT_EQ(0, dataCache_->GetChunkPos());
     ASSERT_EQ(1536 * 1024, dataCache_->GetLen());
-    delete buf;
+    delete[] buf;
 }
 
 TEST_F(DataCacheTest, test_write2) {
@@ -96,7 +96,7 @@ TEST_F(DataCacheTest, test_write2) {
     dataCache_->Write(offset, len, buf, mergeDataCacheVer);
     ASSERT_EQ(0, dataCache_->GetChunkPos());
     ASSERT_EQ(2048 * 1024, dataCache_->GetLen());
-    delete buf;
+    delete[] buf;
 }
 
 TEST_F(DataCacheTest, test_write3) {
@@ -111,7 +111,7 @@ TEST_F(DataCacheTest, test_write3) {
     dataCache_->Write(offset, len, buf, mergeDataCacheVer);
     ASSERT_EQ(0, dataCache_->GetChunkPos());
     ASSERT_EQ(4096 * 1024, dataCache_->GetLen());
-    delete buf;
+    delete[] buf;
 }
 
 TEST_F(DataCacheTest, test_write4) {
@@ -122,7 +122,7 @@ TEST_F(DataCacheTest, test_write4) {
     dataCache_->Write(offset, len, buf, mergeDataCacheVer);
     ASSERT_EQ(512 * 1024, dataCache_->GetChunkPos());
     ASSERT_EQ(1024 * 1024, dataCache_->GetLen());
-    delete buf;
+    delete[] buf;
 }
 
 TEST_F(DataCacheTest, test_write5) {
@@ -133,7 +133,7 @@ TEST_F(DataCacheTest, test_write5) {
     dataCache_->Write(offset, len, buf, mergeDataCacheVer);
     ASSERT_EQ(512 * 1024, dataCache_->GetChunkPos());
     ASSERT_EQ(1536 * 1024, dataCache_->GetLen());
-    delete buf;
+    delete[] buf;
 }
 
 TEST_F(DataCacheTest, test_write6) {
@@ -148,7 +148,7 @@ TEST_F(DataCacheTest, test_write6) {
     dataCache_->Write(offset, len, buf, mergeDataCacheVer);
     ASSERT_EQ(512 * 1024, dataCache_->GetChunkPos());
     ASSERT_EQ(2560 * 1024, dataCache_->GetLen());
-    delete buf;
+    delete[] buf;
 }
 
 TEST_F(DataCacheTest, test_truncate1) {

--- a/curvefs/test/metaserver/storage/dumpfile_test.cpp
+++ b/curvefs/test/metaserver/storage/dumpfile_test.cpp
@@ -27,6 +27,7 @@
 #include <memory>
 #include <thread>
 #include <unordered_map>
+#include <array>
 
 #include "curvefs/src/common/process.h"
 #include "curvefs/src/metaserver/storage/iterator.h"

--- a/nebd/src/common/timeutility.h
+++ b/nebd/src/common/timeutility.h
@@ -28,6 +28,7 @@
 #include <sys/types.h>
 #include <string>
 #include <vector>
+#include <ctime>
 
 namespace nebd {
 namespace common {

--- a/nebd/src/part2/metafile_manager.cpp
+++ b/nebd/src/part2/metafile_manager.cpp
@@ -245,7 +245,7 @@ Json::Value NebdMetaFileParser::ConvertFileMetasToJson(
         Json::Value volume;
         volume[kFileName] = meta.second.fileName;
         volume[kFd] = meta.second.fd;
-        for (const auto item : meta.second.xattr) {
+        for (const auto &item : meta.second.xattr) {
             volume[item.first] = item.second;
         }
         volumes.append(volume);

--- a/nebd/test/part1/fake_file_service.cpp
+++ b/nebd/test/part1/fake_file_service.cpp
@@ -35,11 +35,6 @@ void FakeNebdFileService::OpenFile(::google::protobuf::RpcController* controller
     brpc::Controller* cntl = static_cast<brpc::Controller*>(controller);
 
     LOG(INFO) << "logid = " << cntl->log_id() << ", OpenFile.";
-    if (buffer == nullptr) {
-        response->set_retcode(RetCode::kNoOK);
-        response->set_retmsg("OpenFile FAIL");
-        return;
-    }
 
     response->set_retcode(RetCode::kOK);
     response->set_retmsg("OpenFile OK");

--- a/src/chunkserver/raftlog/curve_segment.cpp
+++ b/src/chunkserver/raftlog/curve_segment.cpp
@@ -66,7 +66,7 @@ int CurveSegment::create() {
     memset(metaPage, 0, _meta_page_size);
     memcpy(metaPage, &_meta.bytes, sizeof(_meta.bytes));
     int res = _walFilePool->GetFile(path, metaPage);
-    delete metaPage;
+    delete[] metaPage;
     if (res != 0) {
         LOG(ERROR) << "Get segment from chunk file pool fail!";
         return -1;
@@ -232,11 +232,11 @@ int CurveSegment::_load_meta() {
     char* metaPage = new char[_meta_page_size];
     int res = ::pread(_fd, metaPage, _meta_page_size, 0);
     if (res != static_cast<int>(_meta_page_size)) {
-        delete metaPage;
+        delete[] metaPage;
         return -1;
     }
     memcpy(&_meta.bytes, metaPage, sizeof(_meta.bytes));
-    delete metaPage;
+    delete[] metaPage;
     LOG(INFO) << "loaded bytes: " << _meta.bytes;
     return 0;
 }

--- a/src/common/timeutility.h
+++ b/src/common/timeutility.h
@@ -27,6 +27,7 @@
 #include <sys/types.h>
 #include <string>
 #include <vector>
+#include <ctime>
 
 namespace curve {
 namespace common {

--- a/src/tools/mds_client.cpp
+++ b/src/tools/mds_client.cpp
@@ -912,7 +912,7 @@ int MDSClient::GetListenAddrFromDummyPort(const std::string& dummyAddr,
 void MDSClient::GetMdsOnlineStatus(std::map<std::string, bool>* onlineStatus) {
     assert(onlineStatus != nullptr);
     onlineStatus->clear();
-    for (const auto item : dummyServerMap_) {
+    for (const auto &item : dummyServerMap_) {
         std::string listenAddr;
         int res = GetListenAddrFromDummyPort(item.second, &listenAddr);
         // 如果获取到的监听地址与记录的mds地址不一致，也认为不在线
@@ -972,7 +972,7 @@ bool MDSClient::ChangeMDServer() {
 
 std::vector<std::string> MDSClient::GetCurrentMds() {
     std::vector<std::string> leaderAddrs;
-    for (const auto item : dummyServerMap_) {
+    for (const auto &item : dummyServerMap_) {
         // 获取status来判断正在服务的地址
         std::string status;
         MetricRet ret = metricClient_.GetMetric(item.second,

--- a/src/tools/snapshot_clone_client.cpp
+++ b/src/tools/snapshot_clone_client.cpp
@@ -76,7 +76,7 @@ int SnapshotCloneClient::InitDummyServerMap(const std::string& dummyPort) {
 
 std::vector<std::string> SnapshotCloneClient::GetActiveAddrs() {
     std::vector<std::string> activeAddrs;
-    for (const auto item : dummyServerMap_) {
+    for (const auto &item : dummyServerMap_) {
         // 获取status来判断正在服务的地址
         std::string status;
         MetricRet ret = metricClient_->GetMetric(item.second,

--- a/test/chunkserver/raftlog/common.cpp
+++ b/test/chunkserver/raftlog/common.cpp
@@ -42,7 +42,7 @@ int prepare_segment(const std::string& path) {
         LOG(ERROR) << "write failed";
         return -1;
     }
-    delete data;
+    delete[] data;
     close(fd);
     return 0;
 }

--- a/test/mds/topology/test_topology_service_manager.cpp
+++ b/test/mds/topology/test_topology_service_manager.cpp
@@ -3573,7 +3573,7 @@ TEST_F(TestTopologyServiceManager, test_SetCopysetsAvailFlag) {
     }
     std::vector<CopySetInfo> copysets =
                 topology_->GetCopySetInfosInLogicalPool(logicalPoolId1);
-    for (const auto copyset : copysets) {
+    for (const auto &copyset : copysets) {
         ASSERT_TRUE(copyset.IsAvailable());
     }
     // success
@@ -3592,7 +3592,7 @@ TEST_F(TestTopologyServiceManager, test_SetCopysetsAvailFlag) {
         serviceManager_->SetCopysetsAvailFlag(&request, &response);
         ASSERT_EQ(kTopoErrCodeSuccess, response.statuscode());
         copysets = topology_->GetCopySetInfosInLogicalPool(logicalPoolId1);
-        for (const auto copyset : copysets) {
+        for (const auto &copyset : copysets) {
             if (copyset.GetId() <= 10) {
                 ASSERT_FALSE(copyset.IsAvailable());
             } else {
@@ -3606,7 +3606,7 @@ TEST_F(TestTopologyServiceManager, test_SetCopysetsAvailFlag) {
         serviceManager_->SetCopysetsAvailFlag(&request, &response);
         ASSERT_EQ(kTopoErrCodeSuccess, response.statuscode());
         copysets = topology_->GetCopySetInfosInLogicalPool(logicalPoolId1);
-        for (const auto copyset : copysets) {
+        for (const auto &copyset : copysets) {
             ASSERT_TRUE(copyset.IsAvailable());
         }
     }

--- a/thirdparties/brpc/fix-gcc11.patch
+++ b/thirdparties/brpc/fix-gcc11.patch
@@ -1,0 +1,463 @@
+diff --git a/BUILD b/BUILD
+index 185f44fe..6b895d6e 100644
+--- a/BUILD
++++ b/BUILD
+@@ -35,7 +35,7 @@ config_setting(
+ 
+ COPTS = [
+     "-DBTHREAD_USE_FAST_PTHREAD_MUTEX",
+-    "-D__const__=",
++    "-D__const__=__unused__",
+     "-D_GNU_SOURCE",
+     "-DUSE_SYMBOLIZE",
+     "-DNO_TCMALLOC",
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index fa2e935c..720c79c3 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -86,7 +86,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DBRPC_WITH_GLOG=${WITH_GLOG_VAL} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CPP_FLAGS "${CMAKE_CPP_FLAGS} -DBTHREAD_USE_FAST_PTHREAD_MUTEX -D__const__= -D_GNU_SOURCE -DUSE_SYMBOLIZE -DNO_TCMALLOC -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -DBRPC_REVISION=\\\"${BRPC_REVISION}\\\" -D__STRICT_ANSI__")
++set(CMAKE_CPP_FLAGS "${CMAKE_CPP_FLAGS} -DBTHREAD_USE_FAST_PTHREAD_MUTEX -D__const__=__unused__ -D_GNU_SOURCE -DUSE_SYMBOLIZE -DNO_TCMALLOC -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -DBRPC_REVISION=\\\"${BRPC_REVISION}\\\" -D__STRICT_ANSI__")
+ set(CMAKE_CPP_FLAGS "${CMAKE_CPP_FLAGS} ${DEBUG_SYMBOL} ${THRIFT_CPP_FLAG}")
+ set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -O2 -pipe -Wall -W -fPIC -fstrict-aliasing -Wno-invalid-offsetof -Wno-unused-parameter -fno-omit-frame-pointer")
+ set(CMAKE_C_FLAGS "${CMAKE_CPP_FLAGS} -O2 -pipe -Wall -W -fPIC -fstrict-aliasing -Wno-unused-parameter -fno-omit-frame-pointer")
+diff --git a/config_brpc.sh b/config_brpc.sh
+index a1934d79..f56c6894 100755
+--- a/config_brpc.sh
++++ b/config_brpc.sh
+@@ -290,7 +290,7 @@ append_to_output "GCC_VERSION=$GCC_VERSION"
+ append_to_output "STATIC_LINKINGS=$STATIC_LINKINGS"
+ append_to_output "DYNAMIC_LINKINGS=$DYNAMIC_LINKINGS"
+ CPPFLAGS="-DBRPC_WITH_GLOG=$WITH_GLOG -DGFLAGS_NS=$GFLAGS_NS"
+-
++CPPFLAGS="${CPPFLAGS} -D__const__=__unused__"
+ if [ ! -z "$DEBUGSYMBOLS" ]; then
+     CPPFLAGS="${CPPFLAGS} $DEBUGSYMBOLS"
+ fi
+diff --git a/docs/cn/getting_started.md b/docs/cn/getting_started.md
+index 8b1bca07..95c2b680 100644
+--- a/docs/cn/getting_started.md
++++ b/docs/cn/getting_started.md
+@@ -346,7 +346,7 @@ The over-aligned issues in GCC7 is suppressed temporarily now.
+ 
+ Using other versions of gcc may generate warnings, contact us to fix.
+ 
+-Adding `-D__const__=` to cxxflags in your makefiles is a must to avoid [errno issue in gcc4+](thread_local.md).
++Adding `-D__const__=__unused__` to cxxflags in your makefiles is a must to avoid [errno issue in gcc4+](thread_local.md).
+ 
+ ## Clang: 3.5-4.0
+ 
+diff --git a/docs/cn/thread_local.md b/docs/cn/thread_local.md
+index f8e1a491..b16d9487 100644
+--- a/docs/cn/thread_local.md
++++ b/docs/cn/thread_local.md
+@@ -57,9 +57,9 @@ Use *p ...                   -  still the errno of original pthread, undefined b
+ 
+ 严格地说这个问题不是gcc4导致的，而是glibc给__errno_location的签名不够准确，一个返回thread-local指针的函数依赖于段寄存器（TLS的一般实现方式），这怎么能算const呢？由于我们还未找到覆盖__errno_location的方法，所以这个问题目前实际的解决方法是：
+ 
+-**务必在直接或间接使用bthread的项目的gcc编译选项中添加`-D__const__=`，即把`__const__`定义为空，避免gcc4做相关优化。**
++**务必在直接或间接使用bthread的项目的gcc编译选项中添加`-D__const__=__unused__`，即把`__const__`定义为空，避免gcc4做相关优化。**
+ 
+ 把`__const__`定义为空对程序其他部分的影响几乎为0。另外如果你没有**直接**使用errno（即你的项目中没有出现errno），或使用的是gcc
+-3.4，即使没有定义`-D__const__=`，程序的正确性也不会受影响，但为了防止未来可能的问题，我们强烈建议加上。
++3.4，即使没有定义`-D__const__=__unused__`，程序的正确性也不会受影响，但为了防止未来可能的问题，我们强烈建议加上。
+ 
+-需要说明的是，和errno类似，pthread_self也有类似的问题，不过一般pthread_self除了打日志没有其他用途，影响面较小，在`-D__const__=`后pthread_self也会正常。
++需要说明的是，和errno类似，pthread_self也有类似的问题，不过一般pthread_self除了打日志没有其他用途，影响面较小，在`-D__const__=__unused__`后pthread_self也会正常。
+diff --git a/example/asynchronous_echo_c++/CMakeLists.txt b/example/asynchronous_echo_c++/CMakeLists.txt
+index 91c3953f..74414e2a 100644
+--- a/example/asynchronous_echo_c++/CMakeLists.txt
++++ b/example/asynchronous_echo_c++/CMakeLists.txt
+@@ -64,7 +64,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+diff --git a/example/auto_concurrency_limiter/CMakeLists.txt b/example/auto_concurrency_limiter/CMakeLists.txt
+index 218f059f..56a1a03e 100644
+--- a/example/auto_concurrency_limiter/CMakeLists.txt
++++ b/example/auto_concurrency_limiter/CMakeLists.txt
+@@ -53,7 +53,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+diff --git a/example/backup_request_c++/CMakeLists.txt b/example/backup_request_c++/CMakeLists.txt
+index 32750645..04110ad2 100644
+--- a/example/backup_request_c++/CMakeLists.txt
++++ b/example/backup_request_c++/CMakeLists.txt
+@@ -64,7 +64,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+diff --git a/example/cancel_c++/CMakeLists.txt b/example/cancel_c++/CMakeLists.txt
+index 998e03e0..359306f9 100644
+--- a/example/cancel_c++/CMakeLists.txt
++++ b/example/cancel_c++/CMakeLists.txt
+@@ -64,7 +64,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+diff --git a/example/cascade_echo_c++/CMakeLists.txt b/example/cascade_echo_c++/CMakeLists.txt
+index bc530e02..0cbc806b 100644
+--- a/example/cascade_echo_c++/CMakeLists.txt
++++ b/example/cascade_echo_c++/CMakeLists.txt
+@@ -63,7 +63,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+diff --git a/example/dynamic_partition_echo_c++/CMakeLists.txt b/example/dynamic_partition_echo_c++/CMakeLists.txt
+index a89d3ede..5cd99284 100644
+--- a/example/dynamic_partition_echo_c++/CMakeLists.txt
++++ b/example/dynamic_partition_echo_c++/CMakeLists.txt
+@@ -68,7 +68,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBRPC_ENABLE_CPU_PROFILER")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+diff --git a/example/echo_c++/CMakeLists.txt b/example/echo_c++/CMakeLists.txt
+index 325918d8..c05e4a6d 100644
+--- a/example/echo_c++/CMakeLists.txt
++++ b/example/echo_c++/CMakeLists.txt
+@@ -64,7 +64,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+diff --git a/example/echo_c++_hulu_pbrpc/CMakeLists.txt b/example/echo_c++_hulu_pbrpc/CMakeLists.txt
+index ced2f81c..a1592de7 100644
+--- a/example/echo_c++_hulu_pbrpc/CMakeLists.txt
++++ b/example/echo_c++_hulu_pbrpc/CMakeLists.txt
+@@ -64,7 +64,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+diff --git a/example/echo_c++_sofa_pbrpc/CMakeLists.txt b/example/echo_c++_sofa_pbrpc/CMakeLists.txt
+index 5cdf1e38..0849e55f 100644
+--- a/example/echo_c++_sofa_pbrpc/CMakeLists.txt
++++ b/example/echo_c++_sofa_pbrpc/CMakeLists.txt
+@@ -64,7 +64,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+diff --git a/example/echo_c++_ubrpc_compack/CMakeLists.txt b/example/echo_c++_ubrpc_compack/CMakeLists.txt
+index ff126582..05b6019f 100644
+--- a/example/echo_c++_ubrpc_compack/CMakeLists.txt
++++ b/example/echo_c++_ubrpc_compack/CMakeLists.txt
+@@ -64,7 +64,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+diff --git a/example/echo_c++_unix_socket/CMakeLists.txt b/example/echo_c++_unix_socket/CMakeLists.txt
+index 325918d8..c05e4a6d 100644
+--- a/example/echo_c++_unix_socket/CMakeLists.txt
++++ b/example/echo_c++_unix_socket/CMakeLists.txt
+@@ -64,7 +64,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+diff --git a/example/grpc_c++/CMakeLists.txt b/example/grpc_c++/CMakeLists.txt
+index c7b0aba0..5c700010 100644
+--- a/example/grpc_c++/CMakeLists.txt
++++ b/example/grpc_c++/CMakeLists.txt
+@@ -58,7 +58,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBRPC_ENABLE_CPU_PROFILER")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+diff --git a/example/http_c++/CMakeLists.txt b/example/http_c++/CMakeLists.txt
+index 0f34c851..bd909e55 100644
+--- a/example/http_c++/CMakeLists.txt
++++ b/example/http_c++/CMakeLists.txt
+@@ -69,7 +69,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBRPC_ENABLE_CPU_PROFILER")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+diff --git a/example/memcache_c++/CMakeLists.txt b/example/memcache_c++/CMakeLists.txt
+index 0fbaaa45..865a8e45 100644
+--- a/example/memcache_c++/CMakeLists.txt
++++ b/example/memcache_c++/CMakeLists.txt
+@@ -64,7 +64,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+diff --git a/example/multi_threaded_echo_c++/CMakeLists.txt b/example/multi_threaded_echo_c++/CMakeLists.txt
+index d0633351..e0860bd7 100644
+--- a/example/multi_threaded_echo_c++/CMakeLists.txt
++++ b/example/multi_threaded_echo_c++/CMakeLists.txt
+@@ -68,7 +68,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBRPC_ENABLE_CPU_PROFILER")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+diff --git a/example/multi_threaded_echo_fns_c++/CMakeLists.txt b/example/multi_threaded_echo_fns_c++/CMakeLists.txt
+index 2840263e..fd70b23a 100644
+--- a/example/multi_threaded_echo_fns_c++/CMakeLists.txt
++++ b/example/multi_threaded_echo_fns_c++/CMakeLists.txt
+@@ -68,7 +68,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBRPC_ENABLE_CPU_PROFILER")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+diff --git a/example/multi_threaded_mcpack_c++/CMakeLists.txt b/example/multi_threaded_mcpack_c++/CMakeLists.txt
+index 9dcbe12f..c51978a4 100644
+--- a/example/multi_threaded_mcpack_c++/CMakeLists.txt
++++ b/example/multi_threaded_mcpack_c++/CMakeLists.txt
+@@ -68,7 +68,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBRPC_ENABLE_CPU_PROFILER")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+diff --git a/example/nshead_extension_c++/CMakeLists.txt b/example/nshead_extension_c++/CMakeLists.txt
+index a5ef77f7..ac5bc4cb 100644
+--- a/example/nshead_extension_c++/CMakeLists.txt
++++ b/example/nshead_extension_c++/CMakeLists.txt
+@@ -64,7 +64,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+diff --git a/example/nshead_pb_extension_c++/CMakeLists.txt b/example/nshead_pb_extension_c++/CMakeLists.txt
+index 0042a828..1362ea3e 100644
+--- a/example/nshead_pb_extension_c++/CMakeLists.txt
++++ b/example/nshead_pb_extension_c++/CMakeLists.txt
+@@ -64,7 +64,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+diff --git a/example/parallel_echo_c++/CMakeLists.txt b/example/parallel_echo_c++/CMakeLists.txt
+index fbe56ced..d05a818e 100644
+--- a/example/parallel_echo_c++/CMakeLists.txt
++++ b/example/parallel_echo_c++/CMakeLists.txt
+@@ -68,7 +68,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBRPC_ENABLE_CPU_PROFILER")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+diff --git a/example/partition_echo_c++/CMakeLists.txt b/example/partition_echo_c++/CMakeLists.txt
+index ffab137d..ebb65245 100644
+--- a/example/partition_echo_c++/CMakeLists.txt
++++ b/example/partition_echo_c++/CMakeLists.txt
+@@ -68,7 +68,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBRPC_ENABLE_CPU_PROFILER")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+diff --git a/example/redis_c++/CMakeLists.txt b/example/redis_c++/CMakeLists.txt
+index 82096c7d..f7c0f1dd 100644
+--- a/example/redis_c++/CMakeLists.txt
++++ b/example/redis_c++/CMakeLists.txt
+@@ -69,7 +69,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+diff --git a/example/selective_echo_c++/CMakeLists.txt b/example/selective_echo_c++/CMakeLists.txt
+index 517464d7..0737abc2 100644
+--- a/example/selective_echo_c++/CMakeLists.txt
++++ b/example/selective_echo_c++/CMakeLists.txt
+@@ -68,7 +68,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBRPC_ENABLE_CPU_PROFILER")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+diff --git a/example/session_data_and_thread_local/CMakeLists.txt b/example/session_data_and_thread_local/CMakeLists.txt
+index 02ccd18f..b0793c04 100644
+--- a/example/session_data_and_thread_local/CMakeLists.txt
++++ b/example/session_data_and_thread_local/CMakeLists.txt
+@@ -68,7 +68,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBRPC_ENABLE_CPU_PROFILER")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+diff --git a/example/streaming_echo_c++/CMakeLists.txt b/example/streaming_echo_c++/CMakeLists.txt
+index d4436fb1..c96270b6 100644
+--- a/example/streaming_echo_c++/CMakeLists.txt
++++ b/example/streaming_echo_c++/CMakeLists.txt
+@@ -64,7 +64,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ 
+ if(CMAKE_VERSION VERSION_LESS "3.1.3")
+     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+diff --git a/src/bthread/mutex.cpp b/src/bthread/mutex.cpp
+index 0de00b27..f55e874c 100644
+--- a/src/bthread/mutex.cpp
++++ b/src/bthread/mutex.cpp
+@@ -41,7 +41,7 @@
+ #include "bthread/log.h"
+ 
+ extern "C" {
+-extern void* _dl_sym(void* handle, const char* symbol, void* caller);
++extern void* __attribute__((weak)) _dl_sym(void* handle, const char* symbol, void* caller);
+ }
+ 
+ namespace bthread {
+@@ -403,10 +403,14 @@ static pthread_once_t init_sys_mutex_lock_once = PTHREAD_ONCE_INIT;
+ // causing deadlock temporarily. This fix is hardly portable.
+ static void init_sys_mutex_lock() {
+ #if defined(OS_LINUX)
+-    // TODO: may need dlvsym when GLIBC has multiple versions of a same symbol.
+-    // http://blog.fesnel.com/blog/2009/08/25/preloading-with-multiple-symbol-versions
+-    sys_pthread_mutex_lock = (MutexOp)_dl_sym(RTLD_NEXT, "pthread_mutex_lock", (void*)init_sys_mutex_lock);
+-    sys_pthread_mutex_unlock = (MutexOp)_dl_sym(RTLD_NEXT, "pthread_mutex_unlock", (void*)init_sys_mutex_lock);
++    if (_dl_sym) {
++        sys_pthread_mutex_lock = (MutexOp)_dl_sym(RTLD_NEXT, "pthread_mutex_lock", (void*)init_sys_mutex_lock);
++        sys_pthread_mutex_unlock = (MutexOp)_dl_sym(RTLD_NEXT, "pthread_mutex_unlock", (void*)init_sys_mutex_lock);
++    } else {
++        // _dl_sym may be undefined reference in some system, fallback to dlsym
++        sys_pthread_mutex_lock = (MutexOp)dlsym(RTLD_NEXT, "pthread_mutex_lock");
++        sys_pthread_mutex_unlock = (MutexOp)dlsym(RTLD_NEXT, "pthread_mutex_unlock");
++    }
+ #elif defined(OS_MACOSX)
+     // TODO: look workaround for dlsym on mac
+     sys_pthread_mutex_lock = (MutexOp)dlsym(RTLD_NEXT, "pthread_mutex_lock");
+diff --git a/src/butil/errno.h b/src/butil/errno.h
+index e1157e3d..86a76213 100644
+--- a/src/butil/errno.h
++++ b/src/butil/errno.h
+@@ -20,7 +20,7 @@
+ #ifndef BUTIL_BAIDU_ERRNO_H
+ #define BUTIL_BAIDU_ERRNO_H
+ 
+-#define __const__
++#define __const__ __unused__
+ #include <errno.h>                           // errno
+ #include "butil/macros.h"                     // BAIDU_CONCAT
+ 
+diff --git a/test/CMakeLists.txt b/test/CMakeLists.txt
+index 1c678081..ee52b649 100644
+--- a/test/CMakeLists.txt
++++ b/test/CMakeLists.txt
+@@ -35,7 +35,7 @@ else()
+ endif()
+ 
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DBRPC_WITH_GLOG=${WITH_GLOG_VAL} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CPP_FLAGS "${CMAKE_CPP_FLAGS} -DBTHREAD_USE_FAST_PTHREAD_MUTEX -D__const__= -D_GNU_SOURCE -DUSE_SYMBOLIZE -DNO_TCMALLOC -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -DUNIT_TEST -Dprivate=public -Dprotected=public -DBVAR_NOT_LINK_DEFAULT_VARIABLES -D__STRICT_ANSI__ -include ${PROJECT_SOURCE_DIR}/test/sstream_workaround.h")
++set(CMAKE_CPP_FLAGS "${CMAKE_CPP_FLAGS} -DBTHREAD_USE_FAST_PTHREAD_MUTEX -D__const__=__unused__ -D_GNU_SOURCE -DUSE_SYMBOLIZE -DNO_TCMALLOC -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -DUNIT_TEST -Dprivate=public -Dprotected=public -DBVAR_NOT_LINK_DEFAULT_VARIABLES -D__STRICT_ANSI__ -include ${PROJECT_SOURCE_DIR}/test/sstream_workaround.h")
+ set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -O2 -pipe -Wall -W -fPIC -fstrict-aliasing -Wno-invalid-offsetof -Wno-unused-parameter -fno-omit-frame-pointer")
+ use_cxx11()
+ 
+diff --git a/tools/CMakeLists.txt b/tools/CMakeLists.txt
+index e3367b0f..b43916b7 100644
+--- a/tools/CMakeLists.txt
++++ b/tools/CMakeLists.txt
+@@ -1,5 +1,5 @@
+ set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DBRPC_WITH_GLOG=${WITH_GLOG_VAL} -DGFLAGS_NS=${GFLAGS_NS}")
+-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -D__STRICT_ANSI__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
++set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__=__unused__ -D__STRICT_ANSI__ -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
+ use_cxx11()
+ set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/output/bin)
+ 

--- a/tools/curvefsTool.cpp
+++ b/tools/curvefsTool.cpp
@@ -364,7 +364,7 @@ int CurvefsTools::InitServerData() {
         LOG(ERROR) << "No servers in cluster map";
         return -1;
     }
-    for (const auto server : clusterMap_[kServers]) {
+    for (const auto &server : clusterMap_[kServers]) {
         CurveServerData serverData;
         if (!server[kName].isString()) {
             LOG(ERROR) << "server name must be string";
@@ -423,7 +423,7 @@ int CurvefsTools::InitLogicalPoolData() {
         LOG(ERROR) << "No servers in cluster map";
         return -1;
     }
-    for (const auto lgPool : clusterMap_[kLogicalPools]) {
+    for (const auto &lgPool : clusterMap_[kLogicalPools]) {
         CurveLogicalPoolData lgPoolData;
         if (!lgPool[kName].isString()) {
             LOG(ERROR) << "logicalpool name must be string";


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

* Support build on GCC 11+.

### What is changed and how it works?

What's Changed: 
* Add a patch to brpc.
* Fix mismatched `new[]` and `delete`. 

How it Works:
* Add `-D__const__=__unused__` to brpc `CXX_FLAGS`.
* Change `CopysetNode::GetAppliedIndex` memory order to `std::memory_order_acquire`.

https://github.com/opencurve/curve/blob/c30eff073d91fabb7a51c84663da1aad144c5f46/curvefs/src/metaserver/copyset/copyset_node.h#L304

See also:
* [GCC -Winvalid-memory-model warning option](https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Winvalid-memory-model)
* [Built-in Functions for Memory Model Aware Atomic Operations](https://gcc.gnu.org/onlinedocs/gcc/_005f_005fatomic-Builtins.html)

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [x] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license
