### PR TITLE
fix curvefs mds get metaserver

### DIFF
--- a/curvefs/src/mds/topology/topology.cpp
+++ b/curvefs/src/mds/topology/topology.cpp
@@ -532,15 +532,19 @@ bool TopologyImpl::GetMetaServer(MetaServerIdType metaserverId,
 bool TopologyImpl::GetMetaServer(const std::string &hostIp, uint32_t port,
                                  MetaServer *out) const {
     ReadLockGuard rlockMetaServerMap(metaServerMutex_);
+    bool find = false;
     for (auto it = metaServerMap_.begin(); it != metaServerMap_.end(); it++) {
         ReadLockGuard rlockMetaServer(it->second.GetRWLockRef());
         if (it->second.GetInternalIp() == hostIp &&
             it->second.GetInternalPort() == port) {
             *out = it->second;
-            return true;
+            find = true;
+            if (it->second.GetOnlineState() == OnlineState::ONLINE) {
+                return find;
+            }
         }
     }
-    return false;
+    return find;
 }
 
 TopoStatusCode TopologyImpl::AddPartition(const Partition &data) {
@@ -1628,6 +1632,7 @@ uint32_t TopologyImpl::GetPartitionIndexOfFS(FsIdType fsId) {
 
 std::vector<CopySetInfo> TopologyImpl::ListCopysetInfo() const {
     std::vector<CopySetInfo> ret;
+    ReadLockGuard rlockCopySet(copySetMutex_);
     for (auto const &i : copySetMap_) {
         ret.emplace_back(i.second);
     }


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?
The mds maybe get the if of retired metaserver when deal with heartbeat from metaserver:
![截屏2023-09-12 15 09 54](https://github.com/opencurve/curve/assets/13496900/76db58a3-6e2a-4bb2-a04d-22abb5f485b0)
![截屏2023-09-12 15 11 18](https://github.com/opencurve/curve/assets/13496900/c6a529de-b33c-495a-aa98-0f52c6047c7c)
<img width="618" alt="截屏2023-09-12 15 19 46" src="https://github.com/opencurve/curve/assets/13496900/650ab577-802c-4548-9665-195b2fec0b9f">

This bug was triggered after the metaserver was added with a new role after changing the disk：
![截屏2023-09-12 15 25 31](https://github.com/opencurve/curve/assets/13496900/e9f41280-0f3d-403d-8ea0-2cd3bc334dff)
![截屏2023-09-12 15 15 18](https://github.com/opencurve/curve/assets/13496900/b8640ad9-bb33-4579-8a7b-29979c9bf7a5)


Issue Number: #xxx <!-- replace xxx with issue number -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
