### PR TITLE
[Feature]: curvefs metaserver support asynchronous snapshot

### DIFF
--- a/curvefs/proto/common.proto
+++ b/curvefs/proto/common.proto
@@ -92,6 +92,14 @@ message PartitionInfo {
     optional bool manageFlag = 13; // if a partition has recyclebin inode, set this flag true
 }
 
+message AppliedIndex {
+    required int64 index = 1;
+}
+
+message ItemCount {
+    required uint64 count = 1;
+}
+
 message Peer {
     optional uint64 id          = 1;
     optional string address     = 2;

--- a/curvefs/proto/metaserver.proto
+++ b/curvefs/proto/metaserver.proto
@@ -145,6 +145,15 @@ message PrepareRenameTxRequest {
     repeated Dentry dentrys = 4;
 }
 
+message TransactionRequest {
+    enum TransactionType {
+        None = 0;
+        Rename = 1;
+    }
+    required TransactionType type = 1;
+    required string rawPayload = 2;
+}
+
 message PrepareRenameTxResponse {
     required MetaStatusCode statusCode = 1;
     optional uint64 appliedIndex = 2;

--- a/curvefs/src/metaserver/copyset/meta_operator.cpp
+++ b/curvefs/src/metaserver/copyset/meta_operator.cpp
@@ -123,16 +123,14 @@ void MetaOperator::FastApplyTask() {
     auto task =
         std::bind(&MetaOperator::OnApply, this, node_->GetAppliedIndex(),
                   new MetaOperatorClosure(this), TimeUtility::GetTimeofDayUs());
-    node_->GetApplyQueue()->Push(HashCode(),
-                                 GetOperatorType(), std::move(task));
+    node_->GetApplyQueue()->Push(HashCode(), GetOperatorType(),
+                                 std::move(task));
     timer.stop();
     g_concurrent_fast_apply_wait_latency << timer.u_elapsed();
 }
 
-#define OPERATOR_CAN_BY_PASS_PROPOSE(TYPE)                                     \
-    bool TYPE##Operator::CanBypassPropose() const {                            \
-        return true;                                                           \
-    }                                                                          \
+#define OPERATOR_CAN_BY_PASS_PROPOSE(TYPE) \
+    bool TYPE##Operator::CanBypassPropose() const { return true; }
 
 // below operator are readonly, so can enable lease read
 OPERATOR_CAN_BY_PASS_PROPOSE(GetDentry);
@@ -144,31 +142,31 @@ OPERATOR_CAN_BY_PASS_PROPOSE(GetVolumeExtent);
 
 #undef OPERATOR_CAN_BY_PASS_PROPOSE
 
-#define OPERATOR_ON_APPLY(TYPE)                                                \
-    void TYPE##Operator::OnApply(int64_t index,                                \
-                                 google::protobuf::Closure *done,              \
-                                 uint64_t startTimeUs) {                       \
-        brpc::ClosureGuard doneGuard(done);                                    \
-        uint64_t timeUs = TimeUtility::GetTimeofDayUs();                       \
-        node_->GetMetric()->WaitInQueueLatency(OperatorType::TYPE,             \
-                                               timeUs - startTimeUs);          \
-        auto status = node_->GetMetaStore()->TYPE(                             \
-            static_cast<const TYPE##Request *>(request_),                      \
-            static_cast<TYPE##Response *>(response_));                         \
-        uint64_t executeTime = TimeUtility::GetTimeofDayUs() - timeUs;         \
-        node_->GetMetric()->ExecuteLatency(OperatorType::TYPE, executeTime);   \
-        if (status == MetaStatusCode::OK) {                                    \
-            node_->UpdateAppliedIndex(index);                                  \
-            static_cast<TYPE##Response *>(response_)->set_appliedindex(        \
-                std::max<uint64_t>(index, node_->GetAppliedIndex()));          \
-            node_->GetMetric()->OnOperatorComplete(                            \
-                OperatorType::TYPE,                                            \
-                TimeUtility::GetTimeofDayUs() - startTimeUs, true);            \
-        } else {                                                               \
-            node_->GetMetric()->OnOperatorComplete(                            \
-                OperatorType::TYPE,                                            \
-                TimeUtility::GetTimeofDayUs() - startTimeUs, false);           \
-        }                                                                      \
+#define OPERATOR_ON_APPLY(TYPE)                                              \
+    void TYPE##Operator::OnApply(int64_t index,                              \
+                                 google::protobuf::Closure* done,            \
+                                 uint64_t startTimeUs) {                     \
+        brpc::ClosureGuard doneGuard(done);                                  \
+        uint64_t timeUs = TimeUtility::GetTimeofDayUs();                     \
+        node_->GetMetric()->WaitInQueueLatency(OperatorType::TYPE,           \
+                                               timeUs - startTimeUs);        \
+        auto status = node_->GetMetaStore()->TYPE(                           \
+            static_cast<const TYPE##Request*>(request_),                     \
+            static_cast<TYPE##Response*>(response_), index);                 \
+        uint64_t executeTime = TimeUtility::GetTimeofDayUs() - timeUs;       \
+        node_->GetMetric()->ExecuteLatency(OperatorType::TYPE, executeTime); \
+        if (status == MetaStatusCode::OK) {                                  \
+            node_->UpdateAppliedIndex(index);                                \
+            static_cast<TYPE##Response*>(response_)->set_appliedindex(       \
+                std::max<uint64_t>(index, node_->GetAppliedIndex()));        \
+            node_->GetMetric()->OnOperatorComplete(                          \
+                OperatorType::TYPE,                                          \
+                TimeUtility::GetTimeofDayUs() - startTimeUs, true);          \
+        } else {                                                             \
+            node_->GetMetric()->OnOperatorComplete(                          \
+                OperatorType::TYPE,                                          \
+                TimeUtility::GetTimeofDayUs() - startTimeUs, false);         \
+        }                                                                    \
     }
 
 OPERATOR_ON_APPLY(GetDentry);
@@ -208,7 +206,8 @@ void GetOrModifyS3ChunkInfoOperator::OnApply(int64_t index,
     {
         brpc::ClosureGuard doneGuard(done);
 
-        rc = metastore->GetOrModifyS3ChunkInfo(request, response, &iterator);
+        rc = metastore->GetOrModifyS3ChunkInfo(request, response, &iterator,
+                                               index);
         if (rc == MetaStatusCode::OK) {
             node_->UpdateAppliedIndex(index);
             response->set_appliedindex(
@@ -251,7 +250,7 @@ void GetVolumeExtentOperator::OnApply(int64_t index,
     auto *response = static_cast<GetVolumeExtentResponse *>(response_);
     auto *metaStore = node_->GetMetaStore();
 
-    auto st = metaStore->GetVolumeExtent(request, response);
+    auto st = metaStore->GetVolumeExtent(request, response, index);
     node_->GetMetric()->OnOperatorComplete(
         OperatorType::GetVolumeExtent,
         TimeUtility::GetTimeofDayUs() - startTimeUs, st == MetaStatusCode::OK);
@@ -292,11 +291,11 @@ void GetVolumeExtentOperator::OnApply(int64_t index,
 }
 
 #define OPERATOR_ON_APPLY_FROM_LOG(TYPE)                                       \
-    void TYPE##Operator::OnApplyFromLog(uint64_t startTimeUs) {                \
+    void TYPE##Operator::OnApplyFromLog(int64_t index, uint64_t startTimeUs) { \
         std::unique_ptr<TYPE##Operator> selfGuard(this);                       \
         TYPE##Response response;                                               \
         auto status = node_->GetMetaStore()->TYPE(                             \
-            static_cast<const TYPE##Request *>(request_), &response);          \
+            static_cast<const TYPE##Request*>(request_), &response, index);    \
         node_->GetMetric()->OnOperatorCompleteFromLog(                         \
             OperatorType::TYPE, TimeUtility::GetTimeofDayUs() - startTimeUs,   \
             status == MetaStatusCode::OK);                                     \
@@ -317,7 +316,8 @@ OPERATOR_ON_APPLY_FROM_LOG(UpdateDeallocatableBlockGroup);
 
 #undef OPERATOR_ON_APPLY_FROM_LOG
 
-void GetOrModifyS3ChunkInfoOperator::OnApplyFromLog(uint64_t startTimeUs) {
+void GetOrModifyS3ChunkInfoOperator::OnApplyFromLog(int64_t index,
+                                                    uint64_t startTimeUs) {
     std::unique_ptr<GetOrModifyS3ChunkInfoOperator> selfGuard(this);
     GetOrModifyS3ChunkInfoRequest request;
     GetOrModifyS3ChunkInfoResponse response;
@@ -325,7 +325,7 @@ void GetOrModifyS3ChunkInfoOperator::OnApplyFromLog(uint64_t startTimeUs) {
     request = *static_cast<const GetOrModifyS3ChunkInfoRequest *>(request_);
     request.set_returns3chunkinfomap(false);
     auto status = node_->GetMetaStore()->GetOrModifyS3ChunkInfo(
-        &request, &response, &iterator);
+        &request, &response, &iterator, index);
     node_->GetMetric()->OnOperatorCompleteFromLog(
         OperatorType::GetOrModifyS3ChunkInfo,
         TimeUtility::GetTimeofDayUs() - startTimeUs,
@@ -333,8 +333,9 @@ void GetOrModifyS3ChunkInfoOperator::OnApplyFromLog(uint64_t startTimeUs) {
 }
 
 #define READONLY_OPERATOR_ON_APPLY_FROM_LOG(TYPE)                              \
-    void TYPE##Operator::OnApplyFromLog(uint64_t startTimeUs) {                \
+    void TYPE##Operator::OnApplyFromLog(int64_t index, uint64_t startTimeUs) { \
         (void)startTimeUs;                                                     \
+        (void)index;                                                           \
         std::unique_ptr<TYPE##Operator> selfGuard(this);                       \
     }
 

--- a/curvefs/src/metaserver/copyset/meta_operator.h
+++ b/curvefs/src/metaserver/copyset/meta_operator.h
@@ -71,16 +71,14 @@ class MetaOperator {
     /**
      * @brief Return internal closure
      */
-    google::protobuf::Closure* Closure() const {
-        return done_;
-    }
+    google::protobuf::Closure* Closure() const { return done_; }
 
     void RedirectRequest();
 
     virtual void OnApply(int64_t index, google::protobuf::Closure* done,
                          uint64_t startTimeUs) = 0;
 
-    virtual void OnApplyFromLog(uint64_t startTimeUs) = 0;
+    virtual void OnApplyFromLog(int64_t index, uint64_t startTimeUs) = 0;
 
     // Get hash code of current operator which is used to push current operator
     // task to apply queue, and apply queue will guarantee that operators with
@@ -109,9 +107,7 @@ class MetaOperator {
     /**
      * @brief Check whether current copyset node is leader
      */
-    bool IsLeaderTerm() const {
-        return node_->IsLeaderTerm();
-    }
+    bool IsLeaderTerm() const { return node_->IsLeaderTerm(); }
 
     /**
      * @brief Propose current operator to braft::Task
@@ -136,9 +132,7 @@ class MetaOperator {
      *        return true if operator is readonly and request carry with
      *        an valid appliedindex
      */
-    virtual bool CanBypassPropose() const {
-        return false;
-    }
+    virtual bool CanBypassPropose() const { return false; }
 
  protected:
     CopysetNode* node_;
@@ -169,7 +163,7 @@ class GetDentryOperator : public MetaOperator {
     void OnApply(int64_t index, google::protobuf::Closure* done,
                  uint64_t startTimeUs) override;
 
-    void OnApplyFromLog(uint64_t startTimeUs) override;
+    void OnApplyFromLog(int64_t index, uint64_t startTimeUs) override;
 
     uint64_t HashCode() const override;
 
@@ -190,7 +184,7 @@ class ListDentryOperator : public MetaOperator {
     void OnApply(int64_t index, google::protobuf::Closure* done,
                  uint64_t startTimeUs) override;
 
-    void OnApplyFromLog(uint64_t startTimeUs) override;
+    void OnApplyFromLog(int64_t index, uint64_t startTimeUs) override;
 
     uint64_t HashCode() const override;
 
@@ -211,7 +205,7 @@ class CreateDentryOperator : public MetaOperator {
     void OnApply(int64_t index, google::protobuf::Closure* done,
                  uint64_t startTimeUs) override;
 
-    void OnApplyFromLog(uint64_t startTimeUs) override;
+    void OnApplyFromLog(int64_t index, uint64_t startTimeUs) override;
 
     uint64_t HashCode() const override;
 
@@ -230,7 +224,7 @@ class DeleteDentryOperator : public MetaOperator {
     void OnApply(int64_t index, google::protobuf::Closure* done,
                  uint64_t startTimeUs) override;
 
-    void OnApplyFromLog(uint64_t startTimeUs) override;
+    void OnApplyFromLog(int64_t index, uint64_t startTimeUs) override;
 
     uint64_t HashCode() const override;
 
@@ -249,7 +243,7 @@ class GetInodeOperator : public MetaOperator {
     void OnApply(int64_t index, google::protobuf::Closure* done,
                  uint64_t startTimeUs) override;
 
-    void OnApplyFromLog(uint64_t startTimeUs) override;
+    void OnApplyFromLog(int64_t index, uint64_t startTimeUs) override;
 
     uint64_t HashCode() const override;
 
@@ -270,7 +264,7 @@ class BatchGetInodeAttrOperator : public MetaOperator {
     void OnApply(int64_t index, google::protobuf::Closure* done,
                  uint64_t startTimeUs) override;
 
-    void OnApplyFromLog(uint64_t startTimeUs) override;
+    void OnApplyFromLog(int64_t index, uint64_t startTimeUs) override;
 
     uint64_t HashCode() const override;
 
@@ -291,7 +285,7 @@ class BatchGetXAttrOperator : public MetaOperator {
     void OnApply(int64_t index, google::protobuf::Closure* done,
                  uint64_t startTimeUs) override;
 
-    void OnApplyFromLog(uint64_t startTimeUs) override;
+    void OnApplyFromLog(int64_t index, uint64_t startTimeUs) override;
 
     uint64_t HashCode() const override;
 
@@ -312,7 +306,7 @@ class CreateInodeOperator : public MetaOperator {
     void OnApply(int64_t index, google::protobuf::Closure* done,
                  uint64_t startTimeUs) override;
 
-    void OnApplyFromLog(uint64_t startTimeUs) override;
+    void OnApplyFromLog(int64_t index, uint64_t startTimeUs) override;
 
     uint64_t HashCode() const override;
 
@@ -331,7 +325,7 @@ class UpdateInodeOperator : public MetaOperator {
     void OnApply(int64_t index, google::protobuf::Closure* done,
                  uint64_t startTimeUs) override;
 
-    void OnApplyFromLog(uint64_t startTimeUs) override;
+    void OnApplyFromLog(int64_t index, uint64_t startTimeUs) override;
 
     uint64_t HashCode() const override;
 
@@ -345,12 +339,12 @@ class UpdateInodeOperator : public MetaOperator {
 
 class GetOrModifyS3ChunkInfoOperator : public MetaOperator {
  public:
-     using MetaOperator::MetaOperator;
+    using MetaOperator::MetaOperator;
 
     void OnApply(int64_t index, google::protobuf::Closure* done,
                  uint64_t startTimeUs) override;
 
-    void OnApplyFromLog(uint64_t startTimeUs) override;
+    void OnApplyFromLog(int64_t index, uint64_t startTimeUs) override;
 
     uint64_t HashCode() const override;
 
@@ -369,7 +363,7 @@ class DeleteInodeOperator : public MetaOperator {
     void OnApply(int64_t index, google::protobuf::Closure* done,
                  uint64_t startTimeUs) override;
 
-    void OnApplyFromLog(uint64_t startTimeUs) override;
+    void OnApplyFromLog(int64_t index, uint64_t startTimeUs) override;
 
     uint64_t HashCode() const override;
 
@@ -388,7 +382,7 @@ class CreateRootInodeOperator : public MetaOperator {
     void OnApply(int64_t index, google::protobuf::Closure* done,
                  uint64_t startTimeUs) override;
 
-    void OnApplyFromLog(uint64_t startTimeUs) override;
+    void OnApplyFromLog(int64_t index, uint64_t startTimeUs) override;
 
     uint64_t HashCode() const override;
 
@@ -407,7 +401,7 @@ class CreateManageInodeOperator : public MetaOperator {
     void OnApply(int64_t index, google::protobuf::Closure* done,
                  uint64_t startTimeUs) override;
 
-    void OnApplyFromLog(uint64_t startTimeUs) override;
+    void OnApplyFromLog(int64_t index, uint64_t startTimeUs) override;
 
     uint64_t HashCode() const override;
 
@@ -426,7 +420,7 @@ class UpdateInodeS3VersionOperator : public MetaOperator {
     void OnApply(int64_t index, google::protobuf::Closure* done,
                  uint64_t startTimeUs) override;
 
-    void OnApplyFromLog(uint64_t startTimeUs) override;
+    void OnApplyFromLog(int64_t index, uint64_t startTimeUs) override;
 
     uint64_t HashCode() const override;
 
@@ -445,7 +439,7 @@ class CreatePartitionOperator : public MetaOperator {
     void OnApply(int64_t index, google::protobuf::Closure* done,
                  uint64_t startTimeUs) override;
 
-    void OnApplyFromLog(uint64_t startTimeUs) override;
+    void OnApplyFromLog(int64_t index, uint64_t startTimeUs) override;
 
     uint64_t HashCode() const override;
 
@@ -464,7 +458,7 @@ class DeletePartitionOperator : public MetaOperator {
     void OnApply(int64_t index, google::protobuf::Closure* done,
                  uint64_t startTimeUs) override;
 
-    void OnApplyFromLog(uint64_t startTimeUs) override;
+    void OnApplyFromLog(int64_t index, uint64_t startTimeUs) override;
 
     uint64_t HashCode() const override;
 
@@ -483,7 +477,7 @@ class PrepareRenameTxOperator : public MetaOperator {
     void OnApply(int64_t index, google::protobuf::Closure* done,
                  uint64_t startTimeUs) override;
 
-    void OnApplyFromLog(uint64_t startTimeUs) override;
+    void OnApplyFromLog(int64_t index, uint64_t startTimeUs) override;
 
     uint64_t HashCode() const override;
 
@@ -499,11 +493,10 @@ class GetVolumeExtentOperator : public MetaOperator {
  public:
     using MetaOperator::MetaOperator;
 
-    void OnApply(int64_t index,
-                 google::protobuf::Closure* done,
+    void OnApply(int64_t index, google::protobuf::Closure* done,
                  uint64_t startTimeUs) override;
 
-    void OnApplyFromLog(uint64_t startTimeUs) override;
+    void OnApplyFromLog(int64_t index, uint64_t startTimeUs) override;
 
     uint64_t HashCode() const override;
 
@@ -521,11 +514,10 @@ class UpdateVolumeExtentOperator : public MetaOperator {
  public:
     using MetaOperator::MetaOperator;
 
-    void OnApply(int64_t index,
-                 google::protobuf::Closure* done,
+    void OnApply(int64_t index, google::protobuf::Closure* done,
                  uint64_t startTimeUs) override;
 
-    void OnApplyFromLog(uint64_t startTimeUs) override;
+    void OnApplyFromLog(int64_t index, uint64_t startTimeUs) override;
 
     uint64_t HashCode() const override;
 
@@ -541,10 +533,10 @@ class UpdateDeallocatableBlockGroupOperator : public MetaOperator {
  public:
     using MetaOperator::MetaOperator;
 
-    void OnApply(int64_t index, google::protobuf::Closure *done,
+    void OnApply(int64_t index, google::protobuf::Closure* done,
                  uint64_t startTimeUs) override;
 
-    void OnApplyFromLog(uint64_t startTimeUs) override;
+    void OnApplyFromLog(int64_t index, uint64_t startTimeUs) override;
 
     uint64_t HashCode() const override;
 

--- a/curvefs/src/metaserver/dentry_manager.h
+++ b/curvefs/src/metaserver/dentry_manager.h
@@ -40,23 +40,26 @@ class DentryManager {
     DentryManager(std::shared_ptr<DentryStorage> dentryStorage,
                   std::shared_ptr<TxManager> txManger);
 
-    MetaStatusCode CreateDentry(const Dentry& dentry);
+    bool Init();
+
+    MetaStatusCode CreateDentry(const Dentry& dentry, int64_t logIndex);
 
     // only invoked from snapshot loadding
-    MetaStatusCode CreateDentry(const DentryVec& vec, bool merge);
+    MetaStatusCode CreateDentry(const DentryVec& vec, bool merge,
+                                int64_t logIndex);
 
-    MetaStatusCode DeleteDentry(const Dentry& dentry);
+    MetaStatusCode DeleteDentry(const Dentry& dentry, int64_t logIndex);
 
     MetaStatusCode GetDentry(Dentry* dentry);
 
     MetaStatusCode ListDentry(const Dentry& dentry,
-                              std::vector<Dentry>* dentrys,
-                              uint32_t limit,
+                              std::vector<Dentry>* dentrys, uint32_t limit,
                               bool onlyDir = false);
 
     void ClearDentry();
 
-    MetaStatusCode HandleRenameTx(const std::vector<Dentry>& dentrys);
+    MetaStatusCode HandleRenameTx(const std::vector<Dentry>& dentrys,
+                                  int64_t logIndex);
 
  private:
     void Log4Dentry(const std::string& request, const Dentry& dentry);
@@ -65,6 +68,7 @@ class DentryManager {
  private:
     std::shared_ptr<DentryStorage> dentryStorage_;
     std::shared_ptr<TxManager> txManager_;
+    int64_t appliedIndex_;
 };
 
 }  // namespace metaserver

--- a/curvefs/src/metaserver/inode_manager.h
+++ b/curvefs/src/metaserver/inode_manager.h
@@ -26,15 +26,16 @@
 #include <time.h>
 
 #include <atomic>
+#include <list>
 #include <memory>
 #include <string>
 #include <vector>
-#include <list>
+
 #include "curvefs/proto/metaserver.pb.h"
 #include "curvefs/src/metaserver/inode_storage.h"
+#include "curvefs/src/metaserver/storage/storage.h"
 #include "curvefs/src/metaserver/trash.h"
 #include "src/common/concurrent/name_lock.h"
-
 
 using ::curve::common::NameLock;
 using ::curvefs::metaserver::S3ChunkInfoList;
@@ -66,19 +67,22 @@ class InodeManager {
                  FileType2InodeNumMap* type2InodeNum)
         : inodeStorage_(inodeStorage),
           trash_(trash),
-          type2InodeNum_(type2InodeNum) {}
+          type2InodeNum_(type2InodeNum),
+          appliedIndex_(-1) {
+        // for compatibility, we initialize applied index to -1
+    }
 
-    MetaStatusCode CreateInode(uint64_t inodeId, const InodeParam &param,
-                               Inode *inode);
-    MetaStatusCode CreateRootInode(const InodeParam &param);
+    bool Init();
 
-    MetaStatusCode CreateManageInode(const InodeParam &param,
-                                     ManageInodeType manageType,
-                                     Inode *inode);
+    MetaStatusCode CreateInode(uint64_t inodeId, const InodeParam& param,
+                               Inode* inode, int64_t logIndex);
+    MetaStatusCode CreateRootInode(const InodeParam& param, int64_t logIndex);
 
-    MetaStatusCode GetInode(uint32_t fsId,
-                            uint64_t inodeId,
-                            Inode *inode,
+    MetaStatusCode CreateManageInode(const InodeParam& param,
+                                     ManageInodeType manageType, Inode* inode,
+                                     int64_t logIndex);
+
+    MetaStatusCode GetInode(uint32_t fsId, uint64_t inodeId, Inode* inode,
                             bool paddingS3ChunkInfo = false);
 
     MetaStatusCode GetInodeAttr(uint32_t fsId, uint64_t inodeId,
@@ -86,69 +90,73 @@ class InodeManager {
 
     MetaStatusCode GetXAttr(uint32_t fsId, uint64_t inodeId, XAttr *xattr);
 
-    MetaStatusCode DeleteInode(uint32_t fsId, uint64_t inodeId);
+    MetaStatusCode DeleteInode(uint32_t fsId, uint64_t inodeId,
+                               int64_t logIndex);
 
-    MetaStatusCode UpdateInode(const UpdateInodeRequest& request);
+    MetaStatusCode UpdateInode(const UpdateInodeRequest& request,
+                               int64_t logIndex);
 
     MetaStatusCode GetOrModifyS3ChunkInfo(
-        uint32_t fsId,
-        uint64_t inodeId,
-        const S3ChunkInfoMap& map2add,
-        const S3ChunkInfoMap& map2del,
-        bool returnS3ChunkInfoMap,
-        std::shared_ptr<Iterator>* iterator4InodeS3Meta);
+        uint32_t fsId, uint64_t inodeId, const S3ChunkInfoMap& map2add,
+        const S3ChunkInfoMap& map2del, bool returnS3ChunkInfoMap,
+        std::shared_ptr<Iterator>* iterator4InodeS3Meta, int64_t logIndex);
 
-    MetaStatusCode PaddingInodeS3ChunkInfo(int32_t fsId,
-                                           uint64_t inodeId,
+    MetaStatusCode PaddingInodeS3ChunkInfo(int32_t fsId, uint64_t inodeId,
                                            S3ChunkInfoMap* m,
                                            uint64_t limit = 0);
 
-    MetaStatusCode UpdateInodeWhenCreateOrRemoveSubNode(
-        const Dentry &dentry,
-        uint64_t now,
-        uint32_t now_ns,
-        bool isCreate);
+    MetaStatusCode UpdateInodeWhenCreateOrRemoveSubNode(const Dentry& dentry,
+                                                        uint64_t now,
+                                                        uint32_t now_ns,
+                                                        bool isCreate,
+                                                        int64_t logIndex);
 
-    MetaStatusCode InsertInode(const Inode &inode);
+    MetaStatusCode InsertInode(const Inode& inode, int64_t logIndex);
 
     bool GetInodeIdList(std::list<uint64_t>* inodeIdList);
 
     // Update one or more volume extent slice
-    MetaStatusCode UpdateVolumeExtent(uint32_t fsId,
-                                      uint64_t inodeId,
-                                      const VolumeExtentSliceList &extents);
+    MetaStatusCode UpdateVolumeExtent(uint32_t fsId, uint64_t inodeId,
+                                      const VolumeExtentSliceList& extents,
+                                      int64_t logIndex);
 
     // Update only one volume extent slice
-    MetaStatusCode UpdateVolumeExtentSlice(uint32_t fsId,
-                                           uint64_t inodeId,
-                                           const VolumeExtentSlice &slice);
+    MetaStatusCode UpdateVolumeExtentSlice(uint32_t fsId, uint64_t inodeId,
+                                           const VolumeExtentSlice& slice,
+                                           int64_t logIndex);
 
-    MetaStatusCode GetVolumeExtent(uint32_t fsId,
-                                   uint64_t inodeId,
-                                   const std::vector<uint64_t> &slices,
-                                   VolumeExtentSliceList *extents);
+    MetaStatusCode GetVolumeExtent(uint32_t fsId, uint64_t inodeId,
+                                   const std::vector<uint64_t>& slices,
+                                   VolumeExtentSliceList* extents);
+
+    MetaStatusCode UpdateDeallocatableBlockGroup(
+        const UpdateDeallocatableBlockGroupRequest& request, int64_t logIndex);
 
  private:
     void GenerateInodeInternal(uint64_t inodeId, const InodeParam &param,
                                Inode *inode);
 
-    bool AppendS3ChunkInfo(uint32_t fsId,
-                           uint64_t inodeId,
+    bool AppendS3ChunkInfo(uint32_t fsId, uint64_t inodeId,
                            S3ChunkInfoMap added);
 
     static std::string GetInodeLockName(uint32_t fsId, uint64_t inodeId) {
         return std::to_string(fsId) + "_" + std::to_string(inodeId);
     }
 
+    MetaStatusCode UpdateVolumeExtentSliceLocked(uint32_t fsId,
+                                                 uint64_t inodeId,
+                                                 const VolumeExtentSlice& slice,
+                                                 int64_t logIndex);
+
     MetaStatusCode UpdateVolumeExtentSliceLocked(
-        uint32_t fsId,
-        uint64_t inodeId,
-        const VolumeExtentSlice &slice);
+        std::shared_ptr<storage::StorageTransaction>* txn, uint32_t fsId,
+        uint64_t inodeId, const VolumeExtentSlice& slice, int64_t logIndex);
 
  private:
     std::shared_ptr<InodeStorage> inodeStorage_;
     std::shared_ptr<Trash> trash_;
     FileType2InodeNumMap* type2InodeNum_;
+    int64_t appliedIndex_;
 
     NameLock inodeLock_;
 };

--- a/curvefs/src/metaserver/metastore_fstream.h
+++ b/curvefs/src/metaserver/metastore_fstream.h
@@ -61,26 +61,9 @@ class MetaStoreFStream {
                        const std::string& key,
                        const std::string& value);
 
-    bool LoadInode(uint32_t partitionId,
-                   const std::string& key,
-                   const std::string& value);
-
-    bool LoadDentry(uint8_t version,
-                    uint32_t partitionId,
-                    const std::string& key,
-                    const std::string& value);
-
     bool LoadPendingTx(uint32_t partitionId,
                        const std::string& key,
                        const std::string& value);
-
-    bool LoadInodeS3ChunkInfoList(uint32_t partitionId,
-                                  const std::string& key,
-                                  const std::string& value);
-
-    bool LoadVolumeExtentList(uint32_t partitionId,
-                              const std::string& key,
-                              const std::string& value);
 
     std::shared_ptr<Iterator> NewPartitionIterator();
 

--- a/curvefs/src/metaserver/partition.cpp
+++ b/curvefs/src/metaserver/partition.cpp
@@ -25,18 +25,20 @@
 #include <assert.h>
 
 #include <algorithm>
+#include <cstdint>
 #include <memory>
+#include <string>
 #include <utility>
 
 #include "curvefs/proto/metaserver.pb.h"
-#include "curvefs/src/metaserver/s3compact_manager.h"
-#include "curvefs/src/metaserver/trash_manager.h"
-#include "curvefs/src/metaserver/storage/converter.h"
-#include "curvefs/src/metaserver/s3compact.h"
-#include "curvefs/src/metaserver/space/inode_volume_space_deallocate.h"
-#include "curvefs/src/metaserver/space/volume_deallocate_manager.h"
 #include "curvefs/src/metaserver/copyset/copyset_node_manager.h"
 #include "curvefs/src/metaserver/mds/fsinfo_manager.h"
+#include "curvefs/src/metaserver/s3compact.h"
+#include "curvefs/src/metaserver/s3compact_manager.h"
+#include "curvefs/src/metaserver/space/inode_volume_space_deallocate.h"
+#include "curvefs/src/metaserver/space/volume_deallocate_manager.h"
+#include "curvefs/src/metaserver/storage/converter.h"
+#include "curvefs/src/metaserver/trash_manager.h"
 
 namespace curvefs {
 namespace metaserver {
@@ -44,8 +46,8 @@ namespace metaserver {
 using ::curvefs::metaserver::storage::NameGenerator;
 
 Partition::Partition(PartitionInfo partition,
-                     std::shared_ptr<KVStorage> kvStorage,
-                     bool startCompact, bool startVolumeDeallocate) {
+                     std::shared_ptr<KVStorage> kvStorage, bool startCompact,
+                     bool startVolumeDeallocate) {
     assert(partition.start() <= partition.end());
     partitionInfo_ = std::move(partition);
     uint32_t partitionId = partitionInfo_.partitionid();
@@ -69,7 +71,7 @@ Partition::Partition(PartitionInfo partition,
     auto trash = std::make_shared<TrashImpl>(inodeStorage_);
     inodeManager_ = std::make_shared<InodeManager>(
         inodeStorage_, trash, partitionInfo_.mutable_filetype2inodenum());
-    txManager_ = std::make_shared<TxManager>(dentryStorage_);
+    txManager_ = std::make_shared<TxManager>(dentryStorage_, partitionInfo_);
     dentryManager_ =
         std::make_shared<DentryManager>(dentryStorage_, txManager_);
     if (!partitionInfo_.has_nextid()) {
@@ -88,73 +90,95 @@ Partition::Partition(PartitionInfo partition,
     }
 }
 
-#define PRECHECK(fsId, inodeId)                                                \
-    do {                                                                       \
-        if (!IsInodeBelongs((fsId), (inodeId))) {                              \
-            return MetaStatusCode::PARTITION_ID_MISSMATCH;                     \
-        }                                                                      \
-        if (GetStatus() == PartitionStatus::DELETING) {                        \
-            return MetaStatusCode::PARTITION_DELETING;                         \
-        }                                                                      \
+#define PRECHECK(fsId, inodeId)                            \
+    do {                                                   \
+        if (!IsInodeBelongs((fsId), (inodeId))) {          \
+            return MetaStatusCode::PARTITION_ID_MISSMATCH; \
+        }                                                  \
+        if (GetStatus() == PartitionStatus::DELETING) {    \
+            return MetaStatusCode::PARTITION_DELETING;     \
+        }                                                  \
     } while (0)
 
-#define PRECHECK_FSID(fsId)                                                    \
-    do {                                                                       \
-        if (!IsInodeBelongs((fsId))) {                                         \
-            return MetaStatusCode::PARTITION_ID_MISSMATCH;                     \
-        }                                                                      \
-        if (GetStatus() == PartitionStatus::DELETING) {                        \
-            return MetaStatusCode::PARTITION_DELETING;                         \
-        }                                                                      \
+#define PRECHECK_FSID(fsId)                                \
+    do {                                                   \
+        if (!IsInodeBelongs((fsId))) {                     \
+            return MetaStatusCode::PARTITION_ID_MISSMATCH; \
+        }                                                  \
+        if (GetStatus() == PartitionStatus::DELETING) {    \
+            return MetaStatusCode::PARTITION_DELETING;     \
+        }                                                  \
     } while (0)
 
-MetaStatusCode Partition::CreateDentry(const Dentry& dentry,
-                                       const Time& tm) {
+MetaStatusCode Partition::CreateDentry(const Dentry& dentry, const Time& tm,
+                                       int64_t logIndex) {
     PRECHECK(dentry.fsid(), dentry.parentinodeid());
-
-    MetaStatusCode ret = dentryManager_->CreateDentry(dentry);
+    MetaStatusCode ret = dentryManager_->CreateDentry(dentry, logIndex);
     if (MetaStatusCode::OK == ret) {
         if (dentry.has_type()) {
             return inodeManager_->UpdateInodeWhenCreateOrRemoveSubNode(
-                dentry, tm.sec(), tm.nsec(), true);
+                dentry, tm.sec(), tm.nsec(), true, logIndex);
         } else {
             LOG(ERROR) << "CreateDentry does not have type, "
                        << dentry.ShortDebugString();
             return MetaStatusCode::PARAM_ERROR;
         }
     } else if (MetaStatusCode::IDEMPOTENCE_OK == ret) {
+        if (dentry.has_type()) {
+            // NOTE: we enter here means that
+            // this log maybe is "half apply"
+            ret = inodeManager_->UpdateInodeWhenCreateOrRemoveSubNode(
+                dentry, tm.sec(), tm.nsec(), true, logIndex);
+            if (ret == MetaStatusCode::IDEMPOTENCE_OK) {
+                ret = MetaStatusCode::OK;
+            }
+            if (ret != MetaStatusCode::OK) {
+                return ret;
+            }
+        }
         return MetaStatusCode::OK;
     } else {
         return ret;
     }
 }
 
-MetaStatusCode Partition::LoadDentry(const DentryVec& vec, bool merge) {
+MetaStatusCode Partition::LoadDentry(const DentryVec& vec, bool merge,
+                                     int64_t logIndex) {
     auto dentry = vec.dentrys(0);
 
     PRECHECK(dentry.fsid(), dentry.parentinodeid());
 
-    MetaStatusCode rc = dentryManager_->CreateDentry(vec, merge);
-    if (rc == MetaStatusCode::OK ||
-        rc == MetaStatusCode::IDEMPOTENCE_OK) {
+    MetaStatusCode rc = dentryManager_->CreateDentry(vec, merge, logIndex);
+    if (rc == MetaStatusCode::OK || rc == MetaStatusCode::IDEMPOTENCE_OK) {
         return MetaStatusCode::OK;
     }
     return rc;
 }
 
-MetaStatusCode Partition::DeleteDentry(const Dentry& dentry) {
+MetaStatusCode Partition::DeleteDentry(const Dentry& dentry, int64_t logIndex) {
     PRECHECK(dentry.fsid(), dentry.parentinodeid());
 
-    MetaStatusCode ret = dentryManager_->DeleteDentry(dentry);
+    MetaStatusCode ret = dentryManager_->DeleteDentry(dentry, logIndex);
     if (MetaStatusCode::OK == ret) {
         if (dentry.has_type()) {
             return inodeManager_->UpdateInodeWhenCreateOrRemoveSubNode(
-                dentry, 0, 0, false);
+                dentry, 0, 0, false, logIndex);
         } else {
             LOG(ERROR) << "DeleteDentry does not have type, "
                        << dentry.ShortDebugString();
             return MetaStatusCode::PARAM_ERROR;
         }
+    } else if (MetaStatusCode::IDEMPOTENCE_OK == ret) {
+        if (dentry.has_type()) {
+            // NOTE: we enter here means that
+            // this log maybe is "half apply"
+            ret = inodeManager_->UpdateInodeWhenCreateOrRemoveSubNode(
+                dentry, 0, 0, false, logIndex);
+        }
+        if (ret == MetaStatusCode::IDEMPOTENCE_OK) {
+            ret = MetaStatusCode::OK;
+        }
+        return ret;
     } else {
         return ret;
     }
@@ -167,22 +191,20 @@ MetaStatusCode Partition::GetDentry(Dentry* dentry) {
 
 MetaStatusCode Partition::ListDentry(const Dentry& dentry,
                                      std::vector<Dentry>* dentrys,
-                                     uint32_t limit,
-                                     bool onlyDir) {
+                                     uint32_t limit, bool onlyDir) {
     PRECHECK(dentry.fsid(), dentry.parentinodeid());
     return dentryManager_->ListDentry(dentry, dentrys, limit, onlyDir);
 }
 
-void Partition::ClearDentry() {
-    dentryManager_->ClearDentry();
-}
+void Partition::ClearDentry() { dentryManager_->ClearDentry(); }
 
-MetaStatusCode Partition::HandleRenameTx(const std::vector<Dentry>& dentrys) {
-    for (const auto &it : dentrys) {
+MetaStatusCode Partition::HandleRenameTx(const std::vector<Dentry>& dentrys,
+                                         int64_t logIndex) {
+    for (const auto& it : dentrys) {
         PRECHECK(it.fsid(), it.parentinodeid());
     }
 
-    return dentryManager_->HandleRenameTx(dentrys);
+    return dentryManager_->HandleRenameTx(dentrys, logIndex);
 }
 
 bool Partition::InsertPendingTx(const PrepareRenameTxRequest& pendingTx) {
@@ -198,6 +220,19 @@ bool Partition::InsertPendingTx(const PrepareRenameTxRequest& pendingTx) {
     return txManager_->InsertPendingTx(renameTx);
 }
 
+bool Partition::Init() {
+    // NOTE: invoke `dentryStorage::Init()`
+    // and `inodeStorage::Init()` is unnecessary
+    // they will be invoked by `manager`
+    return dentryManager_->Init() && inodeManager_->Init() &&
+           txManager_->Init();
+}
+
+void Partition::SerializeRenameTx(const RenameTx& in,
+                                  PrepareRenameTxRequest* out) {
+    txManager_->SerializeRenameTx(in, out);
+}
+
 bool Partition::FindPendingTx(PrepareRenameTxRequest* pendingTx) {
     if (GetStatus() == PartitionStatus::DELETING) {
         return false;
@@ -209,17 +244,13 @@ bool Partition::FindPendingTx(PrepareRenameTxRequest* pendingTx) {
         return false;
     }
 
-    auto dentrys = renameTx.GetDentrys();
-    pendingTx->set_poolid(partitionInfo_.poolid());
-    pendingTx->set_copysetid(partitionInfo_.copysetid());
-    pendingTx->set_partitionid(partitionInfo_.partitionid());
-    *pendingTx->mutable_dentrys() = {dentrys->begin(), dentrys->end()};
+    SerializeRenameTx(renameTx, pendingTx);
     return true;
 }
 
 // inode
-MetaStatusCode Partition::CreateInode(const InodeParam &param,
-                                      Inode* inode) {
+MetaStatusCode Partition::CreateInode(const InodeParam& param, Inode* inode,
+                                      int64_t logIndex) {
     if (GetStatus() == PartitionStatus::READONLY) {
         return MetaStatusCode::PARTITION_ALLOC_ID_FAIL;
     }
@@ -237,19 +268,33 @@ MetaStatusCode Partition::CreateInode(const InodeParam &param,
         return MetaStatusCode::PARTITION_ID_MISSMATCH;
     }
 
-    return inodeManager_->CreateInode(inodeId, param, inode);
+    auto ret = inodeManager_->CreateInode(inodeId, param, inode, logIndex);
+    if (ret == MetaStatusCode::IDEMPOTENCE_OK) {
+        ret = MetaStatusCode::OK;
+    }
+    return ret;
 }
 
-MetaStatusCode Partition::CreateRootInode(const InodeParam &param) {
+MetaStatusCode Partition::CreateRootInode(const InodeParam& param,
+                                          int64_t logIndex) {
     PRECHECK_FSID(param.fsId);
-    return inodeManager_->CreateRootInode(param);
+    auto ret = inodeManager_->CreateRootInode(param, logIndex);
+    if (ret == MetaStatusCode::IDEMPOTENCE_OK) {
+        ret = MetaStatusCode::OK;
+    }
+    return ret;
 }
 
-MetaStatusCode Partition::CreateManageInode(const InodeParam &param,
+MetaStatusCode Partition::CreateManageInode(const InodeParam& param,
                                             ManageInodeType manageType,
-                                            Inode* inode) {
+                                            Inode* inode, int64_t logIndex) {
     PRECHECK_FSID(param.fsId);
-    return inodeManager_->CreateManageInode(param, manageType, inode);
+    auto ret =
+        inodeManager_->CreateManageInode(param, manageType, inode, logIndex);
+    if (ret == MetaStatusCode::IDEMPOTENCE_OK) {
+        ret = MetaStatusCode::OK;
+    }
+    return ret;
 }
 
 MetaStatusCode Partition::GetInode(uint32_t fsId, uint64_t inodeId,
@@ -270,26 +315,38 @@ MetaStatusCode Partition::GetXAttr(uint32_t fsId, uint64_t inodeId,
     return inodeManager_->GetXAttr(fsId, inodeId, xattr);
 }
 
-MetaStatusCode Partition::DeleteInode(uint32_t fsId, uint64_t inodeId) {
+MetaStatusCode Partition::DeleteInode(uint32_t fsId, uint64_t inodeId,
+                                      int64_t logIndex) {
     PRECHECK(fsId, inodeId);
-    return inodeManager_->DeleteInode(fsId, inodeId);
+    auto ret = inodeManager_->DeleteInode(fsId, inodeId, logIndex);
+    if (ret == MetaStatusCode::IDEMPOTENCE_OK) {
+        ret = MetaStatusCode::OK;
+    }
+    return ret;
 }
 
-MetaStatusCode Partition::UpdateInode(const UpdateInodeRequest& request) {
+MetaStatusCode Partition::UpdateInode(const UpdateInodeRequest& request,
+                                      int64_t logIndex) {
     PRECHECK(request.fsid(), request.inodeid());
-    return inodeManager_->UpdateInode(request);
+    auto ret = inodeManager_->UpdateInode(request, logIndex);
+    if (ret == MetaStatusCode::IDEMPOTENCE_OK) {
+        ret = MetaStatusCode::OK;
+    }
+    return ret;
 }
 
 MetaStatusCode Partition::GetOrModifyS3ChunkInfo(
-    uint32_t fsId,
-    uint64_t inodeId,
-    const S3ChunkInfoMap& map2add,
-    const S3ChunkInfoMap& map2del,
-    bool returnS3ChunkInfoMap,
-    std::shared_ptr<Iterator>* iterator) {
+    uint32_t fsId, uint64_t inodeId, const S3ChunkInfoMap& map2add,
+    const S3ChunkInfoMap& map2del, bool returnS3ChunkInfoMap,
+    std::shared_ptr<Iterator>* iterator, int64_t logIndex) {
     PRECHECK(fsId, inodeId);
-    return inodeManager_->GetOrModifyS3ChunkInfo(
-        fsId, inodeId, map2add, map2del, returnS3ChunkInfoMap, iterator);
+    auto ret = inodeManager_->GetOrModifyS3ChunkInfo(
+        fsId, inodeId, map2add, map2del, returnS3ChunkInfoMap, iterator,
+        logIndex);
+    if (ret == MetaStatusCode::IDEMPOTENCE_OK) {
+        ret = MetaStatusCode::OK;
+    }
+    return ret;
 }
 
 MetaStatusCode Partition::PaddingInodeS3ChunkInfo(int32_t fsId,
@@ -300,9 +357,13 @@ MetaStatusCode Partition::PaddingInodeS3ChunkInfo(int32_t fsId,
     return inodeManager_->PaddingInodeS3ChunkInfo(fsId, inodeId, m, limit);
 }
 
-MetaStatusCode Partition::InsertInode(const Inode& inode) {
+MetaStatusCode Partition::InsertInode(const Inode& inode, int64_t logIndex) {
     PRECHECK(inode.fsid(), inode.inodeid());
-    return inodeManager_->InsertInode(inode);
+    auto ret = inodeManager_->InsertInode(inode, logIndex);
+    if (ret == MetaStatusCode::IDEMPOTENCE_OK) {
+        ret = MetaStatusCode::OK;
+    }
+    return ret;
 }
 
 bool Partition::GetInodeIdList(std::list<uint64_t>* InodeIdList) {
@@ -393,6 +454,10 @@ bool Partition::Clear() {
     return true;
 }
 
+// NOTE: store nextid to kvstroage is unnecessary
+// we will replay the logs filter the log entries that
+// already applied, but keep nextid changes in memory
+// so it will grow to corrected value after replay
 uint64_t Partition::GetNewInodeId() {
     if (partitionInfo_.nextid() > partitionInfo_.end()) {
         partitionInfo_.set_status(PartitionStatus::READONLY);
@@ -411,9 +476,7 @@ uint32_t Partition::GetDentryNum() {
     return static_cast<uint32_t>(dentryStorage_->Size());
 }
 
-bool Partition::EmptyInodeStorage() {
-    return inodeStorage_->Empty();
-}
+bool Partition::EmptyInodeStorage() { return inodeStorage_->Empty(); }
 
 std::string Partition::GetInodeTablename() {
     std::ostringstream oss;
@@ -427,23 +490,31 @@ std::string Partition::GetDentryTablename() {
     return oss.str();
 }
 
-MetaStatusCode
-Partition::UpdateVolumeExtent(uint32_t fsId, uint64_t inodeId,
-                              const VolumeExtentSliceList &extents) {
+MetaStatusCode Partition::UpdateVolumeExtent(
+    uint32_t fsId, uint64_t inodeId, const VolumeExtentSliceList& extents,
+    int64_t logIndex) {
     PRECHECK(fsId, inodeId);
-    return inodeManager_->UpdateVolumeExtent(fsId, inodeId, extents);
+    auto ret =
+        inodeManager_->UpdateVolumeExtent(fsId, inodeId, extents, logIndex);
+    if (ret == MetaStatusCode::IDEMPOTENCE_OK) {
+        ret = MetaStatusCode::OK;
+    }
+    return ret;
 }
 
 MetaStatusCode Partition::UpdateVolumeExtentSlice(
-    uint32_t fsId,
-    uint64_t inodeId,
-    const VolumeExtentSlice& slice) {
+    uint32_t fsId, uint64_t inodeId, const VolumeExtentSlice& slice,
+    int64_t logIndex) {
     PRECHECK(fsId, inodeId);
-    return inodeManager_->UpdateVolumeExtentSlice(fsId, inodeId, slice);
+    auto ret =
+        inodeManager_->UpdateVolumeExtentSlice(fsId, inodeId, slice, logIndex);
+    if (ret == MetaStatusCode::IDEMPOTENCE_OK) {
+        ret = MetaStatusCode::OK;
+    }
+    return ret;
 }
 
-MetaStatusCode Partition::GetVolumeExtent(uint32_t fsId,
-                                          uint64_t inodeId,
+MetaStatusCode Partition::GetVolumeExtent(uint32_t fsId, uint64_t inodeId,
                                           const std::vector<uint64_t>& slices,
                                           VolumeExtentSliceList* extents) {
     PRECHECK(fsId, inodeId);
@@ -451,14 +522,17 @@ MetaStatusCode Partition::GetVolumeExtent(uint32_t fsId,
 }
 
 MetaStatusCode Partition::UpdateDeallocatableBlockGroup(
-    const UpdateDeallocatableBlockGroupRequest &request) {
+    const UpdateDeallocatableBlockGroupRequest& request, int64_t logIndex) {
     PRECHECK_FSID(request.fsid());
-    return inodeStorage_->UpdateDeallocatableBlockGroup(request.fsid(),
-                                                        request.update());
+    auto ret = inodeManager_->UpdateDeallocatableBlockGroup(request, logIndex);
+    if (ret == MetaStatusCode::IDEMPOTENCE_OK) {
+        ret = MetaStatusCode::OK;
+    }
+    return ret;
 }
 
 MetaStatusCode Partition::GetAllBlockGroup(
-    std::vector<DeallocatableBlockGroup> *deallocatableBlockGroupVec) {
+    std::vector<DeallocatableBlockGroup>* deallocatableBlockGroupVec) {
     return inodeStorage_->GetAllBlockGroup(deallocatableBlockGroupVec);
 }
 

--- a/curvefs/src/metaserver/partition.h
+++ b/curvefs/src/metaserver/partition.h
@@ -22,11 +22,13 @@
 
 #ifndef CURVEFS_SRC_METASERVER_PARTITION_H_
 #define CURVEFS_SRC_METASERVER_PARTITION_H_
+#include <cstdint>
 #include <list>
 #include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
+
 #include "curvefs/proto/common.pb.h"
 #include "curvefs/proto/metaserver.pb.h"
 #include "curvefs/src/common/define.h"
@@ -34,15 +36,16 @@
 #include "curvefs/src/metaserver/dentry_storage.h"
 #include "curvefs/src/metaserver/inode_manager.h"
 #include "curvefs/src/metaserver/inode_storage.h"
-#include "curvefs/src/metaserver/trash_manager.h"
 #include "curvefs/src/metaserver/storage/iterator.h"
+#include "curvefs/src/metaserver/trash_manager.h"
 
 namespace curvefs {
 namespace metaserver {
+using curvefs::common::AppliedIndex;
 using curvefs::common::PartitionInfo;
 using curvefs::common::PartitionStatus;
-using ::curvefs::metaserver::storage::KVStorage;
 using ::curvefs::metaserver::storage::Iterator;
+using ::curvefs::metaserver::storage::KVStorage;
 using S3ChunkInfoMap = google::protobuf::Map<uint64_t, S3ChunkInfoList>;
 
 // skip ROOTINODEID and RECYCLEINODEID
@@ -50,43 +53,47 @@ constexpr uint64_t kMinPartitionStartId = ROOTINODEID + 2;
 
 class Partition {
  public:
-    Partition(PartitionInfo partition,
-              std::shared_ptr<KVStorage> kvStorage,
+    Partition(PartitionInfo partition, std::shared_ptr<KVStorage> kvStorage,
               bool startCompact = true, bool startVolumeDeallocate = true);
     Partition() = default;
 
     // dentry
-    MetaStatusCode CreateDentry(const Dentry& dentry,
-                                const Time& tm);
+    MetaStatusCode CreateDentry(const Dentry& dentry, const Time& tm,
+                                int64_t logIndex);
 
-    MetaStatusCode LoadDentry(const DentryVec& vec, bool merge);
+    MetaStatusCode LoadDentry(const DentryVec& vec, bool merge,
+                              int64_t logIndex);
 
-    MetaStatusCode DeleteDentry(const Dentry& dentry);
+    MetaStatusCode DeleteDentry(const Dentry& dentry, int64_t logIndex);
 
     MetaStatusCode GetDentry(Dentry* dentry);
 
     MetaStatusCode ListDentry(const Dentry& dentry,
-                              std::vector<Dentry>* dentrys,
-                              uint32_t limit,
+                              std::vector<Dentry>* dentrys, uint32_t limit,
                               bool onlyDir = false);
 
     void ClearDentry();
 
-    MetaStatusCode HandleRenameTx(const std::vector<Dentry>& dentrys);
+    MetaStatusCode HandleRenameTx(const std::vector<Dentry>& dentrys,
+                                  int64_t logIndex);
 
     bool InsertPendingTx(const PrepareRenameTxRequest& pendingTx);
 
     bool FindPendingTx(PrepareRenameTxRequest* pendingTx);
 
+    void SerializeRenameTx(const RenameTx& in, PrepareRenameTxRequest* out);
+
+    bool Init();
+
     // inode
-    MetaStatusCode CreateInode(const InodeParam &param,
-                               Inode* inode);
+    MetaStatusCode CreateInode(const InodeParam& param, Inode* inode,
+                               int64_t logIndex);
 
-    MetaStatusCode CreateRootInode(const InodeParam &param);
+    MetaStatusCode CreateRootInode(const InodeParam& param, int64_t logIndex);
 
-    MetaStatusCode CreateManageInode(const InodeParam &param,
-                                     ManageInodeType manageType,
-                                     Inode* inode);
+    MetaStatusCode CreateManageInode(const InodeParam& param,
+                                     ManageInodeType manageType, Inode* inode,
+                                     int64_t logIndex);
 
     MetaStatusCode GetInode(uint32_t fsId, uint64_t inodeId, Inode* inode);
 
@@ -95,43 +102,42 @@ class Partition {
 
     MetaStatusCode GetXAttr(uint32_t fsId, uint64_t inodeId, XAttr* xattr);
 
-    MetaStatusCode DeleteInode(uint32_t fsId, uint64_t inodeId);
+    MetaStatusCode DeleteInode(uint32_t fsId, uint64_t inodeId,
+                               int64_t logIndex);
 
-    MetaStatusCode UpdateInode(const UpdateInodeRequest& request);
+    MetaStatusCode UpdateInode(const UpdateInodeRequest& request,
+                               int64_t logIndex);
 
-    MetaStatusCode GetOrModifyS3ChunkInfo(uint32_t fsId,
-                                          uint64_t inodeId,
+    MetaStatusCode GetOrModifyS3ChunkInfo(uint32_t fsId, uint64_t inodeId,
                                           const S3ChunkInfoMap& map2add,
                                           const S3ChunkInfoMap& map2del,
                                           bool returnS3ChunkInfoMap,
-                                          std::shared_ptr<Iterator>* iterator);
+                                          std::shared_ptr<Iterator>* iterator,
+                                          int64_t logIndex);
 
-    MetaStatusCode PaddingInodeS3ChunkInfo(int32_t fsId,
-                                           uint64_t inodeId,
+    MetaStatusCode PaddingInodeS3ChunkInfo(int32_t fsId, uint64_t inodeId,
                                            S3ChunkInfoMap* m,
                                            uint64_t limit = 0);
 
-    MetaStatusCode UpdateVolumeExtent(uint32_t fsId,
-                                      uint64_t inodeId,
-                                      const VolumeExtentSliceList& extents);
+    MetaStatusCode UpdateVolumeExtent(uint32_t fsId, uint64_t inodeId,
+                                      const VolumeExtentSliceList& extents,
+                                      int64_t logIndex);
 
-    MetaStatusCode UpdateVolumeExtentSlice(uint32_t fsId,
-                                           uint64_t inodeId,
-                                           const VolumeExtentSlice& slice);
+    MetaStatusCode UpdateVolumeExtentSlice(uint32_t fsId, uint64_t inodeId,
+                                           const VolumeExtentSlice& slice,
+                                           int64_t logIndex);
 
-    MetaStatusCode GetVolumeExtent(uint32_t fsId,
-                                   uint64_t inodeId,
+    MetaStatusCode GetVolumeExtent(uint32_t fsId, uint64_t inodeId,
                                    const std::vector<uint64_t>& slices,
                                    VolumeExtentSliceList* extents);
 
-
     MetaStatusCode UpdateDeallocatableBlockGroup(
-        const UpdateDeallocatableBlockGroupRequest &request);
+        const UpdateDeallocatableBlockGroupRequest& request, int64_t logIndex);
 
     virtual MetaStatusCode GetAllBlockGroup(
-        std::vector<DeallocatableBlockGroup> *deallocatableBlockGroupVec);
+        std::vector<DeallocatableBlockGroup>* deallocatableBlockGroupVec);
 
-    MetaStatusCode InsertInode(const Inode& inode);
+    MetaStatusCode InsertInode(const Inode& inode, int64_t logIndex);
 
     bool GetInodeIdList(std::list<uint64_t>* InodeIdList);
 

--- a/curvefs/src/metaserver/storage/converter.h
+++ b/curvefs/src/metaserver/storage/converter.h
@@ -46,6 +46,10 @@ enum KEY_TYPE : unsigned char {
     kTypeBlockGroup = 6,
     kTypeDeallocatableBlockGroup = 7,
     kTypeDeallocatableInode = 8,
+    kTypeAppliedIndex = 9,
+    kTypeTransaction = 10,
+    kTypeInodeCount = 11,
+    kTypeDentryCount = 12
 };
 
 // NOTE: you must generate all table name by NameGenerator class for
@@ -71,6 +75,14 @@ class NameGenerator {
 
     std::string GetDeallocatableBlockGroupTableName() const;
 
+    std::string GetAppliedIndexTableName() const;
+
+    std::string GetTransactionTableName() const;
+
+    std::string GetInodeCountTableName() const;
+
+    std::string GetDentryCountTableName() const;
+
     static size_t GetFixedLength();
 
  private:
@@ -84,6 +96,10 @@ class NameGenerator {
     std::string tableName4Dentry_;
     std::string tableName4VolumeExtent_;
     std::string tableName4InodeAuxInfo_;
+    std::string tableName4AppliedIndex_;
+    std::string tableName4Transaction_;
+    std::string tableName4InodeCount_;
+    std::string tableName4DentryCount_;
 };
 
 class StorageKey {

--- a/curvefs/src/metaserver/storage/dumpfile.cpp
+++ b/curvefs/src/metaserver/storage/dumpfile.cpp
@@ -67,7 +67,7 @@ using ::curve::common::CRC32;
 
 const std::string DumpFile::kCurvefs_ = "CURVEFS";  // NOLINT
 const uint32_t DumpFile::kEOF_ = 0;
-const uint8_t DumpFile::kVersion_ = kDumpFileV3;
+const uint8_t DumpFile::kVersion_ = kDumpFileV4;
 
 const uint32_t DumpFile::kMaxStringLength_ = 1024 * 1024 * 1024;  // 1GB
 

--- a/curvefs/src/metaserver/storage/dumpfile.h
+++ b/curvefs/src/metaserver/storage/dumpfile.h
@@ -87,6 +87,10 @@ enum DumpFileVersion : uint8_t {
     // kDumpFileV2 (because they're not inserted into rocksdb), other metadata
     // is saved by rocksdb
     kDumpFileV3 = 3,
+    // Version 4 only dumps partitions into file based on
+    // kDumpFileV3 (because they're not inserted into rocksdb), other metadata
+    // is saved by rocksdb
+    kDumpFileV4 = 4,
 };
 
 std::ostream& operator<<(std::ostream& os, DUMPFILE_ERROR code);

--- a/curvefs/src/metaserver/storage/storage_fstream.h
+++ b/curvefs/src/metaserver/storage/storage_fstream.h
@@ -183,6 +183,11 @@ inline bool LoadFromFile(const std::string &pathname, uint8_t *version,
         std::string key = ukey.second;
         std::string value = iter->Value();
         uint8_t version = dumpfile.GetVersion();
+        if (version < static_cast<uint8_t>(DumpFileVersion::kDumpFileV3)) {
+            LOG(ERROR) << "The dumpfile is too old, "
+                       << "the version of dumpfile should be V3 at least";
+            return false;
+        }
         switch (entryType) {
             CASE_TYPE_CALLBACK(INODE);
             CASE_TYPE_CALLBACK(DENTRY);

--- a/curvefs/src/metaserver/transaction.h
+++ b/curvefs/src/metaserver/transaction.h
@@ -23,12 +23,14 @@
 #ifndef CURVEFS_SRC_METASERVER_TRANSACTION_H_
 #define CURVEFS_SRC_METASERVER_TRANSACTION_H_
 
-#include <vector>
 #include <memory>
+#include <string>
 #include <unordered_map>
+#include <utility>
+#include <vector>
 
-#include "src/common/concurrent/rw_lock.h"
 #include "curvefs/src/metaserver/dentry_storage.h"
+#include "src/common/concurrent/rw_lock.h"
 
 namespace curvefs {
 namespace metaserver {
@@ -40,17 +42,19 @@ class RenameTx {
     RenameTx(const std::vector<Dentry>& dentrys,
              std::shared_ptr<DentryStorage> storage);
 
-    bool Prepare();
+    bool Prepare(const std::string& txPayload, int64_t logIndex);
 
-    bool Commit();
+    bool Commit(int64_t logIndex);
 
-    bool Rollback();
+    bool Rollback(int64_t logIndex);
 
     uint64_t GetTxId();
 
     uint64_t GetTxSequence();
 
     std::vector<Dentry>* GetDentrys();
+
+    const std::vector<Dentry>* GetDentrys() const;
 
     bool operator==(const RenameTx& rhs);
 
@@ -69,9 +73,11 @@ class RenameTx {
 
 class TxManager {
  public:
-    explicit TxManager(std::shared_ptr<DentryStorage> storage);
+    explicit TxManager(std::shared_ptr<DentryStorage> storage,
+                       common::PartitionInfo partitionInfo);
 
-    MetaStatusCode HandleRenameTx(const std::vector<Dentry>& dentrys);
+    MetaStatusCode HandleRenameTx(const std::vector<Dentry>& dentrys,
+                                  int64_t logIndex);
 
     MetaStatusCode PreCheck(const std::vector<Dentry>& dentrys);
 
@@ -81,7 +87,11 @@ class TxManager {
 
     void DeletePendingTx();
 
-    bool HandlePendingTx(uint64_t txId, RenameTx* pendingTx);
+    bool HandlePendingTx(uint64_t txId, RenameTx* pendingTx, int64_t logIndex);
+
+    void SerializeRenameTx(const RenameTx& in, PrepareRenameTxRequest* out);
+
+    bool Init();
 
  private:
     RWLock rwLock_;
@@ -89,6 +99,10 @@ class TxManager {
     std::shared_ptr<DentryStorage> storage_;
 
     RenameTx EMPTY_TX, pendingTx_;
+
+    Converter conv_;
+
+    common::PartitionInfo partitionInfo_;
 };
 
 }  // namespace metaserver

--- a/curvefs/src/metaserver/trash.cpp
+++ b/curvefs/src/metaserver/trash.cpp
@@ -231,7 +231,7 @@ MetaStatusCode TrashImpl::DeleteInodeAndData(const TrashItem &item) {
             return MetaStatusCode::S3_DELETE_ERR;
         }
     }
-    ret = inodeStorage_->Delete(Key4Inode(item.fsId, item.inodeId));
+    ret = inodeStorage_->ForceDelete(Key4Inode(item.fsId, item.inodeId));
     if (ret != MetaStatusCode::OK && ret != MetaStatusCode::NOT_FOUND) {
         LOG(ERROR) << "Delete Inode fail, fsId = " << item.fsId
                    << ", inodeId = " << item.inodeId

--- a/curvefs/test/metaserver/copyset/concurrent_apply_queue_test.cpp
+++ b/curvefs/test/metaserver/copyset/concurrent_apply_queue_test.cpp
@@ -197,6 +197,7 @@ TEST(ApplyQueue, ConcurrentTest) {
     };
 
     auto flush = [&concurrentapply, &stop, &testnum]() {
+        (void)testnum;
         while (!stop.load()) {
             std::this_thread::sleep_for(std::chrono::milliseconds(100));
             concurrentapply.Flush();

--- a/curvefs/test/metaserver/copyset/copyset_node_block_group_test.cpp
+++ b/curvefs/test/metaserver/copyset/copyset_node_block_group_test.cpp
@@ -76,7 +76,7 @@ class CopysetNodeBlockGroupTest : public testing::Test {
         ASSERT_TRUE(nodeManager_->Init(options_));
     }
 
-    void TearDown() {
+    void TearDown() override {
         system(std::string("rm -rf " + dataPath_).c_str());
     }
 

--- a/curvefs/test/metaserver/dentry_manager_test.cpp
+++ b/curvefs/test/metaserver/dentry_manager_test.cpp
@@ -36,9 +36,9 @@ namespace curvefs {
 namespace metaserver {
 
 using ::curvefs::metaserver::storage::KVStorage;
-using ::curvefs::metaserver::storage::StorageOptions;
-using ::curvefs::metaserver::storage::RocksDBStorage;
 using ::curvefs::metaserver::storage::RandomStoragePath;
+using ::curvefs::metaserver::storage::RocksDBStorage;
+using ::curvefs::metaserver::storage::StorageOptions;
 
 namespace {
 auto localfs = curve::fs::Ext4FileSystemImpl::getInstance();
@@ -58,11 +58,16 @@ class DentryManagerTest : public ::testing::Test {
         options.localFileSystem = localfs.get();
         kvStorage_ = std::make_shared<RocksDBStorage>(options);
         ASSERT_TRUE(kvStorage_->Open());
-        dentryStorage_ = std::make_shared<DentryStorage>(
-            kvStorage_, nameGenerator_, 0);
-        txManager_ = std::make_shared<TxManager>(dentryStorage_);
-        dentryManager_ = std::make_shared<DentryManager>(
-            dentryStorage_, txManager_);
+        dentryStorage_ =
+            std::make_shared<DentryStorage>(kvStorage_, nameGenerator_, 0);
+        common::PartitionInfo partitionInfo;
+        partitionInfo.set_partitionid(1);
+        txManager_ = std::make_shared<TxManager>(dentryStorage_, partitionInfo);
+        dentryManager_ =
+            std::make_shared<DentryManager>(dentryStorage_, txManager_);
+        ASSERT_TRUE(dentryManager_->Init());
+        ASSERT_TRUE(txManager_->Init());
+        logIndex_ = 0;
     }
 
     void TearDown() override {
@@ -84,12 +89,8 @@ class DentryManagerTest : public ::testing::Test {
         return result;
     }
 
-    Dentry GenDentry(uint32_t fsId,
-                     uint64_t parentId,
-                     const std::string& name,
-                     uint64_t txId,
-                     uint64_t inodeId,
-                     bool deleteMarkFlag) {
+    Dentry GenDentry(uint32_t fsId, uint64_t parentId, const std::string& name,
+                     uint64_t txId, uint64_t inodeId, bool deleteMarkFlag) {
         Dentry dentry;
         dentry.set_fsid(fsId);
         dentry.set_parentinodeid(parentId);
@@ -108,17 +109,19 @@ class DentryManagerTest : public ::testing::Test {
     std::shared_ptr<DentryStorage> dentryStorage_;
     std::shared_ptr<DentryManager> dentryManager_;
     std::shared_ptr<TxManager> txManager_;
+    int64_t logIndex_;
 };
 
 TEST_F(DentryManagerTest, CreateDentry) {
     // CASE 1: CreateDentry: success
     auto dentry = GenDentry(1, 0, "A", 0, 1, false);
-    ASSERT_EQ(dentryManager_->CreateDentry(dentry), MetaStatusCode::OK);
+    ASSERT_EQ(dentryManager_->CreateDentry(dentry, logIndex_++),
+              MetaStatusCode::OK);
     ASSERT_EQ(dentryStorage_->Size(), 1);
 
     // CASE 2: CreateDentry: dentry exist
     auto dentry2 = GenDentry(1, 0, "A", 0, 2, false);
-    ASSERT_EQ(dentryManager_->CreateDentry(dentry2),
+    ASSERT_EQ(dentryManager_->CreateDentry(dentry2, logIndex_++),
               MetaStatusCode::DENTRY_EXIST);
     ASSERT_EQ(dentryStorage_->Size(), 1);
 }
@@ -126,18 +129,22 @@ TEST_F(DentryManagerTest, CreateDentry) {
 TEST_F(DentryManagerTest, DeleteDentry) {
     // CASE 1: DeleteDentry: not found
     auto dentry = GenDentry(1, 0, "A", 0, 1, false);
-    ASSERT_EQ(dentryManager_->DeleteDentry(dentry), MetaStatusCode::NOT_FOUND);
+    ASSERT_EQ(dentryManager_->DeleteDentry(dentry, logIndex_++),
+              MetaStatusCode::NOT_FOUND);
 
     // CASE 2: DeleteDentry: sucess
-    ASSERT_EQ(dentryManager_->CreateDentry(dentry), MetaStatusCode::OK);
+    ASSERT_EQ(dentryManager_->CreateDentry(dentry, logIndex_++),
+              MetaStatusCode::OK);
     ASSERT_EQ(dentryStorage_->Size(), 1);
-    ASSERT_EQ(dentryManager_->DeleteDentry(dentry), MetaStatusCode::OK);
+    ASSERT_EQ(dentryManager_->DeleteDentry(dentry, logIndex_++),
+              MetaStatusCode::OK);
     ASSERT_EQ(dentryStorage_->Size(), 0);
 }
 
 TEST_F(DentryManagerTest, ClearDentry) {
     auto dentry = GenDentry(1, 0, "A", 0, 1, false);
-    ASSERT_EQ(dentryManager_->CreateDentry(dentry), MetaStatusCode::OK);
+    ASSERT_EQ(dentryManager_->CreateDentry(dentry, logIndex_++),
+              MetaStatusCode::OK);
     ASSERT_EQ(dentryStorage_->Size(), 1);
     dentryManager_->ClearDentry();
     ASSERT_EQ(dentryStorage_->Size(), 0);
@@ -149,7 +156,8 @@ TEST_F(DentryManagerTest, GetDentry) {
     ASSERT_EQ(dentryManager_->GetDentry(&dentry), MetaStatusCode::NOT_FOUND);
 
     // CASE 2: GetDentry: success
-    ASSERT_EQ(dentryManager_->CreateDentry(dentry), MetaStatusCode::OK);
+    ASSERT_EQ(dentryManager_->CreateDentry(dentry, logIndex_++),
+              MetaStatusCode::OK);
     ASSERT_EQ(dentryStorage_->Size(), 1);
     dentry = GenDentry(1, 0, "A", 0, 0, false);
     ASSERT_EQ(dentryManager_->GetDentry(&dentry), MetaStatusCode::OK);
@@ -159,8 +167,10 @@ TEST_F(DentryManagerTest, GetDentry) {
 TEST_F(DentryManagerTest, ListDentry) {
     auto dentry1 = GenDentry(1, 0, "A", 0, 1, false);
     auto dentry2 = GenDentry(1, 0, "B", 0, 2, false);
-    ASSERT_EQ(dentryManager_->CreateDentry(dentry1), MetaStatusCode::OK);
-    ASSERT_EQ(dentryManager_->CreateDentry(dentry2), MetaStatusCode::OK);
+    ASSERT_EQ(dentryManager_->CreateDentry(dentry1, logIndex_++),
+              MetaStatusCode::OK);
+    ASSERT_EQ(dentryManager_->CreateDentry(dentry2, logIndex_++),
+              MetaStatusCode::OK);
     ASSERT_EQ(dentryStorage_->Size(), 2);
 
     std::vector<Dentry> dentrys;
@@ -175,15 +185,15 @@ TEST_F(DentryManagerTest, ListDentry) {
 TEST_F(DentryManagerTest, HandleRenameTx) {
     // CASE 1: HandleRenameTx: param error
     auto dentrys = std::vector<Dentry>();
-    auto rc = txManager_->HandleRenameTx(dentrys);
+    auto rc = txManager_->HandleRenameTx(dentrys, logIndex_++);
     ASSERT_EQ(rc, MetaStatusCode::PARAM_ERROR);
 
     // CASE 2: HandleRenameTx success
-    dentrys = std::vector<Dentry> {
+    dentrys = std::vector<Dentry>{
         // { fsId, parentId, name, txId, inodeId, deleteMarkFlag }
         GenDentry(1, 0, "A", 1, 1, false),
     };
-    rc = txManager_->HandleRenameTx(dentrys);
+    rc = txManager_->HandleRenameTx(dentrys, logIndex_++);
     ASSERT_EQ(rc, MetaStatusCode::OK);
     ASSERT_EQ(dentryStorage_->Size(), 1);
 }

--- a/curvefs/test/metaserver/dentry_storage_test.cpp
+++ b/curvefs/test/metaserver/dentry_storage_test.cpp
@@ -34,11 +34,10 @@ namespace curvefs {
 namespace metaserver {
 
 using ::curvefs::metaserver::storage::KVStorage;
-using ::curvefs::metaserver::storage::StorageOptions;
-using ::curvefs::metaserver::storage::RocksDBStorage;
 using ::curvefs::metaserver::storage::NameGenerator;
 using ::curvefs::metaserver::storage::RandomStoragePath;
-using TX_OP_TYPE = DentryStorage::TX_OP_TYPE;
+using ::curvefs::metaserver::storage::RocksDBStorage;
+using ::curvefs::metaserver::storage::StorageOptions;
 
 namespace {
 auto localfs = curve::fs::Ext4FileSystemImpl::getInstance();
@@ -48,12 +47,14 @@ class DentryStorageTest : public ::testing::Test {
  protected:
     void SetUp() override {
         nameGenerator_ = std::make_shared<NameGenerator>(1);
-        dataDir_ = RandomStoragePath();;
+        dataDir_ = RandomStoragePath();
+
         StorageOptions options;
         options.dataDir = dataDir_;
         options.localFileSystem = localfs.get();
         kvStorage_ = std::make_shared<RocksDBStorage>(options);
         ASSERT_TRUE(kvStorage_->Open());
+        logIndex_ = 0;
     }
 
     void TearDown() override {
@@ -76,12 +77,8 @@ class DentryStorageTest : public ::testing::Test {
         return result;
     }
 
-    Dentry GenDentry(uint32_t fsId,
-                     uint64_t parentId,
-                     const std::string& name,
-                     uint64_t txId,
-                     uint64_t inodeId,
-                     bool deleteMarkFlag,
+    Dentry GenDentry(uint32_t fsId, uint64_t parentId, const std::string& name,
+                     uint64_t txId, uint64_t inodeId, bool deleteMarkFlag,
                      FsFileType type = FsFileType::TYPE_FILE) {
         Dentry dentry;
         dentry.set_fsid(fsId);
@@ -96,10 +93,13 @@ class DentryStorageTest : public ::testing::Test {
 
     void InsertDentrys(DentryStorage* storage,
                        const std::vector<Dentry>&& dentrys) {
-        for (const auto& dentry : dentrys) {
-            auto rc = storage->HandleTx(TX_OP_TYPE::PREPARE, dentry);
-            ASSERT_EQ(rc, MetaStatusCode::OK);
-        }
+        // NOTE: store real transaction is unnecessary
+        metaserver::TransactionRequest request;
+        request.set_type(metaserver::TransactionRequest::None);
+        request.set_rawpayload("");
+
+        auto rc = storage->PrepareTx(dentrys, request, logIndex_++);
+        ASSERT_EQ(rc, MetaStatusCode::OK);
         ASSERT_EQ(storage->Size(), dentrys.size());
     }
 
@@ -112,11 +112,12 @@ class DentryStorageTest : public ::testing::Test {
     std::string dataDir_;
     std::shared_ptr<NameGenerator> nameGenerator_;
     std::shared_ptr<KVStorage> kvStorage_;
+    int64_t logIndex_;
 };
 
 TEST_F(DentryStorageTest, Insert) {
     DentryStorage storage(kvStorage_, nameGenerator_, 0);
-
+    ASSERT_TRUE(storage.Init());
     Dentry dentry;
     dentry.set_fsid(1);
     dentry.set_parentinodeid(1);
@@ -132,30 +133,42 @@ TEST_F(DentryStorageTest, Insert) {
     dentry2.set_txid(0);
 
     // CASE 1: insert success
-    ASSERT_EQ(storage.Insert(dentry), MetaStatusCode::OK);
+    ASSERT_EQ(storage.Insert(dentry, logIndex_++), MetaStatusCode::OK);
 
     // CASE 2: insert with dentry exist
-    ASSERT_EQ(storage.Insert(dentry2), MetaStatusCode::DENTRY_EXIST);
+    ASSERT_EQ(storage.Insert(dentry2, logIndex_++),
+              MetaStatusCode::DENTRY_EXIST);
     ASSERT_EQ(storage.Size(), 1);
 
     // CASE 3: insert dentry failed with higher txid
     dentry.set_txid(1);
-    ASSERT_EQ(storage.Insert(dentry), MetaStatusCode::IDEMPOTENCE_OK);
+    ASSERT_EQ(storage.Insert(dentry, logIndex_++),
+              MetaStatusCode::IDEMPOTENCE_OK);
     ASSERT_EQ(storage.Size(), 1);
 
     // CASE 4: direct insert success by handle tx
-    auto rc = storage.HandleTx(TX_OP_TYPE::PREPARE, dentry);
+    // NOTE: store real transaction is unnecessary
+    metaserver::TransactionRequest request;
+    request.set_type(metaserver::TransactionRequest::None);
+    request.set_rawpayload("");
+    auto rc = storage.PrepareTx({dentry}, request, logIndex_++);
     ASSERT_EQ(rc, MetaStatusCode::OK);
     ASSERT_EQ(storage.Size(), 2);
 
     // CASE 5: insert idempotence
-    ASSERT_EQ(storage.Insert(dentry), MetaStatusCode::IDEMPOTENCE_OK);
+    ASSERT_EQ(storage.Insert(dentry, logIndex_++),
+              MetaStatusCode::IDEMPOTENCE_OK);
     ASSERT_EQ(storage.Size(), 1);
 }
 
 TEST_F(DentryStorageTest, Delete) {
     DentryStorage storage(kvStorage_, nameGenerator_, 0);
+    ASSERT_TRUE(storage.Init());
 
+    // NOTE: store real transaction is unnecessary
+    metaserver::TransactionRequest request;
+    request.set_type(metaserver::TransactionRequest::None);
+    request.set_rawpayload("");
     Dentry dentry;
     dentry.set_fsid(1);
     dentry.set_parentinodeid(1);
@@ -164,63 +177,66 @@ TEST_F(DentryStorageTest, Delete) {
     dentry.set_txid(0);
 
     // CASE 1: dentry not found
-    ASSERT_EQ(storage.Delete(dentry), MetaStatusCode::NOT_FOUND);
+    ASSERT_EQ(storage.Delete(dentry, logIndex_++), MetaStatusCode::NOT_FOUND);
     ASSERT_EQ(storage.Size(), 0);
 
     // CASE 2: delete success
-    ASSERT_EQ(storage.Insert(dentry), MetaStatusCode::OK);
+    ASSERT_EQ(storage.Insert(dentry, logIndex_++), MetaStatusCode::OK);
     ASSERT_EQ(storage.Size(), 1);
 
-    ASSERT_EQ(storage.Delete(dentry), MetaStatusCode::OK);
+    ASSERT_EQ(storage.Delete(dentry, logIndex_++), MetaStatusCode::OK);
     ASSERT_EQ(storage.Size(), 0);
 
     // CASE 3: delete multi-dentrys with different txid
-    ASSERT_EQ(storage.Insert(dentry), MetaStatusCode::OK);
+    ASSERT_EQ(storage.Insert(dentry, logIndex_++), MetaStatusCode::OK);
     dentry.set_txid(1);
-    auto rc = storage.HandleTx(TX_OP_TYPE::PREPARE, dentry);
+    // NOTE: store real transaction is unnecessary
+    auto rc = storage.PrepareTx({dentry}, request, logIndex_++);
     ASSERT_EQ(rc, MetaStatusCode::OK);
     ASSERT_EQ(storage.Size(), 2);
 
     dentry.set_txid(2);
-    ASSERT_EQ(storage.Delete(dentry), MetaStatusCode::OK);
+    ASSERT_EQ(storage.Delete(dentry, logIndex_++), MetaStatusCode::OK);
     ASSERT_EQ(storage.Size(), 0);
 
     // CASE 4: delete by higher txid
     dentry.set_txid(2);
-    ASSERT_EQ(storage.Insert(dentry), MetaStatusCode::OK);
+    ASSERT_EQ(storage.Insert(dentry, logIndex_++), MetaStatusCode::OK);
     ASSERT_EQ(storage.Size(), 1);
 
     dentry.set_txid(1);
-    ASSERT_EQ(storage.Delete(dentry), MetaStatusCode::NOT_FOUND);
+    ASSERT_EQ(storage.Delete(dentry, logIndex_++), MetaStatusCode::NOT_FOUND);
     ASSERT_EQ(storage.Size(), 1);
 
     dentry.set_txid(2);
-    ASSERT_EQ(storage.Delete(dentry), MetaStatusCode::OK);
+    ASSERT_EQ(storage.Delete(dentry, logIndex_++), MetaStatusCode::OK);
     ASSERT_EQ(storage.Size(), 0);
 
     // CASE 5: dentry deleted with DELETE_MARK_FLAG flag
     dentry.set_flag(DentryFlag::DELETE_MARK_FLAG);
-    ASSERT_EQ(storage.Insert(dentry), MetaStatusCode::OK);
+    ASSERT_EQ(storage.Insert(dentry, logIndex_++), MetaStatusCode::OK);
     ASSERT_EQ(storage.Size(), 1);
 
-    ASSERT_EQ(storage.Delete(dentry), MetaStatusCode::NOT_FOUND);
+    ASSERT_EQ(storage.Delete(dentry, logIndex_++), MetaStatusCode::NOT_FOUND);
     ASSERT_EQ(storage.Size(), 0);
 
     // CASE 6: delete by last dentry with DELETE_MARK_FLAG flag
     dentry.set_txid(0);
-    ASSERT_EQ(storage.Insert(dentry), MetaStatusCode::OK);
+    ASSERT_EQ(storage.Insert(dentry, logIndex_++), MetaStatusCode::OK);
     dentry.set_txid(1);
     dentry.set_flag(DentryFlag::DELETE_MARK_FLAG);
-    rc = storage.HandleTx(TX_OP_TYPE::PREPARE, dentry);
+    // NOTE: store real transaction is unnecessary
+    rc = storage.PrepareTx({dentry}, request, logIndex_++);
     ASSERT_EQ(rc, MetaStatusCode::OK);
     ASSERT_EQ(storage.Size(), 2);
 
-    ASSERT_EQ(storage.Delete(dentry), MetaStatusCode::NOT_FOUND);
+    ASSERT_EQ(storage.Delete(dentry, logIndex_++), MetaStatusCode::NOT_FOUND);
     ASSERT_EQ(storage.Size(), 0);
 }
 
 TEST_F(DentryStorageTest, Get) {
     DentryStorage storage(kvStorage_, nameGenerator_, 0);
+    ASSERT_TRUE(storage.Init());
     Dentry dentry;
 
     // CASE 1: dentry not found
@@ -228,11 +244,12 @@ TEST_F(DentryStorageTest, Get) {
     ASSERT_EQ(storage.Get(&dentry), MetaStatusCode::NOT_FOUND);
 
     // CASE 2: get success
-    InsertDentrys(&storage, std::vector<Dentry>{
-        // { fsId, parentId, name, txId, inodeId, deleteMarkFlag }
-        GenDentry(1, 0, "A", 0, 1, false),
-        GenDentry(1, 0, "B", 0, 2, false),
-    });
+    InsertDentrys(&storage,
+                  std::vector<Dentry>{
+                      // { fsId, parentId, name, txId, inodeId, deleteMarkFlag }
+                      GenDentry(1, 0, "A", 0, 1, false),
+                      GenDentry(1, 0, "B", 0, 2, false),
+                  });
 
     dentry = GenDentry(1, 0, "A", 0, 0, false);
     ASSERT_EQ(storage.Get(&dentry), MetaStatusCode::OK);
@@ -246,11 +263,12 @@ TEST_F(DentryStorageTest, Get) {
 
     // CASE 3: get multi-dentrys with different txid
     storage.Clear();
-    InsertDentrys(&storage, std::vector<Dentry>{
-        // { fsId, parentId, name, txId, inodeId, deleteMarkFlag }
-        GenDentry(1, 0, "A", 0, 1, false),
-        GenDentry(1, 0, "A", 1, 2, false),
-    });
+    InsertDentrys(&storage,
+                  std::vector<Dentry>{
+                      // { fsId, parentId, name, txId, inodeId, deleteMarkFlag }
+                      GenDentry(1, 0, "A", 0, 1, false),
+                      GenDentry(1, 0, "A", 1, 2, false),
+                  });
 
     dentry = GenDentry(1, 0, "A", 1, 0, false);
     ASSERT_EQ(storage.Get(&dentry), MetaStatusCode::OK);
@@ -259,11 +277,12 @@ TEST_F(DentryStorageTest, Get) {
 
     // CASE 4: get dentry with DELETE_MARK_FLAG flag
     storage.Clear();
-    InsertDentrys(&storage, std::vector<Dentry>{
-        // { fsId, parentId, name, txId, inodeId, deleteMarkFlag }
-        GenDentry(1, 0, "A", 0, 1, false),
-        GenDentry(1, 0, "A", 1, 1, true),
-    });
+    InsertDentrys(&storage,
+                  std::vector<Dentry>{
+                      // { fsId, parentId, name, txId, inodeId, deleteMarkFlag }
+                      GenDentry(1, 0, "A", 0, 1, false),
+                      GenDentry(1, 0, "A", 1, 1, true),
+                  });
 
     dentry = GenDentry(1, 0, "A", 1, 0, false);
     ASSERT_EQ(storage.Get(&dentry), MetaStatusCode::NOT_FOUND);
@@ -273,29 +292,31 @@ TEST_F(DentryStorageTest, Get) {
 
 TEST_F(DentryStorageTest, List) {
     DentryStorage storage(kvStorage_, nameGenerator_, 0);
+    ASSERT_TRUE(storage.Init());
     std::vector<Dentry> dentrys;
     Dentry dentry;
 
     // CASE 1: basic list
-    InsertDentrys(&storage, std::vector<Dentry>{
-        // { fsId, parentId, name, txId, inodeId, deleteMarkFlag }
-        GenDentry(1, 0, "A1", 0, 1, false),
-        GenDentry(1, 0, "A2", 0, 2, false),
-        GenDentry(1, 0, "A3", 0, 3, false),
-        GenDentry(1, 0, "A4", 0, 4, false),
-        GenDentry(1, 0, "A5", 0, 5, false),
-    });
+    InsertDentrys(&storage,
+                  std::vector<Dentry>{
+                      // { fsId, parentId, name, txId, inodeId, deleteMarkFlag }
+                      GenDentry(1, 0, "A1", 0, 1, false),
+                      GenDentry(1, 0, "A2", 0, 2, false),
+                      GenDentry(1, 0, "A3", 0, 3, false),
+                      GenDentry(1, 0, "A4", 0, 4, false),
+                      GenDentry(1, 0, "A5", 0, 5, false),
+                  });
 
     dentry = GenDentry(1, 0, "", 0, 0, false);
     ASSERT_EQ(storage.List(dentry, &dentrys, 0), MetaStatusCode::OK);
     ASSERT_EQ(dentrys.size(), 5);
     ASSERT_DENTRYS_EQ(dentrys, std::vector<Dentry>{
-        GenDentry(1, 0, "A1", 0, 1, false),
-        GenDentry(1, 0, "A2", 0, 2, false),
-        GenDentry(1, 0, "A3", 0, 3, false),
-        GenDentry(1, 0, "A4", 0, 4, false),
-        GenDentry(1, 0, "A5", 0, 5, false),
-    });
+                                   GenDentry(1, 0, "A1", 0, 1, false),
+                                   GenDentry(1, 0, "A2", 0, 2, false),
+                                   GenDentry(1, 0, "A3", 0, 3, false),
+                                   GenDentry(1, 0, "A4", 0, 4, false),
+                                   GenDentry(1, 0, "A5", 0, 5, false),
+                               });
 
     // CASE 2: list by specify name
     dentrys.clear();
@@ -303,27 +324,28 @@ TEST_F(DentryStorageTest, List) {
     ASSERT_EQ(storage.List(dentry, &dentrys, 0), MetaStatusCode::OK);
     ASSERT_EQ(dentrys.size(), 2);
     ASSERT_DENTRYS_EQ(dentrys, std::vector<Dentry>{
-        GenDentry(1, 0, "A4", 0, 4, false),
-        GenDentry(1, 0, "A5", 0, 5, false),
-    });
+                                   GenDentry(1, 0, "A4", 0, 4, false),
+                                   GenDentry(1, 0, "A5", 0, 5, false),
+                               });
 
     // CASE 3: list by lower txid
     storage.Clear();
-    InsertDentrys(&storage, std::vector<Dentry>{
-        // { fsId, parentId, name, txId, inodeId, deleteMarkFlag }
-        GenDentry(1, 0, "A1", 1, 1, false),
-        GenDentry(1, 0, "A2", 2, 2, false),
-        GenDentry(1, 0, "A3", 3, 3, false),
-    });
+    InsertDentrys(&storage,
+                  std::vector<Dentry>{
+                      // { fsId, parentId, name, txId, inodeId, deleteMarkFlag }
+                      GenDentry(1, 0, "A1", 1, 1, false),
+                      GenDentry(1, 0, "A2", 2, 2, false),
+                      GenDentry(1, 0, "A3", 3, 3, false),
+                  });
 
     dentrys.clear();
     dentry = GenDentry(1, 0, "", 2, 0, false);
     ASSERT_EQ(storage.List(dentry, &dentrys, 0), MetaStatusCode::OK);
     ASSERT_EQ(dentrys.size(), 2);
     ASSERT_DENTRYS_EQ(dentrys, std::vector<Dentry>{
-        GenDentry(1, 0, "A1", 1, 1, false),
-        GenDentry(1, 0, "A2", 2, 2, false),
-    });
+                                   GenDentry(1, 0, "A1", 1, 1, false),
+                                   GenDentry(1, 0, "A2", 2, 2, false),
+                               });
 
     // CASE 4: list by higher txid
     dentrys.clear();
@@ -331,86 +353,90 @@ TEST_F(DentryStorageTest, List) {
     ASSERT_EQ(storage.List(dentry, &dentrys, 0), MetaStatusCode::OK);
     ASSERT_EQ(dentrys.size(), 3);
     ASSERT_DENTRYS_EQ(dentrys, std::vector<Dentry>{
-        GenDentry(1, 0, "A1", 1, 1, false),
-        GenDentry(1, 0, "A2", 2, 2, false),
-        GenDentry(1, 0, "A3", 3, 3, false),
-    });
+                                   GenDentry(1, 0, "A1", 1, 1, false),
+                                   GenDentry(1, 0, "A2", 2, 2, false),
+                                   GenDentry(1, 0, "A3", 3, 3, false),
+                               });
 
     // CASE 5: list dentrys which has DELETE_MARK_FLAG flag
     storage.Clear();
-    InsertDentrys(&storage, std::vector<Dentry>{
-        // { fsId, parentId, name, txId, inodeId, deleteMarkFlag }
-        GenDentry(1, 0, "A1", 1, 1, false),
-        GenDentry(1, 0, "A2", 2, 2, true),
-        GenDentry(1, 0, "A3", 3, 3, false),
-    });
+    InsertDentrys(&storage,
+                  std::vector<Dentry>{
+                      // { fsId, parentId, name, txId, inodeId, deleteMarkFlag }
+                      GenDentry(1, 0, "A1", 1, 1, false),
+                      GenDentry(1, 0, "A2", 2, 2, true),
+                      GenDentry(1, 0, "A3", 3, 3, false),
+                  });
 
     dentrys.clear();
     dentry = GenDentry(1, 0, "", 3, 0, false);
     ASSERT_EQ(storage.List(dentry, &dentrys, 0), MetaStatusCode::OK);
     ASSERT_EQ(dentrys.size(), 2);
     ASSERT_DENTRYS_EQ(dentrys, std::vector<Dentry>{
-        GenDentry(1, 0, "A1", 1, 1, false),
-        GenDentry(1, 0, "A3", 3, 3, false),
-    });
+                                   GenDentry(1, 0, "A1", 1, 1, false),
+                                   GenDentry(1, 0, "A3", 3, 3, false),
+                               });
 
     // CASE 6: list same dentrys with different txid
     storage.Clear();
-    InsertDentrys(&storage, std::vector<Dentry>{
-        // { fsId, parentId, name, txId, inodeId, deleteMarkFlag }
-        GenDentry(1, 0, "A", 0, 1, false),
-        GenDentry(1, 0, "A", 1, 1, false),
-        GenDentry(1, 0, "A", 2, 1, false),
-    });
+    InsertDentrys(&storage,
+                  std::vector<Dentry>{
+                      // { fsId, parentId, name, txId, inodeId, deleteMarkFlag }
+                      GenDentry(1, 0, "A", 0, 1, false),
+                      GenDentry(1, 0, "A", 1, 1, false),
+                      GenDentry(1, 0, "A", 2, 1, false),
+                  });
 
     dentrys.clear();
     dentry = GenDentry(1, 0, "", 2, 0, false);
     ASSERT_EQ(storage.List(dentry, &dentrys, 0), MetaStatusCode::OK);
     ASSERT_EQ(dentrys.size(), 1);
     ASSERT_DENTRYS_EQ(dentrys, std::vector<Dentry>{
-        GenDentry(1, 0, "A", 2, 1, false),
-    });
+                                   GenDentry(1, 0, "A", 2, 1, false),
+                               });
 
     // CASE 7: list by dentry tree
     storage.Clear();
-    InsertDentrys(&storage, std::vector<Dentry>{
-        // { fsId, parentId, name, txId, inodeId, deleteMarkFlag }
-        GenDentry(1, 0, "A", 0, 1, false),
-        GenDentry(1, 0, "B", 0, 2, false),
-        GenDentry(1, 2, "C", 0, 3, false),
-        GenDentry(1, 2, "D", 0, 4, false),
-        GenDentry(1, 2, "E", 0, 5, false),
-        GenDentry(1, 4, "F", 0, 6, true),
-        GenDentry(1, 4, "G", 0, 7, false),
-    });
+    InsertDentrys(&storage,
+                  std::vector<Dentry>{
+                      // { fsId, parentId, name, txId, inodeId, deleteMarkFlag }
+                      GenDentry(1, 0, "A", 0, 1, false),
+                      GenDentry(1, 0, "B", 0, 2, false),
+                      GenDentry(1, 2, "C", 0, 3, false),
+                      GenDentry(1, 2, "D", 0, 4, false),
+                      GenDentry(1, 2, "E", 0, 5, false),
+                      GenDentry(1, 4, "F", 0, 6, true),
+                      GenDentry(1, 4, "G", 0, 7, false),
+                  });
 
     dentrys.clear();
     dentry = GenDentry(1, 2, "", 0, 0, false);
     ASSERT_EQ(storage.List(dentry, &dentrys, 0), MetaStatusCode::OK);
     ASSERT_EQ(dentrys.size(), 3);
     ASSERT_DENTRYS_EQ(dentrys, std::vector<Dentry>{
-        GenDentry(1, 2, "C", 0, 3, false),
-        GenDentry(1, 2, "D", 0, 4, false),
-        GenDentry(1, 2, "E", 0, 5, false),
-    });
+                                   GenDentry(1, 2, "C", 0, 3, false),
+                                   GenDentry(1, 2, "D", 0, 4, false),
+                                   GenDentry(1, 2, "E", 0, 5, false),
+                               });
 
     dentrys.clear();
     dentry = GenDentry(1, 4, "", 0, 0, false);
     ASSERT_EQ(storage.List(dentry, &dentrys, 0), MetaStatusCode::OK);
     ASSERT_EQ(dentrys.size(), 1);
     ASSERT_DENTRYS_EQ(dentrys, std::vector<Dentry>{
-        GenDentry(1, 4, "G", 0, 7, false),
-    });
+                                   GenDentry(1, 4, "G", 0, 7, false),
+                               });
 
     // CASE 8: list empty directory
     storage.Clear();
-    InsertDentrys(&storage, std::vector<Dentry>{
-        // { fsId, parentId, name, txId, inodeId, deleteMarkFlag }
-        GenDentry(1, 0, "A", 0, 1, false),
-        GenDentry(1, 0, "B", 0, 2, false),
-        GenDentry(1, 2, "D", 0, 4, true),
-        GenDentry(1, 2, "E", 0, 5, true),
-    });
+    InsertDentrys(&storage,
+                  std::vector<Dentry>{
+                      // { fsId, parentId, name, txId, inodeId, deleteMarkFlag }
+                      GenDentry(1, 0, "A", 0, 1, false),
+                      GenDentry(1, 0, "B", 0, 2, false),
+                      GenDentry(1, 2, "D", 0, 4, true),
+                      GenDentry(1, 2, "E", 0, 5, true),
+                  });
 
     dentrys.clear();
     dentry = GenDentry(1, 2, "", 0, 0, false);
@@ -429,13 +455,15 @@ TEST_F(DentryStorageTest, List) {
 
     // CASE 9: list directory only
     storage.Clear();
-    InsertDentrys(&storage, std::vector<Dentry>{
-        // { fsId, parentId, name, txId, inodeId, deleteMarkFlag }
-        GenDentry(1, 0, "A", 0, 1, false, FsFileType::TYPE_DIRECTORY),
-        GenDentry(1, 0, "B", 0, 2, true, FsFileType::TYPE_DIRECTORY),
-        GenDentry(1, 0, "D", 0, 3, false),
-        GenDentry(1, 0, "E", 0, 4, false),
-    });
+    InsertDentrys(
+        &storage,
+        std::vector<Dentry>{
+            // { fsId, parentId, name, txId, inodeId, deleteMarkFlag }
+            GenDentry(1, 0, "A", 0, 1, false, FsFileType::TYPE_DIRECTORY),
+            GenDentry(1, 0, "B", 0, 2, true, FsFileType::TYPE_DIRECTORY),
+            GenDentry(1, 0, "D", 0, 3, false),
+            GenDentry(1, 0, "E", 0, 4, false),
+        });
 
     dentrys.clear();
     dentry = GenDentry(1, 0, "", 0, 0, false);
@@ -444,12 +472,13 @@ TEST_F(DentryStorageTest, List) {
 
     // CASE 10: list directory only with limit
     storage.Clear();
-    InsertDentrys(&storage, std::vector<Dentry>{
-        // { fsId, parentId, name, txId, inodeId, deleteMarkFlag }
-        GenDentry(1, 0, "A", 0, 1, false),
-        GenDentry(1, 0, "B", 0, 2, false),
-        GenDentry(1, 0, "D", 0, 3, false),
-    });
+    InsertDentrys(&storage,
+                  std::vector<Dentry>{
+                      // { fsId, parentId, name, txId, inodeId, deleteMarkFlag }
+                      GenDentry(1, 0, "A", 0, 1, false),
+                      GenDentry(1, 0, "B", 0, 2, false),
+                      GenDentry(1, 0, "D", 0, 3, false),
+                  });
 
     dentrys.clear();
     dentry = GenDentry(1, 0, "", 0, 0, false);
@@ -457,12 +486,14 @@ TEST_F(DentryStorageTest, List) {
     ASSERT_EQ(dentrys.size(), 1);
 
     storage.Clear();
-    InsertDentrys(&storage, std::vector<Dentry>{
-        // { fsId, parentId, name, txId, inodeId, deleteMarkFlag }
-        GenDentry(1, 0, "A", 0, 1, false, FsFileType::TYPE_DIRECTORY),
-        GenDentry(1, 0, "B", 0, 2, false),
-        GenDentry(1, 0, "D", 0, 3, false),
-    });
+    InsertDentrys(
+        &storage,
+        std::vector<Dentry>{
+            // { fsId, parentId, name, txId, inodeId, deleteMarkFlag }
+            GenDentry(1, 0, "A", 0, 1, false, FsFileType::TYPE_DIRECTORY),
+            GenDentry(1, 0, "B", 0, 2, false),
+            GenDentry(1, 0, "D", 0, 3, false),
+        });
 
     dentrys.clear();
     dentry = GenDentry(1, 0, "", 0, 0, false);
@@ -472,28 +503,35 @@ TEST_F(DentryStorageTest, List) {
 
 TEST_F(DentryStorageTest, HandleTx) {
     DentryStorage storage(kvStorage_, nameGenerator_, 0);
+    ASSERT_TRUE(storage.Init());
     std::vector<Dentry> dentrys;
     Dentry dentry;
-
+    // NOTE: store real transaction is unnecessary
+    metaserver::TransactionRequest request;
+    request.set_type(metaserver::TransactionRequest::None);
+    request.set_rawpayload("");
     // CASE 1: prepare success
-    InsertDentrys(&storage, std::vector<Dentry>{
-        // { fsId, parentId, name, txId, inodeId, deleteMarkFlag }
-        GenDentry(1, 0, "A", 0, 1, false),
-    });
+    InsertDentrys(&storage,
+                  std::vector<Dentry>{
+                      // { fsId, parentId, name, txId, inodeId, deleteMarkFlag }
+                      GenDentry(1, 0, "A", 0, 1, false),
+                  });
 
     dentry = GenDentry(1, 0, "A", 1, 2, false);
-    auto rc = storage.HandleTx(TX_OP_TYPE::PREPARE, dentry);
+    // NOTE: store real transaction is unnecessary
+    auto rc = storage.PrepareTx({dentry}, request, logIndex_++);
     ASSERT_EQ(rc, MetaStatusCode::OK);
     ASSERT_EQ(storage.Size(), 2);
 
     // CASE 2: prepare with dentry exist
     dentry = GenDentry(1, 0, "A", 1, 2, false);
-    rc = storage.HandleTx(TX_OP_TYPE::PREPARE, dentry);
+    /// NOTE: store real transaction is unnecessary
+    rc = storage.PrepareTx({dentry}, request, logIndex_++);
     ASSERT_EQ(rc, MetaStatusCode::OK);
     ASSERT_EQ(storage.Size(), 2);
 
     // CASE 3: commit success
-    rc = storage.HandleTx(TX_OP_TYPE::COMMIT, dentry);
+    rc = storage.CommitTx({dentry}, logIndex_++);
     ASSERT_EQ(rc, MetaStatusCode::OK);
     ASSERT_EQ(storage.Size(), 1);
 
@@ -503,28 +541,30 @@ TEST_F(DentryStorageTest, HandleTx) {
 
     // CASE 3: commit dentry with DELETE_MARK_FLAG flag
     storage.Clear();
-    InsertDentrys(&storage, std::vector<Dentry>{
-        // { fsId, parentId, name, txId, inodeId, deleteMarkFlag }
-        GenDentry(1, 0, "A", 0, 1, false),
-        GenDentry(1, 0, "A", 1, 1, true),
-    });
+    InsertDentrys(&storage,
+                  std::vector<Dentry>{
+                      // { fsId, parentId, name, txId, inodeId, deleteMarkFlag }
+                      GenDentry(1, 0, "A", 0, 1, false),
+                      GenDentry(1, 0, "A", 1, 1, true),
+                  });
 
     dentry = GenDentry(1, 0, "A", 1, 0, false);
-    rc = storage.HandleTx(TX_OP_TYPE::COMMIT, dentry);
+    rc = storage.CommitTx({dentry}, logIndex_++);
     ASSERT_EQ(rc, MetaStatusCode::OK);
     ASSERT_EQ(storage.Size(), 0);
 
     // CASE 4: Rollback success
     storage.Clear();
-    InsertDentrys(&storage, std::vector<Dentry>{
-        // { fsId, parentId, name, txId, inodeId, deleteMarkFlag }
-        GenDentry(1, 0, "A", 0, 1, false),
-        GenDentry(1, 0, "A", 1, 2, false),
-    });
+    InsertDentrys(&storage,
+                  std::vector<Dentry>{
+                      // { fsId, parentId, name, txId, inodeId, deleteMarkFlag }
+                      GenDentry(1, 0, "A", 0, 1, false),
+                      GenDentry(1, 0, "A", 1, 2, false),
+                  });
     ASSERT_EQ(storage.Size(), 2);
 
     dentry = GenDentry(1, 0, "A", 1, 2, false);
-    rc = storage.HandleTx(TX_OP_TYPE::ROLLBACK, dentry);
+    rc = storage.RollbackTx({dentry}, logIndex_++);
     ASSERT_EQ(rc, MetaStatusCode::OK);
     ASSERT_EQ(storage.Size(), 1);
 

--- a/curvefs/test/metaserver/inode_manager_test.cpp
+++ b/curvefs/test/metaserver/inode_manager_test.cpp
@@ -46,12 +46,12 @@ using ::testing::SaveArg;
 using ::testing::SetArgPointee;
 using ::testing::StrEq;
 
-using ::curvefs::metaserver::storage::KVStorage;
-using ::curvefs::metaserver::storage::StorageOptions;
-using ::curvefs::metaserver::storage::RocksDBStorage;
-using ::curvefs::metaserver::storage::NameGenerator;
 using ::curvefs::metaserver::storage::Key4S3ChunkInfoList;
+using ::curvefs::metaserver::storage::KVStorage;
+using ::curvefs::metaserver::storage::NameGenerator;
 using ::curvefs::metaserver::storage::RandomStoragePath;
+using ::curvefs::metaserver::storage::RocksDBStorage;
+using ::curvefs::metaserver::storage::StorageOptions;
 
 namespace curvefs {
 namespace metaserver {
@@ -71,12 +71,13 @@ class InodeManagerTest : public ::testing::Test {
         ASSERT_TRUE(kvStorage_->Open());
 
         auto nameGenerator = std::make_shared<NameGenerator>(1);
-        auto inodeStorage = std::make_shared<InodeStorage>(
-            kvStorage_, nameGenerator, 0);
+        auto inodeStorage =
+            std::make_shared<InodeStorage>(kvStorage_, nameGenerator, 0);
         auto trash = std::make_shared<TrashImpl>(inodeStorage);
         filetype2InodeNum_ = std::make_shared<FileType2InodeNumMap>();
         manager = std::make_shared<InodeManager>(inodeStorage, trash,
                                                  filetype2InodeNum_.get());
+        ASSERT_TRUE(manager->Init());
 
         param_.fsId = 1;
         param_.length = 100;
@@ -88,6 +89,7 @@ class InodeManagerTest : public ::testing::Test {
         param_.rdev = 0;
 
         conv_ = std::make_shared<Converter>();
+        logIndex_ = 0;
     }
 
     void TearDown() override {
@@ -110,7 +112,7 @@ class InodeManagerTest : public ::testing::Test {
         return result;
     }
 
-    bool CompareInode(const Inode &first, const Inode &second) {
+    bool CompareInode(const Inode& first, const Inode& second) {
         return first.fsid() == second.fsid() &&
                first.atime() == second.atime() &&
                first.inodeid() == second.inodeid() &&
@@ -125,11 +127,9 @@ class InodeManagerTest : public ::testing::Test {
 
     bool EqualS3ChunkInfo(const S3ChunkInfo& lhs, const S3ChunkInfo& rhs) {
         return lhs.chunkid() == rhs.chunkid() &&
-            lhs.compaction() == rhs.compaction() &&
-            lhs.offset() == rhs.offset() &&
-            lhs.len() == rhs.len() &&
-            lhs.size() == rhs.size() &&
-            lhs.zero() == rhs.zero();
+               lhs.compaction() == rhs.compaction() &&
+               lhs.offset() == rhs.offset() && lhs.len() == rhs.len() &&
+               lhs.size() == rhs.size() && lhs.zero() == rhs.zero();
     }
 
     bool EqualS3ChunkInfoList(const S3ChunkInfoList& lhs,
@@ -187,6 +187,7 @@ class InodeManagerTest : public ::testing::Test {
     std::string dataDir_;
     std::shared_ptr<KVStorage> kvStorage_;
     std::shared_ptr<FileType2InodeNumMap> filetype2InodeNum_;
+    int64_t logIndex_;
 };
 
 TEST_F(InodeManagerTest, test1) {
@@ -194,28 +195,28 @@ TEST_F(InodeManagerTest, test1) {
     uint32_t fsId = 1;
 
     Inode inode1;
-    ASSERT_EQ(manager->CreateInode(2, param_, &inode1),
+    ASSERT_EQ(manager->CreateInode(2, param_, &inode1, logIndex_++),
               MetaStatusCode::OK);
     ASSERT_EQ(inode1.inodeid(), 2);
 
     Inode inode2;
-    ASSERT_EQ(manager->CreateInode(3, param_, &inode2),
+    ASSERT_EQ(manager->CreateInode(3, param_, &inode2, logIndex_++),
               MetaStatusCode::OK);
     ASSERT_EQ(inode2.inodeid(), 3);
 
     Inode inode3;
     param_.type = FsFileType::TYPE_SYM_LINK;
-    ASSERT_EQ(manager->CreateInode(4, param_, &inode3),
+    ASSERT_EQ(manager->CreateInode(4, param_, &inode3, logIndex_++),
               MetaStatusCode::SYM_LINK_EMPTY);
 
     param_.symlink = "SYMLINK";
-    ASSERT_EQ(manager->CreateInode(4, param_, &inode3),
+    ASSERT_EQ(manager->CreateInode(4, param_, &inode3, logIndex_++),
               MetaStatusCode::OK);
     ASSERT_EQ(inode3.inodeid(), 4);
 
     Inode inode4;
     param_.type = FsFileType::TYPE_S3;
-    ASSERT_EQ(manager->CreateInode(5, param_, &inode4),
+    ASSERT_EQ(manager->CreateInode(5, param_, &inode4, logIndex_++),
               MetaStatusCode::OK);
     ASSERT_EQ(inode4.inodeid(), 5);
     ASSERT_EQ(inode4.type(), FsFileType::TYPE_S3);
@@ -225,7 +226,7 @@ TEST_F(InodeManagerTest, test1) {
     struct timespec now;
     clock_gettime(CLOCK_REALTIME, &now);
     param_.timestamp = absl::make_optional<struct timespec>(now);
-    ASSERT_EQ(manager->CreateInode(6, param_, &inode5),
+    ASSERT_EQ(manager->CreateInode(6, param_, &inode5, logIndex_++),
               MetaStatusCode::OK);
 
     // GET
@@ -250,18 +251,20 @@ TEST_F(InodeManagerTest, test1) {
     ASSERT_TRUE(CompareInode(inode4, temp4));
 
     // DELETE
-    ASSERT_EQ(manager->DeleteInode(fsId, inode1.inodeid()), MetaStatusCode::OK);
-    ASSERT_EQ(manager->DeleteInode(fsId, inode1.inodeid()),
+    ASSERT_EQ(manager->DeleteInode(fsId, inode1.inodeid(), logIndex_++),
+              MetaStatusCode::OK);
+    ASSERT_EQ(manager->DeleteInode(fsId, inode1.inodeid(), logIndex_++),
               MetaStatusCode::OK);
     ASSERT_EQ(manager->GetInode(fsId, inode1.inodeid(), &temp1),
               MetaStatusCode::NOT_FOUND);
 
     // UPDATE
     UpdateInodeRequest request = MakeUpdateInodeRequestFromInode(inode1);
-    ASSERT_EQ(manager->UpdateInode(request), MetaStatusCode::NOT_FOUND);
+    ASSERT_EQ(manager->UpdateInode(request, logIndex_++),
+              MetaStatusCode::NOT_FOUND);
     temp2.set_atime(100);
     UpdateInodeRequest request2 = MakeUpdateInodeRequestFromInode(temp2);
-    ASSERT_EQ(manager->UpdateInode(request2), MetaStatusCode::OK);
+    ASSERT_EQ(manager->UpdateInode(request2, logIndex_++), MetaStatusCode::OK);
     Inode temp5;
     ASSERT_EQ(manager->GetInode(fsId, inode2.inodeid(), &temp5),
               MetaStatusCode::OK);
@@ -290,29 +293,27 @@ TEST_F(InodeManagerTest, GetOrModifyS3ChunkInfo) {
 
         std::shared_ptr<Iterator> iterator;
         MetaStatusCode rc = manager->GetOrModifyS3ChunkInfo(
-            fsId, inodeId, map2add, map2del, true, &iterator);
+            fsId, inodeId, map2add, map2del, true, &iterator, logIndex_++);
         ASSERT_EQ(rc, MetaStatusCode::OK);
 
-        CHECK_ITERATOR_S3CHUNKINFOLIST(iterator,
-            std::vector<uint64_t>{ 1, 2, 3 },
-            std::vector<S3ChunkInfoList>{
-                GenS3ChunkInfoList(1, 1),
-                GenS3ChunkInfoList(2, 2),
-                GenS3ChunkInfoList(3, 3),
-            });
+        CHECK_ITERATOR_S3CHUNKINFOLIST(iterator, std::vector<uint64_t>{1, 2, 3},
+                                       std::vector<S3ChunkInfoList>{
+                                           GenS3ChunkInfoList(1, 1),
+                                           GenS3ChunkInfoList(2, 2),
+                                           GenS3ChunkInfoList(3, 3),
+                                       });
 
         LOG(INFO) << "CASE 1.1: check idempotent for GetOrModifyS3ChunkInfo()";
-        rc = manager->GetOrModifyS3ChunkInfo(
-            fsId, inodeId, map2add, map2del, true, &iterator);
+        rc = manager->GetOrModifyS3ChunkInfo(fsId, inodeId, map2add, map2del,
+                                             true, &iterator, logIndex_++);
         ASSERT_EQ(rc, MetaStatusCode::OK);
 
-        CHECK_ITERATOR_S3CHUNKINFOLIST(iterator,
-            std::vector<uint64_t>{ 1, 2, 3 },
-            std::vector<S3ChunkInfoList>{
-                GenS3ChunkInfoList(1, 1),
-                GenS3ChunkInfoList(2, 2),
-                GenS3ChunkInfoList(3, 3),
-            });
+        CHECK_ITERATOR_S3CHUNKINFOLIST(iterator, std::vector<uint64_t>{1, 2, 3},
+                                       std::vector<S3ChunkInfoList>{
+                                           GenS3ChunkInfoList(1, 1),
+                                           GenS3ChunkInfoList(2, 2),
+                                           GenS3ChunkInfoList(3, 3),
+                                       });
     }
 
     // CASE 2: GetOrModifyS3ChunkInfo() with delete
@@ -327,12 +328,11 @@ TEST_F(InodeManagerTest, GetOrModifyS3ChunkInfo) {
 
         std::shared_ptr<Iterator> iterator;
         MetaStatusCode rc = manager->GetOrModifyS3ChunkInfo(
-            fsId, inodeId, map2add, map2del, true, &iterator);
+            fsId, inodeId, map2add, map2del, true, &iterator, logIndex_++);
         ASSERT_EQ(rc, MetaStatusCode::OK);
 
-        CHECK_ITERATOR_S3CHUNKINFOLIST(iterator,
-            std::vector<uint64_t>{},
-            std::vector<S3ChunkInfoList>{});
+        CHECK_ITERATOR_S3CHUNKINFOLIST(iterator, std::vector<uint64_t>{},
+                                       std::vector<S3ChunkInfoList>{});
     }
 
     // CASE 3: GetOrModifyS3ChunkInfo() with add and delete
@@ -351,7 +351,7 @@ TEST_F(InodeManagerTest, GetOrModifyS3ChunkInfo) {
 
         std::shared_ptr<Iterator> iterator;
         MetaStatusCode rc = manager->GetOrModifyS3ChunkInfo(
-            fsId, inodeId, map2add, map2del, true, &iterator);
+            fsId, inodeId, map2add, map2del, true, &iterator, logIndex_++);
         ASSERT_EQ(rc, MetaStatusCode::OK);
         ASSERT_EQ(iterator->Status(), 0);
 
@@ -369,21 +369,21 @@ TEST_F(InodeManagerTest, GetOrModifyS3ChunkInfo) {
         map2del[8] = GenS3ChunkInfoList(1, 100);
         map2del[9] = GenS3ChunkInfoList(1, 100);
 
-        rc = manager->GetOrModifyS3ChunkInfo(
-            fsId, inodeId, map2add, map2del, true, &iterator);
+        rc = manager->GetOrModifyS3ChunkInfo(fsId, inodeId, map2add, map2del,
+                                             true, &iterator, logIndex_++);
         ASSERT_EQ(rc, MetaStatusCode::OK);
         ASSERT_EQ(iterator->Status(), 0);
 
         CHECK_ITERATOR_S3CHUNKINFOLIST(iterator,
-            std::vector<uint64_t>{ 0, 1, 2, 7, 8, 9 },
-            std::vector<S3ChunkInfoList>{
-                GenS3ChunkInfoList(100, 100),
-                GenS3ChunkInfoList(1, 100),
-                GenS3ChunkInfoList(1, 100),
-                GenS3ChunkInfoList(100, 100),
-                GenS3ChunkInfoList(100, 100),
-                GenS3ChunkInfoList(100, 100),
-            });
+                                       std::vector<uint64_t>{0, 1, 2, 7, 8, 9},
+                                       std::vector<S3ChunkInfoList>{
+                                           GenS3ChunkInfoList(100, 100),
+                                           GenS3ChunkInfoList(1, 100),
+                                           GenS3ChunkInfoList(1, 100),
+                                           GenS3ChunkInfoList(100, 100),
+                                           GenS3ChunkInfoList(100, 100),
+                                           GenS3ChunkInfoList(100, 100),
+                                       });
 
         // step3: delete all s3chunkinfo
         map2add.clear();
@@ -394,21 +394,21 @@ TEST_F(InodeManagerTest, GetOrModifyS3ChunkInfo) {
         map2del[1] = GenS3ChunkInfoList(1, 100);
         map2del[2] = GenS3ChunkInfoList(1, 100);
 
-        rc = manager->GetOrModifyS3ChunkInfo(
-            fsId, inodeId, map2add, map2del, true, &iterator);
+        rc = manager->GetOrModifyS3ChunkInfo(fsId, inodeId, map2add, map2del,
+                                             true, &iterator, logIndex_++);
         ASSERT_EQ(rc, MetaStatusCode::OK);
         ASSERT_EQ(iterator->Status(), 0);
 
         CHECK_ITERATOR_S3CHUNKINFOLIST(iterator,
-            std::vector<uint64_t>{ 0, 1, 2, 7, 8, 9 },
-            std::vector<S3ChunkInfoList>{
-                GenS3ChunkInfoList(100, 100),
-                GenS3ChunkInfoList(100, 100),
-                GenS3ChunkInfoList(100, 100),
-                GenS3ChunkInfoList(100, 100),
-                GenS3ChunkInfoList(100, 100),
-                GenS3ChunkInfoList(100, 100),
-            });
+                                       std::vector<uint64_t>{0, 1, 2, 7, 8, 9},
+                                       std::vector<S3ChunkInfoList>{
+                                           GenS3ChunkInfoList(100, 100),
+                                           GenS3ChunkInfoList(100, 100),
+                                           GenS3ChunkInfoList(100, 100),
+                                           GenS3ChunkInfoList(100, 100),
+                                           GenS3ChunkInfoList(100, 100),
+                                           GenS3ChunkInfoList(100, 100),
+                                       });
     }
 }
 
@@ -417,16 +417,15 @@ TEST_F(InodeManagerTest, UpdateInode) {
     uint64_t ino = 2;
 
     Inode inode;
-    ASSERT_EQ(MetaStatusCode::OK, manager->CreateInode(ino, param_, &inode));
+    ASSERT_EQ(MetaStatusCode::OK,
+              manager->CreateInode(ino, param_, &inode, logIndex_++));
 
     // test update ok
     UpdateInodeRequest request = MakeUpdateInodeRequestFromInode(inode);
-    ASSERT_EQ(MetaStatusCode::OK,
-              manager->UpdateInode(request));
+    ASSERT_EQ(MetaStatusCode::OK, manager->UpdateInode(request, logIndex_++));
 
     // test update fail
-    ASSERT_EQ(MetaStatusCode::OK,
-              manager->UpdateInode(request));
+    ASSERT_EQ(MetaStatusCode::OK, manager->UpdateInode(request, logIndex_++));
 }
 
 
@@ -434,8 +433,8 @@ TEST_F(InodeManagerTest, testGetAttr) {
     // CREATE
     uint32_t fsId = 1;
     Inode inode1;
-    ASSERT_EQ(manager->CreateInode(2, param_, &inode1),
-        MetaStatusCode::OK);
+    ASSERT_EQ(manager->CreateInode(2, param_, &inode1, logIndex_++),
+              MetaStatusCode::OK);
     ASSERT_EQ(inode1.inodeid(), 2);
 
     InodeAttr attr;
@@ -456,14 +455,14 @@ TEST_F(InodeManagerTest, testGetXAttr) {
     // CREATE
     uint32_t fsId = 1;
     Inode inode1;
-    ASSERT_EQ(manager->CreateInode(2, param_, &inode1),
-        MetaStatusCode::OK);
+    ASSERT_EQ(manager->CreateInode(2, param_, &inode1, logIndex_++),
+              MetaStatusCode::OK);
     ASSERT_EQ(inode1.inodeid(), 2);
     ASSERT_TRUE(inode1.xattr().empty());
 
     Inode inode2;
     param_.type = FsFileType::TYPE_DIRECTORY;
-    ASSERT_EQ(manager->CreateInode(3, param_, &inode2),
+    ASSERT_EQ(manager->CreateInode(3, param_, &inode2, logIndex_++),
               MetaStatusCode::OK);
     ASSERT_FALSE(inode2.xattr().empty());
     ASSERT_EQ(inode2.xattr().find(XATTRFILES)->second, "0");
@@ -489,7 +488,7 @@ TEST_F(InodeManagerTest, testGetXAttr) {
     inode2.mutable_xattr()->find(XATTRENTRIES)->second = "2";
     inode2.mutable_xattr()->find(XATTRFBYTES)->second = "100";
     UpdateInodeRequest request = MakeUpdateInodeRequestFromInode(inode2);
-    ASSERT_EQ(manager->UpdateInode(request), MetaStatusCode::OK);
+    ASSERT_EQ(manager->UpdateInode(request, logIndex_++), MetaStatusCode::OK);
 
     // GET
     XAttr xattr1;
@@ -508,7 +507,7 @@ TEST_F(InodeManagerTest, testCreateManageInode) {
     ManageInodeType type = ManageInodeType::TYPE_RECYCLE;
     Inode inode;
     ASSERT_EQ(MetaStatusCode::OK,
-        manager->CreateManageInode(param_, type, &inode));
+              manager->CreateManageInode(param_, type, &inode, logIndex_++));
     ASSERT_EQ(inode.inodeid(), RECYCLEINODEID);
     ASSERT_EQ(inode.parent()[0], ROOTINODEID);
 

--- a/curvefs/test/metaserver/mock/mock_kv_storage.h
+++ b/curvefs/test/metaserver/mock/mock_kv_storage.h
@@ -36,15 +36,13 @@ namespace curvefs {
 namespace metaserver {
 namespace storage {
 
-class MockKVStorage : public KVStorage {
+class MockKVStorage : public KVStorage, public StorageTransaction {
  public:
     MOCK_METHOD3(HGet,
                  Status(const std::string&, const std::string&, ValueType*));
 
-    MOCK_METHOD3(HSet,
-                 Status(const std::string&,
-                        const std::string&,
-                        const ValueType&));
+    MOCK_METHOD3(HSet, Status(const std::string&, const std::string&,
+                              const ValueType&));
 
     MOCK_METHOD2(HDel, Status(const std::string&, const std::string&));
 
@@ -57,16 +55,13 @@ class MockKVStorage : public KVStorage {
     MOCK_METHOD3(SGet,
                  Status(const std::string&, const std::string&, ValueType*));
 
-    MOCK_METHOD3(SSet,
-                 Status(const std::string&,
-                        const std::string&,
-                        const ValueType&));
+    MOCK_METHOD3(SSet, Status(const std::string&, const std::string&,
+                              const ValueType&));
 
     MOCK_METHOD2(SDel, Status(const std::string&, const std::string&));
 
-    MOCK_METHOD2(SSeek,
-                 std::shared_ptr<Iterator>(const std::string&,
-                                           const std::string&));
+    MOCK_METHOD2(SSeek, std::shared_ptr<Iterator>(const std::string&,
+                                                  const std::string&));
 
     MOCK_METHOD1(SGetAll, std::shared_ptr<Iterator>(const std::string&));
 
@@ -88,6 +83,10 @@ class MockKVStorage : public KVStorage {
                  bool(const std::string&, std::vector<std::string>*));
 
     MOCK_METHOD1(Recover, bool(const std::string&));
+
+    MOCK_METHOD0(Commit, Status());
+
+    MOCK_METHOD0(Rollback, Status());
 };
 
 }  // namespace storage

--- a/curvefs/test/metaserver/mock/mock_metastore.h
+++ b/curvefs/test/metaserver/mock/mock_metastore.h
@@ -25,10 +25,11 @@
 
 #include <gmock/gmock.h>
 
-#include <string>
 #include <list>
-#include <memory>
 #include <map>
+#include <memory>
+#include <string>
+#include <vector>
 
 #include "curvefs/src/metaserver/metastore.h"
 
@@ -39,72 +40,88 @@ namespace mock {
 class MockMetaStore : public curvefs::metaserver::MetaStore {
  public:
     MOCK_METHOD1(Load, bool(const std::string&));
-    MOCK_METHOD2(Save, bool(const std::string&, OnSnapshotSaveDoneClosure*));
+    MOCK_METHOD2(SaveMeta,
+                 bool(const std::string&, std::vector<std::string>* files));
+    MOCK_METHOD2(SaveData,
+                 bool(const std::string&, std::vector<std::string>* files));
     MOCK_METHOD0(Clear, bool());
     MOCK_METHOD0(Destroy, bool());
 
-    MOCK_METHOD2(CreatePartition, MetaStatusCode(const CreatePartitionRequest*,
-                                                 CreatePartitionResponse*));
-    MOCK_METHOD2(DeletePartition, MetaStatusCode(const DeletePartitionRequest*,
-                                                 DeletePartitionResponse*));
-    MOCK_METHOD1(GetPartitionInfoList, bool(std::list<PartitionInfo> *));
+    MOCK_METHOD3(CreatePartition,
+                 MetaStatusCode(const CreatePartitionRequest*,
+                                CreatePartitionResponse*, int64_t logIndex));
+    MOCK_METHOD3(DeletePartition,
+                 MetaStatusCode(const DeletePartitionRequest*,
+                                DeletePartitionResponse*, int64_t logIndex));
+    MOCK_METHOD1(GetPartitionInfoList, bool(std::list<PartitionInfo>*));
     MOCK_METHOD1(GetPartitionSnap,
-                 bool(std::map<uint32_t, std::shared_ptr<Partition>> *));
+                 bool(std::map<uint32_t, std::shared_ptr<Partition>>*));
 
-    MOCK_METHOD2(CreateDentry, MetaStatusCode(const CreateDentryRequest*,
-                                              CreateDentryResponse*));
-    MOCK_METHOD2(DeleteDentry, MetaStatusCode(const DeleteDentryRequest*,
-                                              DeleteDentryResponse*));
-    MOCK_METHOD2(GetDentry,
-                 MetaStatusCode(const GetDentryRequest*, GetDentryResponse*));
-    MOCK_METHOD2(ListDentry,
-                 MetaStatusCode(const ListDentryRequest*, ListDentryResponse*));
+    MOCK_METHOD3(CreateDentry,
+                 MetaStatusCode(const CreateDentryRequest*,
+                                CreateDentryResponse*, int64_t logIndex));
+    MOCK_METHOD3(DeleteDentry,
+                 MetaStatusCode(const DeleteDentryRequest*,
+                                DeleteDentryResponse*, int64_t logIndex));
+    MOCK_METHOD3(GetDentry,
+                 MetaStatusCode(const GetDentryRequest*, GetDentryResponse*,
+                                int64_t logIndex));
+    MOCK_METHOD3(ListDentry,
+                 MetaStatusCode(const ListDentryRequest*, ListDentryResponse*,
+                                int64_t logIndex));
 
-    MOCK_METHOD2(CreateInode, MetaStatusCode(const CreateInodeRequest*,
-                                             CreateInodeResponse*));
-    MOCK_METHOD2(CreateRootInode, MetaStatusCode(const CreateRootInodeRequest*,
-                                                 CreateRootInodeResponse*));
-    MOCK_METHOD2(CreateManageInode,
-                MetaStatusCode(const CreateManageInodeRequest*,
-                                                 CreateManageInodeResponse*));
-    MOCK_METHOD2(GetInode,
-                 MetaStatusCode(const GetInodeRequest*, GetInodeResponse*));
-    MOCK_METHOD2(BatchGetInodeAttr,
+    MOCK_METHOD3(CreateInode,
+                 MetaStatusCode(const CreateInodeRequest*, CreateInodeResponse*,
+                                int64_t logIndex));
+    MOCK_METHOD3(CreateRootInode,
+                 MetaStatusCode(const CreateRootInodeRequest*,
+                                CreateRootInodeResponse*, int64_t logIndex));
+    MOCK_METHOD3(CreateManageInode,
+                 MetaStatusCode(const CreateManageInodeRequest*,
+                                CreateManageInodeResponse*, int64_t logIndex));
+    MOCK_METHOD3(GetInode, MetaStatusCode(const GetInodeRequest*,
+                                          GetInodeResponse*, int64_t logIndex));
+    MOCK_METHOD3(BatchGetInodeAttr,
                  MetaStatusCode(const BatchGetInodeAttrRequest*,
-                 BatchGetInodeAttrResponse*));
-    MOCK_METHOD2(BatchGetXAttr,
+                                BatchGetInodeAttrResponse*, int64_t logIndex));
+    MOCK_METHOD3(BatchGetXAttr,
                  MetaStatusCode(const BatchGetXAttrRequest*,
-                 BatchGetXAttrResponse*));
-    MOCK_METHOD2(DeleteInode, MetaStatusCode(const DeleteInodeRequest*,
-                                             DeleteInodeResponse*));
-    MOCK_METHOD2(UpdateInode, MetaStatusCode(const UpdateInodeRequest*,
-                                             UpdateInodeResponse*));
+                                BatchGetXAttrResponse*, int64_t logIndex));
+    MOCK_METHOD3(DeleteInode,
+                 MetaStatusCode(const DeleteInodeRequest*, DeleteInodeResponse*,
+                                int64_t logIndex));
+    MOCK_METHOD3(UpdateInode,
+                 MetaStatusCode(const UpdateInodeRequest*, UpdateInodeResponse*,
+                                int64_t logIndex));
 
-    MOCK_METHOD2(PrepareRenameTx, MetaStatusCode(const PrepareRenameTxRequest*,
-                                                 PrepareRenameTxResponse*));
+    MOCK_METHOD3(PrepareRenameTx,
+                 MetaStatusCode(const PrepareRenameTxRequest*,
+                                PrepareRenameTxResponse*, int64_t logIndex));
 
     MOCK_METHOD0(GetStreamServer, std::shared_ptr<StreamServer>());
 
-    MOCK_METHOD3(GetOrModifyS3ChunkInfo, MetaStatusCode(
-        const GetOrModifyS3ChunkInfoRequest* request,
-        GetOrModifyS3ChunkInfoResponse* response,
-        std::shared_ptr<Iterator>* iterator));
+    MOCK_METHOD4(GetOrModifyS3ChunkInfo,
+                 MetaStatusCode(const GetOrModifyS3ChunkInfoRequest* request,
+                                GetOrModifyS3ChunkInfoResponse* response,
+                                std::shared_ptr<Iterator>* iterator,
+                                int64_t logIndex));
 
-    MOCK_METHOD2(SendS3ChunkInfoByStream, MetaStatusCode(
-        std::shared_ptr<StreamConnection> connection,
-        std::shared_ptr<Iterator> iterator));
+    MOCK_METHOD2(SendS3ChunkInfoByStream,
+                 MetaStatusCode(std::shared_ptr<StreamConnection> connection,
+                                std::shared_ptr<Iterator> iterator));
 
-    MOCK_METHOD2(GetVolumeExtent,
+    MOCK_METHOD3(GetVolumeExtent,
                  MetaStatusCode(const GetVolumeExtentRequest*,
-                                GetVolumeExtentResponse*));
+                                GetVolumeExtentResponse*, int64_t logIndex));
 
-    MOCK_METHOD2(UpdateVolumeExtent,
+    MOCK_METHOD3(UpdateVolumeExtent,
                  MetaStatusCode(const UpdateVolumeExtentRequest*,
-                                UpdateVolumeExtentResponse*));
+                                UpdateVolumeExtentResponse*, int64_t logIndex));
 
-    MOCK_METHOD2(UpdateDeallocatableBlockGroup,
-                 MetaStatusCode(const UpdateDeallocatableBlockGroupRequest *,
-                                UpdateDeallocatableBlockGroupResponse *));
+    MOCK_METHOD3(UpdateDeallocatableBlockGroup,
+                 MetaStatusCode(const UpdateDeallocatableBlockGroupRequest*,
+                                UpdateDeallocatableBlockGroupResponse*,
+                                int64_t logIndex));
 };
 
 }  // namespace mock

--- a/curvefs/test/metaserver/mock/mock_partition.h
+++ b/curvefs/test/metaserver/mock/mock_partition.h
@@ -34,7 +34,7 @@ class MockPartition : public curvefs::metaserver::Partition {
  public:
     MockPartition() : Partition() {}
     MOCK_METHOD1(GetAllBlockGroup,
-                 MetaStatusCode(std::vector<DeallocatableBlockGroup> *));
+                 MetaStatusCode(std::vector<DeallocatableBlockGroup>*));
     MOCK_CONST_METHOD0(GetPartitionId, uint32_t());
     MOCK_CONST_METHOD0(GetFsId, uint32_t());
 };

--- a/curvefs/test/metaserver/space/utils.h
+++ b/curvefs/test/metaserver/space/utils.h
@@ -23,7 +23,11 @@
 #ifndef CURVEFS_TEST_METASERVER_SPACE_UTILS_H_
 #define CURVEFS_TEST_METASERVER_SPACE_UTILS_H_
 
+#include <array>
+#include <memory>
+#include <stdexcept>
 #include <string>
+#include <utility>
 
 namespace curvefs {
 namespace metaserver {

--- a/curvefs/test/metaserver/storage/iterator_test.cpp
+++ b/curvefs/test/metaserver/storage/iterator_test.cpp
@@ -51,7 +51,7 @@ class HashIterator : public Iterator {
     void Next() override { iter_++; }
     std::string Key() override { return iter_->first; }
     std::string Value() override { return iter_->second; }
-    bool ParseFromValue(ValueType* value) { return true; }
+    bool ParseFromValue(ValueType* value) override { return true; }
     int Status() override { return 0; }
 
  private:


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #1617

Problem Summary:

* `on_snapshot_save()` will block the apply thread, it should to be asynchronous.

### What is changed and how it works?

What's Changed:

* Add a `logIndex` argument to each meta operations.
* Filter the logs that already applied.

How it Works:


* Due to the non-idempotency of the log application, we store some sentinel values on `KVStorage`, there are:
  * `inode applied index` -  record the application progress of the `InodeStorage` .
  * `dentry applied index` - record the application progress of the `DentryStorage`.
  * `handle tx applied index` - record the application progress of the `CommitTx/RollbackTx`.
* Move `pengdTx` to `KVStorage` from `MetaFStream`.
* Move `dentry count` and `inode count`  to `KVStorage` from `MetaFStream`.
* Set `allow_write_stall` to `false`.
* Invoke `KVStorage::Checkpoint()` in other threads.

See also:
* [`FlushOptions::allow_write_stall`](https://github.com/facebook/rocksdb/blob/1e77e35d269f843e4c5e2ed8edc87f07a907636b/HISTORY.md?plain=1#L1669)

Side effects(Breaking backward compatibility? Performance regression?):

* The older version of metaserver cannot use newer version of metaserver snapshot.
* If there are `Inode` and `Dentry` in `MetaFStream`, there cannot be loaded by current version.

### Check List

- [x] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license
