### PR TITLE
feat(build): mount `/etc/hosts` to docker

### DIFF
--- a/util/docker_opts.sh
+++ b/util/docker_opts.sh
@@ -9,6 +9,7 @@ g_docker_opts=(
     "-v /etc/sudoers.d/:/etc/sudoers.d/"
     "-v /etc/sudoers:/etc/sudoers:ro"
     "-v /etc/shadow:/etc/shadow:ro"
+    "-v /etc/hosts:/etc/hosts"
     "-v /var/run/docker.sock:/var/run/docker.sock"
     "-v /root/.docker:/root/.docker"
     "--ulimit core=-1"


### PR DESCRIPTION
<!-- Thank you for contributing to curve! -->

### What problem does this PR solve?

Issue Number: #2978 <!-- replace xxx with issue number -->

Problem Summary:
It may download go1.12.8 unsucessfully when build etcdclient in docker. 

### What is changed and how it works?

What's Changed:
I add relevant parameters to `g_docker_opts`. At this time, we can specify correct IPs in the local hosts so that the download can be successful in docker.

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [x] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license
