### PR TITLE
Perf(common): optimize cache promotion and demotion

### DIFF
--- a/test/client/client_metric_test.cpp
+++ b/test/client/client_metric_test.cpp
@@ -383,5 +383,10 @@ TEST(MetricTest, MetricHelperTest) {
     ASSERT_NO_THROW(MetricHelper::IncremSlowRequestNum(nullptr));
 }
 
+TEST(MetricTest, CollectMetricsTest) {
+    InterfaceMetric interface("curve_client", "test");
+    ASSERT_NO_THROW(CollectMetrics(&interface, 1, 1));
+}
+
 }   //  namespace client
 }   //  namespace curve

--- a/test/client/libcbd_ext4_test.cpp
+++ b/test/client/libcbd_ext4_test.cpp
@@ -166,6 +166,9 @@ TEST(TestLibcbdExt4, AioReadWriteTest) {
 
     ret = cbd_lib_fini();
     ASSERT_EQ(ret, 0);
+
+    ret = cbd_lib_filesize("no_exist_file");
+    ASSERT_EQ(ret, -1);
 }
 
 TEST(TestLibcbdExt4, IncreaseEpochTest) {

--- a/test/client/libcurve_client_unittest.cpp
+++ b/test/client/libcurve_client_unittest.cpp
@@ -210,6 +210,15 @@ TEST_F(CurveClientTest, TestAioWrite) {
     }
 }
 
+TEST_F(CurveClientTest, TestIncreaseEpoch) {
+    {
+        EXPECT_CALL(*mockFileClient_, IncreaseEpoch(_)).Times(0);
+
+        ASSERT_EQ(-LIBCURVE_ERROR::FAILED,
+                  client_.IncreaseEpoch(kWrongFileName));
+    }
+}
+
 }  // namespace client
 }  // namespace curve
 

--- a/test/client/mock/mock_file_client.h
+++ b/test/client/mock/mock_file_client.h
@@ -56,6 +56,7 @@ class MockFileClient : public FileClient {
     MOCK_METHOD4(ReOpen, int(const std::string&, const std::string&,
                              const UserInfo&, std::string*));
     MOCK_METHOD3(Extend, int(const std::string&, const UserInfo&, uint64_t));
+    MOCK_METHOD1(IncreaseEpoch, int(const std::string &));
 };
 
 }   // namespace client


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #2946 <!-- replace xxx with issue number -->

Problem Summary: current cache promotion and demotion need to copy a duplica, erase old elem and reinsert duplica.

### What is changed and how it works?

What's Changed: optimize cache promotion and demotion using `list.splice` and add some tests.

How it Works: `list.splice` will update cache object priority without object duplica, list reinsertion and hashtable update.

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [x] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license
