### PR TITLE
improve partition range management

### DIFF
--- a/curvefs/src/mds/topology/topology.cpp
+++ b/curvefs/src/mds/topology/topology.cpp
@@ -565,6 +565,8 @@ TopoStatusCode TopologyImpl::AddPartition(const Partition &data) {
 
                 // update fs partition number
                 clusterInfo_.AddPartitionIndexOfFs(data.GetFsId());
+                clusterInfo_.UpdateFsNextInodeId(data.GetFsId(),
+                                                 data.GetIdEnd());
                 if (!storage_->StorageClusterInfo(clusterInfo_)) {
                     LOG(ERROR) << "AddPartitionIndexOfFs failed, fsId = "
                                << data.GetFsId();
@@ -1043,6 +1045,12 @@ TopoStatusCode TopologyImpl::Init(const TopologyOption &option) {
         return TopoStatusCode::TOPO_STORGE_FAIL;
     }
     idGenerator_->initPartitionIdGenerator(maxPartitionId);
+
+    // update fs next inodeId
+    for (const auto& p : partitionMap_) {
+        clusterInfo_.UpdateFsNextInodeId(p.second.GetFsId(),
+                                         p.second.GetIdEnd());
+    }
 
     // MemcacheCluster
     MemcacheClusterIdType maxMemcacheClusterId;
@@ -1624,6 +1632,11 @@ TopologyImpl::GenCopysetAddrBatch(uint32_t needCreateNum,
 uint32_t TopologyImpl::GetPartitionIndexOfFS(FsIdType fsId) {
     ReadLockGuard rlock(clusterMutex_);
     return clusterInfo_.GetPartitionIndexOfFS(fsId);
+}
+
+uint64_t TopologyImpl::GetFsNextInodeId(FsIdType fsId) {
+    ReadLockGuard rlock(clusterMutex_);
+    return clusterInfo_.GetFsNextInodeId(fsId);
 }
 
 std::vector<CopySetInfo> TopologyImpl::ListCopysetInfo() const {

--- a/curvefs/src/mds/topology/topology.h
+++ b/curvefs/src/mds/topology/topology.h
@@ -23,6 +23,7 @@
 #define CURVEFS_SRC_MDS_TOPOLOGY_TOPOLOGY_H_
 
 #include <algorithm>
+#include <cstdint>
 #include <list>
 #include <map>
 #include <memory>
@@ -280,6 +281,8 @@ class Topology {
 
     virtual uint32_t GetPartitionIndexOfFS(FsIdType fsId) = 0;
 
+    virtual uint64_t GetFsNextInodeId(FsIdType fsId) = 0;
+
     virtual std::vector<CopySetInfo> ListCopysetInfo() const = 0;
 
     virtual void GetMetaServersSpace(
@@ -525,7 +528,9 @@ class TopologyImpl : public Topology {
     TopoStatusCode GenCopysetAddrBatchForPool(PoolIdType poolId,
     uint16_t replicaNum, std::list<CopysetCreateInfo>* copysetList) override;
 
-    uint32_t GetPartitionIndexOfFS(FsIdType fsId);
+    uint32_t GetPartitionIndexOfFS(FsIdType fsId) override;
+
+    uint64_t GetFsNextInodeId(FsIdType fsId) override;
 
     TopoStatusCode GetPoolIdByMetaserverId(MetaServerIdType id,
                                            PoolIdType *poolIdOut);

--- a/curvefs/src/mds/topology/topology_item.h
+++ b/curvefs/src/mds/topology/topology_item.h
@@ -55,6 +55,8 @@ struct ClusterInformation {
     std::string clusterId;
     // <fsId, partition index of this fs>
     std::map<uint32_t, uint32_t> partitionIndexs;
+    // <fsId, next inode id>
+    std::unordered_map<uint32_t, uint64_t> fsNextInodeId;
 
     ClusterInformation() = default;
     explicit ClusterInformation(const std::string &clusterId)
@@ -74,6 +76,14 @@ struct ClusterInformation {
 
     void AddPartitionIndexOfFs(uint32_t fsId) {
         partitionIndexs[fsId]++;
+    }
+
+    void UpdateFsNextInodeId(uint32_t fsId, uint64_t inodeId) {
+        fsNextInodeId[fsId] = std::max(fsNextInodeId[fsId], inodeId);
+    }
+
+    uint64_t GetFsNextInodeId(uint32_t fsId) {
+        return fsNextInodeId[fsId] == 0 ? 0 : fsNextInodeId[fsId] + 1;
     }
 
     bool SerializeToString(std::string *value) const;

--- a/curvefs/src/mds/topology/topology_manager.cpp
+++ b/curvefs/src/mds/topology/topology_manager.cpp
@@ -649,9 +649,8 @@ TopoStatusCode TopologyManager::CreatePartitionOnCopyset(
     }
 
     // calculate inodeId start and end of partition
-    uint32_t index = topology_->GetPartitionIndexOfFS(fsId);
-    uint64_t idStart = index * option_.idNumberInPartition;
-    uint64_t idEnd = (index + 1) * option_.idNumberInPartition - 1;
+    uint64_t idStart = topology_->GetFsNextInodeId(fsId);
+    uint64_t idEnd = idStart + option_.idNumberInPartition - 1;
     PartitionIdType partitionId = topology_->AllocatePartitionId();
 
     if (partitionId == static_cast<ServerIdType>(UNINITIALIZE_ID)) {


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?
The previous logic of allocate inode range to partition is: index of partiton in this fs * range form conf.
For example, there are five partitions in fs and each manage 100 inodes:
p1 0-99
p2 100-199
p3 200-299
p4 300-399
p5 400-499

If you make  this conf value smaller(maybe 80) and upgrade mds:
p1 0-99
p2 100-199
p3 200-299
p4 300-399
p5 400-499

p6: 400-479    new allocated partition will have repetitive parts with previous partition.

Issue Number: #xxx <!-- replace xxx with issue number -->

Problem Summary:

### What is changed and how it works?

Now we will change allocation algorithm and record max inodeId of fs.

previous:
![截屏2023-08-31 16 25 50](https://github.com/opencurve/curve/assets/13496900/7ccb8b23-dd82-4901-b922-33b2202efd80)

after fix:
![截屏2023-08-31 16 35 03](https://github.com/opencurve/curve/assets/13496900/4f81afb1-d86f-40f9-90f9-5fa848e7d0b3)


What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
