### PR TITLE
[fix] tools-v2: fix incorrect error output

### DIFF
--- a/tools-v2/internal/error/error.go
+++ b/tools-v2/internal/error/error.go
@@ -23,6 +23,7 @@
 package cmderror
 
 import (
+	"errors"
 	"fmt"
 
 	fscopyset "github.com/opencurve/curve/tools-v2/proto/curvefs/proto/copyset"
@@ -69,7 +70,7 @@ func (ce *CmdError) ToError() error {
 	if ce.Code == CODE_SUCCESS {
 		return nil
 	}
-	return fmt.Errorf(ce.Message)
+	return errors.New(ce.Message)
 }
 
 func NewSucessCmdError() *CmdError {


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #2801

Problem Summary: Error messages contains character `%` cannot be output correctly because `%` is treated as the prefix of a format verb.

### What is changed and how it works?

What's Changed: Replaced `fmt.Errorf(ce.Message)` with `errors.New(ce.Message)` in `ToError()`

How it Works: `errors.New` treats the error messages as plain text instead of format strings.

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license
