### PR TITLE
curvefs: add quota bytes support to s3 client

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,6 +4,7 @@ BasedOnStyle:  Google
 AccessModifierOffset: -3
 DerivePointerAlignment: false
 IndentWidth:     4
+SortIncludes: false
 ---
 Language: Proto
 BasedOnStyle:  Google

--- a/curvefs/proto/metaserver.proto
+++ b/curvefs/proto/metaserver.proto
@@ -531,6 +531,24 @@ message UpdateVolumeExtentResponse {
     optional uint64 appliedIndex = 2;
 }
 
+message FsUsedDelta {
+    required uint32 fsId = 1;
+    optional int64 bytes = 2;
+}
+
+message UpdateFsUsedRequest {
+    required uint32 poolId = 1;
+    required uint32 copysetId = 2;
+    required uint32 partitionId = 3;
+    optional FsUsedDelta delta = 4;
+    optional bool fromClient = 5;
+}
+
+message UpdateFsUsedResponse {
+    required MetaStatusCode statusCode = 1;
+    optional uint64 appliedIndex = 2;
+}
+
 service MetaServerService {
     // dentry interface
     rpc GetDentry(GetDentryRequest) returns (GetDentryResponse);
@@ -561,4 +579,7 @@ service MetaServerService {
 
     // block group with deallocatable inode list interface
     rpc UpdateDeallocatableBlockGroup(UpdateDeallocatableBlockGroupRequest) returns (UpdateDeallocatableBlockGroupResponse);
+
+    // update fsused
+    rpc UpdateFsUsed(UpdateFsUsedRequest) returns (UpdateFsUsedResponse);
 }

--- a/curvefs/src/client/common/common.cpp
+++ b/curvefs/src/client/common/common.cpp
@@ -72,6 +72,9 @@ std::ostream &operator<<(std::ostream &os, MetaServerOpType optype) {
     case MetaServerOpType::UpdateVolumeExtent:
         os << "UpdateVolumeExtent";
         break;
+    case MetaServerOpType::UpdateFsUsed:
+        os << "UpdateFsUsed";
+        break;
     default:
         os << "Unknow opType";
     }

--- a/curvefs/src/client/common/common.h
+++ b/curvefs/src/client/common/common.h
@@ -61,6 +61,7 @@ enum class MetaServerOpType {
     UpdateVolumeExtent,
     CreateManageInode,
     UpdateDeallocatableBlockGroup,
+    UpdateFsUsed,
 };
 
 std::ostream &operator<<(std::ostream &os, MetaServerOpType optype);

--- a/curvefs/src/client/fsquota_checker.cpp
+++ b/curvefs/src/client/fsquota_checker.cpp
@@ -1,3 +1,19 @@
+/*
+ *  Copyright (c) 2023 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 #include "curvefs/src/client/fsquota_checker.h"
 #include "curvefs/src/client/fsused_updater.h"
 
@@ -53,7 +69,7 @@ void FsQuotaChecker::UpdateQuotaCache() {
     }
 }
 
-bool UpdateQuotaCacheTask::OnTriggeringTask(timespec *next_abstime) {
+bool UpdateQuotaCacheTask::OnTriggeringTask(timespec* next_abstime) {
     fsQuotaChecker_->UpdateQuotaCache();
     *next_abstime = butil::seconds_from_now(interval_s_);
     return true;
@@ -61,13 +77,12 @@ bool UpdateQuotaCacheTask::OnTriggeringTask(timespec *next_abstime) {
 
 void UpdateQuotaCacheTask::OnDestroyingTask() {}
 
-void StartUpdateQuotaCacheTask(FsQuotaChecker *updater, int64_t interval_s) {
+void StartUpdateQuotaCacheTask(FsQuotaChecker* updater, int64_t interval_s) {
     brpc::PeriodicTaskManager::StartTaskAt(
         new UpdateQuotaCacheTask(updater, interval_s),
         butil::seconds_from_now(interval_s));
 }
 
 }  // namespace client
-
 
 }  // namespace curvefs

--- a/curvefs/src/client/fsquota_checker.cpp
+++ b/curvefs/src/client/fsquota_checker.cpp
@@ -1,0 +1,73 @@
+#include "curvefs/src/client/fsquota_checker.h"
+#include "curvefs/src/client/fsused_updater.h"
+
+namespace curvefs {
+
+namespace client {
+
+void FsQuotaChecker::Init(
+    uint32_t fsId, std::shared_ptr<rpcclient::MdsClient> mdsClient,
+    std::shared_ptr<rpcclient::MetaServerClient> metaserverClient) {
+    fsId_ = fsId;
+    fsCapacityCache_.store(0);
+    fsUsedBytesCache_.store(0);
+    mdsClient_ = mdsClient;
+    metaserverClient_ = metaserverClient;
+}
+
+bool FsQuotaChecker::QuotaBytesCheck(uint64_t incBytes) {
+    uint64_t capacity = fsCapacityCache_.load();
+    uint64_t usedBytes = fsUsedBytesCache_.load();
+    // quota disabled
+    if (capacity == 0) {
+        return true;
+    }
+    // need consider local delta
+    auto localDelta = FsUsedUpdater::GetInstance().GetDeltaBytes();
+    return capacity - usedBytes >= localDelta + incBytes;
+}
+
+void FsQuotaChecker::UpdateQuotaCache() {
+    {
+        // update quota bytes
+        FsInfo fsinfo;
+        auto ret = mdsClient_->GetFsInfo(fsId_, &fsinfo);
+        if (ret == FSStatusCode::OK) {
+            fsCapacityCache_.exchange(fsinfo.capacity());
+        }
+    }
+    {
+        // update used
+        Inode inode;
+        bool streaming;
+        auto ret =
+            metaserverClient_->GetInode(fsId_, ROOTINODEID, &inode, &streaming);
+        if (ret == MetaStatusCode::OK) {
+            const auto& xattrs = inode.xattr();
+            if (xattrs.find(curvefs::XATTR_FS_BYTES) != xattrs.end()) {
+                // old fs do not have this xattr, be careful
+                fsUsedBytesCache_.exchange(
+                    std::stoull(xattrs.at(curvefs::XATTR_FS_BYTES)));
+            }
+        }
+    }
+}
+
+bool UpdateQuotaCacheTask::OnTriggeringTask(timespec *next_abstime) {
+    fsQuotaChecker_->UpdateQuotaCache();
+    *next_abstime = butil::seconds_from_now(interval_s_);
+    return true;
+}
+
+void UpdateQuotaCacheTask::OnDestroyingTask() {}
+
+void StartUpdateQuotaCacheTask(FsQuotaChecker *updater, int64_t interval_s) {
+    brpc::PeriodicTaskManager::StartTaskAt(
+        new UpdateQuotaCacheTask(updater, interval_s),
+        butil::seconds_from_now(interval_s));
+}
+
+}  // namespace client
+
+
+}  // namespace curvefs

--- a/curvefs/src/client/fsquota_checker.h
+++ b/curvefs/src/client/fsquota_checker.h
@@ -1,0 +1,54 @@
+#ifndef CURVEFS_SRC_CLIENT_FUSEQUOTA_CHECKER_H_
+#define CURVEFS_SRC_CLIENT_FUSEQUOTA_CHECKER_H_
+
+#include "curvefs/src/client/rpcclient/metaserver_client.h"
+#include <brpc/periodic_task.h>
+
+namespace curvefs {
+namespace client {
+
+class FsQuotaChecker {
+ public:
+    static FsQuotaChecker &GetInstance() {
+        static FsQuotaChecker instance_;
+        return instance_;
+    }
+
+    void Init(uint32_t fsId, std::shared_ptr<rpcclient::MdsClient> mdsClient,
+              std::shared_ptr<rpcclient::MetaServerClient> metaserverClient);
+
+    bool QuotaBytesCheck(uint64_t incBytes);
+
+    void UpdateQuotaCache();
+
+ private:
+    uint32_t fsId_;
+    std::atomic<uint64_t> fsCapacityCache_;
+    std::atomic<uint64_t> fsUsedBytesCache_;
+    std::shared_ptr<rpcclient::MdsClient> mdsClient_;
+    std::shared_ptr<rpcclient::MetaServerClient> metaserverClient_;
+};
+
+class UpdateQuotaCacheTask : public brpc::PeriodicTask {
+ public:
+    explicit UpdateQuotaCacheTask(FsQuotaChecker *fsQuotaChecker,
+                                  int64_t interval_s)
+        : fsQuotaChecker_(fsQuotaChecker), interval_s_(interval_s) {}
+    bool OnTriggeringTask(timespec *next_abstime) override;
+    void OnDestroyingTask() override;
+
+ private:
+    FsQuotaChecker *fsQuotaChecker_;
+    int64_t interval_s_;
+};
+
+
+void StartUpdateQuotaCacheTask(FsQuotaChecker *updater, int64_t interval_s);
+
+
+}  // namespace client
+
+}  // namespace curvefs
+
+
+#endif  // CURVEFS_SRC_CLIENT_FUSEQUOTA_CHECKER_H_

--- a/curvefs/src/client/fsquota_checker.h
+++ b/curvefs/src/client/fsquota_checker.h
@@ -1,15 +1,32 @@
-#ifndef CURVEFS_SRC_CLIENT_FUSEQUOTA_CHECKER_H_
-#define CURVEFS_SRC_CLIENT_FUSEQUOTA_CHECKER_H_
+/*
+ *  Copyright (c) 2023 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 
-#include "curvefs/src/client/rpcclient/metaserver_client.h"
+#ifndef CURVEFS_SRC_CLIENT_FSQUOTA_CHECKER_H_
+#define CURVEFS_SRC_CLIENT_FSQUOTA_CHECKER_H_
+
+#include <time.h>
 #include <brpc/periodic_task.h>
+#include "curvefs/src/client/rpcclient/metaserver_client.h"
 
 namespace curvefs {
 namespace client {
 
 class FsQuotaChecker {
  public:
-    static FsQuotaChecker &GetInstance() {
+    static FsQuotaChecker& GetInstance() {
         static FsQuotaChecker instance_;
         return instance_;
     }
@@ -31,24 +48,21 @@ class FsQuotaChecker {
 
 class UpdateQuotaCacheTask : public brpc::PeriodicTask {
  public:
-    explicit UpdateQuotaCacheTask(FsQuotaChecker *fsQuotaChecker,
+    explicit UpdateQuotaCacheTask(FsQuotaChecker* fsQuotaChecker,
                                   int64_t interval_s)
         : fsQuotaChecker_(fsQuotaChecker), interval_s_(interval_s) {}
-    bool OnTriggeringTask(timespec *next_abstime) override;
+    bool OnTriggeringTask(timespec* next_abstime) override;
     void OnDestroyingTask() override;
 
  private:
-    FsQuotaChecker *fsQuotaChecker_;
+    FsQuotaChecker* fsQuotaChecker_;
     int64_t interval_s_;
 };
 
-
-void StartUpdateQuotaCacheTask(FsQuotaChecker *updater, int64_t interval_s);
-
+void StartUpdateQuotaCacheTask(FsQuotaChecker* updater, int64_t interval_s);
 
 }  // namespace client
 
 }  // namespace curvefs
 
-
-#endif  // CURVEFS_SRC_CLIENT_FUSEQUOTA_CHECKER_H_
+#endif  // CURVEFS_SRC_CLIENT_FSQUOTA_CHECKER_H_

--- a/curvefs/src/client/fsused_updater.cpp
+++ b/curvefs/src/client/fsused_updater.cpp
@@ -19,6 +19,8 @@ void FsUsedUpdater::UpdateFsUsed() {
     metaserverClient_->UpdateFsUsed(fsId_, delta, true);
 }
 
+int64_t FsUsedUpdater::GetDeltaBytes() { return deltaBytes_.load(); }
+
 bool UpdateFsUsedTask::OnTriggeringTask(timespec *next_abstime) {
     fsUsedUpdater_->UpdateFsUsed();
     *next_abstime = butil::seconds_from_now(interval_s_);

--- a/curvefs/src/client/fsused_updater.cpp
+++ b/curvefs/src/client/fsused_updater.cpp
@@ -1,0 +1,36 @@
+#include "curvefs/src/client/fsused_updater.h"
+#include "fsused_updater.h"
+
+namespace curvefs {
+namespace client {
+
+void FsUsedUpdater::UpdateDeltaBytes(int64_t deltaBytes) {
+    deltaBytes_.fetch_add(deltaBytes);
+}
+
+void FsUsedUpdater::UpdateFsUsed() {
+    using curvefs::metaserver::FsUsedDelta;
+    FsUsedDelta delta;
+    delta.set_fsid(fsId_);
+    uint64_t deltaBytes = deltaBytes_.exchange(0);
+    if (deltaBytes == 0)
+        return;
+    delta.set_bytes(deltaBytes);
+    metaserverClient_->UpdateFsUsed(fsId_, delta, true);
+}
+
+bool UpdateFsUsedTask::OnTriggeringTask(timespec *next_abstime) {
+    fsUsedUpdater_->UpdateFsUsed();
+    *next_abstime = butil::seconds_from_now(interval_s_);
+    return true;
+}
+
+void UpdateFsUsedTask::OnDestroyingTask() {}
+
+void StartUpdateFsUsedTask(FsUsedUpdater *updater, int64_t interval_s) {
+    brpc::PeriodicTaskManager::StartTaskAt(
+        new UpdateFsUsedTask(updater, interval_s),
+        butil::seconds_from_now(interval_s));
+}
+}  // namespace client
+}  // namespace curvefs

--- a/curvefs/src/client/fsused_updater.cpp
+++ b/curvefs/src/client/fsused_updater.cpp
@@ -1,5 +1,20 @@
+/*
+ *  Copyright (c) 2023 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 #include "curvefs/src/client/fsused_updater.h"
-#include "fsused_updater.h"
 
 namespace curvefs {
 namespace client {
@@ -13,15 +28,14 @@ void FsUsedUpdater::UpdateFsUsed() {
     FsUsedDelta delta;
     delta.set_fsid(fsId_);
     uint64_t deltaBytes = deltaBytes_.exchange(0);
-    if (deltaBytes == 0)
-        return;
+    if (deltaBytes == 0) return;
     delta.set_bytes(deltaBytes);
     metaserverClient_->UpdateFsUsed(fsId_, delta, true);
 }
 
 int64_t FsUsedUpdater::GetDeltaBytes() { return deltaBytes_.load(); }
 
-bool UpdateFsUsedTask::OnTriggeringTask(timespec *next_abstime) {
+bool UpdateFsUsedTask::OnTriggeringTask(timespec* next_abstime) {
     fsUsedUpdater_->UpdateFsUsed();
     *next_abstime = butil::seconds_from_now(interval_s_);
     return true;
@@ -29,7 +43,7 @@ bool UpdateFsUsedTask::OnTriggeringTask(timespec *next_abstime) {
 
 void UpdateFsUsedTask::OnDestroyingTask() {}
 
-void StartUpdateFsUsedTask(FsUsedUpdater *updater, int64_t interval_s) {
+void StartUpdateFsUsedTask(FsUsedUpdater* updater, int64_t interval_s) {
     brpc::PeriodicTaskManager::StartTaskAt(
         new UpdateFsUsedTask(updater, interval_s),
         butil::seconds_from_now(interval_s));

--- a/curvefs/src/client/fsused_updater.h
+++ b/curvefs/src/client/fsused_updater.h
@@ -1,0 +1,53 @@
+#ifndef CURVEFS_SRC_CLIENT_FUSEUSED_UPDATER_H_
+#define CURVEFS_SRC_CLIENT_FUSEUSED_UPDATER_H_
+
+#include "curvefs/src/client/rpcclient/metaserver_client.h"
+#include <brpc/periodic_task.h>
+
+
+namespace curvefs {
+namespace client {
+
+class FsUsedUpdater {
+ public:
+    static FsUsedUpdater &GetInstance() {
+        static FsUsedUpdater instance_;
+        return instance_;
+    }
+
+    void Init(uint32_t fsId,
+              std::shared_ptr<rpcclient::MetaServerClient> metaserverClient) {
+        fsId_ = fsId;
+        metaserverClient_ = metaserverClient;
+        deltaBytes_.store(0);
+    }
+
+    void UpdateDeltaBytes(int64_t deltaBytes);
+
+    void UpdateFsUsed();
+
+ private:
+    uint32_t fsId_;
+    std::atomic<int64_t> deltaBytes_;
+    std::shared_ptr<rpcclient::MetaServerClient> metaserverClient_;
+};
+
+class UpdateFsUsedTask : public brpc::PeriodicTask {
+ public:
+    explicit UpdateFsUsedTask(FsUsedUpdater *fsUsedUpdater, int64_t interval_s)
+        : fsUsedUpdater_(fsUsedUpdater), interval_s_(interval_s) {}
+    bool OnTriggeringTask(timespec *next_abstime) override;
+    void OnDestroyingTask() override;
+
+ private:
+    FsUsedUpdater *fsUsedUpdater_;
+    int64_t interval_s_;
+};
+
+
+void StartUpdateFsUsedTask(FsUsedUpdater *updater, int64_t interval_s);
+
+}  // namespace client
+}  // namespace curvefs
+
+#endif  // CURVEFS_SRC_CLIENT_FUSEUSED_UPDATER_H_

--- a/curvefs/src/client/fsused_updater.h
+++ b/curvefs/src/client/fsused_updater.h
@@ -1,16 +1,32 @@
-#ifndef CURVEFS_SRC_CLIENT_FUSEUSED_UPDATER_H_
-#define CURVEFS_SRC_CLIENT_FUSEUSED_UPDATER_H_
+/*
+ *  Copyright (c) 2023 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 
-#include "curvefs/src/client/rpcclient/metaserver_client.h"
+#ifndef CURVEFS_SRC_CLIENT_FSUSED_UPDATER_H_
+#define CURVEFS_SRC_CLIENT_FSUSED_UPDATER_H_
+
+#include <time.h>
 #include <brpc/periodic_task.h>
-
+#include "curvefs/src/client/rpcclient/metaserver_client.h"
 
 namespace curvefs {
 namespace client {
 
 class FsUsedUpdater {
  public:
-    static FsUsedUpdater &GetInstance() {
+    static FsUsedUpdater& GetInstance() {
         static FsUsedUpdater instance_;
         return instance_;
     }
@@ -36,20 +52,19 @@ class FsUsedUpdater {
 
 class UpdateFsUsedTask : public brpc::PeriodicTask {
  public:
-    explicit UpdateFsUsedTask(FsUsedUpdater *fsUsedUpdater, int64_t interval_s)
+    explicit UpdateFsUsedTask(FsUsedUpdater* fsUsedUpdater, int64_t interval_s)
         : fsUsedUpdater_(fsUsedUpdater), interval_s_(interval_s) {}
-    bool OnTriggeringTask(timespec *next_abstime) override;
+    bool OnTriggeringTask(timespec* next_abstime) override;
     void OnDestroyingTask() override;
 
  private:
-    FsUsedUpdater *fsUsedUpdater_;
+    FsUsedUpdater* fsUsedUpdater_;
     int64_t interval_s_;
 };
 
-
-void StartUpdateFsUsedTask(FsUsedUpdater *updater, int64_t interval_s);
+void StartUpdateFsUsedTask(FsUsedUpdater* updater, int64_t interval_s);
 
 }  // namespace client
 }  // namespace curvefs
 
-#endif  // CURVEFS_SRC_CLIENT_FUSEUSED_UPDATER_H_
+#endif  // CURVEFS_SRC_CLIENT_FSUSED_UPDATER_H_

--- a/curvefs/src/client/fsused_updater.h
+++ b/curvefs/src/client/fsused_updater.h
@@ -26,6 +26,8 @@ class FsUsedUpdater {
 
     void UpdateFsUsed();
 
+    int64_t GetDeltaBytes();
+
  private:
     uint32_t fsId_;
     std::atomic<int64_t> deltaBytes_;

--- a/curvefs/src/client/fuse_client.cpp
+++ b/curvefs/src/client/fuse_client.cpp
@@ -1108,8 +1108,7 @@ CURVEFS_ERROR FuseClient::FuseOpSetXattr(fuse_req_t req, fuse_ino_t ino,
     std::string strname(name);
     std::string strvalue(value, size);
     VLOG(1) << "FuseOpSetXattr ino: " << ino << ", name: " << name
-            << ", size = " << size
-            << ", strvalue: " << strvalue;
+            << ", size = " << size << ", strvalue: " << strvalue;
 
     if (strname == curvefs::XATTR_FS_BYTES) {
         LOG(INFO) << "set curve.fs.bytes by client is not allowed";

--- a/curvefs/src/client/fuse_client.cpp
+++ b/curvefs/src/client/fuse_client.cpp
@@ -1086,6 +1086,12 @@ CURVEFS_ERROR FuseClient::FuseOpSetXattr(fuse_req_t req, fuse_ino_t ino,
     VLOG(1) << "FuseOpSetXattr ino: " << ino << ", name: " << name
             << ", size = " << size
             << ", strvalue: " << strvalue;
+
+    if (strname == curvefs::XATTR_FS_BYTES) {
+        LOG(INFO) << "set curve.fs.bytes by client is not allowed";
+        return CURVEFS_ERROR::NOPERMISSION;
+    }
+
     if (strname.length() > MAX_XATTR_NAME_LENGTH  ||
         size > MAX_XATTR_VALUE_LENGTH) {
         LOG(ERROR) << "xattr length is too long, name = " << name

--- a/curvefs/src/client/fuse_client.cpp
+++ b/curvefs/src/client/fuse_client.cpp
@@ -47,6 +47,7 @@
 #include "src/client/client_common.h"
 #include "absl/memory/memory.h"
 #include "curvefs/src/client/fsused_updater.h"
+#include "curvefs/src/client/fsquota_checker.h"
 
 #define PORT_LIMIT 65535
 
@@ -189,6 +190,11 @@ CURVEFS_ERROR FuseClient::Init(const FuseClientOption &option) {
 
     FsUsedUpdater::GetInstance().Init(fsInfo_->fsid(), metaClient_);
     StartUpdateFsUsedTask(&FsUsedUpdater::GetInstance(), 5);
+
+    FsQuotaChecker::GetInstance().Init(fsInfo_->fsid(), mdsClient_,
+                                       metaClient_);
+    FsQuotaChecker::GetInstance().UpdateQuotaCache();
+    StartUpdateQuotaCacheTask(&FsQuotaChecker::GetInstance(), 5);
 
     InitQosParam();
 

--- a/curvefs/src/client/fuse_s3_client.cpp
+++ b/curvefs/src/client/fuse_s3_client.cpp
@@ -26,6 +26,7 @@
 
 #include "curvefs/src/client/fuse_s3_client.h"
 #include "curvefs/src/client/kvclient/memcache_client.h"
+#include "curvefs/src/client/fsused_updater.h"
 
 namespace curvefs {
 namespace client {
@@ -218,6 +219,8 @@ CURVEFS_ERROR FuseS3Client::FuseOpWrite(fuse_req_t req, fuse_ino_t ino,
             }
         }
     }
+
+    FsUsedUpdater::GetInstance().UpdateDeltaBytes(changeSize);
 
     inodeWrapper->GetInodeAttrLocked(&fileOut->attr);
     return ret;

--- a/curvefs/src/client/metric/client_metric.h
+++ b/curvefs/src/client/metric/client_metric.h
@@ -98,6 +98,8 @@ struct MetaServerClientMetric {
     InterfaceMetric getVolumeExtent;
     InterfaceMetric updateDeallocatableBlockGroup;
 
+    InterfaceMetric updateFsUsed;
+
     MetaServerClientMetric()
         : getDentry(prefix, "getDentry"), listDentry(prefix, "listDentry"),
           createDentry(prefix, "createDentry"),
@@ -112,7 +114,8 @@ struct MetaServerClientMetric {
           updateVolumeExtent(prefix, "updateVolumeExtent"),
           getVolumeExtent(prefix, "getVolumeExtent"),
           updateDeallocatableBlockGroup(prefix,
-                                        "updateDeallocatableBlockGroup") {}
+                                        "updateDeallocatableBlockGroup"),
+          updateFsUsed(prefix, "updateFsUsed") {}
 };
 
 struct InflightGuard {

--- a/curvefs/src/client/metric/client_metric.h
+++ b/curvefs/src/client/metric/client_metric.h
@@ -101,9 +101,11 @@ struct MetaServerClientMetric {
     InterfaceMetric updateFsUsed;
 
     MetaServerClientMetric()
-        : getDentry(prefix, "getDentry"), listDentry(prefix, "listDentry"),
+        : getDentry(prefix, "getDentry"),
+          listDentry(prefix, "listDentry"),
           createDentry(prefix, "createDentry"),
-          deleteDentry(prefix, "deleteDentry"), getInode(prefix, "getInode"),
+          deleteDentry(prefix, "deleteDentry"),
+          getInode(prefix, "getInode"),
           batchGetInodeAttr(prefix, "batchGetInodeAttr"),
           batchGetXattr(prefix, "batchGetXattr"),
           createInode(prefix, "createInode"),

--- a/curvefs/src/client/rpcclient/metacache.cpp
+++ b/curvefs/src/client/rpcclient/metacache.cpp
@@ -527,7 +527,7 @@ bool MetaCache::GetCopysetInfowithCopySetID(
 }
 
 bool TryGetPartitionIdByInodeId(const std::vector<PartitionInfo> &plist,
-                                RWLock *lock, uint64_t inodeID,
+                                BthreadRWLock *lock, uint64_t inodeID,
                                 PartitionID *pid) {
     ReadLockGuard rl(*lock);
     for (const auto &it : plist) {

--- a/curvefs/src/client/rpcclient/metacache.cpp
+++ b/curvefs/src/client/rpcclient/metacache.cpp
@@ -526,9 +526,9 @@ bool MetaCache::GetCopysetInfowithCopySetID(
     return true;
 }
 
-bool TryGetPartitionIdByInodeId(const std::vector<PartitionInfo> &plist,
-                                BthreadRWLock *lock, uint64_t inodeID,
-                                PartitionID *pid) {
+bool TryGetPartitionIdByInodeId(const std::vector<PartitionInfo>& plist,
+                                BthreadRWLock* lock, uint64_t inodeID,
+                                PartitionID* pid) {
     ReadLockGuard rl(*lock);
     for (const auto &it : plist) {
         if (it.start() <= inodeID && it.end() >= inodeID) {

--- a/curvefs/src/client/rpcclient/metacache.h
+++ b/curvefs/src/client/rpcclient/metacache.h
@@ -43,7 +43,7 @@
 using ::curve::client::CopysetID;
 using ::curve::client::CopysetInfo;
 using ::curve::client::LogicPoolID;
-using ::curve::common::RWLock;
+using ::curve::common::BthreadRWLock;
 using ::curvefs::client::common::MetaCacheOpt;
 using ::curvefs::client::common::MetaserverID;
 using ::curvefs::client::common::MetaServerOpType;
@@ -194,12 +194,12 @@ class MetaCache {
     }
 
  private:
-    RWLock txIdLock_;
+    BthreadRWLock txIdLock_;
     std::unordered_map<uint32_t, uint64_t> partitionTxId_;
 
-    RWLock rwlock4Partitions_;
+    BthreadRWLock rwlock4Partitions_;
     PartitionInfoList partitionInfos_;
-    RWLock rwlock4copysetInfoMap_;
+    BthreadRWLock rwlock4copysetInfoMap_;
     CopysetInfoMap copysetInfoMap_;
 
     Mutex createMutex_;

--- a/curvefs/src/client/rpcclient/metaserver_client.cpp
+++ b/curvefs/src/client/rpcclient/metaserver_client.cpp
@@ -1547,7 +1547,7 @@ MetaStatusCode MetaServerClientImpl::GetInodeAttr(
 }
 
 MetaStatusCode MetaServerClientImpl::UpdateFsUsed(uint32_t fsId,
-                                                  const FsUsedDelta &delta,
+                                                  const FsUsedDelta& delta,
                                                   bool fromClient) {
     auto task = RPCTask {
         (void)txId;

--- a/curvefs/src/client/rpcclient/metaserver_client.h
+++ b/curvefs/src/client/rpcclient/metaserver_client.h
@@ -64,8 +64,8 @@ namespace client {
 namespace rpcclient {
 
 using S3ChunkInfoMap = google::protobuf::Map<uint64_t, S3ChunkInfoList>;
-using ::curvefs::metaserver::VolumeExtentSliceList;
 using ::curvefs::metaserver::FsUsedDelta;
+using ::curvefs::metaserver::VolumeExtentSliceList;
 
 struct DataIndices {
     absl::optional<S3ChunkInfoMap> s3ChunkInfoMap;
@@ -179,7 +179,7 @@ class MetaServerClient {
     UpdateDeallocatableBlockGroup(uint32_t fsId, uint64_t inodeId,
                                   DeallocatableBlockGroupMap *statistic) = 0;
 
-    virtual MetaStatusCode UpdateFsUsed(uint32_t fsId, const FsUsedDelta &delta,
+    virtual MetaStatusCode UpdateFsUsed(uint32_t fsId, const FsUsedDelta& delta,
                                         bool fromClient) = 0;
 };
 
@@ -290,7 +290,7 @@ class MetaServerClientImpl : public MetaServerClient {
         uint32_t fsId, uint64_t inodeId,
         DeallocatableBlockGroupMap *statistic) override;
 
-    MetaStatusCode UpdateFsUsed(uint32_t fsId, const FsUsedDelta &delta,
+    MetaStatusCode UpdateFsUsed(uint32_t fsId, const FsUsedDelta& delta,
                                 bool fromClient) override;
 
  private:

--- a/curvefs/src/client/rpcclient/metaserver_client.h
+++ b/curvefs/src/client/rpcclient/metaserver_client.h
@@ -41,6 +41,7 @@
 #include "curvefs/src/client/metric/client_metric.h"
 #include "curvefs/src/common/rpc_stream.h"
 #include "absl/types/optional.h"
+#include "curvefs/src/common/define.h"
 
 using ::curvefs::client::metric::MetaServerClientMetric;
 using ::curvefs::metaserver::Dentry;
@@ -64,6 +65,7 @@ namespace rpcclient {
 
 using S3ChunkInfoMap = google::protobuf::Map<uint64_t, S3ChunkInfoList>;
 using ::curvefs::metaserver::VolumeExtentSliceList;
+using ::curvefs::metaserver::FsUsedDelta;
 
 struct DataIndices {
     absl::optional<S3ChunkInfoMap> s3ChunkInfoMap;
@@ -176,6 +178,9 @@ class MetaServerClient {
     virtual MetaStatusCode
     UpdateDeallocatableBlockGroup(uint32_t fsId, uint64_t inodeId,
                                   DeallocatableBlockGroupMap *statistic) = 0;
+
+    virtual MetaStatusCode UpdateFsUsed(uint32_t fsId, const FsUsedDelta &delta,
+                                        bool fromClient) = 0;
 };
 
 class MetaServerClientImpl : public MetaServerClient {
@@ -284,6 +289,9 @@ class MetaServerClientImpl : public MetaServerClient {
     MetaStatusCode UpdateDeallocatableBlockGroup(
         uint32_t fsId, uint64_t inodeId,
         DeallocatableBlockGroupMap *statistic) override;
+
+    MetaStatusCode UpdateFsUsed(uint32_t fsId, const FsUsedDelta &delta,
+                                bool fromClient) override;
 
  private:
     MetaStatusCode UpdateInode(const UpdateInodeRequest &request,

--- a/curvefs/src/client/s3/client_s3_adaptor.h
+++ b/curvefs/src/client/s3/client_s3_adaptor.h
@@ -40,6 +40,7 @@
 #include "curvefs/src/client/s3/client_s3_cache_manager.h"
 #include "curvefs/src/client/s3/disk_cache_manager_impl.h"
 #include "src/common/wait_interval.h"
+
 namespace curvefs {
 namespace client {
 

--- a/curvefs/src/common/define.h
+++ b/curvefs/src/common/define.h
@@ -38,5 +38,9 @@ const char XATTRRSUBDIRS[] = "curve.dir.rsubdirs";
 const char XATTRRENTRIES[] = "curve.dir.rentries";
 const char XATTRRFBYTES[] = "curve.dir.rfbytes";
 const char SUMMARYPREFIX[] = "curve.dir";
+
+// fs used bytes, only xattr of root inode is valid
+const char XATTR_FS_BYTES[] = "curve.fs.bytes";
+
 }  // namespace curvefs
 #endif  // CURVEFS_SRC_COMMON_DEFINE_H_

--- a/curvefs/src/metaserver/copyset/meta_operator.cpp
+++ b/curvefs/src/metaserver/copyset/meta_operator.cpp
@@ -433,7 +433,6 @@ OPERATOR_HASH_CODE(UpdateVolumeExtent);
 OPERATOR_HASH_CODE(UpdateDeallocatableBlockGroup);
 OPERATOR_HASH_CODE(UpdateFsUsed);
 
-
 #undef OPERATOR_HASH_CODE
 
 #define PARTITION_OPERATOR_HASH_CODE(TYPE)                                     \

--- a/curvefs/src/metaserver/copyset/meta_operator.cpp
+++ b/curvefs/src/metaserver/copyset/meta_operator.cpp
@@ -186,6 +186,7 @@ OPERATOR_ON_APPLY(DeletePartition);
 OPERATOR_ON_APPLY(PrepareRenameTx);
 OPERATOR_ON_APPLY(UpdateVolumeExtent);
 OPERATOR_ON_APPLY(UpdateDeallocatableBlockGroup);
+OPERATOR_ON_APPLY(UpdateFsUsed);
 
 #undef OPERATOR_ON_APPLY
 
@@ -313,6 +314,7 @@ OPERATOR_ON_APPLY_FROM_LOG(DeletePartition);
 OPERATOR_ON_APPLY_FROM_LOG(PrepareRenameTx);
 OPERATOR_ON_APPLY_FROM_LOG(UpdateVolumeExtent);
 OPERATOR_ON_APPLY_FROM_LOG(UpdateDeallocatableBlockGroup);
+OPERATOR_ON_APPLY_FROM_LOG(UpdateFsUsed);
 
 #undef OPERATOR_ON_APPLY_FROM_LOG
 
@@ -374,6 +376,7 @@ OPERATOR_REDIRECT(PrepareRenameTx);
 OPERATOR_REDIRECT(GetVolumeExtent);
 OPERATOR_REDIRECT(UpdateVolumeExtent);
 OPERATOR_REDIRECT(UpdateDeallocatableBlockGroup);
+OPERATOR_REDIRECT(UpdateFsUsed);
 
 #undef OPERATOR_REDIRECT
 
@@ -401,6 +404,7 @@ OPERATOR_ON_FAILED(PrepareRenameTx);
 OPERATOR_ON_FAILED(GetVolumeExtent);
 OPERATOR_ON_FAILED(UpdateVolumeExtent);
 OPERATOR_ON_FAILED(UpdateDeallocatableBlockGroup);
+OPERATOR_ON_FAILED(UpdateFsUsed);
 
 #undef OPERATOR_ON_FAILED
 
@@ -427,6 +431,7 @@ OPERATOR_HASH_CODE(DeletePartition);
 OPERATOR_HASH_CODE(GetVolumeExtent);
 OPERATOR_HASH_CODE(UpdateVolumeExtent);
 OPERATOR_HASH_CODE(UpdateDeallocatableBlockGroup);
+OPERATOR_HASH_CODE(UpdateFsUsed);
 
 
 #undef OPERATOR_HASH_CODE
@@ -466,6 +471,7 @@ OPERATOR_TYPE(DeletePartition);
 OPERATOR_TYPE(GetVolumeExtent);
 OPERATOR_TYPE(UpdateVolumeExtent);
 OPERATOR_TYPE(UpdateDeallocatableBlockGroup);
+OPERATOR_TYPE(UpdateFsUsed);
 
 #undef OPERATOR_TYPE
 

--- a/curvefs/src/metaserver/copyset/meta_operator.h
+++ b/curvefs/src/metaserver/copyset/meta_operator.h
@@ -552,7 +552,7 @@ class UpdateFsUsedOperator : public MetaOperator {
  public:
     using MetaOperator::MetaOperator;
 
-    void OnApply(int64_t index, google::protobuf::Closure *done,
+    void OnApply(int64_t index, google::protobuf::Closure* done,
                  uint64_t startTimeUs) override;
 
     void OnApplyFromLog(int64_t index, uint64_t startTimeUs) override;

--- a/curvefs/src/metaserver/copyset/meta_operator.h
+++ b/curvefs/src/metaserver/copyset/meta_operator.h
@@ -548,6 +548,25 @@ class UpdateDeallocatableBlockGroupOperator : public MetaOperator {
     void OnFailed(MetaStatusCode code) override;
 };
 
+class UpdateFsUsedOperator : public MetaOperator {
+ public:
+    using MetaOperator::MetaOperator;
+
+    void OnApply(int64_t index, google::protobuf::Closure *done,
+                 uint64_t startTimeUs) override;
+
+    void OnApplyFromLog(int64_t index, uint64_t startTimeUs) override;
+
+    uint64_t HashCode() const override;
+
+    OperatorType GetOperatorType() const override;
+
+ private:
+    void Redirect() override;
+
+    void OnFailed(MetaStatusCode code) override;
+};
+
 }  // namespace copyset
 }  // namespace metaserver
 }  // namespace curvefs

--- a/curvefs/src/metaserver/copyset/operator_type.cpp
+++ b/curvefs/src/metaserver/copyset/operator_type.cpp
@@ -68,6 +68,8 @@ const char* OperatorTypeName(OperatorType type) {
             return "UpdateVolumeExtent";
         case OperatorType::UpdateDeallocatableBlockGroup:
             return "UpdateDeallocatableBlockGroup";
+        case OperatorType::UpdateFsUsed:
+            return "UpdateFsUsed";
         // Add new case before `OperatorType::OperatorTypeMax`
         case OperatorType::OperatorTypeMax:
             break;

--- a/curvefs/src/metaserver/copyset/operator_type.h
+++ b/curvefs/src/metaserver/copyset/operator_type.h
@@ -53,6 +53,7 @@ enum class OperatorType : uint32_t {
     UpdateVolumeExtent = 16,
     CreateManageInode = 17,
     UpdateDeallocatableBlockGroup = 18,
+    UpdateFsUsed = 19,
 
     // NOTE:
     //   Add new operator before `OperatorTypeMax`

--- a/curvefs/src/metaserver/copyset/raft_log_codec.cpp
+++ b/curvefs/src/metaserver/copyset/raft_log_codec.cpp
@@ -169,6 +169,9 @@ std::unique_ptr<MetaOperator> RaftLogCodec::Decode(CopysetNode* node,
             return ParseFromRaftLog<UpdateDeallocatableBlockGroupOperator,
                                     UpdateDeallocatableBlockGroupRequest>(
                 node, type, meta);
+        case OperatorType::UpdateFsUsed:
+            return ParseFromRaftLog<UpdateFsUsedOperator, UpdateFsUsedRequest>(
+                node, type, meta);
         // Add new case before `OperatorType::OperatorTypeMax`
         case OperatorType::OperatorTypeMax:
             break;

--- a/curvefs/src/metaserver/fsused_manager.cpp
+++ b/curvefs/src/metaserver/fsused_manager.cpp
@@ -1,0 +1,52 @@
+#include "curvefs/src/metaserver/fsused_manager.h"
+#include <unordered_map>
+
+namespace curvefs {
+namespace metaserver {
+
+void FsUsedManager::ApplyFsUsedDeltas() {
+    std::deque<FsUsedDelta> fsUsedDeltaDirty;
+    {
+        std::unique_lock<bthread::Mutex> lock_guard(dirtyLock_);
+        fsUsedDeltaDirty = std::move(fsUsedDeltas_);
+    }
+    // merge all deltas
+    std::unordered_map<uint32_t, FsUsedDelta> deltaSum;
+    for (const auto &d : fsUsedDeltaDirty) {
+        auto fsid = d.fsid();
+        if (deltaSum.find(fsid) == deltaSum.end()) {
+            deltaSum[fsid] = FsUsedDelta();
+            deltaSum[fsid].set_fsid(fsid);
+            deltaSum[fsid].set_bytes(0);
+        }
+        if (d.has_bytes()) {
+            deltaSum[fsid].set_bytes(deltaSum[fsid].bytes() + d.bytes());
+        }
+    }
+    // send updates
+    for (auto &delta : deltaSum) {
+        metaserverClient_->UpdateFsUsed(delta.first, delta.second, false);
+    }
+}
+
+void FsUsedManager::AddFsUsedDelta(FsUsedDelta &&fsUsedDelta) {
+    std::unique_lock<bthread::Mutex> lock_guard(dirtyLock_);
+    fsUsedDeltas_.emplace_back(std::move(fsUsedDelta));
+}
+
+bool UpdateFsUsedTask::OnTriggeringTask(timespec *next_abstime) {
+    fsUsedManager_->ApplyFsUsedDeltas();
+    *next_abstime = butil::seconds_from_now(interval_s_);
+    return true;
+}
+
+void UpdateFsUsedTask::OnDestroyingTask() {}
+
+void StartUpdateFsUsedTask(FsUsedManager *fsUsedManager, int64_t interval_s) {
+    brpc::PeriodicTaskManager::StartTaskAt(
+        new UpdateFsUsedTask(fsUsedManager, interval_s),
+        butil::seconds_from_now(interval_s));
+}
+
+}  // namespace metaserver
+}  // namespace curvefs

--- a/curvefs/src/metaserver/fsused_manager.cpp
+++ b/curvefs/src/metaserver/fsused_manager.cpp
@@ -1,5 +1,21 @@
-#include "curvefs/src/metaserver/fsused_manager.h"
+/*
+ *  Copyright (c) 2023 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 #include <unordered_map>
+#include "curvefs/src/metaserver/fsused_manager.h"
 
 namespace curvefs {
 namespace metaserver {
@@ -12,7 +28,7 @@ void FsUsedManager::ApplyFsUsedDeltas() {
     }
     // merge all deltas
     std::unordered_map<uint32_t, FsUsedDelta> deltaSum;
-    for (const auto &d : fsUsedDeltaDirty) {
+    for (const auto& d : fsUsedDeltaDirty) {
         auto fsid = d.fsid();
         if (deltaSum.find(fsid) == deltaSum.end()) {
             deltaSum[fsid] = FsUsedDelta();
@@ -24,17 +40,17 @@ void FsUsedManager::ApplyFsUsedDeltas() {
         }
     }
     // send updates
-    for (auto &delta : deltaSum) {
+    for (auto& delta : deltaSum) {
         metaserverClient_->UpdateFsUsed(delta.first, delta.second, false);
     }
 }
 
-void FsUsedManager::AddFsUsedDelta(FsUsedDelta &&fsUsedDelta) {
+void FsUsedManager::AddFsUsedDelta(FsUsedDelta&& fsUsedDelta) {
     std::unique_lock<bthread::Mutex> lock_guard(dirtyLock_);
     fsUsedDeltas_.emplace_back(std::move(fsUsedDelta));
 }
 
-bool UpdateFsUsedTask::OnTriggeringTask(timespec *next_abstime) {
+bool UpdateFsUsedTask::OnTriggeringTask(timespec* next_abstime) {
     fsUsedManager_->ApplyFsUsedDeltas();
     *next_abstime = butil::seconds_from_now(interval_s_);
     return true;
@@ -42,7 +58,7 @@ bool UpdateFsUsedTask::OnTriggeringTask(timespec *next_abstime) {
 
 void UpdateFsUsedTask::OnDestroyingTask() {}
 
-void StartUpdateFsUsedTask(FsUsedManager *fsUsedManager, int64_t interval_s) {
+void StartUpdateFsUsedTask(FsUsedManager* fsUsedManager, int64_t interval_s) {
     brpc::PeriodicTaskManager::StartTaskAt(
         new UpdateFsUsedTask(fsUsedManager, interval_s),
         butil::seconds_from_now(interval_s));

--- a/curvefs/src/metaserver/fsused_manager.h
+++ b/curvefs/src/metaserver/fsused_manager.h
@@ -34,15 +34,25 @@ using curvefs::client::rpcclient::MetaServerClient;
 class FsUsedManager {
  public:
     explicit FsUsedManager(std::shared_ptr<MetaServerClient> metaserverClient)
-        : metaserverClient_(metaserverClient), fsUsedDeltas_() {}
+        : metaserverClient_(metaserverClient),
+          fsUsedDeltas_(),
+          needStop_(false),
+          stop_(false) {}
 
     void AddFsUsedDelta(FsUsedDelta&& fsUsedDelta);
     void ApplyFsUsedDeltas();
+    void Stop();
+    bool NeedStop();
+    void SetStopped();
 
  private:
     std::shared_ptr<MetaServerClient> metaserverClient_;
     std::deque<FsUsedDelta> fsUsedDeltas_;
     bthread::Mutex dirtyLock_;
+    bool needStop_;
+    bool stop_;
+    bthread::Mutex stopLock_;
+    bthread::ConditionVariable stopCond_;
 };
 
 class UpdateFsUsedTask : public brpc::PeriodicTask {

--- a/curvefs/src/metaserver/fsused_manager.h
+++ b/curvefs/src/metaserver/fsused_manager.h
@@ -1,10 +1,27 @@
+/*
+ *  Copyright (c) 2023 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 #ifndef CURVEFS_SRC_METASERVER_FSUSED_MANAGER_H_
 #define CURVEFS_SRC_METASERVER_FSUSED_MANAGER_H_
 
-#include <deque>
-#include <memory>
+#include <time.h>
 #include <brpc/periodic_task.h>
 #include <bthread/mutex.h>
+#include <deque>
+#include <memory>
 #include "curvefs/src/client/rpcclient/metaserver_client.h"
 #include "curvefs/proto/metaserver.pb.h"
 
@@ -19,7 +36,7 @@ class FsUsedManager {
     explicit FsUsedManager(std::shared_ptr<MetaServerClient> metaserverClient)
         : metaserverClient_(metaserverClient), fsUsedDeltas_() {}
 
-    void AddFsUsedDelta(FsUsedDelta &&fsUsedDelta);
+    void AddFsUsedDelta(FsUsedDelta&& fsUsedDelta);
     void ApplyFsUsedDeltas();
 
  private:
@@ -30,20 +47,19 @@ class FsUsedManager {
 
 class UpdateFsUsedTask : public brpc::PeriodicTask {
  public:
-    explicit UpdateFsUsedTask(FsUsedManager *fsUsedManager, int64_t interval_s)
+    explicit UpdateFsUsedTask(FsUsedManager* fsUsedManager, int64_t interval_s)
         : fsUsedManager_(fsUsedManager), interval_s_(interval_s) {}
-    bool OnTriggeringTask(timespec *next_abstime) override;
+    bool OnTriggeringTask(timespec* next_abstime) override;
     void OnDestroyingTask() override;
 
  private:
-    FsUsedManager *fsUsedManager_;
+    FsUsedManager* fsUsedManager_;
     int64_t interval_s_;
 };
 
-void StartUpdateFsUsedTask(FsUsedManager *fsUsedManager, int64_t interval_s);
+void StartUpdateFsUsedTask(FsUsedManager* fsUsedManager, int64_t interval_s);
 
 }  // namespace metaserver
 }  // namespace curvefs
-
 
 #endif  // CURVEFS_SRC_METASERVER_FSUSED_MANAGER_H_

--- a/curvefs/src/metaserver/fsused_manager.h
+++ b/curvefs/src/metaserver/fsused_manager.h
@@ -1,0 +1,49 @@
+#ifndef CURVEFS_SRC_METASERVER_FSUSED_MANAGER_H_
+#define CURVEFS_SRC_METASERVER_FSUSED_MANAGER_H_
+
+#include <deque>
+#include <memory>
+#include <brpc/periodic_task.h>
+#include <bthread/mutex.h>
+#include "curvefs/src/client/rpcclient/metaserver_client.h"
+#include "curvefs/proto/metaserver.pb.h"
+
+namespace curvefs {
+namespace metaserver {
+
+using curvefs::client::rpcclient::MetaServerClient;
+
+// fs level used manager
+class FsUsedManager {
+ public:
+    explicit FsUsedManager(std::shared_ptr<MetaServerClient> metaserverClient)
+        : metaserverClient_(metaserverClient), fsUsedDeltas_() {}
+
+    void AddFsUsedDelta(FsUsedDelta &&fsUsedDelta);
+    void ApplyFsUsedDeltas();
+
+ private:
+    std::shared_ptr<MetaServerClient> metaserverClient_;
+    std::deque<FsUsedDelta> fsUsedDeltas_;
+    bthread::Mutex dirtyLock_;
+};
+
+class UpdateFsUsedTask : public brpc::PeriodicTask {
+ public:
+    explicit UpdateFsUsedTask(FsUsedManager *fsUsedManager, int64_t interval_s)
+        : fsUsedManager_(fsUsedManager), interval_s_(interval_s) {}
+    bool OnTriggeringTask(timespec *next_abstime) override;
+    void OnDestroyingTask() override;
+
+ private:
+    FsUsedManager *fsUsedManager_;
+    int64_t interval_s_;
+};
+
+void StartUpdateFsUsedTask(FsUsedManager *fsUsedManager, int64_t interval_s);
+
+}  // namespace metaserver
+}  // namespace curvefs
+
+
+#endif  // CURVEFS_SRC_METASERVER_FSUSED_MANAGER_H_

--- a/curvefs/src/metaserver/inode_manager.cpp
+++ b/curvefs/src/metaserver/inode_manager.cpp
@@ -446,8 +446,7 @@ MetaStatusCode InodeManager::UpdateInode(const UpdateInodeRequest& request,
 
 MetaStatusCode InodeManager::UpdateFsUsed(const UpdateFsUsedRequest& request,
                                           int64_t logIndex) {
-    if (!request.has_delta())
-        return MetaStatusCode::OK;
+    if (!request.has_delta()) return MetaStatusCode::OK;
     auto fsid = request.delta().fsid();
     auto inodeid = ROOTINODEID;
     NameLockGuard lg(inodeLock_, GetInodeLockName(fsid, inodeid));

--- a/curvefs/src/metaserver/inode_manager.cpp
+++ b/curvefs/src/metaserver/inode_manager.cpp
@@ -107,6 +107,8 @@ MetaStatusCode InodeManager::CreateRootInode(const InodeParam& param,
     // 1. generate root inode
     Inode inode;
     GenerateInodeInternal(ROOTINODEID, param, &inode);
+    // set fs used bytes to 0 when creation
+    (*inode.mutable_xattr())[curvefs::XATTR_FS_BYTES] = "0";
 
     // 2. insert root inode
     MetaStatusCode ret = inodeStorage_->Insert(inode, logIndex);

--- a/curvefs/src/metaserver/inode_manager.cpp
+++ b/curvefs/src/metaserver/inode_manager.cpp
@@ -444,6 +444,50 @@ MetaStatusCode InodeManager::UpdateInode(const UpdateInodeRequest& request,
     return MetaStatusCode::OK;
 }
 
+MetaStatusCode InodeManager::UpdateFsUsed(const UpdateFsUsedRequest& request,
+                                          int64_t logIndex) {
+    if (!request.has_delta())
+        return MetaStatusCode::OK;
+    auto fsid = request.delta().fsid();
+    auto inodeid = ROOTINODEID;
+    NameLockGuard lg(inodeLock_, GetInodeLockName(fsid, inodeid));
+
+    Inode root;
+    MetaStatusCode ret = inodeStorage_->Get(Key4Inode(fsid, inodeid), &root);
+    if (ret != MetaStatusCode::OK) {
+        LOG(ERROR) << "GetInode fail, " << request.ShortDebugString()
+                   << ", ret: " << MetaStatusCode_Name(ret);
+        return ret;
+    }
+
+    const auto& delta = request.delta();
+
+    auto xattr = root.mutable_xattr();
+    uint64_t usedBytes = 0;
+    if (xattr->find(XATTR_FS_BYTES) == xattr->end()) {
+        // old fs without XATTR_FS_BYTES
+        usedBytes = 0;
+    } else {
+        usedBytes = std::stoull((*xattr)[XATTR_FS_BYTES]);
+    }
+    int64_t deltaBytes = delta.bytes();
+    VLOG(9) << "update fs used, fsid: " << fsid << ", used: " << usedBytes
+            << ", delta: " << deltaBytes;
+    if (deltaBytes < 0 && usedBytes <= abs(deltaBytes)) {
+        (*xattr)[XATTR_FS_BYTES] = "0";
+    } else {
+        (*xattr)[XATTR_FS_BYTES] = std::to_string(usedBytes + deltaBytes);
+    }
+
+    ret = inodeStorage_->Update(root, logIndex);
+    if (ret != MetaStatusCode::OK) {
+        LOG(ERROR) << "UpdateInode fail, " << request.ShortDebugString()
+                   << ", ret: " << MetaStatusCode_Name(ret);
+    }
+
+    return ret;
+}
+
 MetaStatusCode InodeManager::GetOrModifyS3ChunkInfo(
     uint32_t fsId, uint64_t inodeId, const S3ChunkInfoMap& map2add,
     const S3ChunkInfoMap& map2del, bool returnS3ChunkInfoMap,

--- a/curvefs/src/metaserver/inode_manager.h
+++ b/curvefs/src/metaserver/inode_manager.h
@@ -96,6 +96,9 @@ class InodeManager {
     MetaStatusCode UpdateInode(const UpdateInodeRequest& request,
                                int64_t logIndex);
 
+    MetaStatusCode UpdateFsUsed(const UpdateFsUsedRequest& request,
+                                int64_t logIndex);
+
     MetaStatusCode GetOrModifyS3ChunkInfo(
         uint32_t fsId, uint64_t inodeId, const S3ChunkInfoMap& map2add,
         const S3ChunkInfoMap& map2del, bool returnS3ChunkInfoMap,

--- a/curvefs/src/metaserver/metaserver.cpp
+++ b/curvefs/src/metaserver/metaserver.cpp
@@ -573,6 +573,9 @@ void Metaserver::Stop() {
     s3Adaptor_ = nullptr;
     S3CompactManager::GetInstance().Stop();
     VolumeDeallocateManager::GetInstance().Stop();
+
+    fsUsedManager_->Stop();
+
     LOG(INFO) << "MetaServer stopped success";
 }
 

--- a/curvefs/src/metaserver/metaserver.h
+++ b/curvefs/src/metaserver/metaserver.h
@@ -48,6 +48,7 @@
 #include "curvefs/src/metaserver/space/volume_deallocate_manager.h"
 #include "curvefs/src/metaserver/space/inode_volume_space_deallocate.h"
 #include "curvefs/src/metaserver/space/volume_space_manager.h"
+#include "curvefs/src/metaserver/fsused_manager.h"
 
 namespace curvefs {
 namespace metaserver {
@@ -148,6 +149,8 @@ class Metaserver {
 
     std::unique_ptr<InflightThrottle> inflightThrottle_;
     std::shared_ptr<curve::fs::LocalFileSystem> localFileSystem_;
+
+    std::unique_ptr<FsUsedManager> fsUsedManager_;
 };
 }  // namespace metaserver
 }  // namespace curvefs

--- a/curvefs/src/metaserver/metaserver_service.cpp
+++ b/curvefs/src/metaserver/metaserver_service.cpp
@@ -33,27 +33,27 @@ static bvar::LatencyRecorder g_oprequest_in_service_before_propose_latency(
 namespace curvefs {
 namespace metaserver {
 
-using ::curvefs::metaserver::copyset::GetDentryOperator;
-using ::curvefs::metaserver::copyset::ListDentryOperator;
-using ::curvefs::metaserver::copyset::CreateDentryOperator;
-using ::curvefs::metaserver::copyset::DeleteDentryOperator;
-using ::curvefs::metaserver::copyset::GetInodeOperator;
 using ::curvefs::metaserver::copyset::BatchGetInodeAttrOperator;
 using ::curvefs::metaserver::copyset::BatchGetXAttrOperator;
+using ::curvefs::metaserver::copyset::CreateDentryOperator;
 using ::curvefs::metaserver::copyset::CreateInodeOperator;
-using ::curvefs::metaserver::copyset::CreateRootInodeOperator;
 using ::curvefs::metaserver::copyset::CreateManageInodeOperator;
-using ::curvefs::metaserver::copyset::UpdateInodeOperator;
-using ::curvefs::metaserver::copyset::GetOrModifyS3ChunkInfoOperator;
-using ::curvefs::metaserver::copyset::DeleteInodeOperator;
-using ::curvefs::metaserver::copyset::UpdateInodeS3VersionOperator;
 using ::curvefs::metaserver::copyset::CreatePartitionOperator;
+using ::curvefs::metaserver::copyset::CreateRootInodeOperator;
+using ::curvefs::metaserver::copyset::DeleteDentryOperator;
+using ::curvefs::metaserver::copyset::DeleteInodeOperator;
 using ::curvefs::metaserver::copyset::DeletePartitionOperator;
-using ::curvefs::metaserver::copyset::PrepareRenameTxOperator;
+using ::curvefs::metaserver::copyset::GetDentryOperator;
+using ::curvefs::metaserver::copyset::GetInodeOperator;
+using ::curvefs::metaserver::copyset::GetOrModifyS3ChunkInfoOperator;
 using ::curvefs::metaserver::copyset::GetVolumeExtentOperator;
-using ::curvefs::metaserver::copyset::UpdateVolumeExtentOperator;
+using ::curvefs::metaserver::copyset::ListDentryOperator;
+using ::curvefs::metaserver::copyset::PrepareRenameTxOperator;
 using ::curvefs::metaserver::copyset::UpdateDeallocatableBlockGroupOperator;
 using ::curvefs::metaserver::copyset::UpdateFsUsedOperator;
+using ::curvefs::metaserver::copyset::UpdateInodeOperator;
+using ::curvefs::metaserver::copyset::UpdateInodeS3VersionOperator;
+using ::curvefs::metaserver::copyset::UpdateVolumeExtentOperator;
 
 namespace {
 
@@ -312,10 +312,9 @@ void MetaServerServiceImpl::UpdateDeallocatableBlockGroup(
 }
 
 void MetaServerServiceImpl::UpdateFsUsed(
-    ::google::protobuf::RpcController *controller,
-    const UpdateFsUsedRequest *request, UpdateFsUsedResponse *response,
-    ::google::protobuf::Closure *done) {
-
+    ::google::protobuf::RpcController* controller,
+    const UpdateFsUsedRequest* request, UpdateFsUsedResponse* response,
+    ::google::protobuf::Closure* done) {
     if (!request->has_delta() || !request->has_fromclient()) {
         response->set_statuscode(MetaStatusCode::PARAM_ERROR);
         done->Run();
@@ -335,7 +334,6 @@ void MetaServerServiceImpl::UpdateFsUsed(
                                             request->poolid(),
                                             request->copysetid());
 }
-
 
 }  // namespace metaserver
 }  // namespace curvefs

--- a/curvefs/src/metaserver/metaserver_service.h
+++ b/curvefs/src/metaserver/metaserver_service.h
@@ -38,11 +38,12 @@ using ::curvefs::metaserver::copyset::CopysetNodeManager;
 
 class MetaServerServiceImpl : public MetaServerService {
  public:
-    MetaServerServiceImpl(CopysetNodeManager *copysetNodeManager,
-                          InflightThrottle *inflightThrottle,
-                          FsUsedManager *fsUsedManager)
+    MetaServerServiceImpl(CopysetNodeManager* copysetNodeManager,
+                          InflightThrottle* inflightThrottle,
+                          FsUsedManager* fsUsedManager)
         : copysetNodeManager_(copysetNodeManager),
-          inflightThrottle_(inflightThrottle), fsUsedManager_(fsUsedManager) {}
+          inflightThrottle_(inflightThrottle),
+          fsUsedManager_(fsUsedManager) {}
 
     void GetDentry(::google::protobuf::RpcController* controller,
                    const ::curvefs::metaserver::GetDentryRequest* request,
@@ -131,10 +132,10 @@ class MetaServerServiceImpl : public MetaServerService {
         UpdateDeallocatableBlockGroupResponse *response,
         ::google::protobuf::Closure *done) override;
 
-    void UpdateFsUsed(::google::protobuf::RpcController *controller,
-                      const UpdateFsUsedRequest *request,
-                      UpdateFsUsedResponse *response,
-                      ::google::protobuf::Closure *done) override;
+    void UpdateFsUsed(::google::protobuf::RpcController* controller,
+                      const UpdateFsUsedRequest* request,
+                      UpdateFsUsedResponse* response,
+                      ::google::protobuf::Closure* done) override;
 
  private:
     CopysetNodeManager* copysetNodeManager_;

--- a/curvefs/src/metaserver/metaserver_service.h
+++ b/curvefs/src/metaserver/metaserver_service.h
@@ -29,6 +29,7 @@
 #include "curvefs/proto/metaserver.pb.h"
 #include "curvefs/src/metaserver/copyset/copyset_node_manager.h"
 #include "curvefs/src/metaserver/inflight_throttle.h"
+#include "curvefs/src/metaserver/fsused_manager.h"
 
 namespace curvefs {
 namespace metaserver {
@@ -37,10 +38,11 @@ using ::curvefs::metaserver::copyset::CopysetNodeManager;
 
 class MetaServerServiceImpl : public MetaServerService {
  public:
-    MetaServerServiceImpl(CopysetNodeManager* copysetNodeManager,
-                          InflightThrottle* inflightThrottle)
+    MetaServerServiceImpl(CopysetNodeManager *copysetNodeManager,
+                          InflightThrottle *inflightThrottle,
+                          FsUsedManager *fsUsedManager)
         : copysetNodeManager_(copysetNodeManager),
-          inflightThrottle_(inflightThrottle) {}
+          inflightThrottle_(inflightThrottle), fsUsedManager_(fsUsedManager) {}
 
     void GetDentry(::google::protobuf::RpcController* controller,
                    const ::curvefs::metaserver::GetDentryRequest* request,
@@ -129,9 +131,15 @@ class MetaServerServiceImpl : public MetaServerService {
         UpdateDeallocatableBlockGroupResponse *response,
         ::google::protobuf::Closure *done) override;
 
+    void UpdateFsUsed(::google::protobuf::RpcController *controller,
+                      const UpdateFsUsedRequest *request,
+                      UpdateFsUsedResponse *response,
+                      ::google::protobuf::Closure *done) override;
+
  private:
     CopysetNodeManager* copysetNodeManager_;
     InflightThrottle* inflightThrottle_;
+    FsUsedManager* fsUsedManager_;
 };
 }  // namespace metaserver
 }  // namespace curvefs

--- a/curvefs/src/metaserver/metastore.cpp
+++ b/curvefs/src/metaserver/metastore.cpp
@@ -849,6 +849,18 @@ MetaStatusCode MetaStoreImpl::UpdateDeallocatableBlockGroup(
     return st;
 }
 
+MetaStatusCode MetaStoreImpl::UpdateFsUsed(const UpdateFsUsedRequest* request,
+                                           UpdateFsUsedResponse* response,
+                                           int64_t logIndex) {
+    ReadLockGuard readLockGuard(rwLock_);
+    std::shared_ptr<Partition> partition;
+    GET_PARTITION_OR_RETURN(partition);
+
+    MetaStatusCode rc = partition->UpdateFsUsed(*request, logIndex);
+    response->set_statuscode(rc);
+    return rc;
+}
+
 bool MetaStoreImpl::InitStorage() {
     if (storageOptions_.type == "memory") {
         kvStorage_ = std::make_shared<MemoryStorage>(storageOptions_);

--- a/curvefs/src/metaserver/metastore.h
+++ b/curvefs/src/metaserver/metastore.h
@@ -79,6 +79,9 @@ using curvefs::metaserver::CreatePartitionResponse;
 using curvefs::metaserver::DeletePartitionRequest;
 using curvefs::metaserver::DeletePartitionResponse;
 
+using curvefs::metaserver::UpdateFsUsedRequest;
+using curvefs::metaserver::UpdateFsUsedResponse;
+
 using ::curvefs::metaserver::copyset::OnSnapshotSaveDoneClosure;
 using ::curvefs::metaserver::storage::Iterator;
 using ::curvefs::common::StreamServer;
@@ -208,6 +211,10 @@ class MetaStore {
     virtual MetaStatusCode UpdateDeallocatableBlockGroup(
         const UpdateDeallocatableBlockGroupRequest* request,
         UpdateDeallocatableBlockGroupResponse* response, int64_t logIndex) = 0;
+
+    virtual MetaStatusCode UpdateFsUsed(const UpdateFsUsedRequest* request,
+                                        UpdateFsUsedResponse* response,
+                                        int64_t logIndex) = 0;
 };
 
 class MetaStoreImpl : public MetaStore {
@@ -318,6 +325,10 @@ class MetaStoreImpl : public MetaStore {
         const UpdateDeallocatableBlockGroupRequest* request,
         UpdateDeallocatableBlockGroupResponse* response,
         int64_t logIndex) override;
+
+    MetaStatusCode UpdateFsUsed(const UpdateFsUsedRequest* request,
+                                UpdateFsUsedResponse* response,
+                                int64_t logIndex) override;
 
  private:
     FRIEND_TEST(MetastoreTest, partition);

--- a/curvefs/src/metaserver/partition.cpp
+++ b/curvefs/src/metaserver/partition.cpp
@@ -335,6 +335,11 @@ MetaStatusCode Partition::UpdateInode(const UpdateInodeRequest& request,
     return ret;
 }
 
+MetaStatusCode Partition::UpdateFsUsed(const UpdateFsUsedRequest& request,
+                                       int64_t logIndex) {
+    return inodeManager_->UpdateFsUsed(request, logIndex);
+}
+
 MetaStatusCode Partition::GetOrModifyS3ChunkInfo(
     uint32_t fsId, uint64_t inodeId, const S3ChunkInfoMap& map2add,
     const S3ChunkInfoMap& map2del, bool returnS3ChunkInfoMap,

--- a/curvefs/src/metaserver/partition.h
+++ b/curvefs/src/metaserver/partition.h
@@ -108,6 +108,9 @@ class Partition {
     MetaStatusCode UpdateInode(const UpdateInodeRequest& request,
                                int64_t logIndex);
 
+    MetaStatusCode UpdateFsUsed(const UpdateFsUsedRequest& request,
+                                int64_t logIndex);
+
     MetaStatusCode GetOrModifyS3ChunkInfo(uint32_t fsId, uint64_t inodeId,
                                           const S3ChunkInfoMap& map2add,
                                           const S3ChunkInfoMap& map2del,

--- a/curvefs/src/tools/curvefs_tool_define.cpp
+++ b/curvefs/src/tools/curvefs_tool_define.cpp
@@ -76,8 +76,8 @@ DEFINE_uint64(s3_blocksize, 1048576, "s3 block size");
 DEFINE_uint64(s3_chunksize, 4194304, "s3 chunk size");
 DEFINE_uint32(s3_objectPrefix, 0, "object prefix");
 DEFINE_bool(enableSumInDir, false, "statistic info in xattr");
-DEFINE_uint64(capacity, (uint64_t)100 * 1024 * 1024 * 1024,
-              "capacity of fs, default 100G");
+DEFINE_uint64(capacity, (uint64_t)0,
+              "capacity of fs, unit is bytes, default 0 to disable quota");
 DEFINE_string(user, "anonymous", "user of request");
 DEFINE_string(inodeId, "1,2,3", "inodes id");
 

--- a/curvefs/test/client/mock_metaserver_client.h
+++ b/curvefs/test/client/mock_metaserver_client.h
@@ -161,6 +161,9 @@ class MockMetaServerClient : public MetaServerClient {
     MOCK_METHOD3(UpdateDeallocatableBlockGroup,
                  MetaStatusCode(uint32_t, uint64_t,
                                 DeallocatableBlockGroupMap *));
+
+    MOCK_METHOD3(UpdateFsUsed,
+                 MetaStatusCode(uint32_t, const FsUsedDelta&, bool));
 };
 
 }  // namespace rpcclient

--- a/curvefs/test/client/test_fsquota_checker.cpp
+++ b/curvefs/test/client/test_fsquota_checker.cpp
@@ -31,11 +31,11 @@ using testing::Matcher;
 class FsQuotaCheckerTest : public testing::Test {
  protected:
     virtual void SetUp() {
+        mockMdsClient_ = std::make_shared<MockMdsClient>();
+        mockMetaServerClient_ = std::make_shared<MockMetaServerClient>();
         FsQuotaChecker::GetInstance().Init(1, mockMdsClient_,
                                            mockMetaServerClient_);
         FsUsedUpdater::GetInstance().Init(1, mockMetaServerClient_);
-        mockMdsClient_ = std::make_shared<MockMdsClient>();
-        mockMetaServerClient_ = std::make_shared<MockMetaServerClient>();
     }
     virtual void TearDown() {}
 

--- a/curvefs/test/client/test_fsquota_checker.cpp
+++ b/curvefs/test/client/test_fsquota_checker.cpp
@@ -1,0 +1,123 @@
+#include <gtest/gtest.h>
+
+#include "curvefs/src/client/fsquota_checker.h"
+#include "curvefs/src/client/fsused_updater.h"
+#include "mock_metaserver_client.h"
+#include "rpcclient/mock_mds_client.h"
+
+namespace curvefs {
+namespace client {
+
+using curvefs::client::rpcclient::MockMdsClient;
+using curvefs::client::rpcclient::MockMetaServerClient;
+using testing::Matcher;
+
+class FsQuotaCheckerTest : public testing::Test {
+ protected:
+    virtual void SetUp() {
+        FsQuotaChecker::GetInstance().Init(1, mockMdsClient_,
+                                           mockMetaServerClient_);
+        FsUsedUpdater::GetInstance().Init(1, mockMetaServerClient_);
+        mockMdsClient_ = std::make_shared<MockMdsClient>();
+        mockMetaServerClient_ = std::make_shared<MockMetaServerClient>();
+    }
+    virtual void TearDown() {}
+
+    std::shared_ptr<MockMdsClient> mockMdsClient_;
+    std::shared_ptr<MockMetaServerClient> mockMetaServerClient_;
+};
+
+TEST_F(FsQuotaCheckerTest, QuotaBytesCheck) {
+    // case 0: fsused bytes correct
+    FsUsedUpdater::GetInstance().UpdateDeltaBytes(100);
+    ASSERT_EQ(FsUsedUpdater::GetInstance().GetDeltaBytes(), 100);
+    FsUsedUpdater::GetInstance().UpdateDeltaBytes(-100);
+    ASSERT_EQ(FsUsedUpdater::GetInstance().GetDeltaBytes(), 0);
+
+    // case 1: quota disabled
+    EXPECT_CALL(*mockMdsClient_, GetFsInfo(Matcher<uint32_t>(_), _))
+        .WillOnce(testing::Invoke([](uint32_t fsId, FsInfo* fsInfo) {
+            fsInfo->set_capacity(0);
+            return FSStatusCode::OK;
+        }));
+    EXPECT_CALL(*mockMetaServerClient_, GetInode(_, _, _, _))
+        .WillOnce(testing::Invoke(
+            [](uint32_t fsId, uint64_t inodeId, Inode* inode, bool* streaming) {
+                auto xattrs = inode->mutable_xattr();
+                (*xattrs)[curvefs::XATTR_FS_BYTES] = "0";
+                return MetaStatusCode::OK;
+            }));
+    FsQuotaChecker::GetInstance().UpdateQuotaCache();
+    ASSERT_TRUE(FsQuotaChecker::GetInstance().QuotaBytesCheck(100));
+
+    // case 2: incBytes > capacity
+    EXPECT_CALL(*mockMdsClient_, GetFsInfo(Matcher<uint32_t>(_), _))
+        .WillOnce(testing::Invoke([](uint32_t fsId, FsInfo* fsInfo) {
+            fsInfo->set_capacity(1);
+            return FSStatusCode::OK;
+        }));
+    EXPECT_CALL(*mockMetaServerClient_, GetInode(_, _, _, _))
+        .WillOnce(testing::Invoke(
+            [](uint32_t fsId, uint64_t inodeId, Inode* inode, bool* streaming) {
+                auto xattrs = inode->mutable_xattr();
+                (*xattrs)[curvefs::XATTR_FS_BYTES] = "0";
+                return MetaStatusCode::OK;
+            }));
+    FsQuotaChecker::GetInstance().UpdateQuotaCache();
+    ASSERT_FALSE(FsQuotaChecker::GetInstance().QuotaBytesCheck(2));
+
+    // case 3: capacity - usedBytes < incBytes
+    EXPECT_CALL(*mockMdsClient_, GetFsInfo(Matcher<uint32_t>(_), _))
+        .WillOnce(testing::Invoke([](uint32_t fsId, FsInfo* fsInfo) {
+            fsInfo->set_capacity(3);
+            return FSStatusCode::OK;
+        }));
+    EXPECT_CALL(*mockMetaServerClient_, GetInode(_, _, _, _))
+        .WillOnce(testing::Invoke(
+            [](uint32_t fsId, uint64_t inodeId, Inode* inode, bool* streaming) {
+                auto xattrs = inode->mutable_xattr();
+                (*xattrs)[curvefs::XATTR_FS_BYTES] = "1";
+                return MetaStatusCode::OK;
+            }));
+    FsQuotaChecker::GetInstance().UpdateQuotaCache();
+    ASSERT_FALSE(FsQuotaChecker::GetInstance().QuotaBytesCheck(3));
+
+    // case 4: capacity - usedBytes < localDelta + incBytes
+    EXPECT_CALL(*mockMdsClient_, GetFsInfo(Matcher<uint32_t>(_), _))
+        .WillOnce(testing::Invoke([](uint32_t fsId, FsInfo* fsInfo) {
+            fsInfo->set_capacity(4);
+            return FSStatusCode::OK;
+        }));
+    EXPECT_CALL(*mockMetaServerClient_, GetInode(_, _, _, _))
+        .WillOnce(testing::Invoke(
+            [](uint32_t fsId, uint64_t inodeId, Inode* inode, bool* streaming) {
+                auto xattrs = inode->mutable_xattr();
+                (*xattrs)[curvefs::XATTR_FS_BYTES] = "0";
+                return MetaStatusCode::OK;
+            }));
+    FsQuotaChecker::GetInstance().UpdateQuotaCache();
+    FsUsedUpdater::GetInstance().UpdateDeltaBytes(1);
+    ASSERT_FALSE(FsQuotaChecker::GetInstance().QuotaBytesCheck(4));
+    FsUsedUpdater::GetInstance().UpdateDeltaBytes(-1);
+
+    // case 5: capacity - usedBytes >= localDelta + incBytes
+    EXPECT_CALL(*mockMdsClient_, GetFsInfo(Matcher<uint32_t>(_), _))
+        .WillOnce(testing::Invoke([](uint32_t fsId, FsInfo* fsInfo) {
+            fsInfo->set_capacity(5);
+            return FSStatusCode::OK;
+        }));
+    EXPECT_CALL(*mockMetaServerClient_, GetInode(_, _, _, _))
+        .WillOnce(testing::Invoke(
+            [](uint32_t fsId, uint64_t inodeId, Inode* inode, bool* streaming) {
+                auto xattrs = inode->mutable_xattr();
+                (*xattrs)[curvefs::XATTR_FS_BYTES] = "1";
+                return MetaStatusCode::OK;
+            }));
+    FsQuotaChecker::GetInstance().UpdateQuotaCache();
+    FsUsedUpdater::GetInstance().UpdateDeltaBytes(1);
+    ASSERT_TRUE(FsQuotaChecker::GetInstance().QuotaBytesCheck(3));
+    FsUsedUpdater::GetInstance().UpdateDeltaBytes(-1);
+}
+
+}  // namespace client
+}  // namespace curvefs

--- a/curvefs/test/client/test_fsquota_checker.cpp
+++ b/curvefs/test/client/test_fsquota_checker.cpp
@@ -1,8 +1,24 @@
+/*
+ *  Copyright (c) 2023 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 #include <gtest/gtest.h>
 
 #include "curvefs/src/client/fsquota_checker.h"
 #include "curvefs/src/client/fsused_updater.h"
-#include "mock_metaserver_client.h"
+#include "curvefs/test/client/mock_metaserver_client.h"
 #include "rpcclient/mock_mds_client.h"
 
 namespace curvefs {

--- a/curvefs/test/metaserver/BUILD
+++ b/curvefs/test/metaserver/BUILD
@@ -47,6 +47,7 @@ cc_test(
             "//curvefs/test/metaserver/mock:metaserver_test_mock",
             "@com_google_absl//absl/types:optional",
             "//curvefs/test/client/rpcclient:rpcclient_test_mock",
+            "//curvefs/test/client:mock",
     ],
 )
 

--- a/curvefs/test/metaserver/fsused_manager_test.cpp
+++ b/curvefs/test/metaserver/fsused_manager_test.cpp
@@ -1,0 +1,97 @@
+#include "curvefs/src/metaserver/fsused_manager.h"
+
+#include <gtest/gtest.h>
+
+#include "curvefs/test/client/mock_metaserver_client.h"
+
+namespace curvefs {
+namespace metaserver {
+
+using curvefs::client::rpcclient::MockMetaServerClient;
+using testing::_;
+
+class FsUsedManagerTest : public testing::Test {
+ protected:
+    virtual void SetUp() {
+        mockMetaServerClient_ = std::make_shared<MockMetaServerClient>();
+        fsUsedManager_ = std::make_shared<FsUsedManager>(mockMetaServerClient_);
+    }
+    virtual void TearDown() {}
+
+    std::shared_ptr<MockMetaServerClient> mockMetaServerClient_;
+    std::shared_ptr<FsUsedManager> fsUsedManager_;
+};
+
+TEST_F(FsUsedManagerTest, ApplyFsUsedDeltas) {
+    std::unordered_map<uint32_t, FsUsedDelta> applyResult;
+    auto add2result = [&applyResult](uint32_t fsid, const FsUsedDelta& delta,
+                                     bool fromClient) {
+        if (fromClient) {
+            return MetaStatusCode::OK;
+        }
+        if (applyResult.find(fsid) == applyResult.end()) {
+            applyResult[fsid] = delta;
+        } else {
+            applyResult[fsid].set_bytes(applyResult[fsid].bytes() +
+                                        delta.bytes());
+        }
+        return MetaStatusCode::OK;
+    };
+    EXPECT_CALL(*mockMetaServerClient_, UpdateFsUsed(_, _, _))
+        .WillRepeatedly(testing::Invoke(add2result));
+
+    {
+        // case 0: no delta
+        applyResult.clear();
+        fsUsedManager_->ApplyFsUsedDeltas();
+        ASSERT_EQ(applyResult.empty(), true);
+    }
+
+    {
+        // case 1: one delta
+        applyResult.clear();
+        FsUsedDelta delta1;
+        delta1.set_fsid(1);
+        delta1.set_bytes(100);
+        fsUsedManager_->AddFsUsedDelta(std::move(delta1));
+        fsUsedManager_->ApplyFsUsedDeltas();
+        ASSERT_EQ(applyResult.size(), 1);
+        ASSERT_EQ(applyResult[1].bytes(), 100);
+    }
+
+    {
+        // case 2: two deltas
+        applyResult.clear();
+        FsUsedDelta delta1;
+        delta1.set_fsid(1);
+        delta1.set_bytes(100);
+        FsUsedDelta delta2;
+        delta2.set_fsid(1);
+        delta2.set_bytes(100);
+        fsUsedManager_->AddFsUsedDelta(std::move(delta1));
+        fsUsedManager_->AddFsUsedDelta(std::move(delta2));
+        fsUsedManager_->ApplyFsUsedDeltas();
+        ASSERT_EQ(applyResult.size(), 1);
+        ASSERT_EQ(applyResult[1].bytes(), 200);
+    }
+
+    {
+        // case 3: two deltas, different fsid
+        applyResult.clear();
+        FsUsedDelta delta1;
+        delta1.set_fsid(1);
+        delta1.set_bytes(100);
+        FsUsedDelta delta2;
+        delta2.set_fsid(2);
+        delta2.set_bytes(100);
+        fsUsedManager_->AddFsUsedDelta(std::move(delta1));
+        fsUsedManager_->AddFsUsedDelta(std::move(delta2));
+        fsUsedManager_->ApplyFsUsedDeltas();
+        ASSERT_EQ(applyResult.size(), 2);
+        ASSERT_EQ(applyResult[1].bytes(), 100);
+        ASSERT_EQ(applyResult[2].bytes(), 100);
+    }
+}
+
+}  // namespace metaserver
+}  // namespace curvefs

--- a/curvefs/test/metaserver/fsused_manager_test.cpp
+++ b/curvefs/test/metaserver/fsused_manager_test.cpp
@@ -1,3 +1,19 @@
+/*
+ *  Copyright (c) 2023 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 #include "curvefs/src/metaserver/fsused_manager.h"
 
 #include <gtest/gtest.h>

--- a/curvefs/test/metaserver/metaserver_service_test2.cpp
+++ b/curvefs/test/metaserver/metaserver_service_test2.cpp
@@ -62,7 +62,7 @@ class MetaServerServiceTest2 : public testing::Test {
 TEST_F(MetaServerServiceTest2, ServiceOverload) {
     throttle_ = absl::make_unique<InflightThrottle>(0);
     metaServer_ = absl::make_unique<MetaServerServiceImpl>(
-        nullptr, throttle_.get());
+        nullptr, throttle_.get(), nullptr);
 
     throttle_->Increment();
 
@@ -103,7 +103,7 @@ TEST_F(MetaServerServiceTest2, ServiceOverload) {
 TEST_F(MetaServerServiceTest2, CopysetNodeNotFound) {
     throttle_ = absl::make_unique<InflightThrottle>(1);
     metaServer_ = absl::make_unique<MetaServerServiceImpl>(
-        &CopysetNodeManager::GetInstance(), throttle_.get());
+        &CopysetNodeManager::GetInstance(), throttle_.get(), nullptr);
 
 #define TEST_COPYSETNODE_NOTFOUND(TYPE)                                     \
     do {                                                                    \

--- a/curvefs/test/metaserver/mock/mock_metastore.h
+++ b/curvefs/test/metaserver/mock/mock_metastore.h
@@ -122,6 +122,10 @@ class MockMetaStore : public curvefs::metaserver::MetaStore {
                  MetaStatusCode(const UpdateDeallocatableBlockGroupRequest*,
                                 UpdateDeallocatableBlockGroupResponse*,
                                 int64_t logIndex));
+
+    MOCK_METHOD3(UpdateFsUsed,
+                 MetaStatusCode(const UpdateFsUsedRequest*,
+                                UpdateFsUsedResponse*, int64_t logIndex));
 };
 
 }  // namespace mock


### PR DESCRIPTION
## summary

1. add support of quota bytes (fs capacity), default value 0, means disable quota check
2. will update fs used info periodically
3. will check quota bytes when s3 client doing write or truncate
4. [dev doc](https://github.com/opencurve/curve-book/blob/39d6810782152f84fe0e78a975bb9b648358eaca/docs/03-CurveFS/08-dev/01-fsquota.md)
