### PR TITLE
Feat/curvefs/client/change disk cache conf on fly

### DIFF
--- a/curvefs/conf/client.conf
+++ b/curvefs/conf/client.conf
@@ -244,10 +244,19 @@ diskCache.forceFlush=true
 diskCache.trimCheckIntervalSec=5
 # the interval of check to trim load file to s3
 diskCache.asyncLoadPeriodMs=5
-# start trim file when disk cache use ratio is Greater than fullRatio,
-# util less than safeRatio
+#        ok           nearfull               full
+#  |------------|-------------------|----------------------|
+#  0     trimRatio*safeRatio    safeRatio               fullRatio
+# 
+#  1. 0<=ok<trimRatio*safeRatio;
+#  2. trimRatio*safeRatio<=nearfull<safeRatio
+#  3. safeRatio<=full<=fullRatio
+#  If the status is ok or ok->nearfull does not clean up
+#  If the status is full or
+#  full->nearfull clean up
 diskCache.fullRatio=90
 diskCache.safeRatio=70
+diskCache.trimRatio=50
 diskCache.threads=5
 # the max size disk cache can use
 diskCache.maxUsableSpaceBytes=107374182400

--- a/curvefs/src/client/common/config.cpp
+++ b/curvefs/src/client/common/config.cpp
@@ -183,6 +183,8 @@ void InitDiskCacheOption(Configuration *conf,
                               &diskCacheOption->fullRatio);
     conf->GetValueFatalIfFail("diskCache.safeRatio",
                               &diskCacheOption->safeRatio);
+    conf->GetValueFatalIfFail("diskCache.trimRatio",
+                              &diskCacheOption->trimRatio);
     conf->GetValueFatalIfFail("diskCache.maxUsableSpaceBytes",
                               &diskCacheOption->maxUsableSpaceBytes);
     conf->GetValueFatalIfFail("diskCache.maxFileNums",

--- a/curvefs/src/client/common/config.h
+++ b/curvefs/src/client/common/config.h
@@ -89,9 +89,11 @@ struct DiskCacheOption {
     // async load interval
     uint64_t asyncLoadPeriodMs;
     // trim start if disk usage over fullRatio
-    uint64_t fullRatio;
-    // trim finish until disk usage below safeRatio
-    uint64_t safeRatio;
+    uint32_t fullRatio = 90;
+    // disk usage safeRatio
+    uint32_t safeRatio = 70;
+    // trim finish until disk usage < safeRatio*trimRatio/100
+    uint32_t trimRatio = 50;
     // the max size disk cache can use
     uint64_t maxUsableSpaceBytes;
     // the max file nums can cache

--- a/curvefs/src/client/s3/disk_cache_manager.cpp
+++ b/curvefs/src/client/s3/disk_cache_manager.cpp
@@ -19,12 +19,15 @@
  * Created Date: 21-08-13
  * Author: hzwuhongsong
  */
+
+#include <glog/logging.h>
 #include <sys/vfs.h>
 #include <errno.h>
 #include <string>
 #include <cstdio>
 #include <memory>
 #include <list>
+#include <cstdint>
 
 #include "curvefs/src/client/s3/client_s3_adaptor.h"
 #include "curvefs/src/client/s3/disk_cache_manager.h"
@@ -39,6 +42,7 @@ namespace client {
  * for dynamic parameter configuration
  */
 static bool pass_uint32(const char *, uint32_t) { return true; }
+static bool ValidateRatio(const char *, uint32_t ratio) { return ratio <= 100; }
 static bool pass_uint64(const char *, uint64_t) { return true; }
 DEFINE_uint64(avgFlushBytes, 83886080, "the write throttle bps of disk cache");
 DEFINE_validator(avgFlushBytes, &pass_uint64);
@@ -54,16 +58,18 @@ DEFINE_validator(avgReadFileBytes, &pass_uint64);
 DEFINE_uint64(avgReadFileIops, 0, "the read throttle iops of disk cache");
 DEFINE_validator(avgReadFileIops, &pass_uint64);
 
-DEFINE_uint32(nearfullRatio, 70, "the nearfull ratio of disk cache");
-DEFINE_validator(nearfullRatio, &pass_uint32);
-DEFINE_uint32(fullRatio, 90, "the nearfull ratio of disk cache");
-DEFINE_validator(fullRatio, &pass_uint32);
-DEFINE_uint32(trimCheckIntervalSec, 5, "trim check interval seconds");
-DEFINE_validator(trimCheckIntervalSec, &pass_uint32);
-DEFINE_uint64(maxUsableSpaceBytes, 107374182400, "max space bytes can use");
-DEFINE_validator(maxUsableSpaceBytes, &pass_uint64);
-DEFINE_uint64(maxFileNums, 1000000, "max file nums can owner");
-DEFINE_validator(maxFileNums, &pass_uint64);
+DEFINE_uint32(diskNearFullRatio, 70, "the nearfull ratio of disk cache");
+DEFINE_validator(diskNearFullRatio, &ValidateRatio);
+DEFINE_uint32(diskFullRatio, 90, "the nearfull ratio of disk cache");
+DEFINE_validator(diskFullRatio, &ValidateRatio);
+DEFINE_uint32(diskTrimRatio, 50, "the trim ratio when disk nearfull");
+DEFINE_validator(diskTrimRatio, &ValidateRatio);
+DEFINE_uint32(diskTrimCheckIntervalSec, 5, "trim check interval seconds");
+DEFINE_validator(diskTrimCheckIntervalSec, &pass_uint32);
+DEFINE_uint64(diskMaxUsableSpaceBytes, 107374182400, "max space bytes can use");
+DEFINE_validator(diskMaxUsableSpaceBytes, &pass_uint64);
+DEFINE_uint64(diskMaxFileNums, 1000000, "max file nums can owner");
+DEFINE_validator(diskMaxFileNums, &pass_uint64);
 
 DiskCacheManager::DiskCacheManager(std::shared_ptr<PosixWrapper> posixWrapper,
                                    std::shared_ptr<DiskCacheWrite> cacheWrite,
@@ -74,10 +80,7 @@ DiskCacheManager::DiskCacheManager(std::shared_ptr<PosixWrapper> posixWrapper,
     isRunning_ = false;
     usedBytes_ = 0;
     diskFsUsedRatio_ = 0;
-    fullRatio_ = 0;
-    safeRatio_ = 0;
     diskUsedInit_ = false;
-    maxUsableSpaceBytes_ = 0;
     objectPrefix_ = 0;
     // cannot limit the size,
     // because cache is been delete must after upload to s3
@@ -92,12 +95,13 @@ int DiskCacheManager::Init(std::shared_ptr<S3Client> client,
     client_ = client;
 
     option_ = option;
+    FLAGS_diskTrimCheckIntervalSec = option.diskCacheOpt.trimCheckIntervalSec;
+    FLAGS_diskFullRatio = option.diskCacheOpt.fullRatio;
+    FLAGS_diskNearFullRatio = option.diskCacheOpt.safeRatio;
+    FLAGS_diskTrimRatio = option.diskCacheOpt.trimRatio;
     cacheDir_ = option.diskCacheOpt.cacheDir;
-    trimCheckIntervalSec_ = option.diskCacheOpt.trimCheckIntervalSec;
-    fullRatio_ = option.diskCacheOpt.fullRatio;
-    safeRatio_ = option.diskCacheOpt.safeRatio;
-    maxUsableSpaceBytes_ = option.diskCacheOpt.maxUsableSpaceBytes;
-    maxFileNums_ = option.diskCacheOpt.maxFileNums;
+    FLAGS_diskMaxUsableSpaceBytes = option.diskCacheOpt.maxUsableSpaceBytes;
+    FLAGS_diskMaxFileNums = option.diskCacheOpt.maxFileNums;
     cmdTimeoutSec_ = option.diskCacheOpt.cmdTimeoutSec;
     objectPrefix_ = option.objectPrefix;
     cacheWrite_->Init(client_, posixWrapper_, cacheDir_, objectPrefix_,
@@ -126,7 +130,7 @@ int DiskCacheManager::Init(std::shared_ptr<S3Client> client,
     // start trim thread
     TrimRun();
 
-    SetDiskFsUsedRatio();
+    UpdateDiskFsUsedRatio();
 
     FLAGS_avgFlushIops = option_.diskCacheOpt.avgFlushIops;
     FLAGS_avgFlushBytes = option_.diskCacheOpt.avgFlushBytes;
@@ -136,20 +140,14 @@ int DiskCacheManager::Init(std::shared_ptr<S3Client> client,
     FLAGS_avgReadFileBytes = option_.diskCacheOpt.avgReadFileBytes;
     InitQosParam();
 
-    FLAGS_trimCheckIntervalSec = option.diskCacheOpt.trimCheckIntervalSec;
-    FLAGS_fullRatio = option.diskCacheOpt.fullRatio;
-    FLAGS_nearfullRatio = option.diskCacheOpt.safeRatio;
-    FLAGS_maxUsableSpaceBytes = option.diskCacheOpt.maxUsableSpaceBytes;
-    FLAGS_maxFileNums = option.diskCacheOpt.maxFileNums;
-    InitTrimParam();
-
     LOG(INFO) << "DiskCacheManager init success. "
               << ", cache dir is: " << cacheDir_
-              << ", maxUsableSpaceBytes is: " << maxUsableSpaceBytes_
-              << ", maxFileNums is: " << maxFileNums_
+              << ", maxUsableSpaceBytes is: " << FLAGS_diskMaxUsableSpaceBytes
+              << ", maxFileNums is: " << FLAGS_diskMaxFileNums
               << ", cmdTimeoutSec is: " << cmdTimeoutSec_
-              << ", safeRatio is: " << safeRatio_
-              << ", fullRatio is: " << fullRatio_
+              << ", safeRatio is: " << FLAGS_diskNearFullRatio
+              << ", fullRatio is: " << FLAGS_diskFullRatio
+              << ", trimRatio is: " << FLAGS_diskTrimRatio
               << ", disk used bytes: " << GetDiskUsedbytes();
     return 0;
 }
@@ -163,14 +161,6 @@ void DiskCacheManager::InitQosParam() {
     params.bpsRead = ThrottleParams(FLAGS_avgReadFileBytes, 0, 0);
 
     diskCacheThrottle_.UpdateThrottleParams(params);
-}
-
-void DiskCacheManager::InitTrimParam() {
-    trimCheckIntervalSec_ = FLAGS_trimCheckIntervalSec;
-    fullRatio_ = FLAGS_fullRatio;
-    safeRatio_ = FLAGS_nearfullRatio;
-    maxUsableSpaceBytes_ = FLAGS_maxUsableSpaceBytes;
-    maxFileNums_ = FLAGS_maxFileNums;
 }
 
 int DiskCacheManager::UploadAllCacheWriteFile() {
@@ -289,7 +279,7 @@ int DiskCacheManager::LinkWriteToRead(const std::string fileName,
     return cacheRead_->LinkWriteToRead(fileName, fullWriteDir, fullReadDir);
 }
 
-int64_t DiskCacheManager::SetDiskFsUsedRatio() {
+int64_t DiskCacheManager::UpdateDiskFsUsedRatio() {
     struct statfs stat;
     if (posixWrapper_->statfs(cacheDir_.c_str(), &stat) == -1) {
         LOG_EVERY_N(WARNING, 100)
@@ -339,53 +329,77 @@ void DiskCacheManager::SetDiskInitUsedBytes() {
 bool DiskCacheManager::IsDiskCacheFull() {
     int64_t ratio = diskFsUsedRatio_.load();
     uint64_t usedBytes = GetDiskUsedbytes();
-    if (ratio >= fullRatio_ || usedBytes >= maxUsableSpaceBytes_) {
+    if (ratio >= FLAGS_diskFullRatio ||
+        usedBytes >= FLAGS_diskMaxUsableSpaceBytes ||
+        IsExceedFileNums(kRatioLevel)) {
         VLOG(6) << "disk cache is full"
-                     << ", ratio is: " << ratio << ", fullRatio is: "
-                     << fullRatio_ << ", used bytes is: " << usedBytes;
+                << ", ratio is: " << ratio
+                << ", fullRatio is: " << FLAGS_diskFullRatio
+                << ", used bytes is: " << usedBytes;
         waitIntervalSec_.StopWait();
         return true;
     }
-    if (!IsDiskCacheSafe()) {
+    if (!IsDiskCacheSafe(kRatioLevel)) {
         VLOG(6) << "wake up trim thread.";
         waitIntervalSec_.StopWait();
     }
     return false;
 }
 
-bool DiskCacheManager::IsDiskCacheSafe() {
-    if (IsExceedFileNums()) {
+bool DiskCacheManager::IsDiskCacheSafe(uint32_t baseRatio) {
+    if (IsExceedFileNums(baseRatio)) {
         return false;
     }
     int64_t ratio = diskFsUsedRatio_.load();
     uint64_t usedBytes = GetDiskUsedbytes();
-    if ((usedBytes < (safeRatio_ * maxUsableSpaceBytes_ / 100))
-      && (ratio < safeRatio_)) {
+    if ((usedBytes < (FLAGS_diskNearFullRatio * FLAGS_diskMaxUsableSpaceBytes /
+                      kRatioLevel * baseRatio / kRatioLevel)) &&
+        (ratio < FLAGS_diskNearFullRatio * baseRatio / kRatioLevel)) {
         VLOG(9) << "disk cache is safe"
                 << ", usedBytes is: " << usedBytes
-                << ", use ratio is: " << ratio;
+                << ", use ratio is: " << ratio
+                << ", baseRatio is: " << baseRatio;
         return true;
     }
-    VLOG(6) << "disk cache is not safe"
-                << ", usedBytes is: " << usedBytes
-                << ", use ratio is: " << ratio;
+    VLOG_EVERY_N(6, 1000) << "disk cache is not safe"
+            << ", usedBytes is: " << usedBytes << ", limit is "
+            << FLAGS_diskNearFullRatio * FLAGS_diskMaxUsableSpaceBytes /
+                   kRatioLevel * baseRatio / kRatioLevel
+            << ", use ratio is: " << ratio << ", limit is: "
+            << FLAGS_diskNearFullRatio * baseRatio / kRatioLevel;
     return false;
 }
 
 // TODO(wuhongsong):
 // See Also: https://github.com/opencurve/curve/issues/1534
-bool DiskCacheManager::IsExceedFileNums() {
+bool DiskCacheManager::IsExceedFileNums(uint32_t baseRatio) {
     uint64_t fileNums = cachedObjName_->Size();
-    if (fileNums >= maxFileNums_) {
+    if (fileNums >= FLAGS_diskMaxFileNums * baseRatio / kRatioLevel) {
+        VLOG_EVERY_N(9, 1000) << "disk cache file nums is exceed"
+                << ", fileNums is: " << fileNums
+                << ", maxFileNums is: " << FLAGS_diskMaxFileNums
+                << ", baseRatio is: " << baseRatio;
         return true;
     }
     return false;
 }
 
+
+//
+//       ok           nearfull               full
+// |------------|-------------------|----------------------|
+// 0     trimRatio*safeRatio    safeRatio               fullRatio
+//
+// 1. 0<=ok<trimRatio*safeRatio;
+// 2. trimRatio*safeRatio<=nearfull<safeRatio
+// 3. safeRatio<=full<=fullRatio
+// If the status is ok or ok->nearfull does not clean up
+// If the status is full or
+// full->nearfull clean up
 void DiskCacheManager::TrimCache() {
-    const std::chrono::seconds sleepSec(trimCheckIntervalSec_);
+    const std::chrono::seconds sleepSec(FLAGS_diskTrimCheckIntervalSec);
     LOG(INFO) << "trim function start.";
-    waitIntervalSec_.Init(trimCheckIntervalSec_ * 1000);
+    waitIntervalSec_.Init(FLAGS_diskTrimCheckIntervalSec * 1000);
     // trim will start after get the disk size
     while (!IsDiskUsedInited()) {
         if (!isRunning_) {
@@ -395,13 +409,14 @@ void DiskCacheManager::TrimCache() {
     }
     // 1. check cache disk usage every sleepSec seconds.
     // 2. if cache disk is full,
-    //    then remove disk file until cache disk is lower than safeRatio_.
+    //    then remove disk file until cache disk is lower than
+    //    FLAGS_diskNearFullRatio*FLAGS_trimRatio/kRatioLevel.
     std::string cacheReadFullDir, cacheWriteFullDir,
       cacheReadFile, cacheWriteFile, cacheKey;
     cacheReadFullDir = GetCacheReadFullDir();
     cacheWriteFullDir = GetCacheWriteFullDir();
     while (true) {
-        SetDiskFsUsedRatio();
+        UpdateDiskFsUsedRatio();
         waitIntervalSec_.WaitForNextExcution();
         if (!isRunning_) {
             LOG(INFO) << "trim thread end.";
@@ -409,57 +424,58 @@ void DiskCacheManager::TrimCache() {
         }
         VLOG(9) << "trim thread wake up.";
         InitQosParam();
-        InitTrimParam();
-        while (!IsDiskCacheSafe()) {
-            SetDiskFsUsedRatio();
-            if (!cachedObjName_->GetBack(&cacheKey)) {
-                VLOG(9) << "obj is empty";
-                break;
-            }
+        if (!IsDiskCacheSafe(kRatioLevel)) {
+            while (!IsDiskCacheSafe(FLAGS_diskTrimRatio)) {
+                UpdateDiskFsUsedRatio();
+                if (!cachedObjName_->GetBack(&cacheKey)) {
+                    VLOG_EVERY_N(9, 1000) << "obj is empty";
+                    break;
+                }
 
-            VLOG(6) << "obj will be removed01: " << cacheKey;
-            cacheReadFile = cacheReadFullDir + "/" +
-                    curvefs::common::s3util::GenPathByObjName(
-                        cacheKey, objectPrefix_);
-            cacheWriteFile = cacheWriteFullDir + "/" +
-                    curvefs::common::s3util::GenPathByObjName(
-                        cacheKey, objectPrefix_);
-            struct stat statFile;
-            int ret = 0;
-            ret = posixWrapper_->stat(cacheWriteFile.c_str(), &statFile);
-            // if file has not been uploaded to S3,
-            // but remove the cache read file,
-            // then read will fail when do cache read,
-            // and then it cannot load the file from S3.
-            // so read is fail.
-            if (ret == 0) {
-                VLOG(1) << "do not remove this disk file"
-                        << ", file has not been uploaded to S3."
-                        << ", file is: " << cacheKey;
-                usleep(1000);
-                continue;
+                VLOG(6) << "obj will be removed01: " << cacheKey;
+                cacheReadFile = cacheReadFullDir + "/" +
+                                curvefs::common::s3util::GenPathByObjName(
+                                    cacheKey, objectPrefix_);
+                cacheWriteFile = cacheWriteFullDir + "/" +
+                                 curvefs::common::s3util::GenPathByObjName(
+                                     cacheKey, objectPrefix_);
+                struct stat statFile;
+                int ret = 0;
+                ret = posixWrapper_->stat(cacheWriteFile.c_str(), &statFile);
+                // if file has not been uploaded to S3,
+                // but remove the cache read file,
+                // then read will fail when do cache read,
+                // and then it cannot load the file from S3.
+                // so read is fail.
+                if (ret == 0) {
+                    VLOG(1) << "do not remove this disk file"
+                            << ", file has not been uploaded to S3."
+                            << ", file is: " << cacheKey;
+                    usleep(1000);
+                    continue;
+                }
+                cachedObjName_->Remove(cacheKey);
+                struct stat statReadFile;
+                ret = posixWrapper_->stat(cacheReadFile.c_str(), &statReadFile);
+                if (ret != 0) {
+                    VLOG(0) << "stat disk file error"
+                            << ", file is: " << cacheKey;
+                    continue;
+                }
+                // if remove disk file before delete cache,
+                // then read maybe fail.
+                const char *toDelFile;
+                toDelFile = cacheReadFile.c_str();
+                ret = posixWrapper_->remove(toDelFile);
+                if (ret < 0) {
+                    LOG(ERROR)
+                        << "remove disk file error, file is: " << cacheKey
+                        << "error is: " << errno;
+                    continue;
+                }
+                DecDiskUsedBytes(statReadFile.st_size);
+                VLOG(6) << "remove disk file success, file is: " << cacheKey;
             }
-            cachedObjName_->Remove(cacheKey);
-            struct stat statReadFile;
-            ret = posixWrapper_->stat(cacheReadFile.c_str(), &statReadFile);
-            if (ret != 0) {
-                VLOG(0) << "stat disk file error"
-                        << ", file is: " << cacheKey;
-                continue;
-            }
-            // if remove disk file before delete cache,
-            // then read maybe fail.
-            const char *toDelFile;
-            toDelFile = cacheReadFile.c_str();
-            ret = posixWrapper_->remove(toDelFile);
-            if (ret < 0) {
-                LOG(ERROR)
-                    << "remove disk file error, file is: " << cacheKey
-                    << "error is: " << errno;
-                continue;
-            }
-            DecDiskUsedBytes(statReadFile.st_size);
-            VLOG(6) << "remove disk file success, file is: " << cacheKey;
         }
     }
     LOG(INFO) << "trim function end.";

--- a/curvefs/src/client/s3/disk_cache_manager.cpp
+++ b/curvefs/src/client/s3/disk_cache_manager.cpp
@@ -38,6 +38,7 @@ namespace client {
  * use curl -L mdsIp:port/flags/avgFlushBytes?setvalue=true
  * for dynamic parameter configuration
  */
+static bool pass_uint32(const char *, uint32_t) { return true; }
 static bool pass_uint64(const char *, uint64_t) { return true; }
 DEFINE_uint64(avgFlushBytes, 83886080, "the write throttle bps of disk cache");
 DEFINE_validator(avgFlushBytes, &pass_uint64);
@@ -52,6 +53,17 @@ DEFINE_uint64(avgReadFileBytes, 83886080,
 DEFINE_validator(avgReadFileBytes, &pass_uint64);
 DEFINE_uint64(avgReadFileIops, 0, "the read throttle iops of disk cache");
 DEFINE_validator(avgReadFileIops, &pass_uint64);
+
+DEFINE_uint32(nearfullRatio, 70, "the nearfull ratio of disk cache");
+DEFINE_validator(nearfullRatio, &pass_uint32);
+DEFINE_uint32(fullRatio, 90, "the nearfull ratio of disk cache");
+DEFINE_validator(fullRatio, &pass_uint32);
+DEFINE_uint32(trimCheckIntervalSec, 5, "trim check interval seconds");
+DEFINE_validator(trimCheckIntervalSec, &pass_uint32);
+DEFINE_uint64(maxUsableSpaceBytes, 107374182400, "max space bytes can use");
+DEFINE_validator(maxUsableSpaceBytes, &pass_uint64);
+DEFINE_uint64(maxFileNums, 1000000, "max file nums can owner");
+DEFINE_validator(maxFileNums, &pass_uint64);
 
 DiskCacheManager::DiskCacheManager(std::shared_ptr<PosixWrapper> posixWrapper,
                                    std::shared_ptr<DiskCacheWrite> cacheWrite,
@@ -80,10 +92,10 @@ int DiskCacheManager::Init(std::shared_ptr<S3Client> client,
     client_ = client;
 
     option_ = option;
+    cacheDir_ = option.diskCacheOpt.cacheDir;
     trimCheckIntervalSec_ = option.diskCacheOpt.trimCheckIntervalSec;
     fullRatio_ = option.diskCacheOpt.fullRatio;
     safeRatio_ = option.diskCacheOpt.safeRatio;
-    cacheDir_ = option.diskCacheOpt.cacheDir;
     maxUsableSpaceBytes_ = option.diskCacheOpt.maxUsableSpaceBytes;
     maxFileNums_ = option.diskCacheOpt.maxFileNums;
     cmdTimeoutSec_ = option.diskCacheOpt.cmdTimeoutSec;
@@ -122,8 +134,14 @@ int DiskCacheManager::Init(std::shared_ptr<S3Client> client,
     FLAGS_burstSecs = option_.diskCacheOpt.burstSecs;
     FLAGS_avgReadFileIops = option_.diskCacheOpt.avgReadFileIops;
     FLAGS_avgReadFileBytes = option_.diskCacheOpt.avgReadFileBytes;
-
     InitQosParam();
+
+    FLAGS_trimCheckIntervalSec = option.diskCacheOpt.trimCheckIntervalSec;
+    FLAGS_fullRatio = option.diskCacheOpt.fullRatio;
+    FLAGS_nearfullRatio = option.diskCacheOpt.safeRatio;
+    FLAGS_maxUsableSpaceBytes = option.diskCacheOpt.maxUsableSpaceBytes;
+    FLAGS_maxFileNums = option.diskCacheOpt.maxFileNums;
+    InitTrimParam();
 
     LOG(INFO) << "DiskCacheManager init success. "
               << ", cache dir is: " << cacheDir_
@@ -145,6 +163,14 @@ void DiskCacheManager::InitQosParam() {
     params.bpsRead = ThrottleParams(FLAGS_avgReadFileBytes, 0, 0);
 
     diskCacheThrottle_.UpdateThrottleParams(params);
+}
+
+void DiskCacheManager::InitTrimParam() {
+    trimCheckIntervalSec_ = FLAGS_trimCheckIntervalSec;
+    fullRatio_ = FLAGS_fullRatio;
+    safeRatio_ = FLAGS_nearfullRatio;
+    maxUsableSpaceBytes_ = FLAGS_maxUsableSpaceBytes;
+    maxFileNums_ = FLAGS_maxFileNums;
 }
 
 int DiskCacheManager::UploadAllCacheWriteFile() {
@@ -383,6 +409,7 @@ void DiskCacheManager::TrimCache() {
         }
         VLOG(9) << "trim thread wake up.";
         InitQosParam();
+        InitTrimParam();
         while (!IsDiskCacheSafe()) {
             SetDiskFsUsedRatio();
             if (!cachedObjName_->GetBack(&cacheKey)) {

--- a/curvefs/src/client/s3/disk_cache_manager.h
+++ b/curvefs/src/client/s3/disk_cache_manager.h
@@ -148,7 +148,16 @@ class DiskCacheManager {
         return usedBytes_.load();
     }
 
+    /**
+     * @brief qos param for diskcache
+     */
     void InitQosParam();
+
+    /**
+     * @brief trim param for diskcache
+     */
+    void InitTrimParam();
+
     /**
      * @brief trim cache func.
      */

--- a/curvefs/src/client/s3/disk_cache_manager.h
+++ b/curvefs/src/client/s3/disk_cache_manager.h
@@ -53,6 +53,8 @@ using curvefs::client::common::S3ClientAdaptorOption;
 using curvefs::common::PosixWrapper;
 using curvefs::common::SysUtils;
 
+constexpr uint32_t kRatioLevel = 100;
+
 class DiskCacheManager {
  public:
     DiskCacheManager(std::shared_ptr<PosixWrapper> posixWrapper,
@@ -92,13 +94,8 @@ class DiskCacheManager {
     int UploadAllCacheWriteFile();
     int UploadWriteCacheByInode(const std::string &inode);
     int ClearReadCache(const std::list<std::string> &files);
-    /**
-     * @brief get use ratio of cache disk
-     * @return the use ratio
-     */
-    int64_t SetDiskFsUsedRatio();
     virtual bool IsDiskCacheFull();
-    bool IsDiskCacheSafe();
+
     /**
      * @brief: start trim thread.
      */
@@ -118,6 +115,24 @@ class DiskCacheManager {
     }
 
  private:
+    FRIEND_TEST(TestDiskCacheManager, UpdateDiskFsUsedRatio);
+    FRIEND_TEST(TestDiskCacheManager, IsDiskCacheSafe);
+    FRIEND_TEST(TestDiskCacheManager, IsDiskCacheSafe_TrimRatio_Full);
+    FRIEND_TEST(TestDiskCacheManager, IsDiskCacheSafe_TrimRatio_Nearfull);
+    FRIEND_TEST(TestDiskCacheManager, IsDiskCacheSafe_TrimRatio_Ok);
+
+    /**
+     * @brief get use ratio of cache disk
+     * @return the use ratio
+     */
+    int64_t UpdateDiskFsUsedRatio();
+    /**
+     * @brief: Determine whether the cache disk exceeds the safety line
+     * @param ratio: Adjust the safety line judged according to ratio, and the
+     * adjusted safety line is safety line*baseRatio/kRatioLevel.
+     */
+    bool IsDiskCacheSafe(uint32_t baseRatio);
+
     /**
      * @brief add the used bytes of disk cache.
      */
@@ -154,19 +169,15 @@ class DiskCacheManager {
     void InitQosParam();
 
     /**
-     * @brief trim param for diskcache
-     */
-    void InitTrimParam();
-
-    /**
      * @brief trim cache func.
      */
     void TrimCache();
 
     /**
-     * @brief whether the cache file is exceed maxFileNums_.
+     * @brief whether the cache file is exceed
+     * FLAGS_diskMaxFileNums*baseRatio/kRatioLevel.
      */
-    bool IsExceedFileNums();
+    bool IsExceedFileNums(uint32_t baseRatio);
 
     /**
      * @brief check whether cache dir does not exist or there is no cache file
@@ -177,11 +188,6 @@ class DiskCacheManager {
     curve::common::Atomic<bool> isRunning_;
     curve::common::InterruptibleSleeper sleeper_;
     curve::common::WaitInterval waitIntervalSec_;
-    uint32_t trimCheckIntervalSec_;
-    uint32_t fullRatio_;
-    uint32_t safeRatio_;
-    uint64_t maxUsableSpaceBytes_;
-    uint64_t maxFileNums_;
     uint32_t objectPrefix_;
     // used bytes of disk cache
     std::atomic<int64_t> usedBytes_;

--- a/curvefs/src/client/s3/disk_cache_manager_impl.h
+++ b/curvefs/src/client/s3/disk_cache_manager_impl.h
@@ -50,8 +50,9 @@ struct DiskCacheOption {
     DiskCacheType diskCacheType;
     uint64_t trimCheckIntervalSec;
     uint64_t asyncLoadPeriodMs;
-    uint64_t fullRatio;
-    uint64_t safeRatio;
+    uint32_t fullRatio;
+    uint32_t safeRatio;
+    uint32_t trimRatio;
     std::string cacheDir;
     bool forceFlush;
     uint64_t maxUsableSpaceBytes;

--- a/curvefs/test/client/test_disk_cache_manager.cpp
+++ b/curvefs/test/client/test_disk_cache_manager.cpp
@@ -20,6 +20,8 @@
  * Author: hzwuhongsong
  */
 
+#include <dirent.h>
+#include <gflags/gflags_declare.h>
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 #include <sys/stat.h>
@@ -42,6 +44,7 @@ using ::testing::DoAll;
 using ::testing::ElementsAre;
 using ::testing::Ge;
 using ::testing::Gt;
+using ::testing::Invoke;
 using ::testing::Mock;
 using ::testing::NotNull;
 using ::testing::Return;
@@ -52,6 +55,8 @@ using ::testing::ReturnRef;
 using ::testing::SetArgPointee;
 using ::testing::SetArgReferee;
 using ::testing::StrEq;
+
+DECLARE_uint32(diskTrimRatio);
 
 class TestDiskCacheManager : public ::testing::Test {
  protected:
@@ -208,9 +213,9 @@ TEST_F(TestDiskCacheManager, IsCached) {
     ASSERT_EQ(true, ret);
 }
 
-TEST_F(TestDiskCacheManager, SetDiskFsUsedRatio) {
+TEST_F(TestDiskCacheManager, UpdateDiskFsUsedRatio) {
     EXPECT_CALL(*wrapper, statfs(NotNull(), NotNull())).WillOnce(Return(-1));
-    int ret = diskCacheManager_->SetDiskFsUsedRatio();
+    int ret = diskCacheManager_->UpdateDiskFsUsedRatio();
     ASSERT_EQ(-1, ret);
 
     struct statfs stat;
@@ -220,7 +225,7 @@ TEST_F(TestDiskCacheManager, SetDiskFsUsedRatio) {
     stat.f_bavail = 0;
     EXPECT_CALL(*wrapper, statfs(NotNull(), _))
         .WillOnce(DoAll(SetArgPointee<1>(stat), Return(0)));
-    ret = diskCacheManager_->SetDiskFsUsedRatio();
+    ret = diskCacheManager_->UpdateDiskFsUsedRatio();
     ASSERT_EQ(-1, ret);
 
     stat.f_frsize = 1;
@@ -229,16 +234,13 @@ TEST_F(TestDiskCacheManager, SetDiskFsUsedRatio) {
     stat.f_bavail = 0;
     EXPECT_CALL(*wrapper, statfs(NotNull(), _))
         .WillOnce(DoAll(SetArgPointee<1>(stat), Return(0)));
-    ret = diskCacheManager_->SetDiskFsUsedRatio();
+    ret = diskCacheManager_->UpdateDiskFsUsedRatio();
     ASSERT_EQ(101, ret);
 }
 
 TEST_F(TestDiskCacheManager, IsDiskCacheFull) {
     int ret = diskCacheManager_->IsDiskCacheFull();
-    ASSERT_EQ(true, ret);
-
-    ret = diskCacheManager_->IsDiskCacheFull();
-    ASSERT_EQ(true, ret);
+    ASSERT_EQ(false, ret);
 }
 
 TEST_F(TestDiskCacheManager, IsDiskCacheSafe) {
@@ -253,7 +255,7 @@ TEST_F(TestDiskCacheManager, IsDiskCacheSafe) {
     option.diskCacheOpt.cmdTimeoutSec = 5;
     option.diskCacheOpt.asyncLoadPeriodMs = 10;
     diskCacheManager_->Init(client_, option);
-    bool ret = diskCacheManager_->IsDiskCacheSafe();
+    bool ret = diskCacheManager_->IsDiskCacheSafe(kRatioLevel);
     ASSERT_EQ(false, ret);
 
     option.diskCacheOpt.fullRatio = 100;
@@ -261,8 +263,114 @@ TEST_F(TestDiskCacheManager, IsDiskCacheSafe) {
     option.diskCacheOpt.maxUsableSpaceBytes = 100000000;
     option.objectPrefix = 0;
     diskCacheManager_->Init(client_, option);
-    ret = diskCacheManager_->IsDiskCacheSafe();
+    ret = diskCacheManager_->IsDiskCacheSafe(kRatioLevel);
     ASSERT_EQ(true, ret);
+}
+
+
+TEST_F(TestDiskCacheManager, IsDiskCacheSafe_TrimRatio_Full) {
+    //
+    //       ok           nearfull               full
+    // |------------|-------------------|----------------------|
+    // 0     trimRatio*safeRatio    safeRatio               fullRatio
+    //
+    // 1. 0<=ok<trimRatio*safeRatio;
+    // 2. trimRatio*safeRatio<=nearfull<safeRatio
+    // 3. safeRatio<=full<=fullRatio
+    S3ClientAdaptorOption option;
+    option.objectPrefix = 0;
+    option.diskCacheOpt.diskCacheType = (DiskCacheType)2;
+    option.diskCacheOpt.cacheDir = "/mnt/test_unit";
+    option.diskCacheOpt.trimCheckIntervalSec = 1;
+    option.diskCacheOpt.fullRatio = 90;
+    option.diskCacheOpt.safeRatio = 70;
+    option.diskCacheOpt.trimRatio = 50;
+    option.diskCacheOpt.cmdTimeoutSec = 5;
+    option.diskCacheOpt.asyncLoadPeriodMs = 10;
+    diskCacheManager_->Init(client_, option);
+
+    struct statfs stat;
+    stat.f_frsize = 1;
+    stat.f_blocks = 100;  // total
+    stat.f_bfree = 5;  // free
+    stat.f_bavail = 5;  // avaliable
+    EXPECT_CALL(*wrapper, statfs(NotNull(), _))
+        .WillOnce(DoAll(SetArgPointee<1>(stat), Return(0)));
+
+    diskCacheManager_->UpdateDiskFsUsedRatio();
+
+    ASSERT_EQ(false, diskCacheManager_->IsDiskCacheSafe(kRatioLevel));
+    ASSERT_EQ(false, diskCacheManager_->IsDiskCacheSafe(FLAGS_diskTrimRatio));
+}
+
+TEST_F(TestDiskCacheManager, IsDiskCacheSafe_TrimRatio_Nearfull) {
+    //
+    //       ok           nearfull               full
+    // |------------|-------------------|----------------------|
+    // 0     trimRatio*safeRatio    safeRatio               fullRatio
+    //
+    // 1. 0<=ok<trimRatio*safeRatio;
+    // 2. trimRatio*safeRatio<=nearfull<safeRatio
+    // 3. safeRatio<=full<=fullRatio
+    S3ClientAdaptorOption option;
+    option.objectPrefix = 0;
+    option.diskCacheOpt.diskCacheType = (DiskCacheType)2;
+    option.diskCacheOpt.cacheDir = "/mnt/test_unit";
+    option.diskCacheOpt.trimCheckIntervalSec = 1;
+    option.diskCacheOpt.fullRatio = 90;
+    option.diskCacheOpt.safeRatio = 70;
+    option.diskCacheOpt.trimRatio = 50;
+    option.diskCacheOpt.cmdTimeoutSec = 5;
+    option.diskCacheOpt.asyncLoadPeriodMs = 10;
+    diskCacheManager_->Init(client_, option);
+
+    struct statfs stat;
+    stat.f_frsize = 1;
+    stat.f_blocks = 100;  // total
+    stat.f_bfree = 40;     // free
+    stat.f_bavail = 40;    // avaliable
+    EXPECT_CALL(*wrapper, statfs(NotNull(), _))
+        .WillOnce(DoAll(SetArgPointee<1>(stat), Return(0)));
+
+    diskCacheManager_->UpdateDiskFsUsedRatio();
+
+    ASSERT_EQ(true, diskCacheManager_->IsDiskCacheSafe(kRatioLevel));
+    ASSERT_EQ(false, diskCacheManager_->IsDiskCacheSafe(FLAGS_diskTrimRatio));
+}
+
+TEST_F(TestDiskCacheManager, IsDiskCacheSafe_TrimRatio_Ok) {
+    //
+    //       ok           nearfull               full
+    // |------------|-------------------|----------------------|
+    // 0     trimRatio*safeRatio    safeRatio               fullRatio
+    //
+    // 1. 0<=ok<trimRatio*safeRatio;
+    // 2. trimRatio*safeRatio<=nearfull<safeRatio
+    // 3. safeRatio<=full<=fullRatio
+    S3ClientAdaptorOption option;
+    option.objectPrefix = 0;
+    option.diskCacheOpt.diskCacheType = (DiskCacheType)2;
+    option.diskCacheOpt.cacheDir = "/mnt/test_unit";
+    option.diskCacheOpt.trimCheckIntervalSec = 1;
+    option.diskCacheOpt.fullRatio = 90;
+    option.diskCacheOpt.safeRatio = 70;
+    option.diskCacheOpt.trimRatio = 50;
+    option.diskCacheOpt.cmdTimeoutSec = 5;
+    option.diskCacheOpt.asyncLoadPeriodMs = 10;
+    diskCacheManager_->Init(client_, option);
+
+    struct statfs stat;
+    stat.f_frsize = 1;
+    stat.f_blocks = 100;  // total
+    stat.f_bfree = 80;    // free
+    stat.f_bavail = 80;   // avaliable
+    EXPECT_CALL(*wrapper, statfs(NotNull(), _))
+        .WillOnce(DoAll(SetArgPointee<1>(stat), Return(0)));
+
+    diskCacheManager_->UpdateDiskFsUsedRatio();
+
+    ASSERT_EQ(true, diskCacheManager_->IsDiskCacheSafe(kRatioLevel));
+    ASSERT_EQ(true, diskCacheManager_->IsDiskCacheSafe(FLAGS_diskTrimRatio));
 }
 
 TEST_F(TestDiskCacheManager, TrimStop) {
@@ -398,9 +506,10 @@ TEST_F(TestDiskCacheManager, TrimCache_noexceed) {
     option.diskCacheOpt.diskCacheType = (DiskCacheType)2;
     option.diskCacheOpt.cacheDir = "/tmp";
     option.diskCacheOpt.trimCheckIntervalSec = 1;
-    option.diskCacheOpt.fullRatio = 0;
-    option.diskCacheOpt.safeRatio = 0;
-    option.diskCacheOpt.maxUsableSpaceBytes = 0;
+    option.diskCacheOpt.fullRatio = 90;
+    option.diskCacheOpt.safeRatio = 70;
+    option.diskCacheOpt.trimRatio = 50;
+    option.diskCacheOpt.maxUsableSpaceBytes = 374321784000;
     option.diskCacheOpt.cmdTimeoutSec = 5;
     option.diskCacheOpt.asyncLoadPeriodMs = 10;
     option.objectPrefix = 0;
@@ -414,23 +523,17 @@ TEST_F(TestDiskCacheManager, TrimCache_noexceed) {
 
     struct statfs stat;
     stat.f_frsize = 1;
-    stat.f_blocks = 1;
-    stat.f_bfree = 0;
-    stat.f_bavail = 0;
+    stat.f_blocks = 100;  // total
+    stat.f_bfree = 80;    // free
+    stat.f_bavail = 80;   // avaliable
     EXPECT_CALL(*wrapper, statfs(NotNull(), _))
-        .WillRepeatedly(DoAll(SetArgPointee<1>(stat), Return(-1)));
+        .WillRepeatedly(DoAll(SetArgPointee<1>(stat), Return(0)));
     EXPECT_CALL(*wrapper, remove(_)).WillRepeatedly(Return(0));
     diskCacheManager_->AddCache("test");
 
-    struct stat rf;
-    rf.st_size = 0;
-    EXPECT_CALL(*wrapper, stat(NotNull(), NotNull()))
-        .Times(2)
-        .WillOnce(Return(-1))
-        .WillOnce(DoAll(SetArgPointee<1>(rf), Return(0)));
     (void)diskCacheManager_->TrimRun();
     diskCacheManager_->InitMetrics("test");
-    sleep(6);
+    sleep(3);
     diskCacheManager_->UmountDiskCache();
 }
 
@@ -443,6 +546,7 @@ TEST_F(TestDiskCacheManager, TrimCache_exceed) {
     option.diskCacheOpt.trimCheckIntervalSec = 1;
     option.diskCacheOpt.fullRatio = 90;
     option.diskCacheOpt.safeRatio = 70;
+    option.diskCacheOpt.trimRatio = 50;
     option.diskCacheOpt.maxUsableSpaceBytes =
       std::numeric_limits<uint64_t>::max();
     option.diskCacheOpt.cmdTimeoutSec = 5;
@@ -471,9 +575,7 @@ TEST_F(TestDiskCacheManager, TrimCache_exceed) {
     struct stat rf;
     rf.st_size = 0;
     EXPECT_CALL(*wrapper, stat(NotNull(), _))
-        .Times(2)
-        .WillOnce(Return(-1))
-        .WillOnce(DoAll(SetArgPointee<1>(rf), Return(0)));
+        .WillRepeatedly(Return(-1));
     diskCacheManager_->TrimRun();
     diskCacheManager_->InitMetrics("test");
     sleep(6);


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

1. Enables disk cache-related policies to be dynamically adjusted
2. The strategy for updating and cleaning the cache is as follows
``` c++
//       ok           nearfull               full
// |------------|-------------------|----------------------|
// 0     trimRatio*safeRatio    safeRatio               fullRatio
//
// 1. 0<=ok<trimRatio*safeRatio;
// 2. trimRatio*safeRatio<=nearfull<safeRatio
// 3. safeRatio<=full<=fullRatio
// If the status is ok or ok->nearfull does not clean up
// If the status is full or
// full->nearfull clean up
```
Issue Number: #xxx <!-- replace xxx with issue number -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
