### PR TITLE
delete partition after fail

### DIFF
--- a/curvefs/src/mds/heartbeat/heartbeat_manager.cpp
+++ b/curvefs/src/mds/heartbeat/heartbeat_manager.cpp
@@ -43,12 +43,13 @@ namespace heartbeat {
 HeartbeatManager::HeartbeatManager(
     const HeartbeatOption &option, const std::shared_ptr<Topology> &topology,
     const std::shared_ptr<Coordinator> &coordinator,
+    const std::shared_ptr<TopologyManager> &topologyManager,
     const std::shared_ptr<SpaceManager> &spaceManager)
     : topology_(topology), spaceManager_(spaceManager) {
     healthyChecker_ =
         std::make_shared<MetaserverHealthyChecker>(option, topology);
 
-    topoUpdater_ = std::make_shared<TopoUpdater>(topology);
+    topoUpdater_ = std::make_shared<TopoUpdater>(topology, topologyManager);
 
     copysetConfGenerator_ = std::make_shared<CopysetConfGenerator>(
         topology, coordinator, option.mdsStartTime,

--- a/curvefs/src/mds/heartbeat/heartbeat_manager.cpp
+++ b/curvefs/src/mds/heartbeat/heartbeat_manager.cpp
@@ -41,10 +41,10 @@ namespace curvefs {
 namespace mds {
 namespace heartbeat {
 HeartbeatManager::HeartbeatManager(
-    const HeartbeatOption &option, const std::shared_ptr<Topology> &topology,
-    const std::shared_ptr<Coordinator> &coordinator,
-    const std::shared_ptr<TopologyManager> &topologyManager,
-    const std::shared_ptr<SpaceManager> &spaceManager)
+    const HeartbeatOption& option, const std::shared_ptr<Topology>& topology,
+    const std::shared_ptr<Coordinator>& coordinator,
+    const std::shared_ptr<TopologyManager>& topologyManager,
+    const std::shared_ptr<SpaceManager>& spaceManager)
     : topology_(topology), spaceManager_(spaceManager) {
     healthyChecker_ =
         std::make_shared<MetaserverHealthyChecker>(option, topology);

--- a/curvefs/src/mds/heartbeat/heartbeat_manager.h
+++ b/curvefs/src/mds/heartbeat/heartbeat_manager.h
@@ -65,11 +65,11 @@ namespace heartbeat {
 
 class HeartbeatManager {
  public:
-    HeartbeatManager(const HeartbeatOption &option,
-                     const std::shared_ptr<Topology> &topology,
-                     const std::shared_ptr<Coordinator> &coordinator,
-                     const std::shared_ptr<TopologyManager> &topologyManager,
-                     const std::shared_ptr<SpaceManager> &spaceManager);
+    HeartbeatManager(const HeartbeatOption& option,
+                     const std::shared_ptr<Topology>& topology,
+                     const std::shared_ptr<Coordinator>& coordinator,
+                     const std::shared_ptr<TopologyManager>& topologyManager,
+                     const std::shared_ptr<SpaceManager>& spaceManager);
 
     ~HeartbeatManager() { Stop(); }
 

--- a/curvefs/src/mds/heartbeat/heartbeat_manager.h
+++ b/curvefs/src/mds/heartbeat/heartbeat_manager.h
@@ -68,6 +68,7 @@ class HeartbeatManager {
     HeartbeatManager(const HeartbeatOption &option,
                      const std::shared_ptr<Topology> &topology,
                      const std::shared_ptr<Coordinator> &coordinator,
+                     const std::shared_ptr<TopologyManager> &topologyManager,
                      const std::shared_ptr<SpaceManager> &spaceManager);
 
     ~HeartbeatManager() { Stop(); }

--- a/curvefs/src/mds/heartbeat/topo_updater.cpp
+++ b/curvefs/src/mds/heartbeat/topo_updater.cpp
@@ -222,7 +222,7 @@ void TopoUpdater::UpdatePartitionTopo(
             LOG(WARNING) << "hearbeat report partition which is not in topo"
                          << ", copysetId = " << copySetId
                          << ", partitionId = " << it.GetPartitionId();
-            
+
             const int maxRetries = 3;
             int retries = 0;
 
@@ -230,19 +230,21 @@ void TopoUpdater::UpdatePartitionTopo(
             std::set<std::string> copysetMemberAddr;
             TopoStatusCode ret;
             do {
-                ret = topologyManager_->GetCopysetMembers(it.GetPoolId(), copySetId, &copysetMemberAddr);
+                ret = topologyManager_->GetCopysetMembers(
+                    it.GetPoolId(), copySetId, &copysetMemberAddr);
                 if (ret == TopoStatusCode::TOPO_OK) {
-                break;
-            }
-            ++retries;
+                    break;
+                }
+                ++retries;
             } while (retries < maxRetries);
-            
+
             if (ret != TopoStatusCode::TOPO_OK) {
-                LOG(ERROR) << "GetCopysetMembers failed, poolId = " << it.GetPoolId()
-                        << ", copysetId = " << copySetId;
-            } 
-            else {
-                 topologyManager_->DeleteAbnormalPartition(it.GetPoolId(), copySetId, it.GetPartitionId(), copysetMemberAddr); 
+                LOG(ERROR) << "GetCopysetMembers failed, poolId = "
+                           << it.GetPoolId() << ", copysetId = " << copySetId;
+            } else {
+                topologyManager_->DeleteAbnormalPartition(
+                    it.GetPoolId(), copySetId, it.GetPartitionId(),
+                    copysetMemberAddr); 
             }
             continue;
         }

--- a/curvefs/src/mds/heartbeat/topo_updater.cpp
+++ b/curvefs/src/mds/heartbeat/topo_updater.cpp
@@ -222,6 +222,28 @@ void TopoUpdater::UpdatePartitionTopo(
             LOG(WARNING) << "hearbeat report partition which is not in topo"
                          << ", copysetId = " << copySetId
                          << ", partitionId = " << it.GetPartitionId();
+            
+            const int maxRetries = 3;
+            int retries = 0;
+
+            // get copyset members
+            std::set<std::string> copysetMemberAddr;
+            TopoStatusCode ret;
+            do {
+                ret = topologyManager_->GetCopysetMembers(it.GetPoolId(), copySetId, &copysetMemberAddr);
+                if (ret == TopoStatusCode::TOPO_OK) {
+                break;
+            }
+            ++retries;
+            } while (retries < maxRetries);
+            
+            if (ret != TopoStatusCode::TOPO_OK) {
+                LOG(ERROR) << "GetCopysetMembers failed, poolId = " << it.GetPoolId()
+                        << ", copysetId = " << copySetId;
+            } 
+            else {
+                 topologyManager_->DeleteAbnormalPartition(it.GetPoolId(), copySetId, it.GetPartitionId(), copysetMemberAddr); 
+            }
             continue;
         }
 

--- a/curvefs/src/mds/heartbeat/topo_updater.h
+++ b/curvefs/src/mds/heartbeat/topo_updater.h
@@ -37,8 +37,10 @@ namespace heartbeat {
 using curvefs::mds::topology::CopySetIdType;
 class TopoUpdater {
  public:
-    explicit TopoUpdater(const std::shared_ptr<Topology> &topo,
-    const std::shared_ptr<TopologyManager> &topologyManager) : topo_(topo), topologyManager_(topologyManager){}
+    explicit TopoUpdater(
+        const std::shared_ptr<Topology>& topo,
+        const std::shared_ptr<TopologyManager>& topologyManager)
+        : topo_(topo), topologyManager_(topologyManager) {}
     ~TopoUpdater() {}
 
     /*

--- a/curvefs/src/mds/heartbeat/topo_updater.h
+++ b/curvefs/src/mds/heartbeat/topo_updater.h
@@ -37,7 +37,8 @@ namespace heartbeat {
 using curvefs::mds::topology::CopySetIdType;
 class TopoUpdater {
  public:
-    explicit TopoUpdater(const std::shared_ptr<Topology> &topo) : topo_(topo) {}
+    explicit TopoUpdater(const std::shared_ptr<Topology> &topo,
+    const std::shared_ptr<TopologyManager> &topologyManager) : topo_(topo), topologyManager_(topologyManager){}
     ~TopoUpdater() {}
 
     /*
@@ -65,6 +66,7 @@ class TopoUpdater {
 
  private:
     std::shared_ptr<Topology> topo_;
+    std::shared_ptr<TopologyManager> topologyManager_;
 };
 }  // namespace heartbeat
 }  // namespace mds

--- a/curvefs/src/mds/mds.cpp
+++ b/curvefs/src/mds/mds.cpp
@@ -422,7 +422,7 @@ void MDS::InitHeartbeatManager() {
 
     heartbeatOption.mdsStartTime = steady_clock::now();
     heartbeatManager_ = std::make_shared<HeartbeatManager>(
-        heartbeatOption, topology_, coordinator_, spaceManager_);
+        heartbeatOption, topology_, coordinator_, topologyManager_, spaceManager_);
     heartbeatManager_->Init();
 }
 

--- a/curvefs/src/mds/mds.cpp
+++ b/curvefs/src/mds/mds.cpp
@@ -422,7 +422,8 @@ void MDS::InitHeartbeatManager() {
 
     heartbeatOption.mdsStartTime = steady_clock::now();
     heartbeatManager_ = std::make_shared<HeartbeatManager>(
-        heartbeatOption, topology_, coordinator_, topologyManager_, spaceManager_);
+        heartbeatOption, topology_, coordinator_, topologyManager_,
+        spaceManager_);
     heartbeatManager_->Init();
 }
 

--- a/curvefs/src/mds/topology/topology_manager.cpp
+++ b/curvefs/src/mds/topology/topology_manager.cpp
@@ -765,12 +765,14 @@ TopoStatusCode TopologyManager::DeletePartition(uint32_t partitionId) {
     return TopoStatusCode::TOPO_OK;
 }
 
-void TopologyManager::DeleteAbnormalPartition(uint32_t poolId, uint32_t copysetId, uint32_t partitionId,
-                             const std::set<std::string> &addrs){
-    auto fret = metaserverClient_->DeletePartition(poolId, copysetId, partitionId, addrs);
+void TopologyManager::DeleteAbnormalPartition(
+    uint32_t poolId, uint32_t copysetId, uint32_t partitionId,
+    const std::set<std::string>& addrs) {
+    auto fret = metaserverClient_->DeletePartition(poolId, copysetId,
+                                                   partitionId, addrs);
     if (fret != FSStatusCode::OK) {
-        LOG(ERROR) << "Failed to delete partition. PoolId: " << poolId 
-                   << ", CopysetId: " << copysetId 
+        LOG(ERROR) << "Failed to delete partition. PoolId: " << poolId
+                   << ", CopysetId: " << copysetId
                    << ", PartitionId: " << partitionId;
     }
 }
@@ -1268,7 +1270,7 @@ void TopologyManager::GetTopology(ListTopologyResponse *response) {
     ListMetaserverOfCluster(response->mutable_metaservers());
 }
 
-std::shared_ptr<MetaserverClient> TopologyManager::GetMetaserverClient(){
+std::shared_ptr<MetaserverClient> TopologyManager::GetMetaserverClient() {
     return metaserverclient_;
 }
 

--- a/curvefs/src/mds/topology/topology_manager.cpp
+++ b/curvefs/src/mds/topology/topology_manager.cpp
@@ -765,6 +765,16 @@ TopoStatusCode TopologyManager::DeletePartition(uint32_t partitionId) {
     return TopoStatusCode::TOPO_OK;
 }
 
+void TopologyManager::DeleteAbnormalPartition(uint32_t poolId, uint32_t copysetId, uint32_t partitionId,
+                             const std::set<std::string> &addrs){
+    auto fret = metaserverClient_->DeletePartition(poolId, copysetId, partitionId, addrs);
+    if (fret != FSStatusCode::OK) {
+        LOG(ERROR) << "Failed to delete partition. PoolId: " << poolId 
+                   << ", CopysetId: " << copysetId 
+                   << ", PartitionId: " << partitionId;
+    }
+}
+
 void TopologyManager::DeletePartition(const DeletePartitionRequest *request,
                                       DeletePartitionResponse *response) {
     uint32_t partitionId = request->partitionid();
@@ -1256,6 +1266,10 @@ void TopologyManager::GetTopology(ListTopologyResponse *response) {
     ListZone(response->mutable_zones());
     ListServer(response->mutable_servers());
     ListMetaserverOfCluster(response->mutable_metaservers());
+}
+
+std::shared_ptr<MetaserverClient> TopologyManager::GetMetaserverClient(){
+    return metaserverclient_;
 }
 
 void TopologyManager::ListZone(ListZoneResponse *response) {

--- a/curvefs/src/mds/topology/topology_manager.h
+++ b/curvefs/src/mds/topology/topology_manager.h
@@ -109,6 +109,9 @@ class TopologyManager {
     virtual void CreatePartitions(const CreatePartitionRequest *request,
                                   CreatePartitionResponse *response);
 
+    virtual void DeleteAbnormalPartition(uint32_t poolId, uint32_t copysetId, uint32_t partitionId,
+                                         const std::set<std::string> &addrs);
+
     virtual void DeletePartition(const DeletePartitionRequest *request,
                                  DeletePartitionResponse *response);
 
@@ -161,6 +164,8 @@ class TopologyManager {
             curvefs::mds::topology::MetadataUsage>* spaces);
 
     virtual void GetTopology(ListTopologyResponse* response);
+
+    virtual std::shared_ptr<MetaserverClient> GetMetaserverClient();
 
     virtual void ListZone(ListZoneResponse* response);
 

--- a/curvefs/src/mds/topology/topology_manager.h
+++ b/curvefs/src/mds/topology/topology_manager.h
@@ -109,8 +109,9 @@ class TopologyManager {
     virtual void CreatePartitions(const CreatePartitionRequest *request,
                                   CreatePartitionResponse *response);
 
-    virtual void DeleteAbnormalPartition(uint32_t poolId, uint32_t copysetId, uint32_t partitionId,
-                                         const std::set<std::string> &addrs);
+    virtual void DeleteAbnormalPartition(uint32_t poolId, uint32_t copysetId,
+                                         uint32_t partitionId,
+                                         const std::set<std::string>& addrs);
 
     virtual void DeletePartition(const DeletePartitionRequest *request,
                                  DeletePartitionResponse *response);

--- a/curvefs/test/mds/heartbeat/topo_update_test.cpp
+++ b/curvefs/test/mds/heartbeat/topo_update_test.cpp
@@ -197,6 +197,13 @@ TEST_F(TestTopoUpdater, test_UpdatePartitionTopo_case4) {
 
     EXPECT_CALL(*topology_, GetPartition(_, _)).WillOnce(Return(false));
 
+    std::set<std::string> copysetMemberAddr;
+    EXPECT_CALL(*topologyManager_, GetCopysetMembers(_, _, _))
+        .Times(AtMost(3))
+        .WillRepeatedly(DoAll(SetArgPointee<2>(copysetMemberAddr), Return(TopoStatusCode::TOPO_OK)));
+
+    EXPECT_CALL(*topologyManager_, DeleteAbnormalPartition(_, _, _, _)).Times(1);
+
     std::list<::curvefs::mds::topology::Partition> partitionList;
     partitionList.push_back(partition);
 

--- a/curvefs/test/mds/heartbeat/topo_update_test.cpp
+++ b/curvefs/test/mds/heartbeat/topo_update_test.cpp
@@ -200,9 +200,11 @@ TEST_F(TestTopoUpdater, test_UpdatePartitionTopo_case4) {
     std::set<std::string> copysetMemberAddr;
     EXPECT_CALL(*topologyManager_, GetCopysetMembers(_, _, _))
         .Times(AtMost(3))
-        .WillRepeatedly(DoAll(SetArgPointee<2>(copysetMemberAddr), Return(TopoStatusCode::TOPO_OK)));
+        .WillRepeatedly(DoAll(SetArgPointee<2>(copysetMemberAddr),
+                              Return(TopoStatusCode::TOPO_OK)));
 
-    EXPECT_CALL(*topologyManager_, DeleteAbnormalPartition(_, _, _, _)).Times(1);
+    EXPECT_CALL(*topologyManager_, DeleteAbnormalPartition(_, _, _, _))
+        .Times(1);
 
     std::list<::curvefs::mds::topology::Partition> partitionList;
     partitionList.push_back(partition);


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Problem Summary:
When the partition is successfully created on the metaserver, but fails to persist in the topology, we should go to the metaserver to delete the partition
### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
