### PR TITLE
【Feature】When the cluster capacity is almost full, make the cluster read only

### DIFF
--- a/conf/chunkserver.conf
+++ b/conf/chunkserver.conf
@@ -128,6 +128,8 @@ copyset.sync_chunk_limits=2097152
 copyset.sync_threshold=65536
 # check syncing interval
 copyset.check_syncing_interval_ms=500
+# wait for retry time when disk space is insufficient
+copyset.wait_for_disk_freed_interval_ms=60000
 
 #
 # Clone settings
@@ -215,6 +217,11 @@ chunkfilepool.allocate_percent=80
 chunkfilepool.chunk_file_pool_size=1GB
 # The thread num for format chunks
 chunkfilepool.thread_num=1
+# When the chunkserver disk usage exceeds the percentage, heartbeat sets the disk status
+chunkfilepool.disk_usage_percent_limit=95
+# Reserve part of the chunk number, and the write operation returns readonly to the client
+# when the available value is too small to avoid chunkfilepool and walfilepool not being able to obtain the chunk.
+chunkfilepool.chunk_reserved=100
 
 #
 # WAL file pool

--- a/conf/chunkserver.conf.example
+++ b/conf/chunkserver.conf.example
@@ -120,6 +120,8 @@ copyset.sync_chunk_limits=2097152
 copyset.sync_threshold=65536
 # check syncing interval
 copyset.check_syncing_interval_ms=500
+# wait for retry time when disk space is insufficient
+copyset.wait_for_disk_freed_interval_ms=60000
 
 #
 # Clone settings
@@ -207,6 +209,11 @@ chunkfilepool.allocate_percent=80
 chunkfilepool.chunk_file_pool_size=1GB
 # The thread num for format chunks
 chunkfilepool.thread_num=1
+# When the chunkserver disk usage exceeds the percentage, heartbeat sets the disk status
+chunkfilepool.disk_usage_percent_limit=95
+# Reserve part of the chunk number, and the write operation returns readonly to the client
+# when the available value is too small to avoid chunkfilepool and walfilepool not being able to obtain the chunk.
+chunkfilepool.chunk_reserved=0
 
 #
 # WAL file pool

--- a/proto/chunk.proto
+++ b/proto/chunk.proto
@@ -85,6 +85,7 @@ enum CHUNK_OP_STATUS {
     CHUNK_OP_STATUS_BACKWARD = 10;          // 请求的版本落后当前chunk的版本
     CHUNK_OP_STATUS_CHUNK_EXIST = 11;       // chunk已存在
     CHUNK_OP_STATUS_EPOCH_TOO_OLD = 12;     // request epoch too old
+    CHUNK_OP_STATUS_READONLY = 13;          // If there is insufficient disk space, set the chunkserver to read-only
 };
 
 message ChunkResponse {

--- a/proto/heartbeat.proto
+++ b/proto/heartbeat.proto
@@ -71,8 +71,13 @@ message CopysetStatistics {
     required uint32 writeIOPS = 4;
 }
 
+enum ErrorType {
+    NORMAL = 0;
+    DISKFULL = 1;
+}
+
 message DiskState {
-    required uint32 errType = 1;
+    required ErrorType errType = 1;
     required string errMsg = 2;
 }
 

--- a/proto/topology.proto
+++ b/proto/topology.proto
@@ -48,6 +48,7 @@ enum ChunkServerStatus {
 enum DiskState {
     DISKNORMAL = 0;
     DISKERROR = 1;
+    DISKFULL = 2;
 }
 
 enum OnlineState {

--- a/src/chunkserver/chunkserver.cpp
+++ b/src/chunkserver/chunkserver.cpp
@@ -503,6 +503,9 @@ void ChunkServer::InitChunkFilePoolOptions(
     LOG_IF(FATAL, !conf->GetBoolValue(
         "chunkfilepool.enable_get_chunk_from_pool",
         &chunkFilePoolOptions->getFileFromPool));
+    LOG_IF(FATAL, !conf->GetUInt32Value(
+        "chunkfilepool.chunk_reserved",
+        &chunkFilePoolOptions->chunkReserved));
 
     if (chunkFilePoolOptions->getFileFromPool == false) {
         std::string chunkFilePoolUri;
@@ -710,6 +713,9 @@ void ChunkServer::InitCopysetNodeOptions(
         LOG_IF(FATAL, !conf->GetUInt32Value("copyset.sync_trigger_seconds",
                 &copysetNodeOptions->syncTriggerSeconds));
     }
+    LOG_IF(FATAL, !conf->GetUInt32Value(
+        "copyset.wait_for_disk_freed_interval_ms",
+        &copysetNodeOptions->waitForDiskFreedIntervalMs));
 }
 
 void ChunkServer::InitCopyerOptions(
@@ -781,6 +787,9 @@ void ChunkServer::InitHeartbeatOptions(
         &heartbeatOptions->intervalSec));
     LOG_IF(FATAL, !conf->GetUInt32Value("mds.heartbeat_timeout",
         &heartbeatOptions->timeout));
+    LOG_IF(FATAL, !conf->GetUInt32Value(
+        "chunkfilepool.disk_usage_percent_limit",
+        &heartbeatOptions->chunkserverDiskLimit));
 }
 
 void ChunkServer::InitRegisterOptions(

--- a/src/chunkserver/config_info.h
+++ b/src/chunkserver/config_info.h
@@ -140,6 +140,8 @@ struct CopysetNodeOptions {
     uint64_t syncThreshold = 64 * 1024;
     // check syncing interval
     uint32_t checkSyncingIntervalMs = 500u;
+    // wait for retry time when disk space is insufficient
+    uint32_t waitForDiskFreedIntervalMs = 60000;
 
     CopysetNodeOptions();
 };

--- a/src/chunkserver/copyset_node.h
+++ b/src/chunkserver/copyset_node.h
@@ -469,6 +469,8 @@ class CopysetNode : public braft::StateMachine,
 
     void WaitSnapshotDone();
 
+    bool ReadOnly() const;
+
  private:
     inline std::string GroupId() {
         return ToGroupId(logicPoolId_, copysetId_);

--- a/src/chunkserver/datastore/chunkserver_chunkfile.cpp
+++ b/src/chunkserver/datastore/chunkserver_chunkfile.cpp
@@ -19,6 +19,7 @@
  * File Created: Thursday, 6th September 2018 10:49:53 am
  * Author: yangyaokai
  */
+#include <errno.h>
 #include <fcntl.h>
 #include <algorithm>
 #include <memory>
@@ -207,7 +208,8 @@ CSErrorCode CSChunkFile::Open(bool createFile) {
         if (rc != 0  && rc != -EEXIST) {
             LOG(ERROR) << "Error occured when create file."
                        << " filepath = " << chunkFilePath;
-            return CSErrorCode::InternalError;
+            return rc == -ENOSPC ? CSErrorCode::NoSpaceError :
+             CSErrorCode::InternalError;
         }
     }
     int rc = -1;
@@ -400,7 +402,8 @@ CSErrorCode CSChunkFile::Write(SequenceNum sn,
                    << "ChunkID: " << chunkId_
                    << ",request sn: " << sn
                    << ",chunk sn: " << metaPage_.sn;
-        return CSErrorCode::InternalError;
+        return rc == -ENOSPC ? CSErrorCode::NoSpaceError :
+         CSErrorCode::InternalError;
     }
     // If it is a clone chunk, the bitmap will be updated
     CSErrorCode errorCode = flush();
@@ -478,7 +481,8 @@ CSErrorCode CSChunkFile::Paste(const char * buf, off_t offset, size_t length) {
                        << "ChunkID: " << chunkId_
                        << ", offset: " << offset
                        << ", length: " << length;
-            return CSErrorCode::InternalError;
+            return rc == -ENOSPC ? CSErrorCode::NoSpaceError :
+             CSErrorCode::InternalError;
         }
     }
 

--- a/src/chunkserver/datastore/chunkserver_datastore.cpp
+++ b/src/chunkserver/datastore/chunkserver_datastore.cpp
@@ -44,7 +44,8 @@ CSDataStore::CSDataStore(std::shared_ptr<LocalFileSystem> lfs,
       baseDir_(options.baseDir),
       chunkFilePool_(chunkFilePool),
       lfs_(lfs),
-      enableOdsyncWhenOpenChunkFile_(options.enableOdsyncWhenOpenChunkFile) {
+      enableOdsyncWhenOpenChunkFile_(options.enableOdsyncWhenOpenChunkFile),
+      waitForDiskFreedIntervalMs_(options.waitForDiskFreedIntervalMs) {
     CHECK(!baseDir_.empty()) << "Create datastore failed";
     CHECK(lfs_ != nullptr) << "Create datastore failed";
     CHECK(chunkFilePool_ != nullptr) << "Create datastore failed";
@@ -426,6 +427,10 @@ CSErrorCode CSDataStore::loadChunkFile(ChunkID id) {
 
 ChunkMap CSDataStore::GetChunkMap() {
     return metaCache_.GetMap();
+}
+
+bool CSDataStore::EnoughChunk() {
+    return chunkFilePool_->EnoughChunk();
 }
 
 }  // namespace chunkserver

--- a/src/chunkserver/datastore/chunkserver_datastore.h
+++ b/src/chunkserver/datastore/chunkserver_datastore.h
@@ -63,6 +63,7 @@ struct DataStoreOptions {
     PageSizeType                        metaPageSize;
     uint32_t                            locationLimit;
     bool                                enableOdsyncWhenOpenChunkFile;
+    uint32_t                            waitForDiskFreedIntervalMs;
 };
 
 /**
@@ -328,12 +329,18 @@ class CSDataStore {
 
     virtual ChunkMap GetChunkMap();
 
+    virtual bool EnoughChunk();
+
     void SetCacheCondPtr(std::shared_ptr<std::condition_variable> cond) {
         metaCache_.SetCondPtr(cond);
     }
 
     void SetCacheLimits(const uint64_t limit, const uint64_t threshold) {
         metaCache_.SetSyncChunkLimits(limit, threshold);
+    }
+
+    void WaitForDiskFreed() {
+        bthread_usleep(waitForDiskFreedIntervalMs_);
     }
 
  private:
@@ -362,6 +369,8 @@ class CSDataStore {
     DataStoreMetricPtr metric_;
     // enable O_DSYNC When Open ChunkFile
     bool enableOdsyncWhenOpenChunkFile_;
+    // wait for retry time when disk space is insufficient
+    uint32_t waitForDiskFreedIntervalMs_;
 };
 
 }  // namespace chunkserver

--- a/src/chunkserver/datastore/define.h
+++ b/src/chunkserver/datastore/define.h
@@ -73,6 +73,8 @@ enum CSErrorCode {
     // The page has not been written, it will appear when the page that has not
     // been written is read when the clone chunk is read
     PageNerverWrittenError = 13,
+    // ENOSPC error
+    NoSpaceError = 14,
 };
 
 // Chunk details

--- a/src/chunkserver/datastore/file_pool.h
+++ b/src/chunkserver/datastore/file_pool.h
@@ -71,6 +71,7 @@ struct FilePoolOptions {
     uint32_t preAllocateNum;
     uint64_t filePoolSize;
     uint32_t formatThreadNum;
+    uint32_t chunkReserved;
 
     std::string copysetDir;
     std::string recycleDir;
@@ -94,6 +95,7 @@ struct FilePoolOptions {
         formatThreadNum = 1;
         ::memset(metaPath, 0, 256);
         ::memset(filePoolDir, 0, 256);
+        chunkReserved = 0;
     }
 };
 
@@ -219,6 +221,10 @@ class CURVE_CACHELINE_ALIGNMENT FilePool {
      */
     virtual size_t Size();
     /**
+     * Returns whether there is enough chunk space
+     */
+    virtual bool EnoughChunk();
+    /**
      * Get the allocation status of FilePool
      */
     virtual FilePoolState GetState() const;
@@ -289,9 +295,9 @@ class CURVE_CACHELINE_ALIGNMENT FilePool {
      * Perform metapage assignment for the new chunkfile
      * @param: sourcepath is the file path to be written
      * @param: page is the metapage information to be written
-     * @return: returns true if successful, otherwise false
+     * @return: return 0 if successful, otherwise return less than 0
      */
-    bool WriteMetaPage(const std::string& sourcepath, const char* page);
+    int WriteMetaPage(const std::string& sourcepath, const char* page);
     /**
      * Directly allocate chunks, not from FilePool
      * @param: chunkpath is the path of the chunk file in the datastore
@@ -304,9 +310,9 @@ class CURVE_CACHELINE_ALIGNMENT FilePool {
      * @param needClean: Whether need the zeroed chunk
      * @param chunkid: The return chunk's id
      * @param isCleaned: Whether the return chunk is zeroed
-     * @return: Return false if there is no valid chunk, else return true
+     * @return: return 0 if successful, otherwise return less than 0
      */
-    bool GetChunk(bool needClean, uint64_t* chunkid, bool* isCleaned);
+    int GetChunk(bool needClean, uint64_t* chunkid, bool* isCleaned);
 
     /**
      * @brief: Zeroing specify chunk file
@@ -314,9 +320,9 @@ class CURVE_CACHELINE_ALIGNMENT FilePool {
      * @param onlyMarked: Use fallocate() to zeroing chunk file 
      *                    if onlyMarked is ture, otherwise 
      *                    write all bytes in chunk to zero
-     * @return: Return true if success, else return false
+     * @return: return 0 if successful, otherwise return less than 0
      */
-    bool CleanChunk(uint64_t chunkid, bool onlyMarked);
+    int CleanChunk(uint64_t chunkid, bool onlyMarked);
 
     /**
      * @brief: Clean chunk one by one

--- a/src/chunkserver/heartbeat.cpp
+++ b/src/chunkserver/heartbeat.cpp
@@ -238,7 +238,7 @@ int Heartbeat::BuildRequest(HeartbeatRequest* req) {
      */
     curve::mds::heartbeat::DiskState* diskState =
                     new curve::mds::heartbeat::DiskState();
-    diskState->set_errtype(0);
+    diskState->set_errtype(curve::mds::heartbeat::NORMAL);
     diskState->set_errmsg("");
     req->set_allocated_diskstate(diskState);
 
@@ -294,6 +294,12 @@ int Heartbeat::BuildRequest(HeartbeatRequest* req) {
     }
     req->set_diskcapacity(cap);
     req->set_diskused(cap - avail);
+
+    if (options_.chunkserverDiskLimit > 0 &&
+        req->diskused() * 100 / cap > options_.chunkserverDiskLimit) {
+        diskState->set_errtype(curve::mds::heartbeat::DISKFULL);
+        diskState->set_errmsg("Disk near full");
+    }
 
     std::vector<CopysetNodePtr> copysets;
     copysetMan_->GetAllCopysetNodes(&copysets);

--- a/src/chunkserver/heartbeat.h
+++ b/src/chunkserver/heartbeat.h
@@ -69,6 +69,7 @@ struct HeartbeatOptions {
     uint32_t                timeout;
     CopysetNodeManager*     copysetNodeManager;
     ScanManager*            scanManager;
+    uint32_t                chunkserverDiskLimit;
 
     std::shared_ptr<LocalFileSystem> fs;
     std::shared_ptr<FilePool> chunkFilePool;

--- a/src/client/chunk_closure.h
+++ b/src/client/chunk_closure.h
@@ -113,6 +113,12 @@ class ClientClosure : public Closure {
     // handle epoch too old
     void OnEpochTooOld();
 
+    // handle readonly
+    void OnReadOnly();
+
+    // handle nospace
+    void OnNoSpace();
+
     // 非法参数
     void OnInvalidRequest();
 

--- a/src/client/config_info.h
+++ b/src/client/config_info.h
@@ -138,6 +138,8 @@ struct ChunkServerUnstableOption {
  * copyset 标记为unstable，促使其下次发送rpc前，先去getleader。
  * @chunkserverMinRetryTimesForceTimeoutBackoff:
  * 当一个请求重试次数超过阈值时，还在重试 使其超时时间进行指数退避
+ * @chunkserverWaitDiskFreeRetryIntervalMS:
+ * 当请求返回readonly或者nospace错误，hang住io等待一段时间后重试。
  */
 struct FailureRequestOption {
     uint32_t chunkserverOPMaxRetry = 3;
@@ -146,6 +148,7 @@ struct FailureRequestOption {
     uint64_t chunkserverMaxRPCTimeoutMS = 64000;
     uint64_t chunkserverMaxRetrySleepIntervalUS = 64ull * 1000 * 1000;
     uint64_t chunkserverMinRetryTimesForceTimeoutBackoff = 5;
+    uint64_t chunkserverWaitDiskFreeRetryIntervalMS = 60 * 1000;
 
     // When a request remains outstanding beyond this threshold, it is marked as
     // a slow request.

--- a/src/mds/nameserver2/curvefs.cpp
+++ b/src/mds/nameserver2/curvefs.cpp
@@ -171,6 +171,7 @@ void CurveFS::Uninit() {
     allocStatistic_ = nullptr;
     fileRecordManager_ = nullptr;
     snapshotCloneClient_ = nullptr;
+    topology_ = nullptr;
 }
 
 void CurveFS::InitRootFile(void) {

--- a/test/chunkserver/fake_datastore.h
+++ b/test/chunkserver/fake_datastore.h
@@ -51,6 +51,7 @@ class FakeCSDataStore : public CSDataStore {
         snapDeleteFlag_ = false;
         error_ = CSErrorCode::Success;
         chunkSize_ = options.chunkSize;
+        enoughChunk_ = true;
     }
     virtual ~FakeCSDataStore() {
         delete chunk_;
@@ -204,6 +205,14 @@ class FakeCSDataStore : public CSDataStore {
         }
     }
 
+    bool EnoughChunk() {
+        return enoughChunk_;
+    }
+
+    void SetEnoughChunk(bool enoughChunk) {
+        enoughChunk_ = enoughChunk;
+    }
+
     void InjectError(CSErrorCode errorCode = CSErrorCode::InternalError) {
         error_ = errorCode;
     }
@@ -226,6 +235,7 @@ class FakeCSDataStore : public CSDataStore {
     SequenceNum sn_;
     CSErrorCode error_;
     uint32_t chunkSize_;
+    bool enoughChunk_;
 };
 
 class FakeFilePool : public FilePool {

--- a/test/integration/heartbeat/common.cpp
+++ b/test/integration/heartbeat/common.cpp
@@ -92,6 +92,17 @@ void HeartbeatIntegrationCommon::UpdateCopysetTopo(
     ASSERT_EQ(0, topology_->UpdateCopySetTopo(copysetInfo));
 }
 
+void HeartbeatIntegrationCommon::CheckCopysetAvail(ChunkServerIdType id,
+    bool avail) {
+    std::vector<CopySetKey> keys = topology_->GetCopySetsInChunkServer(id);
+    for (auto key : keys) {
+        CopySetInfo info;
+        if (topology_->GetCopySet(key, &info)) {
+            ASSERT_EQ(avail, info.IsAvailable());
+        }
+    }
+}
+
 void HeartbeatIntegrationCommon::SendHeartbeat(
     const ChunkServerHeartbeatRequest &request, bool expectFailed,
     ChunkServerHeartbeatResponse *response) {
@@ -119,7 +130,7 @@ void HeartbeatIntegrationCommon::BuildBasicChunkServerRequest(
     req->set_ip(out.GetHostIp());
     req->set_port(out.GetPort());
     auto diskState = new ::curve::mds::heartbeat::DiskState();
-    diskState->set_errtype(0);
+    diskState->set_errtype(curve::mds::heartbeat::NORMAL);
     diskState->set_errmsg("disk ok");
     req->set_allocated_diskstate(diskState);
     req->set_diskcapacity(100);

--- a/test/integration/heartbeat/common.h
+++ b/test/integration/heartbeat/common.h
@@ -294,6 +294,13 @@ class HeartbeatIntegrationCommon {
                            const std::set<ChunkServerIdType> &members,
                            ChunkServerIdType candidate = UNINTIALIZE_ID);
 
+    /* CheckCopysetAvail 检查copyset的状态
+     *
+     * @param[in] chunkserverId chunkserver的id
+     * @param[in] avail copyset状态
+     */
+    void CheckCopysetAvail(ChunkServerIdType chunkserverId, bool avail);
+
     /* SendHeartbeat 发送心跳
      *
      * @param[in] req

--- a/test/mds/heartbeat/common.cpp
+++ b/test/mds/heartbeat/common.cpp
@@ -38,7 +38,7 @@ ChunkServerHeartbeatRequest GetChunkServerHeartbeatRequestForTest() {
     request.set_copysetcount(100);
 
     DiskState *state = new DiskState();
-    state->set_errtype(1);
+    state->set_errtype(curve::mds::heartbeat::NORMAL);
     std::string *errMsg = new std::string("healthy");
     state->set_allocated_errmsg(errMsg);
     request.set_allocated_diskstate(state);

--- a/test/mds/server/mds_test.cpp
+++ b/test/mds/server/mds_test.cpp
@@ -181,7 +181,7 @@ TEST_F(MDSTest, common) {
     request1.set_ip("127.0.0.1");
     request1.set_port(8888);
     heartbeat::DiskState *diskState = new heartbeat::DiskState();
-    diskState->set_errtype(0);
+    diskState->set_errtype(curve::mds::heartbeat::NORMAL);
     diskState->set_errmsg("");
     request1.set_allocated_diskstate(diskState);
     request1.set_diskcapacity(2ull * 1024 * 1024 * 1024);

--- a/tools-v2/pkg/cli/command/curvebs/list/list.go
+++ b/tools-v2/pkg/cli/command/curvebs/list/list.go
@@ -34,6 +34,7 @@ import (
 	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/list/server"
 	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/list/snapshot"
 	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/list/space"
+	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvebs/list/unavailcopysets"
 	"github.com/spf13/cobra"
 )
 
@@ -55,6 +56,7 @@ func (listCmd *ListCommand) AddSubCommands() {
 		may_broken_vol.NewMayBrokenVolCommand(),
 		formatstatus.NewFormatStatusCommand(),
 		snapshot.NewSnapShotCommand(),
+		unavailcopysets.NewUnAvailCopySetsCommand(),
 	)
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #2561

Problem Summary:  When the space of a single chunkserver of curvebs is insufficient, chunkserver will down directly

### What is changed and how it works?

What's Changed:

    1.Heartbeat reports disk full error and mds set copyset availflag false and set disk status error.
    2.Copyset node leader set readonly when receive copyset availflag false from heartbeat.
    3.If the disk becomes full while writing to the chunk file, the server return no space err and client hangs until space is freed up manually.

How it Works:
     
    1.When the disk is full, the heartbeat uploads the disk status. MDS sets the disk status to error to prevent other copysets from migrating to this disk, and sets the copyset to be unavailable to avoid creating new space from these copysets.
    2.When copyset status is unavailable, copysetnode will be set to readonly. when a new write request comes in, a read-only prompt will be returned.
    3.If the disk becomes full while writing to the chunk file, the server return no space err and client hangs until space is freed up manually.


Side effects(Breaking backward compatibility? Performance regression?):
Older versions of chunkserver need to add disk limit usage percentage configuration
### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
