### PR TITLE
curvefs: support client mdsaddrs override

### DIFF
--- a/curvefs/proto/mds.proto
+++ b/curvefs/proto/mds.proto
@@ -236,6 +236,14 @@ message CommitTxResponse {
     required FSStatusCode statusCode = 1;
 }
 
+message SetClientMdsAddrsOverrideRequest {
+    required string clientMdsAddrsOverride = 1;
+}
+
+message SetClientMdsAddrsOverrideResponse {
+    required FSStatusCode statusCode = 1;
+}
+
 service MdsService {
     // fs interface
     rpc CreateFs(CreateFsRequest) returns (CreateFsResponse);
@@ -253,4 +261,7 @@ service MdsService {
 
     // client lease
     rpc RefreshSession(RefreshSessionRequest) returns (RefreshSessionResponse);
+
+    // client mds addrs override, for mds migration
+    rpc SetClientMdsAddrsOverride(SetClientMdsAddrsOverrideRequest) returns (SetClientMdsAddrsOverrideResponse);
 }

--- a/curvefs/proto/mds.proto
+++ b/curvefs/proto/mds.proto
@@ -194,6 +194,7 @@ message RefreshSessionRequest {
     required string fsName = 2;
     required Mountpoint mountpoint = 3;
     optional FsDelta fsDelta = 4;
+    optional string mdsAddrs = 5;
 }
 
 message RefreshSessionResponse {
@@ -202,6 +203,7 @@ message RefreshSessionResponse {
     optional bool enableSumInDir = 3;
     optional uint64 fsCapacity = 4;
     optional uint64 fsUsedBytes = 5;
+    optional string mdsAddrsOverride = 6;
 }
 
 message DLockValue {

--- a/curvefs/src/client/lease/lease_excutor.cpp
+++ b/curvefs/src/client/lease/lease_excutor.cpp
@@ -77,9 +77,11 @@ bool LeaseExecutor::RefreshLease() {
 
     // refresh from mds
     std::vector<PartitionTxId> latestTxIdList;
-    FSStatusCode ret = mdsCli_->RefreshSession(txIds, &latestTxIdList,
-                                               fsName_, mountpoint_,
-                                               enableSumInDir_);
+    std::string mdsAddrs = mdsCli_->GetMdsAddrs();
+    std::string mdsAddrsOverride;
+    FSStatusCode ret =
+        mdsCli_->RefreshSession(txIds, &latestTxIdList, fsName_, mountpoint_,
+                                enableSumInDir_, mdsAddrs, &mdsAddrsOverride);
     if (ret != FSStatusCode::OK) {
         LOG(ERROR) << "LeaseExecutor refresh session fail, ret = " << ret
                    << ", errorName = " << FSStatusCode_Name(ret);
@@ -91,6 +93,8 @@ bool LeaseExecutor::RefreshLease() {
                   [&](const PartitionTxId &item) {
                       metaCache_->SetTxId(item.partitionid(), item.txid());
                   });
+    // update mds addrs
+    mdsCli_->SetMdsAddrs(mdsAddrsOverride);
     return true;
 }
 

--- a/curvefs/src/client/rpcclient/BUILD
+++ b/curvefs/src/client/rpcclient/BUILD
@@ -39,5 +39,6 @@ cc_library(
         "//src/client:curve_client",
         "@com_google_absl//absl/cleanup",
         "@com_google_absl//absl/types:optional",
+        "@com_google_absl//absl/strings",
     ],
 )

--- a/curvefs/src/client/rpcclient/mds_client.h
+++ b/curvefs/src/client/rpcclient/mds_client.h
@@ -112,12 +112,15 @@ class MdsClient {
     virtual FSStatusCode AllocS3ChunkId(uint32_t fsId, uint32_t idNum,
                                         uint64_t *chunkId) = 0;
 
-    virtual FSStatusCode
-    RefreshSession(const std::vector<PartitionTxId> &txIds,
-                   std::vector<PartitionTxId> *latestTxIdList,
-                   const std::string& fsName,
-                   const Mountpoint& mountpoint,
-                   std::atomic<bool>* enableSumInDir) = 0;
+    virtual FSStatusCode RefreshSession(
+        const std::vector<PartitionTxId> &txIds,
+        std::vector<PartitionTxId> *latestTxIdList, const std::string &fsName,
+        const Mountpoint &mountpoint, std::atomic<bool> *enableSumInDir,
+        const std::string &mdsAddrs, std::string *mdsAddrsOverride) = 0;
+
+    virtual std::string GetMdsAddrs() = 0;
+
+    virtual void SetMdsAddrs(const std::string &mdsAddrs) = 0;
 
     virtual FSStatusCode GetLatestTxId(uint32_t fsId,
                                        std::vector<PartitionTxId>* txIds) = 0;
@@ -203,9 +206,15 @@ class MdsClientImpl : public MdsClient {
 
     FSStatusCode RefreshSession(const std::vector<PartitionTxId> &txIds,
                                 std::vector<PartitionTxId> *latestTxIdList,
-                                const std::string& fsName,
-                                const Mountpoint& mountpoint,
-                                std::atomic<bool>* enableSumInDir) override;
+                                const std::string &fsName,
+                                const Mountpoint &mountpoint,
+                                std::atomic<bool> *enableSumInDir,
+                                const std::string &mdsAddrs,
+                                std::string *mdsAddrsOverride) override;
+
+    std::string GetMdsAddrs() override;
+
+    void SetMdsAddrs(const std::string &mdsAddrs) override;
 
     FSStatusCode GetLatestTxId(uint32_t fsId,
                                std::vector<PartitionTxId>* txIds) override;

--- a/curvefs/src/mds/fs_manager.cpp
+++ b/curvefs/src/mds/fs_manager.cpp
@@ -1289,6 +1289,11 @@ bool FsManager::FillVolumeInfo(common::Volume* volume) {
     return true;
 }
 
+std::string FsManager::GetClientMdsAddrsOverride() {
+    ReadLockGuard lock(clientMdsAddrsOverrideMutex_);
+    return clientMdsAddrsOverride_;
+}
+
 void FsManager::SetClientMdsAddrsOverride(const std::string& addrs) {
     // always add active mds to override to improve availability
     auto addrsWithActiveMds = addrs + "," + option_.mdsListenAddr;

--- a/curvefs/src/mds/fs_manager.cpp
+++ b/curvefs/src/mds/fs_manager.cpp
@@ -976,6 +976,15 @@ void FsManager::RefreshSession(const RefreshSessionRequest* request,
     FsUsage usage;
     fsStorage_->GetFsUsage(request->fsname(), &usage, true);
     response->set_fsusedbytes(usage.usedbytes());
+    {
+        ReadLockGuard lock(clientMdsAddrsOverrideMutex_);
+        VLOG(6) << "clientMdsAddrsOverride_ = " << clientMdsAddrsOverride_
+                << ", request->mdsaddrs() = " << request->mdsaddrs();
+        if (!clientMdsAddrsOverride_.empty() && request->has_mdsaddrs() &&
+            request->mdsaddrs() != clientMdsAddrsOverride_) {
+            response->set_mdsaddrsoverride(clientMdsAddrsOverride_);
+        }
+    }
 }
 
 FSStatusCode FsManager::ReloadFsVolumeSpace() {
@@ -1278,6 +1287,13 @@ bool FsManager::FillVolumeInfo(common::Volume* volume) {
     volume->set_volumesize(size);
     volume->set_extendalignment(alignment);
     return true;
+}
+
+void FsManager::SetClientMdsAddrsOverride(const std::string& addrs) {
+    // always add active mds to override to improve availability
+    auto addrsWithActiveMds = addrs + "," + option_.mdsListenAddr;
+    WriteLockGuard lock(clientMdsAddrsOverrideMutex_);
+    clientMdsAddrsOverride_ = addrsWithActiveMds;
 }
 
 }  // namespace mds

--- a/curvefs/src/mds/fs_manager.h
+++ b/curvefs/src/mds/fs_manager.h
@@ -211,6 +211,7 @@ class FsManager {
     bool GetClientAliveTime(const std::string& mountpoint,
         std::pair<std::string, uint64_t>* out);
 
+    std::string GetClientMdsAddrsOverride();
     void SetClientMdsAddrsOverride(const std::string& addrs);
 
  private:

--- a/curvefs/src/mds/fs_manager.h
+++ b/curvefs/src/mds/fs_manager.h
@@ -74,6 +74,7 @@ struct FsManagerOption {
     uint32_t spaceReloadConcurrency = 10;
     uint32_t clientTimeoutSec = 20;
     curve::common::S3AdapterOption s3AdapterOption;
+    std::string mdsListenAddr;
 };
 
 class FsManager {
@@ -210,6 +211,8 @@ class FsManager {
     bool GetClientAliveTime(const std::string& mountpoint,
         std::pair<std::string, uint64_t>* out);
 
+    void SetClientMdsAddrsOverride(const std::string& addrs);
+
  private:
      // return 0: ExactlySame; 1: uncomplete, -1: neither
     int IsExactlySameOrCreateUnComplete(const std::string& fsName,
@@ -279,6 +282,9 @@ class FsManager {
     mutable RWLock recorderMutex_;
     // fsuage update lock
     mutable RWLock fsUsageMutex_;
+    // client mds addrs override
+    std::string clientMdsAddrsOverride_;
+    mutable RWLock clientMdsAddrsOverrideMutex_;
 };
 }  // namespace mds
 }  // namespace curvefs

--- a/curvefs/src/mds/mds.cpp
+++ b/curvefs/src/mds/mds.cpp
@@ -163,6 +163,7 @@ void MDS::InitFsManagerOptions(FsManagerOption* fsManagerOption) {
            "default value: "
         << fsManagerOption->spaceReloadConcurrency;
 
+    fsManagerOption->mdsListenAddr = conf_->GetStringValue("mds.listen.addr");
     ::curve::common::InitS3AdaptorOptionExceptS3InfoOption(
         conf_.get(), &fsManagerOption->s3AdapterOption);
 }

--- a/curvefs/src/mds/mds_service.cpp
+++ b/curvefs/src/mds/mds_service.cpp
@@ -365,5 +365,20 @@ void MdsServiceImpl::CommitTx(::google::protobuf::RpcController *controller,
     VLOG(3) << "CommitTx [response]: " << request->DebugString();
 }
 
+void MdsServiceImpl::SetClientMdsAddrsOverride(
+    ::google::protobuf::RpcController *controller,
+    const ::curvefs::mds::SetClientMdsAddrsOverrideRequest *request,
+    ::curvefs::mds::SetClientMdsAddrsOverrideResponse *response,
+    ::google::protobuf::Closure *done) {
+    (void)controller;
+    brpc::ClosureGuard guard(done);
+    VLOG(3) << "SetClientMdsAddrsOverride [request]: "
+            << request->DebugString();
+    fsManager_->SetClientMdsAddrsOverride(request->clientmdsaddrsoverride());
+    response->set_statuscode(FSStatusCode::OK);
+    VLOG(3) << "SetClientMdsAddrsOverride [response]: "
+            << response->DebugString();
+}
+
 }  // namespace mds
 }  // namespace curvefs

--- a/curvefs/src/mds/mds_service.h
+++ b/curvefs/src/mds/mds_service.h
@@ -101,6 +101,12 @@ class MdsServiceImpl : public MdsService {
                   CommitTxResponse* response,
                   ::google::protobuf::Closure* done);
 
+    void SetClientMdsAddrsOverride(
+        ::google::protobuf::RpcController* controller,
+        const SetClientMdsAddrsOverrideRequest* request,
+        SetClientMdsAddrsOverrideResponse* response,
+        ::google::protobuf::Closure* done);
+
  private:
     std::shared_ptr<FsManager> fsManager_;
     std::shared_ptr<ChunkIdAllocator> chunkIdAllocator_;

--- a/curvefs/test/client/lease/lease_executor_test.cpp
+++ b/curvefs/test/client/lease/lease_executor_test.cpp
@@ -89,7 +89,7 @@ TEST_F(LeaseExecutorTest, test_start_stop) {
     EXPECT_CALL(*metaCache_, GetAllTxIds(_))
         .WillOnce(SetArgPointee<0>(std::vector<PartitionTxId>{}))
         .WillRepeatedly(SetArgPointee<0>(txIds));
-    EXPECT_CALL(*mdsCli_, RefreshSession(_, _, _, _, _))
+    EXPECT_CALL(*mdsCli_, RefreshSession(_, _, _, _, _, _, _))
         .WillOnce(Return(FSStatusCode::UNKNOWN_ERROR))
         .WillRepeatedly(
             DoAll(SetArgPointee<1>(txIds), Return(FSStatusCode::OK)));

--- a/curvefs/test/client/rpcclient/mds_client_test.cpp
+++ b/curvefs/test/client/rpcclient/mds_client_test.cpp
@@ -839,6 +839,7 @@ TEST_F(MdsClientImplTest, RefreshSession) {
     // out
     std::vector<PartitionTxId> out;
     std::atomic<bool>* enableSumInDir = new std::atomic<bool> (true);
+    std::string mdsAddrsOverride;
     RefreshSessionResponse response;
 
     {
@@ -846,8 +847,9 @@ TEST_F(MdsClientImplTest, RefreshSession) {
         response.set_statuscode(FSStatusCode::OK);
         EXPECT_CALL(mockmdsbasecli_, RefreshSession(_, _, _, _))
             .WillOnce(SetArgPointee<1>(response));
-        ASSERT_FALSE(mdsclient_.RefreshSession(txIds, &out,
-                                fsName, mountpoint, enableSumInDir));
+        ASSERT_FALSE(mdsclient_.RefreshSession(txIds, &out, fsName, mountpoint,
+                                               enableSumInDir, std::string(),
+                                               &mdsAddrsOverride));
         ASSERT_TRUE(out.empty());
     }
 
@@ -857,8 +859,9 @@ TEST_F(MdsClientImplTest, RefreshSession) {
         *response.mutable_latesttxidlist() = {txIds.begin(), txIds.end()};
         EXPECT_CALL(mockmdsbasecli_, RefreshSession(_, _, _, _))
             .WillOnce(SetArgPointee<1>(response));
-        ASSERT_FALSE(mdsclient_.RefreshSession(txIds, &out,
-                            fsName, mountpoint, enableSumInDir));
+        ASSERT_FALSE(mdsclient_.RefreshSession(txIds, &out, fsName, mountpoint,
+                                               enableSumInDir, std::string(),
+                                               &mdsAddrsOverride));
         ASSERT_EQ(1, out.size());
         ASSERT_TRUE(
             google::protobuf::util::MessageDifferencer::Equals(out[0], tmp))
@@ -874,8 +877,9 @@ TEST_F(MdsClientImplTest, RefreshSession) {
         EXPECT_CALL(mockmdsbasecli_, RefreshSession(_, _, _, _))
             .WillRepeatedly(Invoke(RefreshSessionRpcFailed));
         ASSERT_EQ(FSStatusCode::RPC_ERROR,
-            mdsclient_.RefreshSession(txIds, &out, fsName, mountpoint,
-            enableSumInDir));
+                  mdsclient_.RefreshSession(txIds, &out, fsName, mountpoint,
+                                            enableSumInDir, std::string(),
+                                            &mdsAddrsOverride));
     }
 }
 

--- a/curvefs/test/client/rpcclient/mds_client_test.cpp
+++ b/curvefs/test/client/rpcclient/mds_client_test.cpp
@@ -1046,6 +1046,16 @@ TEST_F(MdsClientImplTest, test_AllocOrGetMemcacheCluster) {
               mdsclient_.AllocOrGetMemcacheCluster(1, &cluster2));
 }
 
+TEST_F(MdsClientImplTest, test_GetMdsAddrs) {
+    ASSERT_EQ(mdsclient_.GetMdsAddrs(), addr_);
+}
+
+TEST_F(MdsClientImplTest, test_SetMdsAddrs) {
+    auto addr_new = addr_ + ",127.0.0.1:5600";
+    mdsclient_.SetMdsAddrs(addr_new);
+    ASSERT_EQ(mdsclient_.GetMdsAddrs(), addr_new);
+}
+
 }  // namespace rpcclient
 }  // namespace client
 }  // namespace curvefs

--- a/curvefs/test/client/rpcclient/mock_mds_client.h
+++ b/curvefs/test/client/rpcclient/mock_mds_client.h
@@ -106,12 +106,18 @@ class MockMdsClient : public MdsClient {
                  bool(uint32_t fsID,
                       std::vector<PartitionInfo>* partitionInfos));
 
-    MOCK_METHOD5(RefreshSession,
-                 FSStatusCode(const std::vector<PartitionTxId> &txIds,
-                              std::vector<PartitionTxId> *latestTxIdList,
+    MOCK_METHOD7(RefreshSession,
+                 FSStatusCode(const std::vector<PartitionTxId>& txIds,
+                              std::vector<PartitionTxId>* latestTxIdList,
                               const std::string& fsName,
                               const Mountpoint& mountpoint,
-                              std::atomic<bool>* enableSumInDir));
+                              std::atomic<bool>* enableSumInDir,
+                              const std::string& mdsAddrs,
+                              std::string* mdsAddrsOverride));
+
+    MOCK_METHOD0(GetMdsAddrs, std::string());
+
+    MOCK_METHOD1(SetMdsAddrs, void(const std::string& mdsAddrs));
 
     MOCK_METHOD4(AllocateVolumeBlockGroup,
                  SpaceErrCode(uint32_t,

--- a/src/client/mds_client.h
+++ b/src/client/mds_client.h
@@ -48,7 +48,13 @@ class RPCExcutorRetryPolicy {
     RPCExcutorRetryPolicy()
         : retryOpt_(), currentWorkingMDSAddrIndex_(0), cntlID_(1) {}
 
+    MetaServerOption::RpcRetryOption GetOption() {
+        ReadLockGuard lock(retryOptLock_);
+        return retryOpt_;
+    }
+
     void SetOption(const MetaServerOption::RpcRetryOption &option) {
+        WriteLockGuard lock(retryOptLock_);
         retryOpt_ = option;
     }
     using RPCFunc = std::function<int(int addrindex, uint64_t rpctimeoutMS,
@@ -147,6 +153,7 @@ class RPCExcutorRetryPolicy {
  private:
     // 执行rpc时必要的配置信息
     MetaServerOption::RpcRetryOption retryOpt_;
+    BthreadRWLock retryOptLock_;
 
     // 记录上一次重试过的leader信息
     std::atomic<int> currentWorkingMDSAddrIndex_;

--- a/tools-v2/pkg/cli/command/curvefs/update/mds/clientMdsAddrsOverride.go
+++ b/tools-v2/pkg/cli/command/curvefs/update/mds/clientMdsAddrsOverride.go
@@ -1,0 +1,140 @@
+/*
+ *  Copyright (c) 2023 NetEase Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package mds
+
+import (
+	"context"
+	"fmt"
+
+	cmderror "github.com/opencurve/curve/tools-v2/internal/error"
+	cobrautil "github.com/opencurve/curve/tools-v2/internal/utils"
+	basecmd "github.com/opencurve/curve/tools-v2/pkg/cli/command"
+	"github.com/opencurve/curve/tools-v2/pkg/config"
+	"github.com/opencurve/curve/tools-v2/pkg/output"
+	mds "github.com/opencurve/curve/tools-v2/proto/curvefs/proto/mds"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"google.golang.org/grpc"
+)
+
+const (
+	example = `$ curve fs update mds client-mds-addrs-override 1.2.3.4:1234,2.3.4.5:2345`
+)
+
+type SetClientMdsAddrsOverride struct {
+	Info      *basecmd.Rpc
+	Request   *mds.SetClientMdsAddrsOverrideRequest
+	mdsClient mds.MdsServiceClient
+}
+
+var _ basecmd.RpcFunc = (*SetClientMdsAddrsOverride)(nil) // check interface
+
+type SetClientMdsAddrsOverrideCommand struct {
+	basecmd.FinalCurveCmd
+	Rpc *SetClientMdsAddrsOverride
+}
+
+var _ basecmd.FinalCurveCmdFunc = (*SetClientMdsAddrsOverrideCommand)(nil) // check interface
+
+func (ufRp *SetClientMdsAddrsOverride) NewRpcClient(cc grpc.ClientConnInterface) {
+	ufRp.mdsClient = mds.NewMdsServiceClient(cc)
+}
+
+func (ufRp *SetClientMdsAddrsOverride) Stub_Func(ctx context.Context) (interface{}, error) {
+	return ufRp.mdsClient.SetClientMdsAddrsOverride(ctx, ufRp.Request)
+}
+
+func NewSetClientMdsAddrsOverrideCommand() *cobra.Command {
+	cmd := &SetClientMdsAddrsOverrideCommand{
+		FinalCurveCmd: basecmd.FinalCurveCmd{
+			Use:     "client-mds-addrs-override",
+			Short:   "set client mds addrs override",
+			Long:    "set client mds addrs override",
+			Example: example,
+		},
+	}
+	basecmd.NewFinalCurveCli(&cmd.FinalCurveCmd, cmd)
+	return cmd.Cmd
+}
+
+func (fCmd *SetClientMdsAddrsOverrideCommand) AddFlags() {
+	config.AddRpcRetryTimesFlag(fCmd.Cmd)
+	config.AddRpcTimeoutFlag(fCmd.Cmd)
+	config.AddFsMdsAddrFlag(fCmd.Cmd)
+}
+
+func (fCmd *SetClientMdsAddrsOverrideCommand) Init(cmd *cobra.Command, args []string) error {
+	addrs, addrErr := config.GetFsMdsAddrSlice(fCmd.Cmd)
+	if addrErr.TypeCode() != cmderror.CODE_SUCCESS {
+		return fmt.Errorf(addrErr.Message)
+	}
+	timeout := viper.GetDuration(config.VIPER_GLOBALE_RPCTIMEOUT)
+	retrytimes := viper.GetInt32(config.VIPER_GLOBALE_RPCRETRYTIMES)
+
+	// output format
+	header := []string{cobrautil.ROW_RESULT}
+	fCmd.SetHeader(header)
+
+	if len(args) != 1 {
+		return fmt.Errorf("please specify client mds addrs override, example: " + example)
+	}
+
+	request := &mds.SetClientMdsAddrsOverrideRequest{
+		ClientMdsAddrsOverride: &args[0],
+	}
+	// set rpc
+	fCmd.Rpc = &SetClientMdsAddrsOverride{
+		Request: request,
+	}
+	fCmd.Rpc.Info = basecmd.NewRpc(addrs, timeout, retrytimes, "change client mds addrs override")
+	return nil
+}
+
+func (fCmd *SetClientMdsAddrsOverrideCommand) Print(cmd *cobra.Command, args []string) error {
+	return output.FinalCmdOutput(&fCmd.FinalCurveCmd, fCmd)
+}
+
+func (fCmd *SetClientMdsAddrsOverrideCommand) RunCommand(cmd *cobra.Command, args []string) error {
+	result, errCmd := basecmd.GetRpcResponse(fCmd.Rpc.Info, fCmd.Rpc)
+	if errCmd.TypeCode() != cmderror.CODE_SUCCESS {
+		return fmt.Errorf(errCmd.Message)
+	}
+
+	response := result.(*mds.SetClientMdsAddrsOverrideResponse)
+	errMsg := mds.FSStatusCode_name[int32(response.GetStatusCode())]
+	row := map[string]string{
+		cobrautil.ROW_RESULT: errMsg,
+	}
+
+	fCmd.TableNew.Append(cobrautil.Map2List(row, fCmd.Header))
+
+	var errs []*cmderror.CmdError
+	res, errTranslate := output.MarshalProtoJson(response)
+	if errTranslate != nil {
+		errMar := cmderror.ErrMarShalProtoJson()
+		errMar.Format(errTranslate.Error())
+		errs = append(errs, errMar)
+	}
+
+	fCmd.Result = res
+	fCmd.Error = cmderror.MostImportantCmdError(errs)
+	return nil
+}
+
+func (fCmd *SetClientMdsAddrsOverrideCommand) ResultPlainOutput() error {
+	return output.FinalCmdOutputPlain(&fCmd.FinalCurveCmd)
+}

--- a/tools-v2/pkg/cli/command/curvefs/update/mds/mds.go
+++ b/tools-v2/pkg/cli/command/curvefs/update/mds/mds.go
@@ -14,34 +14,31 @@
  *  limitations under the License.
  */
 
-package update
+package mds
 
 import (
 	basecmd "github.com/opencurve/curve/tools-v2/pkg/cli/command"
-	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvefs/update/fs"
-	"github.com/opencurve/curve/tools-v2/pkg/cli/command/curvefs/update/mds"
 	"github.com/spf13/cobra"
 )
 
-type UpdateCommand struct {
+type MdsCommand struct {
 	basecmd.MidCurveCmd
 }
 
-var _ basecmd.MidCurveCmdFunc = (*UpdateCommand)(nil) // check interface
+var _ basecmd.MidCurveCmdFunc = (*MdsCommand)(nil) // check interface
 
-func (updateCmd *UpdateCommand) AddSubCommands() {
-	updateCmd.Cmd.AddCommand(
-		fs.NewFsCommand(),
-		mds.NewMdsCommand(),
+func (mdsCmd *MdsCommand) AddSubCommands() {
+	mdsCmd.Cmd.AddCommand(
+		NewSetClientMdsAddrsOverrideCommand(),
 	)
 }
 
-func NewUpdateCommand() *cobra.Command {
-	updateCmd := &UpdateCommand{
+func NewMdsCommand() *cobra.Command {
+	mdsCmd := &MdsCommand{
 		basecmd.MidCurveCmd{
-			Use:   "update",
-			Short: "update resources in the curvefs",
+			Use:   "mds",
+			Short: "mds resources in the curvefs",
 		},
 	}
-	return basecmd.NewMidCurveCli(&updateCmd.MidCurveCmd, updateCmd)
+	return basecmd.NewMidCurveCli(&mdsCmd.MidCurveCmd, mdsCmd)
 }


### PR DESCRIPTION
we need to make client alive when migrate mds to new ones. so we add online client mds addrs override to broadcast by session. 

tool -> send SetClientMdsAddrsOverride to mds, will keep active mds
mds -> refresh session send to client
client -> change mds addr to override ones

use case:
client -> mds A,B,C
change to client -> mds A,B,C,D,E,F
change to client -> mds D,E,F
