### PR TITLE
curvefs: fix list xattr miss someone

### DIFF
--- a/curvefs/src/client/fuse_client.cpp
+++ b/curvefs/src/client/fuse_client.cpp
@@ -1137,6 +1137,13 @@ CURVEFS_ERROR FuseClient::FuseOpListXattr(fuse_req_t req, fuse_ino_t ino,
         // +1 because, the format is key\0key\0
         *realSize += it.first.length() + 1;
     }
+    // add summary xattr key
+    if (inodeAttr.type() == FsFileType::TYPE_DIRECTORY) {
+        *realSize += strlen(XATTR_DIR_RFILES) + 1;
+        *realSize += strlen(XATTR_DIR_RSUBDIRS) + 1;
+        *realSize += strlen(XATTR_DIR_RENTRIES) + 1;
+        *realSize += strlen(XATTR_DIR_RFBYTES) + 1;
+    }
 
     if (size == 0) {
         return CURVEFS_ERROR::OK;
@@ -1149,6 +1156,16 @@ CURVEFS_ERROR FuseClient::FuseOpListXattr(fuse_req_t req, fuse_ino_t ino,
             auto tsize = it.first.length() + 1;
             memcpy(value, it.first.c_str(), tsize);
             value += tsize;
+        }
+        if (inodeAttr.type() == FsFileType::TYPE_DIRECTORY) {
+            memcpy(value, XATTR_DIR_RFILES, strlen(XATTR_DIR_RFILES) + 1);
+            value += strlen(XATTR_DIR_RFILES) + 1;
+            memcpy(value, XATTR_DIR_RSUBDIRS, strlen(XATTR_DIR_RSUBDIRS) + 1);
+            value += strlen(XATTR_DIR_RSUBDIRS) + 1;
+            memcpy(value, XATTR_DIR_RENTRIES, strlen(XATTR_DIR_RENTRIES) + 1);
+            value += strlen(XATTR_DIR_RENTRIES) + 1;
+            memcpy(value, XATTR_DIR_RFBYTES, strlen(XATTR_DIR_RFBYTES) + 1);
+            value += strlen(XATTR_DIR_RFBYTES) + 1;
         }
         return CURVEFS_ERROR::OK;
     }

--- a/curvefs/test/client/test_fuse_s3_client.cpp
+++ b/curvefs/test/client/test_fuse_s3_client.cpp
@@ -4065,7 +4065,10 @@ TEST_F(TestFuseS3Client, FuseOpListXattr) {
         .WillOnce(DoAll(SetArgPointee<1>(inode), Return(CURVEFS_ERROR::OK)));
     ret = client_->FuseOpListXattr(req, ino, buf, size, &realSize);
     ASSERT_EQ(CURVEFS_ERROR::OK, ret);
-    auto expected = key.length() + 1;
+    auto expected = key.length() + 1 + strlen(XATTR_DIR_RFILES) + 1 +
+                    strlen(XATTR_DIR_RSUBDIRS) + 1 +
+                    strlen(XATTR_DIR_RENTRIES) + 1 +
+                    strlen(XATTR_DIR_RFBYTES) + 1;
     ASSERT_EQ(realSize, expected);
 
     realSize = 0;


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

The list xattr will miss curve.dir.r* summary xattrs.


Issue Number: #xxx <!-- replace xxx with issue number -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
