### PR TITLE
[test] curvefs/mds: split large test cases into focused smaller ones

### DIFF
--- a/curvefs/test/mds/fs_manager_test.cpp
+++ b/curvefs/test/mds/fs_manager_test.cpp
@@ -19,21 +19,22 @@
  * @Date: 2021-06-10 10:04:37
  * @Author: chenwei
  */
-#include "curvefs/src/mds/fs_manager.h"
 #include <brpc/channel.h>
 #include <brpc/server.h>
 #include <butil/endpoint.h>
 #include <gmock/gmock.h>
 #include <google/protobuf/util/message_differencer.h>
 #include <gtest/gtest.h>
+#include "absl/memory/memory.h"
+#include "curvefs/src/mds/fs_manager.h"
 #include "curvefs/test/mds/mock/mock_cli2.h"
 #include "curvefs/test/mds/mock/mock_fs_stroage.h"
 #include "curvefs/test/mds/mock/mock_metaserver.h"
 #include "curvefs/test/mds/mock/mock_topology.h"
-#include "test/common/mock_s3_adapter.h"
 #include "curvefs/test/mds/mock/mock_space_manager.h"
 #include "curvefs/test/mds/mock/mock_volume_space.h"
 #include "curvefs/test/mds/utils.h"
+#include "test/common/mock_s3_adapter.h"
 
 using ::testing::AtLeast;
 using ::testing::StrEq;
@@ -88,6 +89,23 @@ using ::curvefs::mds::space::MockVolumeSpace;
 
 namespace curvefs {
 namespace mds {
+
+template <bool FAIL>
+struct RpcService {
+    template <typename Request, typename Response>
+    void operator()(google::protobuf::RpcController* cntl_base,
+                    const Request* /*request*/,
+                    Response* /*response*/,
+                    google::protobuf::Closure* done) const {
+        if (FAIL) {
+            brpc::Controller* cntl = static_cast<brpc::Controller*>(cntl_base);
+            cntl->SetFailed(112, "Not connected to");
+        }
+
+        done->Run();
+    }
+};
+
 class FSManagerTest : public ::testing::Test {
  protected:
     void SetUp() override {
@@ -133,12 +151,120 @@ class FSManagerTest : public ::testing::Test {
                                         brpc::SERVER_DOESNT_OWN_SERVICE));
 
         ASSERT_EQ(0, server_.Start(addr_.c_str(), nullptr));
+
+        volumeSize = fakeCurveFsService_.volumeSize;
+
+        bool enableSumInDir = false;
+        curvefs::common::Volume volume;
+        volume.set_blocksize(4096);
+        volume.set_volumename("volume1");
+        volume.set_user("user1");
+        volume.add_cluster(addr_);
+
+        FsDetail detail;
+        detail.set_allocated_volume(new Volume(volume));
+
+        req.set_fsname(kFsName1);
+        req.set_blocksize(kBlockSize);
+        req.set_fstype(FSType::TYPE_VOLUME);
+        req.set_allocated_fsdetail(new FsDetail(detail));
+        req.set_enablesumindir(enableSumInDir);
+        req.set_owner("test");
+        req.set_capacity((uint64_t)100*1024*1024*1024);
+
+        std::string leader = addr_ + ":0";
+        getLeaderResponse.mutable_leader()->set_address(leader);
+
+        // create s3 test
+        std::set<std::string> addrs{addr_};
+        curvefs::common::S3Info s3Info;
+        s3Info.set_ak("ak");
+        s3Info.set_sk("sk");
+        s3Info.set_endpoint("endpoint");
+        s3Info.set_bucketname("bucketname");
+        s3Info.set_blocksize(4096);
+        s3Info.set_chunksize(4096);
+        CreateRootInodeResponse response2;
+        FsDetail detail2;
+        detail2.set_allocated_s3info(new S3Info(s3Info));
+
+        s3Req.set_fsname(kFsName2);
+        s3Req.set_allocated_fsdetail(new FsDetail(detail2));
+        s3Req.set_fstype(FSType::TYPE_S3);
+        s3Req.set_blocksize(kBlockSize);
+        s3Req.set_enablesumindir(enableSumInDir);
+        s3Req.set_owner("test");
+        s3Req.set_capacity((uint64_t)100*1024*1024*1024);
+
+        s3MountPoint.set_hostname("host");
+        s3MountPoint.set_port(90000);
+        s3MountPoint.set_path("/a/b/c");
+        s3MountPoint.set_cto(false);
+
+        volMountPoint.set_hostname("host");
+        volMountPoint.set_port(90000);
+        volMountPoint.set_path("/a/b/c");
+        volMountPoint.set_cto(false);
     }
 
     void TearDown() override {
         server_.Stop(0);
         server_.Join();
         fsManager_->Uninit();
+    }
+
+    FSStatusCode CreateVolFs() {
+        CreateRootInodeResponse response;
+
+        std::set<std::string> addrs { addr_ };
+
+        // create vol fs ok
+        EXPECT_CALL(*topoManager_, CreatePartitionsAndGetMinPartition(_, _))
+            .WillOnce(Return(TopoStatusCode::TOPO_OK));
+        EXPECT_CALL(*topoManager_, GetCopysetMembers(_, _, _))
+            .WillOnce(
+                DoAll(SetArgPointee<2>(addrs),
+                      Return(TopoStatusCode::TOPO_OK)));
+        EXPECT_CALL(mockCliService2_, GetLeader(_, _, _, _))
+            .WillOnce(
+                DoAll(SetArgPointee<2>(getLeaderResponse),
+                    Invoke(RpcService<false>{})));
+
+        response.set_statuscode(MetaStatusCode::OK);
+        EXPECT_CALL(mockMetaserverService_, CreateRootInode(_, _, _, _))
+            .WillOnce(DoAll(
+                SetArgPointee<2>(response),
+                Invoke(RpcService<false>{})));
+
+        return fsManager_->CreateFs(&req, &volumeFsInfo1);
+    }
+
+    FSStatusCode CreateS3Fs() {
+        CreateRootInodeResponse response;
+
+        std::set<std::string> addrs { addr_ };
+
+        // create s3 fs ok
+        EXPECT_CALL(*topoManager_,
+                    CreatePartitionsAndGetMinPartition(_, _))
+            .WillOnce(Return(TopoStatusCode::TOPO_OK));
+        EXPECT_CALL(*topoManager_, GetCopysetMembers(_, _, _))
+            .WillOnce(
+                DoAll(SetArgPointee<2>(addrs),
+                      Return(TopoStatusCode::TOPO_OK)));
+        EXPECT_CALL(mockCliService2_, GetLeader(_, _, _, _))
+            .WillOnce(
+                DoAll(SetArgPointee<2>(getLeaderResponse),
+                    Invoke(RpcService<false>{})));
+
+        response.set_statuscode(MetaStatusCode::OK);
+        EXPECT_CALL(mockMetaserverService_, CreateRootInode(_, _, _, _))
+            .WillOnce(DoAll(
+                SetArgPointee<2>(response),
+                Invoke(RpcService<false>{})));
+        EXPECT_CALL(*s3Adapter_, BucketExist()).WillOnce(Return(true));
+
+        return fsManager_->CreateFs(&s3Req, &s3FsInfo);
     }
 
     static bool CompareVolume(const Volume& first, const Volume& second) {
@@ -184,50 +310,29 @@ class FSManagerTest : public ::testing::Test {
     std::shared_ptr<MockS3Adapter> s3Adapter_;
     FakeCurveFSService fakeCurveFsService_;
     std::string addr_;
+
+    const std::string kFsName1 = "fs1";
+    const uint64_t kBlockSize = 4096;
+    const std::string kFsName2 = "fs2";
+    uint64_t volumeSize;
+    CreateFsRequest req;
+    CreateFsRequest s3Req;
+    GetLeaderResponse2 getLeaderResponse;
+    FsInfo s3FsInfo;
+    Mountpoint s3MountPoint;
+    Mountpoint volMountPoint;
+    FsInfo volumeFsInfo1;
 };
 
-template <typename RpcRequestType, typename RpcResponseType,
-          bool RpcFailed = false>
-void RpcService(google::protobuf::RpcController* cntl_base,
-                const RpcRequestType* request, RpcResponseType* response,
-                google::protobuf::Closure* done) {
-    if (RpcFailed) {
-        brpc::Controller* cntl = static_cast<brpc::Controller*>(cntl_base);
-        cntl->SetFailed(112, "Not connected to");
-    }
-    done->Run();
-}
-
-TEST_F(FSManagerTest, CleanUpWhenCreateFsFail) {
-    std::string addr = addr_;
+TEST_F(FSManagerTest,
+       test_success_cleanup_after_fail_create_volume_fs_on_inode_error) {
     std::string leader = addr_ + ":0";
-    std::set<std::string> addrs{addr};
-    std::string fsName = "fs";
-    uint64_t blockSize = 4096;
-    bool enableSumInDir = false;
-    Volume volume;
-    volume.set_blocksize(blockSize);
-    volume.set_volumename("volume");
-    volume.set_user("user");
-    volume.add_cluster(addr_);
+    std::set<std::string> addrs{addr_};
 
     FsInfo fsInfo;
-    FsDetail fsDetail;
-    fsDetail.set_allocated_volume(new Volume(volume));
-
-    CreateFsRequest req;
-    req.set_fsname(fsName);
-    req.set_blocksize(blockSize);
-    req.set_fstype(FSType::TYPE_VOLUME);
-    req.set_allocated_fsdetail(new FsDetail(fsDetail));
-    req.set_enablesumindir(enableSumInDir);
-    req.set_owner("test");
-    req.set_capacity((uint64_t)100 * 1024 * 1024 * 1024);
-    req.set_recycletimehour(10);
-
     FsInfoWrapper wrapper;
 
-    // case1: create volume fs create recycle inode fail
+    // create volume fs create recycle inode fail
     EXPECT_CALL(*topoManager_, CreatePartitionsAndGetMinPartition(_, _))
         .WillOnce(Return(TopoStatusCode::TOPO_OK));
     EXPECT_CALL(*topoManager_, GetCopysetMembers(_, _, _))
@@ -239,103 +344,140 @@ TEST_F(FSManagerTest, CleanUpWhenCreateFsFail) {
         .Times(2)
         .WillRepeatedly(
             DoAll(SetArgPointee<2>(getLeaderResponse),
-                  Invoke(RpcService<GetLeaderRequest2, GetLeaderResponse2>)));
+                  Invoke(RpcService<false>{})));
+
     CreateRootInodeResponse createRootInodeResponse;
     createRootInodeResponse.set_statuscode(MetaStatusCode::OK);
     EXPECT_CALL(mockMetaserverService_, CreateRootInode(_, _, _, _))
         .WillOnce(DoAll(
             SetArgPointee<2>(createRootInodeResponse),
-            Invoke(
-                RpcService<CreateRootInodeRequest, CreateRootInodeResponse>)));
+            Invoke(RpcService<false>{})));
 
     CreateManageInodeResponse createManageInodeResponse;
     createManageInodeResponse.set_statuscode(MetaStatusCode::UNKNOWN_ERROR);
     EXPECT_CALL(mockMetaserverService_, CreateManageInode(_, _, _, _))
         .WillOnce(DoAll(SetArgPointee<2>(createManageInodeResponse),
-                        Invoke(RpcService<CreateManageInodeRequest,
-                                          CreateManageInodeResponse>)));
+                        Invoke(RpcService<false>{})));
+
     // delete inode, partition and fs in order
     DeleteInodeResponse deleteInodeResponse;
     deleteInodeResponse.set_statuscode(MetaStatusCode::OK);
     EXPECT_CALL(mockMetaserverService_, DeleteInode(_, _, _, _))
         .WillOnce(
             DoAll(SetArgPointee<2>(deleteInodeResponse),
-                  Invoke(RpcService<DeleteInodeRequest, DeleteInodeResponse>)));
+                  Invoke(RpcService<false>{})));
     EXPECT_CALL(*topoManager_, DeletePartition(_))
         .WillOnce(Return(TopoStatusCode::TOPO_OK));
 
+    req.set_recycletimehour(10);
+
     ASSERT_EQ(FSStatusCode::INSERT_MANAGE_INODE_FAIL,
               fsManager_->CreateFs(&req, &fsInfo));
-    ASSERT_EQ(FSStatusCode::NOT_FOUND, fsStorage_->Get(fsName, &wrapper));
+    ASSERT_EQ(FSStatusCode::NOT_FOUND, fsStorage_->Get(kFsName1, &wrapper));
+}
 
-    // case2: create volume fs create recycle dentry fail
+TEST_F(FSManagerTest,
+       test_success_cleanup_after_fail_create_volume_fs_on_dentry_error) {
+    std::string leader = addr_ + ":0";
+    std::set<std::string> addrs{addr_};
+
+    FsInfo fsInfo;
+    FsInfoWrapper wrapper;
+
+    // create volume fs create recycle dentry fail
     EXPECT_CALL(*topoManager_, CreatePartitionsAndGetMinPartition(_, _))
         .WillOnce(Return(TopoStatusCode::TOPO_OK));
     EXPECT_CALL(*topoManager_, GetCopysetMembers(_, _, _))
         .WillOnce(
             DoAll(SetArgPointee<2>(addrs), Return(TopoStatusCode::TOPO_OK)));
+
+    GetLeaderResponse2 getLeaderResponse;
+    getLeaderResponse.mutable_leader()->set_address(leader);
     EXPECT_CALL(mockCliService2_, GetLeader(_, _, _, _))
         .Times(3)
         .WillRepeatedly(
             DoAll(SetArgPointee<2>(getLeaderResponse),
-                  Invoke(RpcService<GetLeaderRequest2, GetLeaderResponse2>)));
+                  Invoke(RpcService<false>{})));
+
+    CreateRootInodeResponse createRootInodeResponse;
+    createRootInodeResponse.set_statuscode(MetaStatusCode::OK);
     EXPECT_CALL(mockMetaserverService_, CreateRootInode(_, _, _, _))
         .WillOnce(DoAll(
             SetArgPointee<2>(createRootInodeResponse),
-            Invoke(
-                RpcService<CreateRootInodeRequest, CreateRootInodeResponse>)));
+            Invoke(RpcService<false>{})));
+
+    CreateManageInodeResponse createManageInodeResponse;
     createManageInodeResponse.set_statuscode(MetaStatusCode::OK);
     EXPECT_CALL(mockMetaserverService_, CreateManageInode(_, _, _, _))
         .WillOnce(DoAll(SetArgPointee<2>(createManageInodeResponse),
-                        Invoke(RpcService<CreateManageInodeRequest,
-                                          CreateManageInodeResponse>)));
+                        Invoke(RpcService<false>{})));
 
     CreateDentryResponse createDentryResponse;
     createDentryResponse.set_statuscode(MetaStatusCode::UNKNOWN_ERROR);
     EXPECT_CALL(mockMetaserverService_, CreateDentry(_, _, _, _))
         .WillOnce(DoAll(
             SetArgPointee<2>(createDentryResponse),
-            Invoke(RpcService<CreateDentryRequest, CreateDentryResponse>)));
+            Invoke(RpcService<false>{})));
+
     // delete inode, partition and fs in order
+    DeleteInodeResponse deleteInodeResponse;
+    deleteInodeResponse.set_statuscode(MetaStatusCode::OK);
     EXPECT_CALL(mockMetaserverService_, DeleteInode(_, _, _, _))
         .Times(2)
         .WillRepeatedly(
             DoAll(SetArgPointee<2>(deleteInodeResponse),
-                  Invoke(RpcService<DeleteInodeRequest, DeleteInodeResponse>)));
+                  Invoke(RpcService<false>{})));
     EXPECT_CALL(*topoManager_, DeletePartition(_))
         .WillOnce(Return(TopoStatusCode::TOPO_OK));
 
+    req.set_recycletimehour(10);
+
     ASSERT_EQ(FSStatusCode::INSERT_DENTRY_FAIL,
               fsManager_->CreateFs(&req, &fsInfo));
-    ASSERT_EQ(FSStatusCode::NOT_FOUND, fsStorage_->Get(fsName, &wrapper));
+    ASSERT_EQ(FSStatusCode::NOT_FOUND, fsStorage_->Get(kFsName1, &wrapper));
 }
 
-TEST_F(FSManagerTest, test1) {
-    std::string addr = addr_;
-    std::string leader = addr_ + ":0";
-    FSStatusCode ret;
-    std::string fsName1 = "fs1";
-    uint64_t blockSize = 4096;
-    bool enableSumInDir = false;
-    curvefs::common::Volume volume;
-    const uint64_t volumeSize = fakeCurveFsService_.volumeSize;
-    volume.set_blocksize(4096);
-    volume.set_volumename("volume1");
-    volume.set_user("user1");
-    volume.add_cluster(addr_);
+TEST_F(FSManagerTest, test_success_create_volume_fs) {
+    FSStatusCode ret = CreateVolFs();
 
+    ASSERT_EQ(ret, FSStatusCode::OK);
+    ASSERT_EQ(volumeFsInfo1.fsid(), 0);
+    ASSERT_EQ(volumeFsInfo1.fsname(), kFsName1);
+    ASSERT_EQ(volumeFsInfo1.status(), FsStatus::INITED);
+    ASSERT_EQ(volumeFsInfo1.rootinodeid(), ROOTINODEID);
+    ASSERT_EQ(volumeFsInfo1.capacity(), volumeSize);
+    ASSERT_EQ(volumeFsInfo1.blocksize(), kBlockSize);
+    ASSERT_EQ(volumeFsInfo1.mountnum(), 0);
+    ASSERT_EQ(volumeFsInfo1.fstype(), ::curvefs::common::FSType::TYPE_VOLUME);
+}
+
+TEST_F(FSManagerTest, test_success_create_s3_fs) {
+    FSStatusCode ret = CreateS3Fs();
+
+    ASSERT_EQ(ret, FSStatusCode::OK);
+    ASSERT_EQ(s3FsInfo.fsid(), 0);
+    ASSERT_EQ(s3FsInfo.fsname(), kFsName2);
+    ASSERT_EQ(s3FsInfo.status(), FsStatus::INITED);
+    ASSERT_EQ(s3FsInfo.rootinodeid(), ROOTINODEID);
+    ASSERT_EQ(s3FsInfo.capacity(), (uint64_t)100 * 1024 * 1024 * 1024);
+    ASSERT_EQ(s3FsInfo.blocksize(), kBlockSize);
+    ASSERT_EQ(s3FsInfo.mountnum(), 0);
+    ASSERT_EQ(s3FsInfo.fstype(), FSType::TYPE_S3);
+}
+
+TEST_F(FSManagerTest,
+       test_success_monotonically_increasing_fsid_for_multiple_fs) {
+    CreateVolFs();
+    CreateS3Fs();
+
+    ASSERT_EQ(volumeFsInfo1.fsid(), 0);
+    ASSERT_EQ(s3FsInfo.fsid(), 1);
+}
+
+TEST_F(FSManagerTest, test_fail_create_volume_fs_on_fail_partition_creation) {
     FsInfo volumeFsInfo1;
-    FsDetail detail;
-    detail.set_allocated_volume(new Volume(volume));
-
-    CreateFsRequest req;
-    req.set_fsname(fsName1);
-    req.set_blocksize(blockSize);
-    req.set_fstype(FSType::TYPE_VOLUME);
-    req.set_allocated_fsdetail(new FsDetail(detail));
-    req.set_enablesumindir(enableSumInDir);
-    req.set_owner("test");
-    req.set_capacity((uint64_t)100*1024*1024*1024);
+    FSStatusCode ret;
+    FsInfoWrapper wrapper;
 
     // create volume fs create partition fail
     EXPECT_CALL(*topoManager_, CreatePartitionsAndGetMinPartition(_, _))
@@ -343,85 +485,44 @@ TEST_F(FSManagerTest, test1) {
 
     ret = fsManager_->CreateFs(&req, &volumeFsInfo1);
     ASSERT_EQ(ret, FSStatusCode::CREATE_PARTITION_ERROR);
+    ASSERT_EQ(fsStorage_->Get(kFsName1, &wrapper), FSStatusCode::NOT_FOUND);
+}
+
+TEST_F(FSManagerTest, test_fail_create_volume_fs_on_failed_root_node_creation) {
+    FsInfo volumeFsInfo1;
+    FSStatusCode ret;
     FsInfoWrapper wrapper;
-    ASSERT_EQ(fsStorage_->Get(fsName1, &wrapper), FSStatusCode::NOT_FOUND);
+    CreateRootInodeResponse response;
 
     // create volume fs create root inode fail
     EXPECT_CALL(*topoManager_, CreatePartitionsAndGetMinPartition(_, _))
         .WillOnce(Return(TopoStatusCode::TOPO_OK));
 
-    std::set<std::string> addrs;
-    addrs.emplace(addr);
+    std::set<std::string> addrs { addr_ };
     EXPECT_CALL(*topoManager_, GetCopysetMembers(_, _, _))
         .WillOnce(
             DoAll(SetArgPointee<2>(addrs), Return(TopoStatusCode::TOPO_OK)));
-    GetLeaderResponse2 getLeaderResponse;
-    getLeaderResponse.mutable_leader()->set_address(leader);
     EXPECT_CALL(mockCliService2_, GetLeader(_, _, _, _))
         .WillOnce(
             DoAll(SetArgPointee<2>(getLeaderResponse),
-                  Invoke(RpcService<GetLeaderRequest2, GetLeaderResponse2>)));
-    CreateRootInodeResponse response;
+                  Invoke(RpcService<false>{})));
     response.set_statuscode(MetaStatusCode::UNKNOWN_ERROR);
     EXPECT_CALL(mockMetaserverService_, CreateRootInode(_, _, _, _))
         .WillOnce(DoAll(
             SetArgPointee<2>(response),
-            Invoke(
-                RpcService<CreateRootInodeRequest, CreateRootInodeResponse>)));
+            Invoke(RpcService<false>{})));
     EXPECT_CALL(*topoManager_, DeletePartition(_))
         .WillOnce(Return(TopoStatusCode::TOPO_OK));
     ret = fsManager_->CreateFs(&req, &volumeFsInfo1);
     ASSERT_EQ(ret, FSStatusCode::INSERT_ROOT_INODE_ERROR);
-    ASSERT_EQ(fsStorage_->Get(fsName1, &wrapper), FSStatusCode::NOT_FOUND);
+    ASSERT_EQ(fsStorage_->Get(kFsName1, &wrapper), FSStatusCode::NOT_FOUND);
+}
 
-    // create volume fs ok
-    EXPECT_CALL(*topoManager_, CreatePartitionsAndGetMinPartition(_, _))
-        .WillOnce(Return(TopoStatusCode::TOPO_OK));
-    EXPECT_CALL(*topoManager_, GetCopysetMembers(_, _, _))
-        .WillOnce(
-            DoAll(SetArgPointee<2>(addrs), Return(TopoStatusCode::TOPO_OK)));
-    EXPECT_CALL(mockCliService2_, GetLeader(_, _, _, _))
-        .WillOnce(
-            DoAll(SetArgPointee<2>(getLeaderResponse),
-                  Invoke(RpcService<GetLeaderRequest2, GetLeaderResponse2>)));
-
-    response.set_statuscode(MetaStatusCode::OK);
-    EXPECT_CALL(mockMetaserverService_, CreateRootInode(_, _, _, _))
-        .WillOnce(DoAll(
-            SetArgPointee<2>(response),
-            Invoke(
-                RpcService<CreateRootInodeRequest, CreateRootInodeResponse>)));
-
-    ret = fsManager_->CreateFs(&req, &volumeFsInfo1);
-    ASSERT_EQ(ret, FSStatusCode::OK);
-    ASSERT_EQ(volumeFsInfo1.fsid(), 2);
-    ASSERT_EQ(volumeFsInfo1.fsname(), fsName1);
-    ASSERT_EQ(volumeFsInfo1.status(), FsStatus::INITED);
-    ASSERT_EQ(volumeFsInfo1.rootinodeid(), ROOTINODEID);
-    ASSERT_EQ(volumeFsInfo1.capacity(), volumeSize);
-    ASSERT_EQ(volumeFsInfo1.blocksize(), blockSize);
-    ASSERT_EQ(volumeFsInfo1.mountnum(), 0);
-    ASSERT_EQ(volumeFsInfo1.fstype(), ::curvefs::common::FSType::TYPE_VOLUME);
-
-    // create volume fs exist
-    FsInfo volumeFsInfo2;
-    ret = fsManager_->CreateFs(&req, &volumeFsInfo1);
-    ASSERT_EQ(ret, FSStatusCode::OK);
-
-    // create s3 test
-    std::string fsName2 = "fs2";
-    curvefs::common::S3Info s3Info;
-    FsInfo s3FsInfo;
-    s3Info.set_ak("ak");
-    s3Info.set_sk("sk");
-    s3Info.set_endpoint("endpoint");
-    s3Info.set_bucketname("bucketname");
-    s3Info.set_blocksize(4096);
-    s3Info.set_chunksize(4096);
-    CreateRootInodeResponse response2;
-    FsDetail detail2;
-    detail2.set_allocated_s3info(new S3Info(s3Info));
-
+TEST_F(FSManagerTest, test_fail_create_s3_fs_on_failed_root_node_creation) {
+    std::set<std::string> addrs { addr_ };
+    CreateRootInodeResponse response;
+    FSStatusCode ret;
+    FsInfoWrapper wrapper;
     // create s3 fs create root inode fail
     EXPECT_CALL(*topoManager_, CreatePartitionsAndGetMinPartition(_, _))
         .WillOnce(Return(TopoStatusCode::TOPO_OK));
@@ -431,336 +532,353 @@ TEST_F(FSManagerTest, test1) {
     EXPECT_CALL(mockCliService2_, GetLeader(_, _, _, _))
         .WillOnce(
             DoAll(SetArgPointee<2>(getLeaderResponse),
-                  Invoke(RpcService<GetLeaderRequest2, GetLeaderResponse2>)));
-
+                    Invoke(RpcService<false>{})));
     response.set_statuscode(MetaStatusCode::UNKNOWN_ERROR);
     EXPECT_CALL(mockMetaserverService_, CreateRootInode(_, _, _, _))
         .WillOnce(DoAll(
             SetArgPointee<2>(response),
-            Invoke(
-                RpcService<CreateRootInodeRequest, CreateRootInodeResponse>)));
+            Invoke(RpcService<false>{})));
     EXPECT_CALL(*s3Adapter_, BucketExist()).WillOnce(Return(true));
     EXPECT_CALL(*topoManager_, DeletePartition(_))
         .WillOnce(Return(TopoStatusCode::TOPO_OK));
-    req.set_fsname(fsName2);
-    req.set_allocated_fsdetail(new FsDetail(detail2));
-    req.set_fstype(FSType::TYPE_S3);
-    ret = fsManager_->CreateFs(&req, &s3FsInfo);
+    ret = fsManager_->CreateFs(&s3Req, &s3FsInfo);
     ASSERT_EQ(ret, FSStatusCode::INSERT_ROOT_INODE_ERROR);
-    ASSERT_EQ(fsStorage_->Get(fsName2, &wrapper), FSStatusCode::NOT_FOUND);
+    ASSERT_EQ(fsStorage_->Get(kFsName2, &wrapper), FSStatusCode::NOT_FOUND);
+}
 
-    // create s3 fs ok
-    EXPECT_CALL(*topoManager_, CreatePartitionsAndGetMinPartition(_, _))
-        .WillOnce(Return(TopoStatusCode::TOPO_OK));
-    EXPECT_CALL(*topoManager_, GetCopysetMembers(_, _, _))
-        .WillOnce(
-            DoAll(SetArgPointee<2>(addrs), Return(TopoStatusCode::TOPO_OK)));
-    EXPECT_CALL(mockCliService2_, GetLeader(_, _, _, _))
-        .WillOnce(
-            DoAll(SetArgPointee<2>(getLeaderResponse),
-                  Invoke(RpcService<GetLeaderRequest2, GetLeaderResponse2>)));
+TEST_F(FSManagerTest, test_fail_create_duplicate_s3_fs_with_different_fsname) {
+    CreateS3Fs();
 
-    response.set_statuscode(MetaStatusCode::OK);
-    EXPECT_CALL(mockMetaserverService_, CreateRootInode(_, _, _, _))
-        .WillOnce(DoAll(
-            SetArgPointee<2>(response),
-            Invoke(
-                RpcService<CreateRootInodeRequest, CreateRootInodeResponse>)));
-    EXPECT_CALL(*s3Adapter_, BucketExist()).WillOnce(Return(true));
-
-    ret = fsManager_->CreateFs(&req, &s3FsInfo);
-    ASSERT_EQ(ret, FSStatusCode::OK);
-    ASSERT_EQ(s3FsInfo.fsid(), 4);
-    ASSERT_EQ(s3FsInfo.fsname(), fsName2);
-    ASSERT_EQ(s3FsInfo.status(), FsStatus::INITED);
-    ASSERT_EQ(s3FsInfo.rootinodeid(), ROOTINODEID);
-    ASSERT_EQ(s3FsInfo.capacity(), (uint64_t)100 * 1024 * 1024 * 1024);
-    ASSERT_EQ(s3FsInfo.blocksize(), blockSize);
-    ASSERT_EQ(s3FsInfo.mountnum(), 0);
-    ASSERT_EQ(s3FsInfo.fstype(), FSType::TYPE_S3);
-
+    FSStatusCode ret;
     // create s3 fs fail
     std::string fsName3 = "fs3";
     EXPECT_CALL(*s3Adapter_, BucketExist()).WillOnce(Return(false));
 
-    req.set_fsname(fsName3);
-    ret = fsManager_->CreateFs(&req, &s3FsInfo);
+    s3Req.set_fsname(fsName3);
+    ret = fsManager_->CreateFs(&s3Req, &s3FsInfo);
     ASSERT_EQ(ret, FSStatusCode::S3_INFO_ERROR);
+}
 
-    // TEST GetFsInfo
-    FsInfo fsInfo1;
-    ret = fsManager_->GetFsInfo(fsName1, &fsInfo1);
-    ASSERT_EQ(ret, FSStatusCode::OK);
-    ASSERT_TRUE(CompareVolumeFs(fsInfo1, volumeFsInfo1));
-
-    ret = fsManager_->GetFsInfo(volumeFsInfo1.fsid(), &fsInfo1);
-    ASSERT_EQ(ret, FSStatusCode::OK);
-    ASSERT_TRUE(CompareVolumeFs(fsInfo1, volumeFsInfo1));
-
-    ret = fsManager_->GetFsInfo(fsName1, volumeFsInfo1.fsid(), &fsInfo1);
-    ASSERT_EQ(ret, FSStatusCode::OK);
-    ASSERT_TRUE(CompareVolumeFs(fsInfo1, volumeFsInfo1));
-
+TEST_F(FSManagerTest, test_success_get_s3_fsinfo_by_fsname) {
+    CreateS3Fs();
+    FSStatusCode ret;
     FsInfo fsInfo2;
-    ret = fsManager_->GetFsInfo(fsName2, &fsInfo2);
+    ret = fsManager_->GetFsInfo(kFsName2, &fsInfo2);
     ASSERT_EQ(ret, FSStatusCode::OK);
     ASSERT_TRUE(CompareS3Fs(fsInfo2, s3FsInfo));
+}
 
+TEST_F(FSManagerTest, test_success_get_s3_fsinfo_by_fsid) {
+    CreateS3Fs();
+    FSStatusCode ret;
+    FsInfo fsInfo2;
     ret = fsManager_->GetFsInfo(s3FsInfo.fsid(), &fsInfo2);
     ASSERT_EQ(ret, FSStatusCode::OK);
     ASSERT_TRUE(CompareS3Fs(fsInfo2, s3FsInfo));
+}
 
-    ret = fsManager_->GetFsInfo(fsName2, s3FsInfo.fsid(), &fsInfo2);
+TEST_F(FSManagerTest, test_success_get_s3_fsinfo_by_consistent_fsid_fsname) {
+    CreateS3Fs();
+    FSStatusCode ret;
+    FsInfo fsInfo2;
+    ret = fsManager_->GetFsInfo(kFsName2, s3FsInfo.fsid(), &fsInfo2);
     ASSERT_EQ(ret, FSStatusCode::OK);
     ASSERT_TRUE(CompareS3Fs(fsInfo2, s3FsInfo));
+}
 
-    ret = fsManager_->GetFsInfo(fsName1, s3FsInfo.fsid(), &fsInfo2);
+TEST_F(FSManagerTest, test_success_get_s3_fsinfo_by_inconsistent_fsid_fsname) {
+    CreateVolFs();
+    CreateS3Fs();
+    FSStatusCode ret;
+    FsInfo fsInfo2;
+    ret = fsManager_->GetFsInfo(kFsName1, s3FsInfo.fsid(), &fsInfo2);
     ASSERT_EQ(ret, FSStatusCode::PARAM_ERROR);
+}
 
-    // TEST MountFs
-    Mountpoint mountPoint;
-    mountPoint.set_hostname("host");
-    mountPoint.set_port(90000);
-    mountPoint.set_path("/a/b/c");
-    mountPoint.set_cto(false);
+TEST_F(FSManagerTest, test_success_mount_s3_fs) {
+    CreateS3Fs();
+    FSStatusCode ret;
+    FsInfo fsInfo4;
+    ret = fsManager_->MountFs(kFsName2, s3MountPoint, &fsInfo4);
+    ASSERT_EQ(ret, FSStatusCode::OK);
+    ASSERT_TRUE(CompareS3Fs(s3FsInfo, fsInfo4));
+    ASSERT_EQ(MessageDifferencer::Equals(fsInfo4.mountpoints(0), s3MountPoint),
+              true);
+}
+
+TEST_F(FSManagerTest, test_fail_repeated_mount_s3_fs) {
+    CreateS3Fs();
+    FSStatusCode ret;
+    FsInfo fsInfo4;
+    ret = fsManager_->MountFs(kFsName2, s3MountPoint, &fsInfo4);
+    ASSERT_EQ(ret, FSStatusCode::OK);
+    ret = fsManager_->MountFs(kFsName2, s3MountPoint, &fsInfo4);
+    ASSERT_EQ(ret, FSStatusCode::MOUNT_POINT_CONFLICT);
+}
+
+TEST_F(FSManagerTest, test_fail_delete_s3_fs_with_existing_mount_path) {
+    CreateS3Fs();
+    FSStatusCode ret;
+    FsInfo fsInfo4;
+    ret = fsManager_->MountFs(kFsName2, s3MountPoint, &fsInfo4);
+    ASSERT_EQ(ret, FSStatusCode::OK);
+    ret = fsManager_->DeleteFs(kFsName2);
+    ASSERT_EQ(ret, FSStatusCode::FS_BUSY);
+}
+
+TEST_F(FSManagerTest, test_success_umount_s3_fs_with_mount_path) {
+    CreateS3Fs();
+    FSStatusCode ret;
+    FsInfo fsInfo4;
+    ret = fsManager_->MountFs(kFsName2, s3MountPoint, &fsInfo4);
+    ASSERT_EQ(ret, FSStatusCode::OK);
+    ret = fsManager_->UmountFs(kFsName2, s3MountPoint);
+    ASSERT_EQ(ret, FSStatusCode::OK);
+}
+
+TEST_F(FSManagerTest, test_success_delete_s3_fs_without_mount_path) {
+    CreateS3Fs();
+    FSStatusCode ret;
+    FsInfo fsInfo4;
+    ret = fsManager_->MountFs(kFsName2, s3MountPoint, &fsInfo4);
+    ASSERT_EQ(ret, FSStatusCode::OK);
+    ret = fsManager_->UmountFs(kFsName2, s3MountPoint);
+    ASSERT_EQ(ret, FSStatusCode::OK);
+    ret = fsManager_->DeleteFs(kFsName2);
+    ASSERT_EQ(ret, FSStatusCode::OK);
+}
+
+TEST_F(FSManagerTest, test_success_create_volume_fs_when_volume_fs_exists) {
+    CreateVolFs();
+    FsInfo volumeFsInfo1;
+    FSStatusCode ret;
+
+    // create volume fs exist
+    FsInfo volumeFsInfo2;
+    ret = fsManager_->CreateFs(&req, &volumeFsInfo1);
+    ASSERT_EQ(ret, FSStatusCode::OK);
+}
+
+TEST_F(FSManagerTest, test_success_get_volume_fsinfo_by_fsname) {
+    CreateVolFs();
+
+    FSStatusCode ret;
+
+    FsInfo fsInfo1;
+    ret = fsManager_->GetFsInfo(kFsName1, &fsInfo1);
+    ASSERT_EQ(ret, FSStatusCode::OK);
+    ASSERT_TRUE(CompareVolumeFs(fsInfo1, volumeFsInfo1));
+}
+
+TEST_F(FSManagerTest, test_success_get_volume_fsinfo_by_fsid) {
+    CreateVolFs();
+
+    FSStatusCode ret;
+
+    FsInfo fsInfo1;
+    ret = fsManager_->GetFsInfo(volumeFsInfo1.fsid(), &fsInfo1);
+    ASSERT_EQ(ret, FSStatusCode::OK);
+    ASSERT_TRUE(CompareVolumeFs(fsInfo1, volumeFsInfo1));
+}
+
+TEST_F(FSManagerTest,
+       test_success_get_volume_fsinfo_by_consistent_fsname_fsid) {
+    FSStatusCode ret;
+    CreateVolFs();
+
+    FsInfo fsInfo1;
+    ret = fsManager_->GetFsInfo(kFsName1, volumeFsInfo1.fsid(), &fsInfo1);
+    ASSERT_EQ(ret, FSStatusCode::OK);
+    ASSERT_TRUE(CompareVolumeFs(fsInfo1, volumeFsInfo1));
+}
+
+TEST_F(FSManagerTest, test_fail_mount_volume_fs_on_space_creation_error) {
+    CreateVolFs();
+    FSStatusCode ret;
     FsInfo fsInfo3;
 
-    // mount volumefs initspace fail
     EXPECT_CALL(*spaceManager_, AddVolume(_))
         .WillOnce(Return(space::SpaceErrCreate));
-    ret = fsManager_->MountFs(fsName1, mountPoint, &fsInfo3);
+    ret = fsManager_->MountFs(kFsName1, volMountPoint, &fsInfo3);
     ASSERT_EQ(ret, FSStatusCode::INIT_SPACE_ERROR);
+}
 
-    // mount volumefs success
+TEST_F(FSManagerTest, test_success_mount_volume_fs) {
+    CreateVolFs();
+    FSStatusCode ret;
+    FsInfo fsInfo3;
+
     EXPECT_CALL(*spaceManager_, AddVolume(_))
         .WillOnce(Return(space::SpaceOk));
-    ret = fsManager_->MountFs(fsName1, mountPoint, &fsInfo3);
+    ret = fsManager_->MountFs(kFsName1, volMountPoint, &fsInfo3);
     ASSERT_EQ(ret, FSStatusCode::OK);
     ASSERT_TRUE(CompareVolumeFs(volumeFsInfo1, fsInfo3));
-    ASSERT_EQ(MessageDifferencer::Equals(fsInfo3.mountpoints(0), mountPoint),
-              true);
+    ASSERT_EQ(MessageDifferencer::Equals(fsInfo3.mountpoints(0),
+              volMountPoint), true);
     std::pair<std::string, uint64_t> tpair;
     std::string mountpath = "host:90000:/a/b/c";
     ASSERT_TRUE(fsManager_->GetClientAliveTime(mountpath, &tpair));
-    ASSERT_EQ(fsName1, tpair.first);
-    // test client timeout and restore session later
-    auto volumeSpace = new MockVolumeSpace();
-    {
-        fsManager_->Run();
-        EXPECT_CALL(*spaceManager_, GetVolumeSpace(_))
-            .WillOnce(Return(volumeSpace));
-        EXPECT_CALL(*volumeSpace,
-                    ReleaseBlockGroups(Matcher<const std::string &>(_)))
-            .WillOnce(Return(space::SpaceOk));
-        // clientTimeoutSec in option
-        sleep(4);
-        FsInfo info;
-        ASSERT_EQ(FSStatusCode::OK, fsManager_->GetFsInfo(fsName1, &info));
-        ASSERT_EQ(0, info.mountpoints_size());
+    ASSERT_EQ(kFsName1, tpair.first);
+}
 
-        RefreshSessionRequest request;
-        RefreshSessionResponse response;
-        request.set_fsname(fsName1);
-        *request.mutable_mountpoint() = mountPoint;
-        fsManager_->RefreshSession(&request, &response);
-        ASSERT_EQ(FSStatusCode::OK, fsManager_->GetFsInfo(fsName1, &info));
-        ASSERT_EQ(1, info.mountpoints_size());
-        ASSERT_EQ(MessageDifferencer::Equals(info.mountpoints(0), mountPoint),
-            true);
-        fsManager_->Stop();
-    }
+TEST_F(FSManagerTest, test_fail_repeated_mount_volume_fs) {
+    CreateVolFs();
+    FSStatusCode ret;
+    FsInfo fsInfo3;
 
+    EXPECT_CALL(*spaceManager_, AddVolume(_))
+        .WillOnce(Return(space::SpaceOk));
+    ret = fsManager_->MountFs(kFsName1, volMountPoint, &fsInfo3);
     // mount volumefs mountpoint exist
-    ret = fsManager_->MountFs(fsName1, mountPoint, &fsInfo3);
+    ret = fsManager_->MountFs(kFsName1, volMountPoint, &fsInfo3);
     ASSERT_EQ(ret, FSStatusCode::MOUNT_POINT_CONFLICT);
+}
 
-    // mount s3 fs success
-    FsInfo fsInfo4;
-    ret = fsManager_->MountFs(fsName2, mountPoint, &fsInfo4);
-    ASSERT_EQ(ret, FSStatusCode::OK);
-    ASSERT_TRUE(CompareS3Fs(s3FsInfo, fsInfo4));
-    ASSERT_EQ(MessageDifferencer::Equals(fsInfo4.mountpoints(0), mountPoint),
-              true);
+TEST_F(FSManagerTest, test_fail_umount_volume_fs_on_failed_uninit_space) {
+    CreateVolFs();
+    FSStatusCode ret;
+    FsInfo fsInfo3;
 
-    // mount s3 fs mount point exist
-    ret = fsManager_->MountFs(fsName2, mountPoint, &fsInfo4);
-    ASSERT_EQ(ret, FSStatusCode::MOUNT_POINT_CONFLICT);
-
-    // TEST UmountFs
-    // umount UnInitSpace fail
+    EXPECT_CALL(*spaceManager_, AddVolume(_))
+        .WillOnce(Return(space::SpaceOk));
+    ret = fsManager_->MountFs(kFsName1, volMountPoint, &fsInfo3);
     EXPECT_CALL(*spaceManager_, GetVolumeSpace(_)).WillOnce(Return(nullptr));
-    ret = fsManager_->UmountFs(fsName1, mountPoint);
+    ret = fsManager_->UmountFs(kFsName1, volMountPoint);
     ASSERT_EQ(ret, FSStatusCode::UNINIT_SPACE_ERROR);
+}
 
+TEST_F(FSManagerTest, test_success_umount_volume_fs_after_uninit) {
+    CreateVolFs();
+    FSStatusCode ret;
+    FsInfo fsInfo3;
+    auto volumeSpace = absl::make_unique<MockVolumeSpace>();
+
+    std::pair<std::string, uint64_t> tpair;
+    std::string mountpath = "host:90000:/a/b/c";
     // for persistence consider
     // umount UnInitSpace success
     EXPECT_CALL(*spaceManager_, GetVolumeSpace(_))
-        .WillOnce(Return(volumeSpace));
+        .WillOnce(Return(volumeSpace.get()));
     EXPECT_CALL(*volumeSpace,
                 ReleaseBlockGroups(Matcher<const std::string &>(_)))
         .WillOnce(Return(space::SpaceOk));
-    ret = fsManager_->UmountFs(fsName1, mountPoint);
+    ret = fsManager_->MountFs(kFsName1, volMountPoint, &fsInfo3);
+    ret = fsManager_->UmountFs(kFsName1, volMountPoint);
     ASSERT_EQ(ret, FSStatusCode::OK);
     ASSERT_FALSE(fsManager_->GetClientAliveTime(mountpath, &tpair));
-    delete volumeSpace;
-
-    // umount not exist mountpoint
-    ret = fsManager_->UmountFs(fsName1, mountPoint);
-    ASSERT_EQ(ret, FSStatusCode::MOUNT_POINT_NOT_EXIST);
-
-    // TEST DeleteFs
-    ret = fsManager_->DeleteFs(fsName1);
-    ASSERT_EQ(ret, FSStatusCode::OK);
-
-    ret = fsManager_->DeleteFs(fsName1);
-    ASSERT_EQ(ret, FSStatusCode::NOT_FOUND);
-
-    ret = fsManager_->DeleteFs(fsName2);
-    ASSERT_EQ(ret, FSStatusCode::FS_BUSY);
-
-    ret = fsManager_->UmountFs(fsName2, mountPoint);
-    ASSERT_EQ(ret, FSStatusCode::OK);
-
-    ret = fsManager_->DeleteFs(fsName2);
-    ASSERT_EQ(ret, FSStatusCode::OK);
 }
 
-TEST_F(FSManagerTest, backgroud_thread_test) {
-    fsManager_->Run();
-    fsManager_->Run();
-    fsManager_->Run();
-    fsManager_->Uninit();
-    fsManager_->Uninit();
-    fsManager_->Run();
-    fsManager_->Uninit();
-}
-
-TEST_F(FSManagerTest, background_thread_deletefs_test) {
-    fsManager_->Run();
-    std::string addr = addr_;
-    std::string leader = addr_ + ":0";
+TEST_F(FSManagerTest, test_fail_umount_volume_fs_non_existent_mount_path) {
+    CreateVolFs();
     FSStatusCode ret;
-    std::string fsName1 = "fs1";
-    uint64_t blockSize = 4096;
-    bool enableSumInDir = false;
-    curvefs::common::Volume volume;
-    const uint64_t volumeSize = fakeCurveFsService_.volumeSize;
-    volume.set_volumesize(volumeSize);
-    volume.set_blocksize(4096);
-    volume.set_volumename("volume1");
-    volume.set_user("user1");
-    volume.add_cluster(addr_);
+    FsInfo fsInfo3;
+    auto volumeSpace = absl::make_unique<MockVolumeSpace>();
 
-    FsInfo volumeFsInfo1;
-    FsDetail detail;
-    detail.set_allocated_volume(new Volume(volume));
+    std::pair<std::string, uint64_t> tpair;
+    std::string mountpath = "host:90000:/a/b/c";
 
-    CreateFsRequest req;
-    req.set_fsname(fsName1);
-    req.set_blocksize(blockSize);
-    req.set_fstype(FSType::TYPE_VOLUME);
-    req.set_allocated_fsdetail(new FsDetail(detail));
-    req.set_enablesumindir(enableSumInDir);
-    req.set_owner("test");
-    req.set_capacity((uint64_t)100*1024*1024*1024);
+    EXPECT_CALL(*spaceManager_, GetVolumeSpace(_))
+        .WillOnce(Return(volumeSpace.get()));
+    EXPECT_CALL(*volumeSpace,
+                ReleaseBlockGroups(Matcher<const std::string &>(_)))
+        .WillOnce(Return(space::SpaceOk));
+    ret = fsManager_->MountFs(kFsName1, volMountPoint, &fsInfo3);
+    ret = fsManager_->UmountFs(kFsName1, volMountPoint);
+    // umount not exist mountpoint
+    ret = fsManager_->UmountFs(kFsName1, volMountPoint);
+    ASSERT_EQ(ret, FSStatusCode::MOUNT_POINT_NOT_EXIST);
+}
 
-    // create volume fs ok
-    std::set<std::string> addrs;
-    addrs.emplace(addr);
-    EXPECT_CALL(*topoManager_, CreatePartitionsAndGetMinPartition(_, _))
-        .WillOnce(Return(TopoStatusCode::TOPO_OK));
-    EXPECT_CALL(*topoManager_, GetCopysetMembers(_, _, _))
-        .WillOnce(
-            DoAll(SetArgPointee<2>(addrs), Return(TopoStatusCode::TOPO_OK)));
-    GetLeaderResponse2 getLeaderResponse;
-    getLeaderResponse.mutable_leader()->set_address(leader);
-    EXPECT_CALL(mockCliService2_, GetLeader(_, _, _, _))
-        .WillOnce(
-            DoAll(SetArgPointee<2>(getLeaderResponse),
-                  Invoke(RpcService<GetLeaderRequest2, GetLeaderResponse2>)));
+TEST_F(FSManagerTest,
+       test_success_delete_volume_fs_after_umount_existing_mount_path) {
+    CreateVolFs();
+    FSStatusCode ret;
+    FsInfo fsInfo3;
+    auto volumeSpace = absl::make_unique<MockVolumeSpace>();
 
-    CreateRootInodeResponse response;
-    response.set_statuscode(MetaStatusCode::OK);
-    EXPECT_CALL(mockMetaserverService_, CreateRootInode(_, _, _, _))
-        .WillOnce(DoAll(
-            SetArgPointee<2>(response),
-            Invoke(
-                RpcService<CreateRootInodeRequest, CreateRootInodeResponse>)));
+    std::pair<std::string, uint64_t> tpair;
+    std::string mountpath = "host:90000:/a/b/c";
 
-    req.set_fsname(fsName1);
-    ret = fsManager_->CreateFs(&req, &volumeFsInfo1);
+    EXPECT_CALL(*spaceManager_, GetVolumeSpace(_))
+        .WillOnce(Return(volumeSpace.get()));
+    EXPECT_CALL(*volumeSpace,
+                ReleaseBlockGroups(Matcher<const std::string &>(_)))
+        .WillOnce(Return(space::SpaceOk));
+    ret = fsManager_->MountFs(kFsName1, volMountPoint, &fsInfo3);
+    ret = fsManager_->UmountFs(kFsName1, volMountPoint);
+    ret = fsManager_->DeleteFs(kFsName1);
     ASSERT_EQ(ret, FSStatusCode::OK);
-    ASSERT_EQ(volumeFsInfo1.fsid(), 0);
-    ASSERT_EQ(volumeFsInfo1.fsname(), fsName1);
-    ASSERT_EQ(volumeFsInfo1.status(), FsStatus::INITED);
-    ASSERT_EQ(volumeFsInfo1.rootinodeid(), ROOTINODEID);
-    ASSERT_EQ(volumeFsInfo1.capacity(), volumeSize);
-    ASSERT_EQ(volumeFsInfo1.blocksize(), blockSize);
-    ASSERT_EQ(volumeFsInfo1.mountnum(), 0);
-    ASSERT_EQ(volumeFsInfo1.fstype(), ::curvefs::common::FSType::TYPE_VOLUME);
+}
 
-    // create s3 test
-    std::string fsName2 = "fs2";
-    curvefs::common::S3Info s3Info;
-    FsInfo s3FsInfo;
-    s3Info.set_ak("ak");
-    s3Info.set_sk("sk");
-    s3Info.set_endpoint("endpoint");
-    s3Info.set_bucketname("bucketname");
-    s3Info.set_blocksize(4096);
-    s3Info.set_chunksize(4096);
-    CreateRootInodeResponse response2;
-    FsDetail detail2;
-    detail2.set_allocated_s3info(new S3Info(s3Info));
+TEST_F(FSManagerTest, test_success_delete_volume_fs_without_mount) {
+    CreateVolFs();
+    FSStatusCode ret;
 
-    // create s3 fs ok
-    EXPECT_CALL(*topoManager_, CreatePartitionsAndGetMinPartition(_, _))
-        .WillOnce(Return(TopoStatusCode::TOPO_OK));
-    EXPECT_CALL(*topoManager_, GetCopysetMembers(_, _, _))
-        .WillOnce(
-            DoAll(SetArgPointee<2>(addrs), Return(TopoStatusCode::TOPO_OK)));
-    EXPECT_CALL(mockCliService2_, GetLeader(_, _, _, _))
-        .WillOnce(
-            DoAll(SetArgPointee<2>(getLeaderResponse),
-                  Invoke(RpcService<GetLeaderRequest2, GetLeaderResponse2>)));
-
-    response.set_statuscode(MetaStatusCode::OK);
-    EXPECT_CALL(mockMetaserverService_, CreateRootInode(_, _, _, _))
-        .WillOnce(DoAll(
-            SetArgPointee<2>(response),
-            Invoke(
-                RpcService<CreateRootInodeRequest, CreateRootInodeResponse>)));
-    EXPECT_CALL(*s3Adapter_, BucketExist()).WillOnce(Return(true));
-
-    req.set_fsname(fsName2);
-    req.set_fstype(FSType::TYPE_S3);
-    req.set_allocated_fsdetail(new FsDetail(detail2));
-    ret = fsManager_->CreateFs(&req, &s3FsInfo);
+    ret = fsManager_->DeleteFs(kFsName1);
     ASSERT_EQ(ret, FSStatusCode::OK);
-    ASSERT_EQ(s3FsInfo.fsid(), 1);
-    ASSERT_EQ(s3FsInfo.fsname(), fsName2);
-    ASSERT_EQ(s3FsInfo.status(), FsStatus::INITED);
-    ASSERT_EQ(s3FsInfo.rootinodeid(), ROOTINODEID);
-    ASSERT_EQ(s3FsInfo.capacity(), (uint64_t)100 * 1024 * 1024 * 1024);
-    ASSERT_EQ(s3FsInfo.blocksize(), blockSize);
-    ASSERT_EQ(s3FsInfo.mountnum(), 0);
-    ASSERT_EQ(s3FsInfo.fstype(), FSType::TYPE_S3);
+}
+
+TEST_F(FSManagerTest, test_fail_repeated_delete_volume_fs) {
+    CreateVolFs();
+    FSStatusCode ret;
+
+    ret = fsManager_->DeleteFs(kFsName1);
+    ret = fsManager_->DeleteFs(kFsName1);
+    ASSERT_EQ(ret, FSStatusCode::NOT_FOUND);
+}
+
+TEST_F(FSManagerTest, test_success_restore_session_after_client_timeout) {
+    CreateVolFs();
+
+    fsManager_->Run();
+
+    sleep(4);
+    FsInfo info;
+    ASSERT_EQ(FSStatusCode::OK, fsManager_->GetFsInfo(kFsName1, &info));
+    ASSERT_EQ(0, info.mountpoints_size());
+
+    RefreshSessionRequest request;
+    RefreshSessionResponse response;
+    request.set_fsname(kFsName1);
+    *request.mutable_mountpoint() = volMountPoint;
+    fsManager_->RefreshSession(&request, &response);
+    ASSERT_EQ(FSStatusCode::OK, fsManager_->GetFsInfo(kFsName1, &info));
+    ASSERT_EQ(1, info.mountpoints_size());
+    ASSERT_EQ(MessageDifferencer::Equals(info.mountpoints(0), volMountPoint),
+        true);
+    fsManager_->Stop();
+}
+
+TEST_F(FSManagerTest, test_success_background_thread_lifecycle) {
+    fsManager_->Run();
+    fsManager_->Run();
+    fsManager_->Run();
+    fsManager_->Uninit();
+    fsManager_->Uninit();
+    fsManager_->Run();
+    fsManager_->Uninit();
+}
+
+TEST_F(FSManagerTest, test_success_background_thread_delete_fs) {
+    fsManager_->Run();
+
+    CreateS3Fs();
+    CreateVolFs();
+
+    std::set<std::string> addrs { addr_ };
+    FSStatusCode ret;
 
     // TEST GetFsInfo
     FsInfo fsInfo1;
-    ret = fsManager_->GetFsInfo(fsName1, &fsInfo1);
-    ASSERT_EQ(ret, FSStatusCode::OK);
-    ASSERT_TRUE(CompareVolumeFs(fsInfo1, volumeFsInfo1));
+    ret = fsManager_->GetFsInfo(kFsName1, &fsInfo1);
 
     FsInfo fsInfo2;
-    ret = fsManager_->GetFsInfo(fsName2, &fsInfo2);
-    ASSERT_EQ(ret, FSStatusCode::OK);
-    ASSERT_TRUE(CompareS3Fs(fsInfo2, s3FsInfo));
+    ret = fsManager_->GetFsInfo(kFsName2, &fsInfo2);
 
     // TEST DeleteFs, delete fs1
-    std::list<PartitionInfo> list;
-    std::list<PartitionInfo> list2;
-    std::list<PartitionInfo> list3;
+    std::list<PartitionInfo> emptyList;
+    std::list<PartitionInfo> oneReadableWriteabePartitionList;
+    std::list<PartitionInfo> deletingList;
 
     PartitionInfo partition;
     uint32_t poolId1 = 1;
@@ -770,16 +888,16 @@ TEST_F(FSManagerTest, background_thread_deletefs_test) {
     partition.set_poolid(poolId1);
     partition.set_copysetid(copysetId1);
     partition.set_partitionid(partitionId1);
-    list2.push_back(partition);
+    oneReadableWriteabePartitionList.push_back(partition);
 
-    PartitionInfo partition2 = partition;
-    partition2.set_status(PartitionStatus::DELETING);
-    list3.push_back(partition2);
+    PartitionInfo deletingPartition = partition;
+    deletingPartition.set_status(PartitionStatus::DELETING);
+    deletingList.push_back(deletingPartition);
 
     EXPECT_CALL(*topoManager_, ListPartitionOfFs(fsInfo1.fsid(), _))
-        .WillOnce(SetArgPointee<1>(list2))
-        .WillOnce(SetArgPointee<1>(list3))
-        .WillOnce(SetArgPointee<1>(list));
+        .WillOnce(SetArgPointee<1>(oneReadableWriteabePartitionList))
+        .WillOnce(SetArgPointee<1>(deletingList))
+        .WillOnce(SetArgPointee<1>(emptyList));
 
     EXPECT_CALL(*topoManager_, GetCopysetMembers(poolId1, copysetId1, _))
         .WillOnce(
@@ -788,22 +906,21 @@ TEST_F(FSManagerTest, background_thread_deletefs_test) {
     EXPECT_CALL(mockCliService2_, GetLeader(_, _, _, _))
         .WillOnce(
             DoAll(SetArgPointee<2>(getLeaderResponse),
-                  Invoke(RpcService<GetLeaderRequest2, GetLeaderResponse2>)));
+                  Invoke(RpcService<false>{})));
 
     DeletePartitionResponse response3;
     response3.set_statuscode(MetaStatusCode::OK);
     EXPECT_CALL(mockMetaserverService_, DeletePartition(_, _, _, _))
         .WillOnce(DoAll(
             SetArgPointee<2>(response3),
-            Invoke(
-                RpcService<DeletePartitionRequest, DeletePartitionResponse>)));
+            Invoke(RpcService<false>{})));
 
     EXPECT_CALL(*topoManager_, UpdatePartitionStatus(_, _))
         .WillOnce(Return(TopoStatusCode::TOPO_OK));
 
     EXPECT_CALL(*spaceManager_, DeleteVolume(_))
         .WillOnce(Return(space::SpaceOk));
-    ret = fsManager_->DeleteFs(fsName1);
+    ret = fsManager_->DeleteFs(kFsName1);
     ASSERT_EQ(ret, FSStatusCode::OK);
 
     sleep(4);
@@ -821,14 +938,15 @@ TEST_F(FSManagerTest, background_thread_deletefs_test) {
     partition.set_copysetid(copysetId2);
     partition.set_partitionid(partitionId2);
     partition.set_status(PartitionStatus::DELETING);
-    std::list<PartitionInfo> list4;
-    list4.push_back(partition);
+
+    deletingList.clear();
+    deletingList.push_back(partition);
 
     EXPECT_CALL(*topoManager_, ListPartitionOfFs(fsInfo2.fsid(), _))
-        .WillOnce(SetArgPointee<1>(list4))
-        .WillOnce(SetArgPointee<1>(list));
+        .WillOnce(SetArgPointee<1>(deletingList))
+        .WillOnce(SetArgPointee<1>(emptyList));
 
-    ret = fsManager_->DeleteFs(fsName2);
+    ret = fsManager_->DeleteFs(kFsName2);
     ASSERT_EQ(ret, FSStatusCode::OK);
 
     sleep(3);
@@ -837,7 +955,8 @@ TEST_F(FSManagerTest, background_thread_deletefs_test) {
     ASSERT_EQ(ret, FSStatusCode::NOT_FOUND);
 }
 
-TEST_F(FSManagerTest, test_refreshSession) {
+TEST_F(FSManagerTest,
+       test_success_refresh_session_with_outdated_partition_txid) {
     PartitionTxId tmp;
     tmp.set_partitionid(1);
     tmp.set_txid(1);
@@ -847,64 +966,69 @@ TEST_F(FSManagerTest, test_refreshSession) {
     mountpoint.set_port(9000);
     mountpoint.set_path("/mnt");
 
-    {
-        LOG(INFO) << "### case1: partition txid need update ###";
-        RefreshSessionRequest request;
-        RefreshSessionResponse response;
-        std::vector<PartitionTxId> txidlist({std::move(tmp)});
-        *request.mutable_txids() = {txidlist.begin(), txidlist.end()};
-        request.set_fsname(fsName);
-        *request.mutable_mountpoint() = mountpoint;
-        EXPECT_CALL(*topoManager_, GetLatestPartitionsTxId(_, _))
-            .WillOnce(SetArgPointee<1>(txidlist));
-        fsManager_->RefreshSession(&request, &response);
-        ASSERT_EQ(1, response.latesttxidlist_size());
-    }
-    {
-        LOG(INFO) << "### case2: partition txid do not need update ###";
-        RefreshSessionResponse response;
-        RefreshSessionRequest request;
-        request.set_fsname(fsName);
-        *request.mutable_mountpoint() = mountpoint;
-        fsManager_->RefreshSession(&request, &response);
-        ASSERT_EQ(0, response.latesttxidlist_size());
-    }
+    LOG(INFO) << "### case1: partition txid need update ###";
+    RefreshSessionRequest request;
+    RefreshSessionResponse response;
+    std::vector<PartitionTxId> txidlist({std::move(tmp)});
+    *request.mutable_txids() = {txidlist.begin(), txidlist.end()};
+    request.set_fsname(fsName);
+    *request.mutable_mountpoint() = mountpoint;
+    EXPECT_CALL(*topoManager_, GetLatestPartitionsTxId(_, _))
+        .WillOnce(SetArgPointee<1>(txidlist));
+    fsManager_->RefreshSession(&request, &response);
+    ASSERT_EQ(1, response.latesttxidlist_size());
 }
 
-TEST_F(FSManagerTest, GetLatestTxId_ParamFsId) {
-    // CASE 1: GetLatestTxId without fsid param
-    {
-        GetLatestTxIdRequest request;
-        GetLatestTxIdResponse response;
-        fsManager_->GetLatestTxId(&request, &response);
-        ASSERT_EQ(response.statuscode(), FSStatusCode::PARAM_ERROR);
-    }
+TEST_F(FSManagerTest,
+       test_success_refresh_session_with_up_to_date_partition_txid) {
+    PartitionTxId tmp;
+    tmp.set_partitionid(1);
+    tmp.set_txid(1);
+    std::string fsName = "fs1";
+    Mountpoint mountpoint;
+    mountpoint.set_hostname("127.0.0.1");
+    mountpoint.set_port(9000);
+    mountpoint.set_path("/mnt");
 
-    // CASE 2: GetLatestTxId with fsid
-    {
-        GetLatestTxIdRequest request;
-        GetLatestTxIdResponse response;
-        request.set_fsid(1);
-        EXPECT_CALL(*topoManager_, ListPartitionOfFs(_, _))
-            .WillOnce(Invoke([&](FsIdType fsId,
-                                 std::list<PartitionInfo>* list) {
-                if (fsId != 1) {
-                    return;
-                }
-                PartitionInfo partition;
-                partition.set_fsid(0);
-                partition.set_poolid(0);
-                partition.set_copysetid(0);
-                partition.set_partitionid(0);
-                partition.set_start(0);
-                partition.set_end(0);
-                partition.set_txid(0);
-                list->push_back(partition);
-            }));
-        fsManager_->GetLatestTxId(&request, &response);
-        ASSERT_EQ(response.statuscode(), FSStatusCode::OK);
-        ASSERT_EQ(response.txids_size(), 1);
-    }
+    LOG(INFO) << "### case2: partition txid do not need update ###";
+    RefreshSessionResponse response;
+    RefreshSessionRequest request;
+    request.set_fsname(fsName);
+    *request.mutable_mountpoint() = mountpoint;
+    fsManager_->RefreshSession(&request, &response);
+    ASSERT_EQ(0, response.latesttxidlist_size());
+}
+
+TEST_F(FSManagerTest, test_fail_get_latest_txid_without_fsid) {
+    GetLatestTxIdRequest request;
+    GetLatestTxIdResponse response;
+    fsManager_->GetLatestTxId(&request, &response);
+    ASSERT_EQ(response.statuscode(), FSStatusCode::PARAM_ERROR);
+}
+
+TEST_F(FSManagerTest, test_success_get_latest_txid_with_fsid) {
+    GetLatestTxIdRequest request;
+    GetLatestTxIdResponse response;
+    request.set_fsid(1);
+    EXPECT_CALL(*topoManager_, ListPartitionOfFs(_, _))
+        .WillOnce(Invoke([&](FsIdType fsId,
+                                std::list<PartitionInfo>* list) {
+            if (fsId != 1) {
+                return;
+            }
+            PartitionInfo partition;
+            partition.set_fsid(0);
+            partition.set_poolid(0);
+            partition.set_copysetid(0);
+            partition.set_partitionid(0);
+            partition.set_start(0);
+            partition.set_end(0);
+            partition.set_txid(0);
+            list->push_back(partition);
+        }));
+    fsManager_->GetLatestTxId(&request, &response);
+    ASSERT_EQ(response.statuscode(), FSStatusCode::OK);
+    ASSERT_EQ(response.txids_size(), 1);
 }
 
 }  // namespace mds

--- a/curvefs/test/mds/mock/mock_fs_stroage.h
+++ b/curvefs/test/mds/mock/mock_fs_stroage.h
@@ -34,6 +34,11 @@
 namespace curvefs {
 namespace mds {
 
+class MockMemoryFsStorage : public MemoryFsStorage {
+ public:
+    MOCK_METHOD2(Get, FSStatusCode(const std::string&, FsInfoWrapper*));
+};
+
 class MockFsStorage : public FsStorage {
  public:
     MockFsStorage() = default;


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #2505

Problem Summary:
All the test cases in these two files are written into one test suite, and the names of the test cases have no meaningful information. Once the code is modified, it is difficult to change the corresponding unit tests accordingly.

### What is changed and how it works?

What's Changed:
1. fs_manager_test.cpp
```
test_success_cleanup_after_fail_create_volume_fs_on_inode_error
test_success_cleanup_after_fail_create_volume_fs_on_dentry_error
test_success_create_volume_fs
test_success_create_s3_fs
test_success_monotonically_increasing_fsid_for_multiple_fs
test_fail_create_volume_fs_on_fail_partition_creation
test_fail_create_volume_fs_on_failed_root_node_creation
test_fail_create_s3_fs_on_failed_root_node_creation
test_fail_create_duplicate_s3_fs_with_different_fsname
test_success_get_s3_fsinfo_by_fsname
test_success_get_s3_fsinfo_by_fsid
test_success_get_s3_fsinfo_by_consistent_fsid_fsname
test_success_get_s3_fsinfo_by_inconsistent_fsid_fsname
test_success_mount_s3_fs
test_fail_repeated_mount_s3_fs
test_fail_delete_s3_fs_with_existing_mount_path
test_success_umount_s3_fs_with_mount_path
test_success_delete_s3_fs_without_mount_path
test_success_create_volume_fs_when_volume_fs_exists
test_success_get_volume_fsinfo_by_fsname
test_success_get_volume_fsinfo_by_fsid
test_success_get_volume_fsinfo_by_consistent_fsname_fsid
test_fail_mount_volume_fs_on_space_creation_error
test_success_mount_volume_fs
test_fail_repeated_mount_volume_fs
test_fail_umount_volume_fs_on_failed_uninit_space
test_success_umount_volume_fs_after_uninit
test_fail_umount_volume_fs_non_existent_mount_path
test_success_delete_volume_fs_after_umount_existing_mount_path
test_success_delete_volume_fs_without_mount
test_fail_repeated_delete_volume_fs
test_success_restore_session_after_client_timeout
test_success_background_thread_lifecycle
test_success_background_thread_delete_fs
test_success_refresh_session_with_outdated_partition_txid
test_success_refresh_session_with_up_to_date_partition_txid
test_fail_get_latest_txid_without_fsid
test_success_get_latest_txid_with_fsid
```

2. mds_service_test.cpp
```
test_fail_create_fs_missing_volume_for_volume_fstype
test_fail_create_fs_missing_s3_info_for_s3_fstype
test_fail_retrieve_fsinfo_non_existent_fsid
test_fail_create_fs_existing_volume_for_volume_fstype
test_fail_create_fs_hybrid_fstype
test_fail_get_fsinfo_missing_fsid_and_fsname
test_success_get_fsinfo_fsid_with_volume_fstype
test_success_get_fsinfo_fsid_with_s3_fstype
test_success_get_fsinfo_fsname_with_volume_fstype
test_success_get_fsinfo_fsname_with_s3_fstype
test_fail_get_fsinfo_non_existent_fsname
test_success_get_fsinfo_consistent_fsname_and_fsid
test_fail_get_fsinfo_inconsistent_fsname_and_fsid
test_success_mount_then_umount_on_single_path
test_success_delete_fs_no_mount_paths
test_fail_delete_fs_mount_paths_still_exist
test_fail_repeatedly_mount_fs_on_same_path
test_fail_repeatedly_umount_fs_on_same_path
test_success_refresh_sessions
test_success_delete_fs_after_umounting_all_paths
```
How it Works:
Those gigantic test cases were now divided into smaller and more focused ones.

Side effects(Breaking backward compatibility? Performance regression?):
None

### Outcome
`$ ./bazel-bin/curvefs/test/mds/curvefs_mds_test --gtest_filter=FSManagerTest*`
![image](https://github.com/opencurve/curve/assets/3871037/82a56f42-b8bb-4400-bc08-adb79b38ff33)

`$ ./bazel-bin/curvefs/test/mds/curvefs_mds_test --gtest_filter=MdsServiceTest*`
![image](https://github.com/opencurve/curve/assets/3871037/30c3f17d-29ab-4d8d-ba96-f5e5d78bfc2e)

### Check List

- [x] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license
