### PR TITLE
[fix]tools-v2: panic when show cluster status

### DIFF
--- a/tools-v2/internal/error/error.go
+++ b/tools-v2/internal/error/error.go
@@ -380,15 +380,12 @@ var (
 	ErrBsListZone = func() *CmdError {
 		return NewInternalCmdError(39, "list zone fail. the error is %s")
 	}
-
 	ErrBsDeleteFile = func() *CmdError {
 		return NewInternalCmdError(40, "delete file fail. the error is %s")
 	}
-
 	ErrRespTypeNoExpected = func() *CmdError {
 		return NewInternalCmdError(41, "the response type is not as expected, should be: %s")
 	}
-
 	ErrGetPeer = func() *CmdError {
 		return NewInternalCmdError(42, "invalid peer args, err: %s")
 	}
@@ -498,7 +495,10 @@ var (
 		return NewInternalCmdError(78, fmt.Sprintf("list snapshot fail, requestId: %s, code: %s, message: %s", requestId, code, message))
 	}
 	ErrBsGetCloneRecover = func() *CmdError {
-		return NewInternalCmdError(73, "get clone-recover fail, err: %s")
+		return NewInternalCmdError(79, "get clone-recover fail, err: %s")
+	}
+	ErrInvalidMetaServerAddr = func() *CmdError {
+		return NewInternalCmdError(80, "invalid metaserver external addr: %s")
 	}
 
 	// http error

--- a/tools-v2/pkg/cli/command/curvefs/status/copyset/copyset.go
+++ b/tools-v2/pkg/cli/command/curvefs/status/copyset/copyset.go
@@ -74,11 +74,10 @@ func (cCmd *CopysetCommand) Init(cmd *cobra.Command, args []string) error {
 		poolIdVec = append(poolIdVec, fmt.Sprintf("%d", info.GetPoolId()))
 	}
 	if len(copysetIdVec) == 0 {
-		var err error
 		cCmd.Error = cmderror.ErrSuccess()
 		cCmd.Result = "No copyset found"
 		cCmd.health = cobrautil.HEALTH_OK
-		return err
+		return nil
 	}
 	copysetIds := strings.Join(copysetIdVec, ",")
 	poolIds := strings.Join(poolIdVec, ",")

--- a/tools-v2/pkg/cli/command/curvefs/status/etcd/etcd.go
+++ b/tools-v2/pkg/cli/command/curvefs/status/etcd/etcd.go
@@ -83,6 +83,7 @@ func (eCmd *EtcdCommand) Init(cmd *cobra.Command, args []string) error {
 	// set main addr
 	etcdAddrs, addrErr := config.GetFsEtcdAddrSlice(eCmd.Cmd)
 	if addrErr.TypeCode() != cmderror.CODE_SUCCESS {
+		eCmd.Error = addrErr
 		return fmt.Errorf(addrErr.Message)
 	}
 	for _, addr := range etcdAddrs {

--- a/tools-v2/pkg/cli/command/curvefs/status/mds/mds.go
+++ b/tools-v2/pkg/cli/command/curvefs/status/mds/mds.go
@@ -76,12 +76,14 @@ func (mCmd *MdsCommand) Init(cmd *cobra.Command, args []string) error {
 	// set main addr
 	mainAddrs, addrErr := config.GetFsMdsAddrSlice(mCmd.Cmd)
 	if addrErr.TypeCode() != cmderror.CODE_SUCCESS {
+		mCmd.Error = addrErr
 		return fmt.Errorf(addrErr.Message)
 	}
 
 	// set dummy addr
 	dummyAddrs, addrErr := config.GetFsMdsDummyAddrSlice(mCmd.Cmd)
 	if addrErr.TypeCode() != cmderror.CODE_SUCCESS {
+		mCmd.Error = addrErr
 		return fmt.Errorf(addrErr.Message)
 	}
 	for _, addr := range dummyAddrs {

--- a/tools-v2/pkg/cli/command/curvefs/status/metaserver/metaserver.go
+++ b/tools-v2/pkg/cli/command/curvefs/status/metaserver/metaserver.go
@@ -88,7 +88,9 @@ func (mCmd *MetaserverCommand) Init(cmd *cobra.Command, args []string) error {
 
 	for i, addr := range externalAddrs {
 		if !config.IsValidAddr(addr) {
-			return fmt.Errorf("invalid metaserver external addr: %s", addr)
+			mCmd.Error = cmderror.ErrInvalidMetaServerAddr()
+			mCmd.Error.Format(addr)
+			return fmt.Errorf(mCmd.Error.Message)
 		}
 
 		// set metrics


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

Issue Number: #2878 

Problem Summary:

When the commands `status cluster` relies on returns an error while `init`, the `cmd.Error` is nil, causing the command to panic. Since I don't have the environment, I am not sure if this is the cause of the problem, but it is risky.

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
