### PR TITLE
[fix]curvefs/client: fix check filetype

### DIFF
--- a/curvefs/src/client/s3/disk_cache_base.h
+++ b/curvefs/src/client/s3/disk_cache_base.h
@@ -51,8 +51,28 @@ class DiskCacheBase {
      * @brief Create Read/Write Cache Dir.
     */
     virtual int CreateIoDir(bool writreDir);
-    virtual bool IsFileExist(const std::string file);
-    virtual int CreateDir(const std::string name);
+    virtual bool IsFileExist(const std::string& file);
+    virtual int CreateDir(const std::string& name);
+
+    enum FileType {
+        kError = -1,
+        kNotExist = 0,
+        kOther = 1,
+        kFile = 2,
+        kDir = 3,
+    };
+    /**
+     * @brief
+     *
+     * @param path
+     * @return FileType
+     * kError = -1,
+     * kNotExist = 0,
+     * kOther = 1,
+     * kFile = 2,
+     * kDir = 3,
+     */
+    virtual FileType GetFileType(const std::string& path);
     /**
      * @brief Get Read/Write Cache full Dir(include CacheDir_).
     */


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #xxx <!-- replace xxx with issue number -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

test.cpp:
```c++
#include <iostream>
#include <dirent.h>
#include <sys/stat.h> // Include the header file for struct stat
#include <ostream>
#include <string>

int main() {
  struct stat statbuf;
  std::string path;
  std::cin >> path;
  if (stat(path.c_str(), &statbuf) == 0){
      if (S_ISREG(statbuf.st_mode)) {
          std::cout << "normal file" << std::endl;
      }
  }
  return 0;
}
```

output:

![image](https://github.com/opencurve/curve/assets/15775037/a130e5c5-7dfd-4262-ae35-857742951e4c)
![image](https://github.com/opencurve/curve/assets/15775037/5464bce3-e550-478d-a4f2-a68045b26049)
![image](https://github.com/opencurve/curve/assets/15775037/adfafda0-742a-4460-8b05-1cef947b1b15)



Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
