### PR TITLE
fix curvefs topology lock

### DIFF
--- a/curvefs/src/mds/topology/topology.cpp
+++ b/curvefs/src/mds/topology/topology.cpp
@@ -227,6 +227,7 @@ TopoStatusCode TopologyImpl::RemoveServer(ServerIdType id) {
 }
 
 TopoStatusCode TopologyImpl::RemoveMetaServer(MetaServerIdType id) {
+    WriteLockGuard wlockPool(poolMutex_);
     WriteLockGuard wlockServer(serverMutex_);
     WriteLockGuard wlockMetaServer(metaServerMutex_);
     auto it = metaServerMap_.find(id);
@@ -243,7 +244,6 @@ TopoStatusCode TopologyImpl::RemoveMetaServer(MetaServerIdType id) {
         metaServerMap_.erase(it);
 
         // update pool
-        WriteLockGuard wlockPool(poolMutex_);
         PoolIdType poolId = ix->second.GetPoolId();
         auto it = poolMap_.find(poolId);
         if (it != poolMap_.end()) {


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Different order of acquiring locks in  `AddMetaServer` and `RemoveMetaServer` may cause deadlock.

Issue Number: #xxx <!-- replace xxx with issue number -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
