### PR TITLE
[CI] Add static checks in github action and sanitizers for unit tests

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -7,4 +7,20 @@ build:gcc7-later --cxxopt -faligned-new
 build --incompatible_blacklisted_protos_requires_proto_info=false
 build --copt=-fdiagnostics-color=always
 
+build:sanitize-common --strip=never
+build:sanitize-common --copt -O1
+build:sanitize-common --copt -g
+build:sanitize-common --copt -fno-omit-frame-pointer
+
+build:asan --config=sanitize-common
+build:asan --copt -fsanitize=address
+build:asan --copt -DADDRESS_SANITIZER
+build:asan --linkopt -fsanitize=address
+
+build:asan --config=sanitize-common
+build:msan --copt -fsanitize=memory
+build:msan --copt -fsanitize=undefined
+build:msan --linkopt -fsanitize=address
+build:msan --linkopt -fsanitize=undefined
+
 run --copt=-fdiagnostics-color=always

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -7,7 +7,16 @@ jobs:
     steps:
       - uses: actions/checkout@v3  
       - uses: deep5050/cppcheck-action@main 
+        with:
+          inconclusive: disable
+          other_options: "--suppress=syntaxError:* --suppress=danglingTemporaryLifetime:* --suppress=deallocuse:* --suppress=uninitvar:* --suppress=unknownMacro:* --suppress=ctuOneDefinitionRuleViolation:*"
+      - name: Error check
+        run: |
+            if grep -qF 'error: ' cppcheck_report.txt; then
+              exit 1
+            fi 
       - uses: actions/upload-artifact@v3
+        if: always()
         with:
           name: cppcheck
           path: cppcheck_report.txt

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -1,0 +1,19 @@
+name: cppcheck-action
+on: [push]
+
+jobs:
+  build:
+    name: cppcheck-test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+          
+      - name: cppcheck
+        uses: deep5050/cppcheck-action@main
+          
+        
+      - name: publish report    
+        uses: actions/upload-artifact@v3
+        with:
+          name: cppcheck
+          path: cppcheck_report.txt

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -1,19 +1,13 @@
 name: cppcheck-action
-on: [push]
+on: [push, pull_request]
 
 jobs:
-  build:
-    name: cppcheck-test
+  cppcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-          
-      - name: cppcheck
-        uses: deep5050/cppcheck-action@main
-          
-        
-      - name: publish report    
-        uses: actions/upload-artifact@v3
+      - uses: actions/checkout@v3  
+      - uses: deep5050/cppcheck-action@main 
+      - uses: actions/upload-artifact@v3
         with:
           name: cppcheck
           path: cppcheck_report.txt

--- a/.github/workflows/cpplint.yml
+++ b/.github/workflows/cpplint.yml
@@ -1,0 +1,17 @@
+name: cpplint-action
+on: [push, pull_request]
+
+jobs:
+  cpplint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+      - run: pip install cpplint
+      - run: cpplint --recursive . > cpplint_report.txt 2>&1
+        continue-on-error: true
+      - uses: actions/upload-artifact@v3
+        with:
+          name: cpplint
+          path: cpplint_report.txt
+

--- a/.github/workflows/cpplint.yml
+++ b/.github/workflows/cpplint.yml
@@ -11,6 +11,7 @@ jobs:
       - run: cpplint --recursive . > cpplint_report.txt 2>&1
         continue-on-error: true
       - uses: actions/upload-artifact@v3
+        if: always()
         with:
           name: cpplint
           path: cpplint_report.txt

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ dep:
 	@bash util/build.sh --stor=$(stor) --only="" --dep=1
 
 ci-build:
-	@bash util/build_in_image.sh --stor=$(stor) --only=$(only) --dep=$(dep) --release=$(release) --ci=$(ci) --os=$(os)
+	@bash util/build_in_image.sh --stor=$(stor) --only=$(only) --dep=$(dep) --release=$(release) --ci=$(ci) --os=$(os) --sanitizer=$(sanitizer)
 
 ci-dep:
 	@bash util/build_in_image.sh --stor=$(stor) --only="" --dep=1

--- a/ut.sh
+++ b/ut.sh
@@ -27,7 +27,7 @@ print_title() {
 ############################ FUNCTIONS
 
 get_options() {
-    local args=`getopt -o ldorh --long stor:,list,dep:,only:,os:,release:,ci:,build_rocksdb: -n "$0" -- "$@"`
+    local args=`getopt -o ldorhS --long sanitizer:,stor:,list,dep:,only:,os:,release:,ci:,build_rocksdb: -n "$0" -- "$@"`
     eval set -- "${args}"
     while true
     do
@@ -54,6 +54,10 @@ get_options() {
                 ;;
             -c|--ci)
                 g_ci=$2
+                shift 2
+                ;;
+            -S|--sanitizer)
+                g_san=$2
                 shift 2
                 ;;
             --os)

--- a/util/build_in_image.sh
+++ b/util/build_in_image.sh
@@ -78,11 +78,15 @@ _EOC_
 }
 
 get_options() {
-    local args=`getopt -o ldorh --long stor:,list,dep:,only:,os:,release:,ci:,build_rocksdb: -n "$0" -- "$@"`
+    local args=`getopt -o ldorhS --long sanitizer:,stor:,list,dep:,only:,os:,release:,ci:,build_rocksdb: -n "$0" -- "$@"`
     eval set -- "${args}"
     while true
     do
         case "$1" in
+            -S|--sanitizer)
+                g_san=$2
+                shift 2
+                ;;
             -s|--stor)
                 g_stor=$2
                 shift 2
@@ -197,6 +201,12 @@ build_target() {
     if [ $g_ci -eq 1 ]; then
         g_build_opts+=("--collect_code_coverage")
         target_array=("...")
+    fi
+
+    if [ $g_san == 1 ]; then
+        g_build_opts+=("--config=asan")
+    elif [ $g_san == 2 ]; then
+        g_build_opts+=("--config=msan")
     fi
 
     for target in "${target_array[@]}"

--- a/util/ut_in_image.sh
+++ b/util/ut_in_image.sh
@@ -1,4 +1,27 @@
 #!/bin/bash
+get_options() {
+    local args=`getopt -o S --long sanitizer: -n "$0" -- "$@"`
+    eval set -- "${args}"
+    while true
+    do
+        case "$1" in
+            -S|--sanitizer)
+                g_san=$2
+                shift 2
+                ;;
+            --)
+                shift
+                break
+                ;;
+            *)
+                exit 1
+                ;;
+        esac
+    done
+}
+
+get_options "$@"
+
 WORKSPACE="/var/lib/jenkins/workspace/curve/curve_multijob/"
 sudo mkdir -p /var/lib/jenkins/log/curve_unittest/$BUILD_NUMBER
 git config --global --add safe.directory /var/lib/jenkins/workspace/curve/curve_multijob
@@ -68,10 +91,10 @@ set -e
 
 #test_bin_dirs="bazel-bin/test/ bazel-bin/nebd/test/ bazel-bin/curvefs/test/"
 if [ $1 == "curvebs" ];then
-make ci-build stor=bs ci=1 dep=1
+make ci-build stor=bs ci=1 dep=1 sanitizer=$g_san
 test_bin_dirs="bazel-bin/test/ bazel-bin/nebd/test/"
 elif [ $1 == "curvefs" ];then
-make ci-build stor=fs ci=1 dep=1 only=curvefs/test/*
+make ci-build stor=fs ci=1 dep=1 only=curvefs/test/* sanitizer=$g_san
 test_bin_dirs="bazel-bin/curvefs/test/"
 fi
 echo $test_bin_dirs


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #2570

Problem Summary: Use github action to do some static checks and code security tests on the code in the curve warehouse

### What is changed and how it works?

What's Changed: Github action workflow, .bazelrc, ut.sh and util/ut_in_image.sh

How it Works: By adding some jobs in github action workflow, cppcheck and cpplint is now automatically performed on push and pull request, and results are published to action files.

The .bazelrc is changed to add building configs for enabling ASan, MSan and UBSan. Then running ut.sh with "--sanitizer [mode]" will use corresponding config to build curve with sanitizers and run tests (specifically, mode=1 for ASan and mode=2 for MSan and UBSan).

Side effects(Breaking backward compatibility? Performance regression?): Running tests with sanitizers may be ~2x-4x slower.

### Check List

- [Y] Relevant documentation/comments is changed or added
- [Y] I acknowledge that all my contributions will be made under the project's license
