### PR TITLE
[Fix]: Stop write log to stderr, when `FLAGS_logtostderr` is `false`

### DIFF
--- a/curvefs/src/client/curve_fuse_op.cpp
+++ b/curvefs/src/client/curve_fuse_op.cpp
@@ -48,6 +48,7 @@
 #include "curvefs/src/common/metric_utils.h"
 #include "src/common/configuration.h"
 #include "src/common/gflags_helper.h"
+#include "src/common/log_util.h"
 
 using ::curve::common::Configuration;
 using ::curvefs::client::CURVEFS_ERROR;
@@ -152,6 +153,7 @@ int InitLog(const char *confPath, const char *argv0) {
     FLAGS_vlog_level = FLAGS_v;
 
     // initialize logging module
+    curve::common::DisableLoggingToStdErr();
     google::InitGoogleLogging(argv0);
 
     bool succ = InitAccessLog(FLAGS_log_dir);

--- a/curvefs/src/mds/main.cpp
+++ b/curvefs/src/mds/main.cpp
@@ -24,6 +24,7 @@
 #include <glog/logging.h>
 
 #include "curvefs/src/mds/mds.h"
+#include "src/common/log_util.h"
 #include "src/common/configuration.h"
 #include "curvefs/src/common/dynamic_vlog.h"
 
@@ -64,6 +65,7 @@ int main(int argc, char **argv) {
     }
 
     // initialize logging module
+    curve::common::DisableLoggingToStdErr();
     google::InitGoogleLogging(argv[0]);
 
     conf->PrintConfig();

--- a/curvefs/src/metaserver/main.cpp
+++ b/curvefs/src/metaserver/main.cpp
@@ -29,6 +29,7 @@
 #include "src/common/configuration.h"
 #include "curvefs/src/common/dynamic_vlog.h"
 #include "curvefs/src/common/threading.h"
+#include "src/common/log_util.h"
 
 DEFINE_string(confPath, "curvefs/conf/metaserver.conf", "metaserver confPath");
 DEFINE_string(ip, "127.0.0.1", "metasetver listen ip");
@@ -126,6 +127,7 @@ int main(int argc, char **argv) {
     FLAGS_vlog_level = FLAGS_v;
 
     // initialize logging module
+    curve::common::DisableLoggingToStdErr();
     google::InitGoogleLogging(argv[0]);
 
     conf->PrintConfig();

--- a/nebd/src/part2/main.cpp
+++ b/nebd/src/part2/main.cpp
@@ -24,12 +24,14 @@
 #include <unistd.h>
 #include <glog/logging.h>
 #include "nebd/src/part2/nebd_server.h"
+#include "src/common/log_util.h"
 
 DEFINE_string(confPath, "/etc/nebd/nebd-server.conf", "nebd server conf path");
 
 int main(int argc, char* argv[]) {
     // 解析参数
     google::ParseCommandLineFlags(&argc, &argv, false);
+    curve::common::DisableLoggingToStdErr();
     google::InitGoogleLogging(argv[0]);
     std::string confPath = FLAGS_confPath.c_str();
 

--- a/src/chunkserver/chunkserver.cpp
+++ b/src/chunkserver/chunkserver.cpp
@@ -45,6 +45,7 @@
 #include "src/common/concurrent/task_thread_pool.h"
 #include "src/common/curve_version.h"
 #include "src/common/uri_parser.h"
+#include "src/common/log_util.h"
 
 using ::curve::fs::LocalFileSystem;
 using ::curve::fs::LocalFileSystemOption;
@@ -105,6 +106,7 @@ int ChunkServer::Run(int argc, char** argv) {
     LoadConfigFromCmdline(&conf);
 
     // 初始化日志模块
+    curve::common::DisableLoggingToStdErr();
     google::InitGoogleLogging(argv[0]);
 
     // 打印参数

--- a/src/common/log_util.h
+++ b/src/common/log_util.h
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (c) 2023 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef SRC_COMMON_LOG_UTIL_H_
+#define SRC_COMMON_LOG_UTIL_H_
+
+#include <glog/logging.h>
+
+namespace curve {
+namespace common {
+    inline void DisableLoggingToStdErr() {
+        // NOTE: https://github.com/google/glog#setting-flags
+        FLAGS_stderrthreshold = 3;
+    }
+}  // namespace common
+}  // namespace curve
+
+#endif  // SRC_COMMON_LOG_UTIL_H_

--- a/src/mds/main/main.cpp
+++ b/src/mds/main/main.cpp
@@ -24,6 +24,7 @@
 
 #include "src/mds/server/mds.h"
 #include "src/mds/common/mds_define.h"
+#include "src/common/log_util.h"
 
 DEFINE_string(confPath, "conf/mds.conf", "mds confPath");
 DEFINE_string(mdsAddr, "127.0.0.1:6666", "mds listen addr");
@@ -107,6 +108,7 @@ int main(int argc, char **argv) {
     }
 
     // initialize logging module
+    curve::common::DisableLoggingToStdErr();
     google::InitGoogleLogging(argv[0]);
 
     // reset SIGPIPE handler

--- a/src/snapshotcloneserver/main.cpp
+++ b/src/snapshotcloneserver/main.cpp
@@ -22,6 +22,7 @@
 #include <glog/logging.h>
 #include <gflags/gflags.h>
 #include "src/snapshotcloneserver/snapshotclone_server.h"
+#include "src/common/log_util.h"
 
 DEFINE_string(conf, "conf/snapshot_clone_server.conf", "snapshot&clone server config file path");  //NOLINT
 DEFINE_string(addr, "127.0.0.1:5555", "snapshotcloneserver address");
@@ -80,6 +81,7 @@ int main(int argc, char **argv) {
     LoadConfigFromCmdline(conf.get());
     conf->PrintConfig();
     conf->ExposeMetric("snapshot_clone_server_config");
+    curve::common::DisableLoggingToStdErr();
     google::InitGoogleLogging(argv[0]);
     snapshotcloneserver_main(conf);
 }


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #2811

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:
* Set `FLAGS_stderrthreshold` to `3`, so only FATAL log will write to stderr.

See also:[Glog Doc](https://github.com/google/glog#setting-flags)

Effect:
```log
┌──(nature㉿LAPTOP-9TS0FG11)-[~/curve]
└─$ docker ps -a
CONTAINER ID   IMAGE                 COMMAND                  CREATED          STATUS          PORTS                                                                                            NAMES
af01056361a9   curvebs:unknown       "/entrypoint.sh --ro…"   13 seconds ago   Up 12 seconds                                                                                                    focused_hofstadter
55a1484d3ef6   portainer/portainer   "/portainer"             5 months ago     Up 4 hours      0.0.0.0:8000->8000/tcp, :::8000->8000/tcp, 0.0.0.0:9000->9000/tcp, :::9000->9000/tcp, 9443/tcp   portainer

┌──(nature㉿LAPTOP-9TS0FG11)-[~/curve]
└─$ docker logs af01056361a9
fileList: []
WARNING: Logging before InitGoogleLogging() is written to STDERR
I 2023-11-09T13:40:54.374593+0800     1 dynamic_vlog.cpp:36] current verbose logging level is `0`
F 2023-11-09T13:40:54.375380+0800     1 main.cpp:73] For test, kill process in here
*** Check failure stack trace: ***
*** Aborted at 1699508454 (unix time) try "date -d @1699508454" if you are using GNU date ***
PC: @                0x0 (unknown)
*** SIGABRT (@0x1) received by PID 1 (TID 0x7fd991255140) from PID 1; stack trace: ***
    @     0x7fd99255a140 (unknown)
    @     0x7fd991cc8ce1 gsignal
    @     0x7fd991cb2537 abort
    @     0x55f53b861e43 google::FlushAndAbort()
    @     0x55f53b85f10a google::LogMessage::Fail()
    @     0x55f53b85f054 google::LogMessage::SendToLog()
    @     0x55f53b85e879 google::LogMessage::Flush()
    @     0x55f53b8617f2 google::LogMessageFatal::~LogMessageFatal()
    @     0x55f53b798ed0 main
    @     0x7fd991cb3d0a __libc_start_main
    @     0x55f53b79884a _start
    @                0x0 (unknown)

┌──(nature㉿LAPTOP-9TS0FG11)-[~/curve]
└─$ cat ./curvefs/docker/debian11/curvefs/mds/logs/curvefs-mds.log.INFO.20231109-134054.1 | grep "docker logs"
E 2023-11-09T13:40:54.375043+0800     1 main.cpp:70] You cann't see me in docker logs
```
Modified source code:
```cpp
/*
 *  Copyright (c) 2021 NetEase Inc.
 *
 *  Licensed under the Apache License, Version 2.0 (the "License");
 *  you may not use this file except in compliance with the License.
 *  You may obtain a copy of the License at
 *
 *      http://www.apache.org/licenses/LICENSE-2.0
 *
 *  Unless required by applicable law or agreed to in writing, software
 *  distributed under the License is distributed on an "AS IS" BASIS,
 *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 *  See the License for the specific language governing permissions and
 *  limitations under the License.
 */

/*
 * Project: curve
 * Created Date: 2021-05-19
 * Author: chenwei
 */

#include <gflags/gflags.h>
#include <glog/logging.h>

#include "curvefs/src/mds/mds.h"
#include "src/common/configuration.h"
#include "curvefs/src/common/dynamic_vlog.h"

using ::curve::common::Configuration;
using ::curvefs::common::FLAGS_vlog_level;

DEFINE_string(confPath, "curvefs/conf/mds.conf", "mds confPath");
DEFINE_string(mdsAddr, "127.0.0.1:6700", "mds listen addr");

void LoadConfigFromCmdline(Configuration *conf) {
    google::CommandLineFlagInfo info;
    if (GetCommandLineFlagInfo("mdsAddr", &info) && !info.is_default) {
        conf->SetStringValue("mds.listen.addr", FLAGS_mdsAddr);
    }

    if (GetCommandLineFlagInfo("v", &info) && !info.is_default) {
        conf->SetIntValue("mds.loglevel", FLAGS_v);
    }
}

int main(int argc, char **argv) {
    // config initialization
    google::ParseCommandLineFlags(&argc, &argv, false);

    std::string confPath = FLAGS_confPath;
    auto conf = std::make_shared<Configuration>();
    conf->SetConfigPath(confPath);
    LOG_IF(FATAL, !conf->LoadConfig())
        << "load mds configuration fail, conf path = " << confPath;
    conf->GetValueFatalIfFail("mds.loglevel", &FLAGS_v);
    LoadConfigFromCmdline(conf.get());
    FLAGS_vlog_level = FLAGS_v;
    if (FLAGS_log_dir.empty()) {
        if (!conf->GetStringValue("mds.common.logDir", &FLAGS_log_dir)) {
            LOG(WARNING) << "no mds.common.logDir in " << confPath
                         << ", will log to /tmp";
        }
    }

    // initialize logging module
    // NOTE: https://github.com/google/glog#setting-flags
    FLAGS_stderrthreshold = 3;
    google::InitGoogleLogging(argv[0]);
    LOG(ERROR) << "You cann't see me in docker logs";

    conf->PrintConfig();
    LOG(FATAL) << "For test, kill process in here";

    curvefs::mds::MDS mds;

    // initialize MDS options
    mds.InitOptions(conf);

    mds.StartDummyServer();

    mds.StartCompaginLeader();

    // Initialize other modules after winning election
    mds.Init();

    // start mds server and wait CTRL+C to quit
    mds.Run();

    // stop server and background threads
    mds.Stop();

    curve::common::S3Adapter::Shutdown();
    google::ShutdownGoogleLogging();
    return 0;
}

```

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [x] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license
