### PR TITLE
[fix]tools-v2: add version in function NewQuerySubUri

### DIFF
--- a/tools-v2/internal/utils/snapshot/snapshot.go
+++ b/tools-v2/internal/utils/snapshot/snapshot.go
@@ -28,6 +28,8 @@ import (
 )
 
 func NewQuerySubUri(params map[string]any) string {
+	params[QueryVersion] = Version
+
 	values := strings.Builder{}
 	for key, value := range params {
 		if value != "" && value != nil {


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #xxx <!-- replace xxx with issue number -->

Problem Summary:

function snapshotutil.NewQuerySubUri does not add the version param.

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [x] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license
